### PR TITLE
Update MySQLDataSourceProvider.java

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLDataSourceProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLDataSourceProvider.java
@@ -90,9 +90,9 @@ public class MySQLDataSourceProvider extends JDBCDataSourceProvider implements D
         String trustStorePath = System.getProperty("user.home") + "/.keystore";
 
         System.setProperty("javax.net.ssl.keyStore", trustStorePath);
-        System.setProperty("javax.net.ssl.keyStorePassword", "password");
+        System.setProperty("javax.net.ssl.keyStorePassword", "changeit");
         System.setProperty("javax.net.ssl.trustStore", trustStorePath);
-        System.setProperty("javax.net.ssl.trustStorePassword", "password");
+        System.setProperty("javax.net.ssl.trustStorePassword", "changeit");
 
         StringBuilder url = new StringBuilder();
         url.append("jdbc:mysql://")

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLDataSourceProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLDataSourceProvider.java
@@ -87,7 +87,7 @@ public class MySQLDataSourceProvider extends JDBCDataSourceProvider implements D
     @Override
     public String getConnectionURL(DBPDriver driver, DBPConnectionConfiguration connectionInfo)
     {
-        String trustStorePath = "D:/temp/ssl/test-cert-store";
+        String trustStorePath = System.getProperty("user.home") + "/.keystore";
 
         System.setProperty("javax.net.ssl.keyStore", trustStorePath);
         System.setProperty("javax.net.ssl.keyStorePassword", "password");


### PR DESCRIPTION
Apparently the ~/.keystore is the default location for the keystore expected by keytool. And, moreover, D:/ is sooo windows only!!!
I would suggest also to use "changeit" instead of "password", because it seems "changeit" is the de-facto default password used with keytool, see for example https://tomcat.apache.org/tomcat-7.0-doc/ssl-howto.html and https://community.oracle.com/thread/1049953?tstart=0
