### PR TITLE
Grammatical correction in result set filter

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterPanel.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterPanel.java
@@ -148,7 +148,7 @@ class ResultSetFilterPanel extends Composite
                     if (filtersText.isEnabled() && filtersText.getCharCount() == 0) {
                         e.gc.setForeground(shadowColor);
                         e.gc.setFont(hintFont);
-                        e.gc.drawText("Enter an SQL expression to filter results", 2, 0);
+                        e.gc.drawText("Enter a SQL expression to filter results", 2, 0);
                         e.gc.setFont(null);
                     }
                 }


### PR DESCRIPTION
Should be "Enter a SQL expression to filter results" not "Enter an SQL expression to filter results"
