### PR TITLE
do not add 1 to hour when generating display string for time and datetime column

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/data/MySQLDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/data/MySQLDateTimeValueHandler.java
@@ -43,7 +43,7 @@ public class MySQLDateTimeValueHandler extends JDBCDateTimeValueHandler {
             if (value instanceof Date && format == DBDDisplayFormat.NATIVE) {
             Calendar cal = Calendar.getInstance();
             cal.setTime((Date) value);
-            final String hourOfDay = getTwoDigitValue(cal.get(Calendar.HOUR_OF_DAY) + 1);
+            final String hourOfDay = getTwoDigitValue(cal.get(Calendar.HOUR_OF_DAY));
             final String minutes = getTwoDigitValue(cal.get(Calendar.MINUTE));
             final String seconds = getTwoDigitValue(cal.get(Calendar.SECOND));
             final String year = String.valueOf(cal.get(Calendar.YEAR));


### PR DESCRIPTION
When generating INSERT statement, the HOUR of a time or datetime column is wrong imho, because it is added 1.
