### PR TITLE
Fixed Error "Internal error: can't obtain entity identifier" in ResultSetPersister for Exasol

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolSchema.java
@@ -115,9 +115,8 @@ public class ExasolSchema extends ExasolGlobalObject implements DBSSchema, DBPRe
     }
 
     @Override
-    public Class<? extends DBSObject> getChildType(DBRProgressMonitor monitor) throws DBException {
-        // TODO Auto-generated method stub
-        return null;
+    public Class<ExasolTableBase> getChildType(DBRProgressMonitor monitor) throws DBException {
+    	return ExasolTableBase.class;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTable.java
@@ -26,8 +26,6 @@ import org.jkiss.dbeaver.ext.exasol.editors.ExasolSourceObject;
 import org.jkiss.dbeaver.ext.exasol.tools.ExasolUtils;
 import org.jkiss.dbeaver.model.DBPNamedObject2;
 import org.jkiss.dbeaver.model.DBPRefreshableObject;
-import org.jkiss.dbeaver.model.data.DBDPseudoAttribute;
-import org.jkiss.dbeaver.model.data.DBDPseudoAttributeContainer;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCStructCache;
 import org.jkiss.dbeaver.model.meta.Association;
@@ -44,7 +42,7 @@ import java.util.Collection;
 /**
  * @author Karl
  */
-public class ExasolTable extends ExasolTableBase implements DBPRefreshableObject, DBPNamedObject2, DBDPseudoAttributeContainer, ExasolSourceObject {
+public class ExasolTable extends ExasolTableBase implements DBPRefreshableObject, DBPNamedObject2, ExasolSourceObject {
 
     private Boolean hasDistKey;
     private Timestamp lastCommit;
@@ -164,11 +162,6 @@ public class ExasolTable extends ExasolTableBase implements DBPRefreshableObject
     public DBSObjectState getObjectState() {
         // table can only be in state normal
         return DBSObjectState.NORMAL;
-    }
-
-    @Override
-    public DBDPseudoAttribute[] getPseudoAttributes() throws DBException {
-        return new DBDPseudoAttribute[]{ExasolConstants.PSEUDO_ATTR_RID_BIT};
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTableColumn.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTableColumn.java
@@ -110,6 +110,13 @@ public class ExasolTableColumn extends JDBCTableColumn<ExasolTableBase>
     public String getTypeName() {
         return this.dataType.getName();
     }
+    
+    @Override
+    public int getTypeID()
+    {
+    	return this.dataType.getTypeID();
+    }
+    
 
     // -----------------
     // Properties


### PR DESCRIPTION
Fixed an error in the Exasol Plugin preventing the user from editing the result set
