### PR TITLE
Fix Apache Drill sample URL

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -732,8 +732,8 @@
                     id="apache_drill"
                     label="Apache Drill"
                     class="org.apache.drill.jdbc.Driver"
-                    sampleURL="jdbc:drill:zk={host}[;schema={database}]:{port}"
-                    defaultPort="5181"
+                    sampleURL="jdbc:drill:zk={host}[:{port}][;schema={database}]"
+                    defaultPort="2181"
                     description="Apache Drill JDBC"
                     webURL="https://drill.apache.org/">
                     <file type="jar" path="maven:/org.apache.drill.exec:drill-jdbc:RELEASE"/>


### PR DESCRIPTION
The current sample URL for Apache Drill has port after schema.
According to http://drill.apache.org/docs/using-the-jdbc-driver/,
port is part of the zookeeper host name.