### PR TITLE
Add Exasol maven repository for automatic driver download

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.core/plugin.xml
@@ -2981,6 +2981,7 @@
 
     <extension point="org.jkiss.dbeaver.mavenRepository">
         <repository id="maven-central" name="Central Repository" url="http://central.maven.org/maven2/"/>
+        <repository id="exasol-jdbc" name="Exasol Repository" url="https://maven.exasol.com/artifactory/exasol-releases"/>
     </extension>
 
     <extension

--- a/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
@@ -331,7 +331,7 @@
                     <property name="querytimeout" value="600"/>
                     <property name="clientname" value="DBeaver"/>
                     <property name="connecttimeout" value="40"/>
-                    <property name="@dbeaver-default-dataformat.type.timestamp.pattern"		
+                    <property name="@dbeaver-default-dataformat.type.timestamp.pattern"
                               value="yyyy-MM-dd-HH.mm.ss.ffffff"/>
                 </driver>
             </drivers>

--- a/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
@@ -321,13 +321,13 @@
                         sampleURL="jdbc:exa:{host}[:{port}][;schema={database}]"
                         defaultPort="8563"
                         description="Exasol JDBC driver"
-                        webURL="https://maven.exasol.com/artifactory/exasol-releases/com/exasol/exasol-jdbc/">
+                        webURL="https://www.exasol.com/portal/display/DOWNLOAD/EXASOL+Download+Section">
+                   <file
+                         path="maven:/com.exasol:exasol-jdbc:{.*5\.0\..*}"
+                         type="jar">
+                   </file>
 
                     <replace provider="generic" driver="exasol"/>
-                    <file
-                          path="https://maven.exasol.com/artifactory/exasol-releases/com/exasol/exasol-jdbc/5.0.17/exasol-jdbc-5.0.17.jar"
-                          type="jar">
-                    </file>
                     <property name="querytimeout" value="600"/>
                     <property name="clientname" value="DBeaver"/>
                     <property name="connecttimeout" value="40"/>

--- a/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
@@ -321,20 +321,16 @@
                         sampleURL="jdbc:exa:{host}[:{port}][;schema={database}]"
                         defaultPort="8563"
                         description="Exasol JDBC driver"
-                        webURL="https://www.exasol.com/portal/display/DOWNLOAD/5.0">
+                        webURL="https://maven.exasol.com/artifactory/exasol-releases/com/exasol/exasol-jdbc/">
 
                     <replace provider="generic" driver="exasol"/>
+                    <file
+                          path="https://maven.exasol.com/artifactory/exasol-releases/com/exasol/exasol-jdbc/5.0.17/exasol-jdbc-5.0.17.jar"
+                          type="jar">
+                    </file>
                     <property name="querytimeout" value="600"/>
                     <property name="clientname" value="DBeaver"/>
                     <property name="connecttimeout" value="40"/>
-                    <property name="@dbeaver-default-dataformat.type.timestamp.pattern"
-                              value="yyyy-MM-dd-HH.mm.ss.ffffff"/>
-                    <library path="C:\Program Files (x86)\EXASOL\EXASolution-5.0\JDBC\exajdbc.jar"/>
-                    <fileSource url="https://www.exasol.com/portal/display/DOWNLOAD/5.0"
-                                name="Exasol JDBC Drivers"
-                                instruction="Download Exasol JDBC (JCC) client driver. Extract downloaded archive and copy exajdbc.jar in some directory. Then add exajdbc.jar as a library in DBeaver driver editor dialog.">
-                        <file name="exajdbc.jar" description="JDBC driver"/>
-                    </fileSource>
                 </driver>
             </drivers>
             <views>

--- a/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
@@ -331,6 +331,8 @@
                     <property name="querytimeout" value="600"/>
                     <property name="clientname" value="DBeaver"/>
                     <property name="connecttimeout" value="40"/>
+                    <property name="@dbeaver-default-dataformat.type.timestamp.pattern"		
+                              value="yyyy-MM-dd-HH.mm.ss.ffffff"/>
                 </driver>
             </drivers>
             <views>


### PR DESCRIPTION
- add exasol maven repository with with v5 jdbc driver (v6 has bug that will break dbeaver functionality)
- remove http file reference for exasol jdbc driver to enable maven download