### PR TITLE
Quote schema query to prevent an IllegalArgumentException.

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
@@ -52,6 +52,7 @@ import java.text.Format;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
 
 /**
  * GenericDataSource
@@ -811,7 +812,7 @@ public class GenericDataSource extends JDBCDataSource
                 if (CommonUtils.isEmpty(querySetActiveDB) || !(entity instanceof GenericObjectContainer)) {
                     throw new DBCException("Active database can't be changed for this kind of datasource!");
                 }
-                String changeQuery = querySetActiveDB.replaceFirst("\\?", entity.getName());
+                String changeQuery = querySetActiveDB.replaceFirst("\\?", Matcher.quoteReplacement(entity.getName()));
                 try (JDBCPreparedStatement dbStat = session.prepareStatement(changeQuery)) {
                     dbStat.execute();
                 }


### PR DESCRIPTION
Using a schema name that contains a dollar symbol ($) would throw a `java.lang.IllegalArgumentException: Illegal group reference`.

[String#replaceFirst()](http://docs.oracle.com/javase/6/docs/api/java/lang/String.html#replaceFirst%28java.lang.String,%20java.lang.String%29):
> Note that backslashes (\) and dollar signs ($) in the replacement string may cause the results to be different than if it were being treated as a literal replacement string; see Matcher.replaceFirst(java.lang.String). Use Matcher.quoteReplacement(java.lang.String) to suppress the special meaning of these characters, if desired.