### PR TITLE
Mysql dump advance option support

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/tools/MySQLExportWizard.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/tools/MySQLExportWizard.java
@@ -133,6 +133,16 @@ class MySQLExportWizard extends AbstractImportExportWizard<MySQLDatabaseExportIn
         UIUtils.launchProgram(outputFolder.getAbsolutePath());
 	}
 
+    private String extraCommandArgs;
+
+    public void setExtraCommandArgs(String extraCommandArgs) {
+        this.extraCommandArgs = extraCommandArgs;
+    }
+
+    public String getExtraCommandArgs() {
+        return extraCommandArgs;
+    }
+
     @Override
     public void fillProcessParameters(List<String> cmd, MySQLDatabaseExportInfo arg) throws IOException
     {
@@ -167,6 +177,10 @@ class MySQLExportWizard extends AbstractImportExportWizard<MySQLDatabaseExportIn
         }
         if (dumpEvents) cmd.add("--events"); //$NON-NLS-1$
         if (comments) cmd.add("--comments"); //$NON-NLS-1$
+	    
+        if (null != getExtraCommandArgs() && getExtraCommandArgs().trim().length() > 0){
+            cmd.add(getExtraCommandArgs());
+        }
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/tools/MySQLExportWizardPageSettings.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/tools/MySQLExportWizardPageSettings.java
@@ -36,6 +36,7 @@ class MySQLExportWizardPageSettings extends MySQLWizardPageSettings<MySQLExportW
 
     private Text outputFolderText;
     private Text outputFileText;
+    private Text extraCommandArgsText;
     private Combo methodCombo;
     private Button noCreateStatementsCheck;
     private Button addDropStatementsCheck;
@@ -117,6 +118,20 @@ class MySQLExportWizardPageSettings extends MySQLWizardPageSettings<MySQLExportW
                 wizard.setOutputFilePattern(outputFileText.getText());
             }
         });
+
+        extraCommandArgsText = UIUtils.createLabelText(outputGroup, "Extra command args", "--no-data");
+        extraCommandArgsText.setToolTipText("Set extra command args for mysqldump.");
+        UIUtils.installContentProposal(
+                extraCommandArgsText,
+                new TextContentAdapter(),
+                new SimpleContentProposalProvider(new String[]{}));
+        extraCommandArgsText.addModifyListener(new ModifyListener() {
+            @Override
+            public void modifyText(ModifyEvent e) {
+                wizard.setExtraCommandArgs(extraCommandArgsText.getText());
+            }
+        });
+        
         if (wizard.getOutputFolder() != null) {
             outputFolderText.setText(wizard.getOutputFolder().getAbsolutePath());
         }
@@ -131,6 +146,7 @@ class MySQLExportWizardPageSettings extends MySQLWizardPageSettings<MySQLExportW
         String fileName = outputFolderText.getText();
         wizard.setOutputFolder(CommonUtils.isEmpty(fileName) ? null : new File(fileName));
         wizard.setOutputFilePattern(outputFileText.getText());
+        wizard.setExtraCommandArgs(extraCommandArgsText.getText());
         switch (methodCombo.getSelectionIndex()) {
             case 0: wizard.method = MySQLExportWizard.DumpMethod.ONLINE; break;
             case 1: wizard.method = MySQLExportWizard.DumpMethod.LOCK_ALL_TABLES; break;


### PR DESCRIPTION
add advanced mysql dump options for expert user.
for example,some one only want to dump data structure but not data,the need to give a "--no-data" option