### PR TITLE
various fixes and enhancements for exasol

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/plugin.xml
@@ -157,8 +157,12 @@
                       </items>
                    </items>
                 </folder>
-                <folder type="" label="%tree.administer.node.name" icon="#folder_admin"
-                        description="Maintenance/Settings">
+                <folder
+                      description="Maintenance/Settings"
+                      icon="#folder_admin"
+                      label="%tree.administer.node.name"
+                      type="org.jkiss.dbeaver.model.struct.DBSObject"
+                      visibleIf="object.dataSource.UserAuthorizedForSessions">
                     <object type="org.jkiss.dbeaver.ext.exasol.model.app.ExasolServerSession"
                             label="%tree.sessions.node.name"
                             icon="#admin"
@@ -177,8 +181,7 @@
                       description="Connections"
                       icon="#folder_connections"
                       label="%tree.connections.node.name"
-                      type="org.jkiss.dbeaver.ext.exasol.model.ExasolConnection"
-                      visibleIf="object.dataSource.authorizedForConnections">
+                      type="org.jkiss.dbeaver.ext.exasol.model.ExasolConnection">
                    <items
                          icon="icons/remoteServer.gif"
                          label="%tree.connection.node.name"

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolConnection.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolConnection.java
@@ -19,8 +19,10 @@ package org.jkiss.dbeaver.ext.exasol.model;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.exasol.tools.ExasolUtils;
 import org.jkiss.dbeaver.model.DBPRefreshableObject;
 import org.jkiss.dbeaver.model.DBPSaveableObject;
+import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
@@ -30,7 +32,7 @@ import java.sql.Date;
 import java.sql.ResultSet;
 
 public class ExasolConnection
-		implements DBPRefreshableObject, DBPSaveableObject {
+		implements DBPRefreshableObject, DBPSaveableObject, DBPScriptObject{
 
 	private ExasolDataSource dataSource;
 	private String connectionName;
@@ -119,6 +121,17 @@ public class ExasolConnection
 			throws DBException
 	{
 		return this;
+	}
+
+	@Override
+	public String getObjectDefinitionText(DBRProgressMonitor monitor)
+			throws DBException
+	{
+		if (getDataSource().isAuthorizedForConnections()) {
+			return ExasolUtils.getConnectionDdl(this, monitor);
+		} else {
+			return "User needs full access to dictionary or dba privilege to generate ddl for connections";
+		}
 	}
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolCurrentUserPrivileges.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolCurrentUserPrivileges.java
@@ -43,6 +43,7 @@ public class ExasolCurrentUserPrivileges {
 	private final Boolean userIsAuthorizedForObjectPrivs;
 	private final Boolean userIsAuthorizedForConnectionPrivs;
 	private final Boolean userIsAuthorizedForSystemPrivs;
+	private final Boolean userIsAuthorizedForSessions;
 	
 	private final int ExasolVersion;
 	
@@ -59,6 +60,7 @@ public class ExasolCurrentUserPrivileges {
 		userIsAuthorizedForObjectPrivs = ExasolCurrentUserPrivileges.verifyPriv(C_OBJECT_PRIV, session);
 		userIsAuthorizedForConnectionPrivs = ExasolCurrentUserPrivileges.verifyPriv(C_CONNECTION_PRIV, session);
 		userIsAuthorizedForSystemPrivs = ExasolCurrentUserPrivileges.verifyPriv("SELECT GRANTEE,PRIVILEGE,ADMIN_OPTION FROM SYS.EXA_DBA_SYS_PRIVS WHERE FALSE", session);
+		userIsAuthorizedForSessions = ExasolCurrentUserPrivileges.verifyPriv("SELECT * FROM SYS.EXA_DBA_SESSIONS", session);
 		
 		JDBCPreparedStatement dbStat;
 		try {
@@ -139,6 +141,11 @@ public class ExasolCurrentUserPrivileges {
 	public Boolean getUserIsAuthorizedForConnectionPrivs()
 	{
 		return userIsAuthorizedForConnectionPrivs;
+	}
+	
+	public Boolean isUserAuthorizedForSessions()
+	{
+		return userIsAuthorizedForSessions;
 	}
 	
 

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolDataSource.java
@@ -181,7 +181,10 @@ public class ExasolDataSource extends JDBCDataSource
 		
 		if (exasolCurrentUserPrivileges.getUserIsAuthorizedForConnections()) {
 			this.connectionCache = new JDBCObjectSimpleCache<>(
-					ExasolConnection.class, "SELECT * FROM EXA_DBA_CONNECTIONS ORDER BY CONNECTION_NAME");
+					ExasolConnection.class, "SELECT * FROM SYS.EXA_DBA_CONNECTIONS ORDER BY CONNECTION_NAME");
+		} else {
+			this.connectionCache = new JDBCObjectSimpleCache<>(
+					ExasolConnection.class, "SELECT * FROM SYS.EXA_SESSION_CONNECTIONS ORDER BY CONNECTION_NAME");
 		}
 		
 		if (exasolCurrentUserPrivileges.getUserIsAuthorizedForConnectionPrivs())
@@ -671,6 +674,11 @@ public class ExasolDataSource extends JDBCDataSource
 		return this.exasolCurrentUserPrivileges.getUserIsAuthorizedForRolePrivs();
 	}
 	
+	public boolean isUserAuthorizedForSessions()
+	{
+		return this.exasolCurrentUserPrivileges.isUserAuthorizedForSessions();
+	}
+	
 	public boolean isatLeastV6()
 	{
 		return this.exasolCurrentUserPrivileges.getatLeastV6();
@@ -796,5 +804,10 @@ public class ExasolDataSource extends JDBCDataSource
 	{
 		return dataTypeCache;
 	}
+    
+    public ExasolCurrentUserPrivileges getUserPriviliges()
+    {
+    	return exasolCurrentUserPrivileges;
+    }
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolStructureAssistant.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolStructureAssistant.java
@@ -224,7 +224,9 @@ public class ExasolStructureAssistant implements DBSStructureAssistant {
         if (schema != null) {
             sql = String.format(SQL_COLS_SCHEMA, ExasolUtils.quoteString(schema.getName()), ExasolUtils.quoteString(searchObjectNameMask));
         } else {
-            sql = String.format(SQL_COLS_ALL, ExasolUtils.quoteString(searchObjectNameMask));
+            // sql = String.format(SQL_COLS_ALL, ExasolUtils.quoteString(searchObjectNameMask));
+        	// search for columns is to slow in exasol
+        	return;
         }
 
 

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTableForeignKey.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTableForeignKey.java
@@ -23,6 +23,7 @@ import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.exasol.tools.ExasolUtils;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTableConstraint;
@@ -40,7 +41,7 @@ import java.util.List;
 /**
  * @author Karl
  */
-public class ExasolTableForeignKey extends JDBCTableConstraint<ExasolTable> implements DBSTableForeignKey {
+public class ExasolTableForeignKey extends JDBCTableConstraint<ExasolTable> implements DBSTableForeignKey,DBPScriptObject {
 
     private ExasolTable refTable;
 
@@ -152,6 +153,13 @@ public class ExasolTableForeignKey extends JDBCTableConstraint<ExasolTable> impl
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
     }
+
+	@Override
+	public String getObjectDefinitionText(DBRProgressMonitor monitor)
+			throws DBException
+	{
+		return ExasolUtils.getFKDdl(this, monitor);
+	}
 
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTableUniqueKey.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTableUniqueKey.java
@@ -21,8 +21,10 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.exasol.ExasolConstants;
+import org.jkiss.dbeaver.ext.exasol.tools.ExasolUtils;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTableConstraint;
@@ -38,7 +40,7 @@ import java.util.List;
 /**
  * @author Karl Griesser
  */
-public class ExasolTableUniqueKey extends JDBCTableConstraint<ExasolTable> implements DBSEntityReferrer {
+public class ExasolTableUniqueKey extends JDBCTableConstraint<ExasolTable> implements DBSEntityReferrer,DBPScriptObject {
 
     private String owner;
     private Boolean enabled;
@@ -132,6 +134,13 @@ public class ExasolTableUniqueKey extends JDBCTableConstraint<ExasolTable> imple
             }
         }
         return false;
+	}
+
+	@Override
+	public String getObjectDefinitionText(DBRProgressMonitor monitor)
+			throws DBException
+	{
+		return ExasolUtils.getPKDdl(this, monitor);
 	}
 
 


### PR DESCRIPTION
* Fixed PK and FK Statements in DDL Generation for Table
* add generate ddl for PK and FK objects
* add generate ddl for connection objects
* change visibility for connection objects for non dba users
* disable column lookup in structure assistant because performance of column meta data query is terribly slow in exasol