### PR TITLE
Inserts instead of COPY option

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizard.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizard.java
@@ -45,6 +45,7 @@ class PostgreBackupWizard extends PostgreBackupRestoreWizard<PostgreDatabaseBack
     String compression;
     String encoding;
     boolean showViews;
+    boolean useInserts;
     public List<PostgreDatabaseBackupInfo> objects = new ArrayList<>();
 
     private PostgreBackupWizardPageObjects objectsPage;
@@ -112,6 +113,9 @@ class PostgreBackupWizard extends PostgreBackupRestoreWizard<PostgreDatabaseBack
         }
         if (!CommonUtils.isEmpty(encoding)) {
             cmd.add("--encoding=" + encoding);
+        }
+        if (!CommonUtils.isEmpty(useInserts)) {
+            cmd.add("--inserts");
         }
 
         // Objects

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizard.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizard.java
@@ -114,7 +114,7 @@ class PostgreBackupWizard extends PostgreBackupRestoreWizard<PostgreDatabaseBack
         if (!CommonUtils.isEmpty(encoding)) {
             cmd.add("--encoding=" + encoding);
         }
-        if (!CommonUtils.isEmpty(useInserts)) {
+        if (useInserts) {
             cmd.add("--inserts");
         }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageSettings.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageSettings.java
@@ -38,6 +38,7 @@ class PostgreBackupWizardPageSettings extends PostgreWizardPageSettings<PostgreB
     private Combo formatCombo;
     private Combo compressCombo;
     private Combo encodingCombo;
+    private Button useInsertsCheck;
 
     protected PostgreBackupWizardPageSettings(PostgreBackupWizard wizard)
     {
@@ -86,6 +87,12 @@ class PostgreBackupWizardPageSettings extends PostgreWizardPageSettings<PostgreB
         encodingCombo = UIUtils.createEncodingCombo(formatGroup, null);
         encodingCombo.addSelectionListener(changeListener);
 
+        useInsertsCheck = UIUtils.createCheckbox(formatGroup,
+            "Use SQL INSERT instead of COPY for rows",
+            false
+        );
+        useInsertsCheck.addSelectionListener(changeListener);
+
         Group outputGroup = UIUtils.createControlGroup(composite, "Output", 2, GridData.FILL_HORIZONTAL, 0);
         outputFolderText = DialogUtils.createOutputFolderChooser(outputGroup, "Output folder", new ModifyListener() {
             @Override
@@ -123,6 +130,7 @@ class PostgreBackupWizardPageSettings extends PostgreWizardPageSettings<PostgreB
         wizard.format = PostgreBackupWizard.ExportFormat.values()[formatCombo.getSelectionIndex()];
         wizard.compression = compressCombo.getText();
         wizard.encoding = encodingCombo.getText();
+        wizard.useInserts = useInsertsCheck.getSelection();
 
         getContainer().updateButtons();
     }


### PR DESCRIPTION
I added an option to backup PostgreSQL with SQL INSERT instead of the default COPY format.

It implements the --inserts flag in pg_dump.
PostgreSQL documentation: https://www.postgresql.org/docs/9.1/static/app-pgdump.html

