### PR TITLE
add clean option to Postgres restore dialog

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreRestoreWizard.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreRestoreWizard.java
@@ -39,6 +39,7 @@ class PostgreRestoreWizard extends PostgreBackupRestoreWizard<PostgreDatabaseRes
     private PostgreDatabaseRestoreInfo restoreInfo;
 
     public String inputFile;
+    boolean cleanFirst;
 
     public PostgreRestoreWizard(PostgreDatabase database) {
         super(Collections.<DBSObject>singletonList(database), "Database restore");
@@ -79,18 +80,22 @@ class PostgreRestoreWizard extends PostgreBackupRestoreWizard<PostgreDatabaseRes
     }
 
     @Override
-	public void onSuccess(long workTime) {
+    public void onSuccess(long workTime) {
         UIUtils.showMessageBox(
             getShell(),
             "Database restore",
             "Restore '" + getObjectsName() + "'",
             SWT.ICON_INFORMATION);
-	}
+    }
 
     @Override
     public void fillProcessParameters(List<String> cmd, PostgreDatabaseRestoreInfo arg) throws IOException
     {
         super.fillProcessParameters(cmd, arg);
+
+        if(cleanFirst){
+          cmd.add("-c");
+        }
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreRestoreWizardPageSettings.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreRestoreWizardPageSettings.java
@@ -33,6 +33,7 @@ class PostgreRestoreWizardPageSettings extends PostgreWizardPageSettings<Postgre
 
     private TextWithOpenFile inputFileText;
     private Combo formatCombo;
+    private Button cleanFirstButton;
 
     protected PostgreRestoreWizardPageSettings(PostgreRestoreWizard wizard)
     {
@@ -68,6 +69,12 @@ class PostgreRestoreWizardPageSettings extends PostgreWizardPageSettings<Postgre
         formatCombo.select(wizard.format.ordinal());
         formatCombo.addListener(SWT.Selection, updateListener);
 
+        cleanFirstButton = UIUtils.createCheckbox(formatGroup,
+            "Clean (drop) database objects before recreating them",
+            false
+        );
+        cleanFirstButton.addListener(SWT.Selection, updateListener);
+
         Group inputGroup = UIUtils.createControlGroup(composite, "Input", 2, GridData.FILL_HORIZONTAL, 0);
         UIUtils.createControlLabel(inputGroup, "Backup file");
         inputFileText = new TextWithOpenFile(inputGroup, "Choose backup file", new String[] {"*.backup","*"});
@@ -83,6 +90,7 @@ class PostgreRestoreWizardPageSettings extends PostgreWizardPageSettings<Postgre
     {
         wizard.format = PostgreBackupWizard.ExportFormat.values()[formatCombo.getSelectionIndex()];
         wizard.inputFile = inputFileText.getText();
+        wizard.cleanFirst = cleanFirstButton.getSelection();
 
         getContainer().updateButtons();
     }


### PR DESCRIPTION
Would be nice to have the option to add the `-c` option for `pg_restore` so the command will "Clean (drop) database objects before recreating them". Otherwise a backup and restore will throw a lot of errors regarding duplicate keys and tables 