### PR TITLE
#2213-env-vars-in-connection-settings

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreMessages.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreMessages.java
@@ -1147,6 +1147,7 @@ public class CoreMessages extends NLS {
 
 	// Connection edit
 	public static String dialog_connection_edit_title;
+	public static String dialog_connection_edit_connection_settings_variables_hint_label;
 
 	public static String dialog_connection_edit_wizard_conn_conf_network_link;
 

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreResources.properties
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreResources.properties
@@ -1114,6 +1114,8 @@ pref_page_sql_editor_checkbox_create_script_folders = Create script folders
 ## Connection edit ##
 dialog_connection_edit_title = Connection ''{0}'' configuration
 
+dialog_connection_edit_connection_settings_variables_hint_label = You can use variables in connection parameters.
+
 dialog_connection_edit_wizard_conn_conf_network_link = Network settings (SSH, SSL, Proxy, ...)
 
 dialog_connection_edit_wizard_general = General

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
@@ -248,7 +248,10 @@ public class DataSourceDescriptor
     @Override
     public DBPConnectionConfiguration getActualConnectionConfiguration()
     {
-        return tunnelConnectionInfo != null ? tunnelConnectionInfo : connectionInfo;
+        DBPConnectionConfiguration connectionConfiguration = new DBPConnectionConfiguration(
+                tunnelConnectionInfo != null ? tunnelConnectionInfo : connectionInfo);
+        connectionConfiguration.resolveSystemEnvironmentVariables();
+        return connectionConfiguration;
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
@@ -134,6 +134,9 @@ public class DataSourceDescriptor
     @NotNull
     private final DBVModel virtualModel;
 
+    private DBPConnectionConfiguration resolvedConnectionInfo = null;
+    private DBPConnectionConfiguration resolvedTunnelConnectionInfo = null;
+
     public DataSourceDescriptor(
         @NotNull DBPDataSourceRegistry registry,
         @NotNull String id,
@@ -242,16 +245,27 @@ public class DataSourceDescriptor
     public void setConnectionInfo(@NotNull DBPConnectionConfiguration connectionInfo)
     {
         this.connectionInfo = connectionInfo;
+        this.resolvedConnectionInfo = null;
     }
 
     @NotNull
     @Override
     public DBPConnectionConfiguration getActualConnectionConfiguration()
     {
-        DBPConnectionConfiguration connectionConfiguration = new DBPConnectionConfiguration(
-                tunnelConnectionInfo != null ? tunnelConnectionInfo : connectionInfo);
-        connectionConfiguration.resolveSystemEnvironmentVariables();
-        return connectionConfiguration;
+        if (tunnelConnectionInfo != null) {
+            if (resolvedTunnelConnectionInfo == null) {
+                resolvedTunnelConnectionInfo = new DBPConnectionConfiguration(tunnelConnectionInfo);
+                resolvedTunnelConnectionInfo.resolveSystemEnvironmentVariables();
+            }
+            return resolvedTunnelConnectionInfo;
+        }
+        {
+            if (resolvedConnectionInfo == null) {
+                resolvedConnectionInfo = new DBPConnectionConfiguration(connectionInfo);
+                resolvedConnectionInfo.resolveSystemEnvironmentVariables();
+            }
+            return resolvedConnectionInfo;
+        }
     }
 
     @NotNull
@@ -669,6 +683,7 @@ public class DataSourceDescriptor
 
         connecting = true;
         tunnelConnectionInfo = null;
+        resolvedTunnelConnectionInfo = null;
         try {
             // Handle tunnel
             // Open tunnel and replace connection info with new one

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/ConnectionPageAbstract.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/ConnectionPageAbstract.java
@@ -18,6 +18,7 @@ package org.jkiss.dbeaver.ui.dialogs.connection;
 
 import org.eclipse.jface.dialogs.DialogPage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
@@ -85,6 +86,19 @@ public abstract class ConnectionPageAbstract extends DialogPage implements IData
                     site.getDriver(),
                     connectionInfo));
         }
+    }
+
+    /**
+     * @param horizontalSpan can be null, default is 2
+     * @param verticalSpan can be null, default is 10
+     */
+    protected CLabel createSettingsVariablesHintLabel(Composite parent, Integer horizontalSpan, Integer verticalSpan) {
+        CLabel infoLabel = UIUtils.createInfoLabel(parent, CoreMessages.dialog_connection_edit_connection_settings_variables_hint_label);
+        GridData gd = new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING);
+        gd.horizontalSpan = horizontalSpan == null ? 2 : horizontalSpan;
+        gd.verticalSpan = verticalSpan == null ? 10 : verticalSpan;
+        infoLabel.setLayoutData(gd);
+        return infoLabel;
     }
 
     protected void createDriverPanel(Composite parent) {

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/views/GenericConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/views/GenericConnectionPage.java
@@ -302,11 +302,7 @@ public class GenericConnectionPage extends ConnectionPageAbstract implements ICo
             passwordText.setLayoutData(gd);
             passwordText.addModifyListener(textListener);
 
-            CLabel infoLabel = UIUtils.createInfoLabel(settingsGroup, CoreMessages.dialog_connection_edit_connection_settings_variables_hint_label);
-            gd = new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING);
-            gd.horizontalSpan = 2;
-            gd.verticalSpan = 10;
-            infoLabel.setLayoutData(gd);
+            CLabel infoLabel = createSettingsVariablesHintLabel(settingsGroup, null, null);
 
             addControlToGroup(GROUP_LOGIN, userNameLabel);
             addControlToGroup(GROUP_LOGIN, userNameText);

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/views/GenericConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/views/GenericConnectionPage.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.generic.views;
 import org.eclipse.jface.dialogs.IDialogPage;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -27,6 +28,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.core.CoreMessages;
 import org.jkiss.dbeaver.core.DBeaverUI;
 import org.jkiss.dbeaver.ext.generic.GenericConstants;
 import org.jkiss.dbeaver.ext.generic.GenericMessages;
@@ -300,11 +302,18 @@ public class GenericConnectionPage extends ConnectionPageAbstract implements ICo
             passwordText.setLayoutData(gd);
             passwordText.addModifyListener(textListener);
 
+            CLabel infoLabel = UIUtils.createInfoLabel(settingsGroup, CoreMessages.dialog_connection_edit_connection_settings_variables_hint_label);
+            gd = new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING);
+            gd.horizontalSpan = 2;
+            gd.verticalSpan = 10;
+            infoLabel.setLayoutData(gd);
+
             addControlToGroup(GROUP_LOGIN, userNameLabel);
             addControlToGroup(GROUP_LOGIN, userNameText);
             addControlToGroup(GROUP_LOGIN, emptyLabel);
             addControlToGroup(GROUP_LOGIN, passwordLabel);
             addControlToGroup(GROUP_LOGIN, passwordText);
+            addControlToGroup(GROUP_LOGIN, infoLabel);
         }
 
         createDriverPanel(settingsGroup);

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/ui/PostgreConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/ui/PostgreConnectionPage.java
@@ -19,11 +19,13 @@ package org.jkiss.dbeaver.ext.postgresql.ui;
 import org.eclipse.jface.dialogs.IDialogPage;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
+import org.jkiss.dbeaver.core.CoreMessages;
 import org.jkiss.dbeaver.ext.postgresql.PostgreActivator;
 import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.PostgresMessages;
@@ -131,6 +133,12 @@ public class PostgreConnectionPage extends ConnectionPageAbstract implements ICo
         gd.grabExcessHorizontalSpace = true;
         passwordText.setLayoutData(gd);
         passwordText.addModifyListener(textListener);
+
+        CLabel infoLabel = UIUtils.createInfoLabel(addrGroup, CoreMessages.dialog_connection_edit_connection_settings_variables_hint_label);
+        gd = new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING);
+        gd.horizontalSpan = 4;
+        gd.verticalSpan = 3;
+        infoLabel.setLayoutData(gd);
 
         {
             Composite buttonsGroup = new Composite(addrGroup, SWT.NONE);

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/ui/PostgreConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/ui/PostgreConnectionPage.java
@@ -134,11 +134,7 @@ public class PostgreConnectionPage extends ConnectionPageAbstract implements ICo
         passwordText.setLayoutData(gd);
         passwordText.addModifyListener(textListener);
 
-        CLabel infoLabel = UIUtils.createInfoLabel(addrGroup, CoreMessages.dialog_connection_edit_connection_settings_variables_hint_label);
-        gd = new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING);
-        gd.horizontalSpan = 4;
-        gd.verticalSpan = 3;
-        infoLabel.setLayoutData(gd);
+        CLabel infoLabel = createSettingsVariablesHintLabel(addrGroup, 4, 3);
 
         {
             Composite buttonsGroup = new Composite(addrGroup, SWT.NONE);

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/connection/DBPConnectionConfiguration.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/connection/DBPConnectionConfiguration.java
@@ -21,6 +21,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.DBPObject;
 import org.jkiss.dbeaver.model.net.DBWHandlerConfiguration;
 import org.jkiss.dbeaver.model.runtime.DBRShellCommand;
+import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.utils.CommonUtils;
 
 import java.util.*;
@@ -354,5 +355,15 @@ public class DBPConnectionConfiguration implements DBPObject
             CommonUtils.equalObjects(this.handlers, source.handlers) &&
             CommonUtils.equalObjects(this.bootstrap, source.bootstrap) &&
             this.keepAliveInterval == source.keepAliveInterval;
+    }
+
+    public void resolveSystemEnvironmentVariables() {
+        hostName = GeneralUtils.replaceSystemEnvironmentVariables(hostName);
+        hostPort = GeneralUtils.replaceSystemEnvironmentVariables(hostPort);
+        serverName = GeneralUtils.replaceSystemEnvironmentVariables(serverName);
+        databaseName = GeneralUtils.replaceSystemEnvironmentVariables(databaseName);
+        userName = GeneralUtils.replaceSystemEnvironmentVariables(userName);
+        userPassword = GeneralUtils.replaceSystemEnvironmentVariables(userPassword);
+        url = GeneralUtils.replaceSystemEnvironmentVariables(url);
     }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCDataSource.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCDataSource.java
@@ -150,14 +150,16 @@ public abstract class JDBCDataSource
             connectProps.setProperty(CommonUtils.toString(prop.getKey()), CommonUtils.toString(prop.getValue()));
         }
         if (!CommonUtils.isEmpty(connectionInfo.getUserName())) {
-            connectProps.put(DBConstants.DATA_SOURCE_PROPERTY_USER, getConnectionUserName(connectionInfo));
+            String user = GeneralUtils.replaceSystemEnvironmentVariables(getConnectionUserName(connectionInfo));
+            connectProps.put(DBConstants.DATA_SOURCE_PROPERTY_USER, user);
         }
         if (!CommonUtils.isEmpty(connectionInfo.getUserPassword())) {
-            connectProps.put(DBConstants.DATA_SOURCE_PROPERTY_PASSWORD, getConnectionUserPassword(connectionInfo));
+            String pass = GeneralUtils.replaceSystemEnvironmentVariables(getConnectionUserPassword(connectionInfo));
+            connectProps.put(DBConstants.DATA_SOURCE_PROPERTY_PASSWORD, pass);
         }
         // Obtain connection
         try {
-            final String url = getConnectionURL(connectionInfo);
+            final String url = GeneralUtils.replaceSystemEnvironmentVariables(getConnectionURL(connectionInfo));
             if (driverInstance != null) {
                 try {
                     if (!driverInstance.acceptsURL(url)) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCDataSource.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCDataSource.java
@@ -150,16 +150,14 @@ public abstract class JDBCDataSource
             connectProps.setProperty(CommonUtils.toString(prop.getKey()), CommonUtils.toString(prop.getValue()));
         }
         if (!CommonUtils.isEmpty(connectionInfo.getUserName())) {
-            String user = GeneralUtils.replaceSystemEnvironmentVariables(getConnectionUserName(connectionInfo));
-            connectProps.put(DBConstants.DATA_SOURCE_PROPERTY_USER, user);
+            connectProps.put(DBConstants.DATA_SOURCE_PROPERTY_USER, getConnectionUserName(connectionInfo));
         }
         if (!CommonUtils.isEmpty(connectionInfo.getUserPassword())) {
-            String pass = GeneralUtils.replaceSystemEnvironmentVariables(getConnectionUserPassword(connectionInfo));
-            connectProps.put(DBConstants.DATA_SOURCE_PROPERTY_PASSWORD, pass);
+            connectProps.put(DBConstants.DATA_SOURCE_PROPERTY_PASSWORD, getConnectionUserPassword(connectionInfo));
         }
         // Obtain connection
         try {
-            final String url = GeneralUtils.replaceSystemEnvironmentVariables(getConnectionURL(connectionInfo));
+            final String url = getConnectionURL(connectionInfo);
             if (driverInstance != null) {
                 try {
                     if (!driverInstance.acceptsURL(url)) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
@@ -381,6 +381,9 @@ public class GeneralUtils {
     }
 
     public static String replaceSystemEnvironmentVariables(String string) {
+        if (string == null) {
+            return null;
+        }
         return replaceVariables(string, new GeneralUtils.IVariableResolver() {
             @Override
             public String get(String name) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
@@ -380,6 +380,15 @@ public class GeneralUtils {
         }
     }
 
+    public static String replaceSystemEnvironmentVariables(String string) {
+        return replaceVariables(string, new GeneralUtils.IVariableResolver() {
+            @Override
+            public String get(String name) {
+                return System.getenv(name);
+            }
+        });
+    }
+
     @NotNull
     public static String variablePattern(String name) {
         return "${" + name + "}";


### PR DESCRIPTION
Environment variables are substituted in connection settings (url, user name and password).
The info label is added only on generic and PostgreSQL connection settings pages (because I have such the datasources now).