### PR TITLE
Remove 'database' from backup/restore title for ext.postgresql 

### DIFF
--- a/nls/bundles/org.jkiss.dbeaver.ext.postgresql.nls/OSGI-INF/l10n/bundle_zh.properties
+++ b/nls/bundles/org.jkiss.dbeaver.ext.postgresql.nls/OSGI-INF/l10n/bundle_zh.properties
@@ -528,10 +528,10 @@ handler.ssl.name=SSL
 handler.ssl.description=\u5B89\u5168\u5957\u63A5\u5C42
 
 # menu tools #
-tools.backup.db.name=\u5907\u4EFD\u6570\u636E\u5E93
-tools.backup.db.description=\u5BFC\u51FA\u6570\u636E\u5E93
-tools.restore.db.name=\u6062\u590D\u6570\u636E\u5E93
-tools.restore.db.description=\u5BFC\u5165\u6570\u636E\u5E93
+tools.backup.db.name=\u5907\u4EFD
+tools.backup.db.description=\u5BFC\u51FA
+tools.restore.db.name=\u6062\u590D
+tools.restore.db.description=\u5BFC\u5165
 tools.execute.script.name=\u6267\u884C\u811A\u672C
 tools.execute.script.description=\u4F7F\u7528\u672C\u5730\u5BA2\u6237\u7AEF\u6267\u884C\u811A\u672C
 tools.analyze.name=\u5206\u6790

--- a/nls/bundles/org.jkiss.dbeaver.ext.postgresql.nls/src/org/jkiss/dbeaver/ext/postgresql/PostgresResources_zh.properties
+++ b/nls/bundles/org.jkiss.dbeaver.ext.postgresql.nls/src/org/jkiss/dbeaver/ext/postgresql/PostgresResources_zh.properties
@@ -1,8 +1,8 @@
 # Copyright (C) 2017 Liu, Yuanyuan (liuyuanyuan@highgo.com)
 
 # backup wizard #
-wizard_backup_title = \u6570\u636E\u5E93\u5907\u4EFD
-wizard_backup_msgbox_success_title = \u6570\u636E\u5E93\u5BFC\u51FA
+wizard_backup_title = \u5907\u4EFD
+wizard_backup_msgbox_success_title = \u5BFC\u51FA
 wizard_backup_msgbox_success_description = \u5BFC\u51FA ''{0}'' \u5B8C\u6210
 
 wizard_backup_page_object_title_schema_table = \u6A21\u5F0F/\u8868
@@ -13,7 +13,7 @@ wizard_backup_page_object_checkbox_show_view = \u663E\u793A\u89C6\u56FE
 
 wizard_backup_page_setting_title_setting = \u8BBE\u7F6E
 wizard_backup_page_setting_title = \u5907\u4EFD\u8BBE\u7F6E
-wizard_backup_page_setting_description = \u6570\u636E\u5E93\u5907\u4EFD\u8BBE\u7F6E
+wizard_backup_page_setting_description = \u5907\u4EFD\u8BBE\u7F6E
 wizard_backup_page_setting_group_setting = \u8BBE\u7F6E
 wizard_backup_page_setting_label_format = \u683C\u5F0F
 wizard_backup_page_setting_label_compression = \u538B\u7F29\u7387
@@ -30,8 +30,9 @@ wizard_backup_page_setting_group_security_btn_authentication = \u8EAB\u4EFD\u9A8
 wizard_backup_page_setting_group_security_btn_reset_default = \u91CD\u7F6E\u4E3A\u9ED8\u8BA4
 
 # wizard restore #
+wizard_restore_title=\u6062\u590D
 wizard_restore_page_setting_btn_clean_first=\u5728\u91CD\u5EFA\u4ED6\u4EEC\u4E4B\u524D\u6E05\u7406 (\u5220\u9664) \u6570\u636E\u5E93\u5BF9\u8C61
-wizard_restore_page_setting_description=\u6570\u636E\u5E93\u6062\u590D\u8BBE\u7F6E
+wizard_restore_page_setting_description=\u6062\u590D\u8BBE\u7F6E
 wizard_restore_page_setting_label_backup_file=\u5907\u4EFD\u6587\u4EF6
 wizard_restore_page_setting_label_choose_backup_file=\u9009\u62E9\u5907\u4EFD\u6587\u4EF6
 wizard_restore_page_setting_label_format=\u683C\u5F0F

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/OSGI-INF/l10n/bundle.properties
@@ -545,10 +545,10 @@ handler.ssl.name=SSL
 handler.ssl.description=Secure socket layer
 
 # menu tools #
-tools.backup.db.name=Backup database
-tools.backup.db.description=Export database
-tools.restore.db.name=Restore database
-tools.restore.db.description=Import database
+tools.backup.db.name=Backup
+tools.backup.db.description=Export
+tools.restore.db.name=Restore
+tools.restore.db.description=Import
 tools.execute.script.name=Execute script
 tools.execute.script.description=Execute script with native client
 tools.analyze.name=Analyze

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgresMessages.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgresMessages.java
@@ -32,6 +32,7 @@ public class PostgresMessages extends NLS {
 	public static String wizard_backup_page_setting_group_security_btn_reset_default;
 
 	/* wizard restore*/
+	public static String wizard_restore_title;
 	public static String wizard_restore_page_setting_btn_clean_first;
 	public static String wizard_restore_page_setting_description;
 	public static String wizard_restore_page_setting_label_backup_file;

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgresResources.properties
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgresResources.properties
@@ -1,8 +1,8 @@
 # Copyright (C) 2017 Liu, Yuanyuan (liuyuanyuan@highgo.com)
 
 # backup wizard #
-wizard_backup_title = Database backup
-wizard_backup_msgbox_success_title = Database export
+wizard_backup_title = Backup
+wizard_backup_msgbox_success_title = Export
 wizard_backup_msgbox_success_description = Export of ''{0}'' completed
 
 wizard_backup_page_object_title_schema_table = Schemas/tables
@@ -13,7 +13,7 @@ wizard_backup_page_object_checkbox_show_view =Show views
 
 wizard_backup_page_setting_title_setting = Settings
 wizard_backup_page_setting_title = Backup settings
-wizard_backup_page_setting_description = Database backup settings
+wizard_backup_page_setting_description = Backup settings
 wizard_backup_page_setting_group_setting = Settings
 wizard_backup_page_setting_label_format = Format
 wizard_backup_page_setting_label_compression = Compression
@@ -30,8 +30,9 @@ wizard_backup_page_setting_group_security_btn_authentication = Authentication
 wizard_backup_page_setting_group_security_btn_reset_default = Reset to default
 
 # wizard restore #
+wizard_restore_title=Restore
 wizard_restore_page_setting_btn_clean_first=Clean (drop) database objects before recreating them
-wizard_restore_page_setting_description=Database restore settings
+wizard_restore_page_setting_description=Restore settings
 wizard_restore_page_setting_label_backup_file=Backup file
 wizard_restore_page_setting_label_choose_backup_file=Choose backup file
 wizard_restore_page_setting_label_format=Format

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreRestoreWizard.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreRestoreWizard.java
@@ -21,6 +21,7 @@ import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.ui.IExportWizard;
 import org.eclipse.ui.IWorkbench;
+import org.jkiss.dbeaver.ext.postgresql.PostgresMessages;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.ui.UIUtils;
@@ -40,7 +41,7 @@ class PostgreRestoreWizard extends PostgreBackupRestoreWizard<PostgreDatabaseRes
     boolean cleanFirst;
 
     PostgreRestoreWizard(PostgreDatabase database) {
-        super(Collections.singletonList(database), "Database restore");
+        super(Collections.singletonList(database), PostgresMessages.wizard_restore_title);
         restoreInfo = new PostgreDatabaseRestoreInfo(database);
     }
 


### PR DESCRIPTION
Remove 'database' from backup/restore title for ext.postgresql.
Because backup/restore title is used for not only database but also schema,table and so on.
