### PR TITLE
"Export resultset as Json" use column label instead of column name.

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/tools/transfer/stream/impl/DataExporterJSON.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/tools/transfer/stream/impl/DataExporterJSON.java
@@ -103,7 +103,7 @@ public class DataExporterJSON extends StreamExporterAbstract {
         out.write("\t{\n");
         for (int i = 0; i < row.length; i++) {
             DBDAttributeBinding column = columns.get(i);
-            String columnName = column.getName();
+            String columnName = column.getLabel();
             out.write("\t\t\"" + escapeJsonString(columnName) + "\" : ");
             Object cellValue = row[i];
             if (DBUtils.isNullValue(cellValue)) {


### PR DESCRIPTION
Fixed column label specified as "AS" to be output to json export.
Json export use column label instead of column name.

Query : SELECT CTGRY_ID AS categoryId FROM TSPC_CTGRY LIMIT 2;
Old result : [{"CTGRY_ID" : 1001}, {"CTGRY_ID" : 1002}]
Change result : [{"categoryId" : 1001}, {"categoryId" : 1002}]
fixed : [{"categoryId" : 1001}, {"categoryId" : 1002}]