### PR TITLE
typo of translation for sql_editor_resultset_filter_panel_control_execute_to_see_reslut

### DIFF
--- a/nls/bundles/org.jkiss.dbeaver.core.nls/src/org/jkiss/dbeaver/core/CoreResources_zh.properties
+++ b/nls/bundles/org.jkiss.dbeaver.core.nls/src/org/jkiss/dbeaver/core/CoreResources_zh.properties
@@ -1232,7 +1232,7 @@ sql_editor_resultset_filter_panel_menu_stop = \u505C\u6B62
 sql_editor_resultset_filter_panel_menu_refresh_interval = \u6BCF {0} \u79D2\u5237\u65B0
 sql_editor_resultset_filter_panel_menu_refresh_interval_1 = \u6BCF {0} \u79D2\u5237\u65B0
 sql_editor_resultset_filter_panel_control_no_data = \u65E0\u6570\u636E
-sql_editor_resultset_filter_panel_control_execute_to_see_reslut = \u6267\u884c\u67e5\u8be2 {0} \u6216\u8005\u811A\u672C {1} \u6765\u67E5\u770B\u7ED3\u679C
+sql_editor_resultset_filter_panel_control_execute_to_see_reslut = \u6267\u884C\u67E5\u8BE2 {0} \u6216\u8005\u811A\u672C {1} \u6765\u67E5\u770B\u7ED3\u679C
 ## SQL editor resultset filter panel ##
 
 ## object properties editor ##

--- a/nls/bundles/org.jkiss.dbeaver.core.nls/src/org/jkiss/dbeaver/core/CoreResources_zh.properties
+++ b/nls/bundles/org.jkiss.dbeaver.core.nls/src/org/jkiss/dbeaver/core/CoreResources_zh.properties
@@ -1232,7 +1232,7 @@ sql_editor_resultset_filter_panel_menu_stop = \u505C\u6B62
 sql_editor_resultset_filter_panel_menu_refresh_interval = \u6BCF {0} \u79D2\u5237\u65B0
 sql_editor_resultset_filter_panel_menu_refresh_interval_1 = \u6BCF {0} \u79D2\u5237\u65B0
 sql_editor_resultset_filter_panel_control_no_data = \u65E0\u6570\u636E
-sql_editor_resultset_filter_panel_control_execute_to_see_reslut = \u6267\u884C\u62C6\u67E5\u8BE2 {0} \u6216\u8005\u811A\u672C {1} \u6765\u67E5\u770B\u7ED3\u679C
+sql_editor_resultset_filter_panel_control_execute_to_see_reslut = \u6267\u884c\u67e5\u8be2 {0} \u6216\u8005\u811A\u672C {1} \u6765\u67E5\u770B\u7ED3\u679C
 ## SQL editor resultset filter panel ##
 
 ## object properties editor ##


### PR DESCRIPTION
should be `执行查询 {0} 或者脚本 {1} 来查看结果`
![image](https://user-images.githubusercontent.com/423077/39351256-8762a9aa-4a33-11e8-9e99-2fc75b6c2b8e.png)
![image](https://user-images.githubusercontent.com/423077/39351266-8f168fae-4a33-11e8-9e1c-6254f614cf18.png)

--------------

And,why there is additional ` single` `double quote` at end of these line ?
@liuyuanyuan 
![image](https://user-images.githubusercontent.com/423077/39351388-f8161290-4a33-11e8-944f-dd8623717837.png)
I didn't change these quote