### PR TITLE
Support for export in DbUnit dataset format - improved formating

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/tools/transfer/stream/impl/DataExporterDbUnit.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/tools/transfer/stream/impl/DataExporterDbUnit.java
@@ -149,7 +149,7 @@ public class DataExporterDbUnit extends StreamExporterAbstract {
             }
             out.write("\"");
         }
-        out.write(">" + CommonUtils.getLineSeparator());
+        out.write("/>" + CommonUtils.getLineSeparator());
     }
 
     @Override


### PR DESCRIPTION
I did more extensive testing on the export and realised that I could not rely on the format used by the original XML export as much as I had hoped since it did locale dependent formating in order to be more human readable. I've added DbUnit-compatible formating and verified the corresponding java classes mapping.