### PR TITLE
#2768 Removed auto unindent on new line after delimiter.

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLIndenter.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLIndenter.java
@@ -137,11 +137,6 @@ public class SQLIndenter {
             if (nonWS < 0) {
                 return "";
             }
-            int indentLength = nonWS - lineOffset;
-            StringBuilder indent = createIndent();
-            if (indentLength > indent.length() && scanner.endsWithDelimiter(lineOffset, lineOffset + line.getLength())) {
-                nonWS -= indent.length();
-            }
 
             return document.get(lineOffset, nonWS - lineOffset);
         } catch (BadLocationException e) {


### PR DESCRIPTION
This is a fix for issue #2768.

My reasons for removing the auto unindentation is because:
* It doesn't work properly/consistently.
* It forces unindentation instead of letting the user keep control.