### PR TITLE
Rename Elastic Search to Elasticsearch (official name)

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.es.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jkiss.dbeaver.ext.es.ui/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Elastic Search UI
+Bundle-Name: Elasticsearch UI
 Bundle-SymbolicName: org.jkiss.dbeaver.ext.es.ui;singleton:=true
 Bundle-Version: 1.0.3.qualifier
 Bundle-Release-Date: 20180911

--- a/plugins/org.jkiss.dbeaver.ext.es.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ext.es.ui/OSGI-INF/l10n/bundle.properties
@@ -1,3 +1,3 @@
 Bundle-Vendor = Rider Soft
-Bundle-Name = DBeaver Elastic Search Extension
-datasource.es.description = Elastic Search datasource
+Bundle-Name = DBeaver Elasticsearch Extension
+datasource.es.description = Elasticsearch datasource

--- a/plugins/org.jkiss.dbeaver.ext.es.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.es.ui/plugin.xml
@@ -5,28 +5,28 @@
 
     <extension point="org.jkiss.dbeaver.dataSourceProvider">
 
-        <!-- ElasticSearch -->
+        <!-- Elasticsearch -->
 
         <datasource
                 class="org.jkiss.dbeaver.ext.es.ElasticSearchDataSourceProvider"
                 description="%datasource.es.description"
                 id="elasticsearch"
                 parent="generic"
-                label="ElasticSearch"
+                label="Elasticsearch"
                 icon="icons/es_icon.png">
             <drivers managable="true">
 
                 <driver
                         id="elastic_search_jdbc"
-                        label="Elastic Search"
+                        label="Elasticsearch"
                         class="org.elasticsearch.xpack.sql.jdbc.jdbc.JdbcDriver"
                         icon="icons/elastic_search_icon.png"
                         sampleURL="jdbc:es://{host}:{port}/"
                         defaultPort="9200"
-                        description="ElasticSearch JDBC driver"
+                        description="Elasticsearch JDBC driver"
                         webURL="https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-jdbc.html">
                     <replace provider="generic" driver="es_generic"/>
-                    <file type="jar" path="maven:/org.elasticsearch.plugin:jdbc:6.3.1"/>
+                    <file type="jar" path="maven:/org.elasticsearch.plugin:jdbc:6.4.0"/>
                 </driver>
 
             </drivers>
@@ -35,7 +35,7 @@
     </extension>
 
     <extension point="org.jkiss.dbeaver.mavenRepository">
-        <repository id="elastic-search-maven-repo" name="Elastic Search Repository" url="https://artifacts.elastic.co/maven" order="20">
+        <repository id="elastic-search-maven-repo" name="Elasticsearch Repository" url="https://artifacts.elastic.co/maven" order="20">
             <scope group="org.elasticsearch.plugin"/>
         </repository>
 


### PR DESCRIPTION
Thank you for adding support for the Elasticsearch JDBC driver.
I've made a small PR to use the proper/official name (Elasticsearch - one word, no camel case) and updated the JDBC driver to the latest version.

P.S. Each version of Elasticsearch comes with its own JDBC driver. Not sure whether it is possible, but it would be great in the maven artifact to use a placeholder like latest to avoid having to manually update the jar on each release: 
`<file type="jar" path="maven:/org.elasticsearch.plugin:jdbc:{latest}"/>`

Cheers!