### PR TITLE
Update plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <dbeaver-version>5.3.1</dbeaver-version>
         <dbeaver-product>DBeaver</dbeaver-product>
-        <tycho-version>1.1.0</tycho-version>
+        <tycho-version>1.3.0</tycho-version>
         <tycho-versions-version>0.26.0</tycho-versions-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>

--- a/product/localRepository/pom.xml
+++ b/product/localRepository/pom.xml
@@ -9,7 +9,7 @@
 	<name>DBeaver - 3rd party dependencies</name>
 
 	<properties>
-		<tycho-version>1.1.0</tycho-version>
+		<tycho-version>1.3.0</tycho-version>
 		<reficio-p2-version>1.2.0</reficio-p2-version>
 		<repo-name>DBeaver CE dependencies</repo-name>
 	</properties>
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-p2-repository-plugin</artifactId>
-                <version>${tycho-version}-SNAPSHOT</version>
+                <version>${tycho-version}</version>
                 <configuration>
                     <repositoryName>${repo-name}</repositoryName>
                     <includeAllDependencies>false</includeAllDependencies>
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>8.1.5.v20120716-SNAPSHOT</version>
+                <version>8.1.16.v20140903</version>
                 <configuration>
                     <scanIntervalSeconds>10</scanIntervalSeconds>
                     <webAppSourceDirectory>${basedir}/target/repository/</webAppSourceDirectory>


### PR DESCRIPTION
- Bump `tycho-p2-repository-plugin` version to `1.3.0` (from `1.1.0` and `1.1.0-SNAPSHOT`)
- Bump `jetty-maven-plugin` version to `8.1.16.v20140903` (from `8.1.5.v20120716-SNAPSHOT`)

Reduce dependence on SNAPSHOT repositories which are out-of-date and unstable, due to the nature of SNAPSHOTs themselves.