### PR TITLE
Rename German translation of label ...core.window.preferences.name

### DIFF
--- a/plugins/org.jkiss.dbeaver.core.application/OSGI-INF/l10n/bundle_de.properties
+++ b/plugins/org.jkiss.dbeaver.core.application/OSGI-INF/l10n/bundle_de.properties
@@ -48,7 +48,7 @@ command.org.jkiss.dbeaver.core.window.navigation.previousEditor.name = Vorherige
 command.org.jkiss.dbeaver.core.window.navigation.previousSubTab.name = Vorheriger Unterreiter
 command.org.jkiss.dbeaver.core.window.navigation.previousTab.name    = Vorheriger Reiter
 command.org.jkiss.dbeaver.core.window.navigation.switchToEditor.name = Wechsle zu Editor
-command.org.jkiss.dbeaver.core.window.preferences.name               = Eigenschaften
+command.org.jkiss.dbeaver.core.window.preferences.name               = Einstellungen
 command.org.jkiss.dbeaver.core.window.resetPerspective.name          = Perspektive zur\u00FCcksetzen
 
 extension.standalone.name = DBeaver Standalone


### PR DESCRIPTION
The German translation of the label "command.org.jkiss.dbeaver.core.window.preferences.name" is currently "Eigenschaften" which actually means "properties" in English. A better translation is the word "Einstellungen" which is commonly used for "preferences" in German application language. In fact I had to search some time until I found the user preferences dialog due to the current translation.