### PR TITLE
GP: Add DDL generation for Greenplum's concept of external tables

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
@@ -1,0 +1,155 @@
+package org.jkiss.dbeaver.ext.greenplum.model;
+
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableColumn;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableRegular;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+
+import java.sql.ResultSet;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+public class GreenplumExternalTable extends PostgreTableRegular {
+    public enum FormatType {
+        c("CSV"),
+        t("TEXT");
+
+        private String formatType;
+
+        FormatType(String formatTypeString) {
+            this.formatType = formatTypeString;
+        }
+
+        public String getValue() {
+            return formatType;
+        }
+    }
+
+    public enum RejectLimitType {
+        r("ROWS");
+
+        private String rejectLimitType;
+
+        RejectLimitType(String rejectLimitTypeString) {
+            this.rejectLimitType = rejectLimitTypeString;
+        }
+
+        public String getValue() {
+            return rejectLimitType;
+        }
+    }
+
+    private final List<String> uriLocations;
+    private final String execLocation;
+    private final FormatType formatType;
+    private final String formatOptions;
+    private final String encoding;
+    private final RejectLimitType rejectLimitType;
+    private final int rejectLimit;
+
+    public GreenplumExternalTable(PostgreSchema catalog, ResultSet dbResult) {
+        super(catalog, dbResult);
+        this.uriLocations = Arrays.asList(JDBCUtils.safeGetString(dbResult, "urilocation")
+                .trim().split(","));
+        this.execLocation = JDBCUtils.safeGetString(dbResult, "execlocation");
+        this.formatType = FormatType.valueOf(JDBCUtils.safeGetString(dbResult, "fmttype"));
+        this.formatOptions = JDBCUtils.safeGetString(dbResult, "fmtopts");
+        this.encoding = JDBCUtils.safeGetString(dbResult, "encoding");
+
+        this.rejectLimit = JDBCUtils.safeGetInt(dbResult, "rejectlimit");
+        String rejectlimittype = JDBCUtils.safeGetString(dbResult, "rejectlimittype");
+        if (rejectlimittype != null && rejectlimittype.length() > 0) {
+            this.rejectLimitType = RejectLimitType.valueOf(rejectlimittype);
+        } else {
+            this.rejectLimitType = null;
+        }
+
+    }
+
+    public List<String> getUriLocations() {
+        return uriLocations;
+    }
+
+    public String getExecLocation() {
+        return execLocation;
+    }
+
+    public FormatType getFormatType() {
+        return formatType;
+    }
+
+    public String getFormatOptions() {
+        return formatOptions;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public RejectLimitType getRejectLimitType() {
+        return rejectLimitType;
+    }
+
+    public int getRejectLimit() {
+        return rejectLimit;
+    }
+
+    public String generateDDL(DBRProgressMonitor monitor) throws DBException {
+        StringBuilder ddlBuilder = new StringBuilder(format("CREATE EXTERNAL TABLE %s.%s.%s (\n",
+                this.getDatabase().getName(),
+                this.getSchema().getName(),
+                this.getName()));
+
+        List<PostgreTableColumn> tableColumns = this.getAttributes(monitor)
+                .stream()
+                .filter(field -> field.getOrdinalPosition() >= 0)
+                .collect(Collectors.toList());
+
+        if (tableColumns.size() == 1) {
+            PostgreTableColumn column = tableColumns.get(0);
+            ddlBuilder.append(format("\t%s %s\n)\n", column.getName(), column.getTypeName()));
+        } else {
+            ddlBuilder.append(tableColumns
+                    .stream()
+                    .map(field -> "\t" + field.getName() + " " + field.getTypeName())
+                    .collect(Collectors.joining(",\n")));
+            ddlBuilder.append("\n)\n");
+        }
+
+        if (this.getUriLocations() != null && !this.getUriLocations().isEmpty()) {
+            ddlBuilder.append("LOCATION (\n");
+
+            ddlBuilder.append(this.getUriLocations()
+                    .stream()
+                    .map(location -> "\t'"+location+"'")
+                    .collect(Collectors.joining(",\n")));
+
+            ddlBuilder.append(format("\n) %s\n", determineExecutionLocation()));
+        }
+
+        ddlBuilder.append(format("FORMAT '%s' ( %s )", this.getFormatType().getValue(), this.getFormatOptions()));
+
+        if (this.getEncoding() != null && this.getEncoding().length() > 0) {
+            ddlBuilder.append(format("\nENCODING '%s'", this.getEncoding()));
+        }
+
+        if (this.getRejectLimit() > 0 && this.getRejectLimitType() != null) {
+            ddlBuilder.append(format("\nSEGMENT REJECT LIMIT %d %s", this.getRejectLimit(), this.getRejectLimitType().getValue()));
+        }
+
+        return ddlBuilder.toString();
+    }
+
+    private String determineExecutionLocation() {
+        if (this.getExecLocation() != null && this.getExecLocation().equalsIgnoreCase("MASTER_ONLY")) {
+            return "ON MASTER";
+        }
+
+        return "ON ALL";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
@@ -1,3 +1,23 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
+ * Copyright (C) 2019 Dmitriy Dubson (ddubson@pivotal.io)
+ * Copyright (C) 2019 Gavin Shaw (gshaw@pivotal.io)
+ * Copyright (C) 2019 Zach Marcin (zmarcin@pivotal.io)
+ * Copyright (C) 2019 Nikhil Pawar (npawar@pivotal.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jkiss.dbeaver.ext.greenplum.model;
 
 import org.jkiss.dbeaver.DBException;
@@ -11,8 +31,6 @@ import java.sql.ResultSet;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static java.lang.String.format;
 
 public class GreenplumExternalTable extends PostgreTableRegular {
     public enum FormatType {
@@ -100,10 +118,8 @@ public class GreenplumExternalTable extends PostgreTableRegular {
     }
 
     public String generateDDL(DBRProgressMonitor monitor) throws DBException {
-        StringBuilder ddlBuilder = new StringBuilder(format("CREATE EXTERNAL TABLE %s.%s.%s (\n",
-                this.getDatabase().getName(),
-                this.getSchema().getName(),
-                this.getName()));
+        StringBuilder ddlBuilder = new StringBuilder("CREATE EXTERNAL TABLE " + this.getDatabase().getName()
+                + "." + this.getSchema().getName() + "." + this.getName() + " (\n");
 
         List<PostgreTableColumn> tableColumns = this.getAttributes(monitor)
                 .stream()
@@ -112,7 +128,7 @@ public class GreenplumExternalTable extends PostgreTableRegular {
 
         if (tableColumns.size() == 1) {
             PostgreTableColumn column = tableColumns.get(0);
-            ddlBuilder.append(format("\t%s %s\n)\n", column.getName(), column.getTypeName()));
+            ddlBuilder.append("\t" + column.getName() + " " + column.getTypeName() + "\n)\n");
         } else {
             ddlBuilder.append(tableColumns
                     .stream()
@@ -126,20 +142,20 @@ public class GreenplumExternalTable extends PostgreTableRegular {
 
             ddlBuilder.append(this.getUriLocations()
                     .stream()
-                    .map(location -> "\t'"+location+"'")
+                    .map(location -> "\t'" + location + "'")
                     .collect(Collectors.joining(",\n")));
 
-            ddlBuilder.append(format("\n) %s\n", determineExecutionLocation()));
+            ddlBuilder.append("\n) " + determineExecutionLocation() + "\n");
         }
 
-        ddlBuilder.append(format("FORMAT '%s' ( %s )", this.getFormatType().getValue(), this.getFormatOptions()));
+        ddlBuilder.append("FORMAT '" + this.getFormatType().getValue() + "' ( " + this.getFormatOptions() + " )");
 
         if (this.getEncoding() != null && this.getEncoding().length() > 0) {
-            ddlBuilder.append(format("\nENCODING '%s'", this.getEncoding()));
+            ddlBuilder.append("\nENCODING '" + this.getEncoding() + "'");
         }
 
         if (this.getRejectLimit() > 0 && this.getRejectLimitType() != null) {
-            ddlBuilder.append(format("\nSEGMENT REJECT LIMIT %d %s", this.getRejectLimit(), this.getRejectLimitType().getValue()));
+            ddlBuilder.append("\nSEGMENT REJECT LIMIT " + this.getRejectLimit() + " " + this.getRejectLimitType().getValue());
         }
 
         return ddlBuilder.toString();

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchema.java
@@ -1,3 +1,23 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
+ * Copyright (C) 2019 Dmitriy Dubson (ddubson@pivotal.io)
+ * Copyright (C) 2019 Gavin Shaw (gshaw@pivotal.io)
+ * Copyright (C) 2019 Zach Marcin (zmarcin@pivotal.io)
+ * Copyright (C) 2019 Nikhil Pawar (npawar@pivotal.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jkiss.dbeaver.ext.greenplum.model;
 
 import org.jkiss.code.NotNull;

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchemaCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchemaCache.java
@@ -1,3 +1,23 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
+ * Copyright (C) 2019 Dmitriy Dubson (ddubson@pivotal.io)
+ * Copyright (C) 2019 Gavin Shaw (gshaw@pivotal.io)
+ * Copyright (C) 2019 Zach Marcin (zmarcin@pivotal.io)
+ * Copyright (C) 2019 Nikhil Pawar (npawar@pivotal.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jkiss.dbeaver.ext.greenplum.model;
 
 import org.jkiss.code.NotNull;

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumWithClauseBuilder.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumWithClauseBuilder.java
@@ -1,3 +1,23 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
+ * Copyright (C) 2019 Dmitriy Dubson (ddubson@pivotal.io)
+ * Copyright (C) 2019 Gavin Shaw (gshaw@pivotal.io)
+ * Copyright (C) 2019 Zach Marcin (zmarcin@pivotal.io)
+ * Copyright (C) 2019 Nikhil Pawar (npawar@pivotal.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jkiss.dbeaver.ext.greenplum.model;
 
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableBase;

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
@@ -1,6 +1,10 @@
 /*
  * DBeaver - Universal Database Manager
  * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
+ * Copyright (C) 2019 Dmitriy Dubson (ddubson@pivotal.io)
+ * Copyright (C) 2019 Gavin Shaw (gshaw@pivotal.io)
+ * Copyright (C) 2019 Zach Marcin (zmarcin@pivotal.io)
+ * Copyright (C) 2019 Nikhil Pawar (npawar@pivotal.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
@@ -21,8 +21,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.Mockito.mock;
-
 @RunWith(MockitoJUnitRunner.class)
 public class GreenplumExternalTableTest {
     @Mock
@@ -266,7 +264,7 @@ public class GreenplumExternalTableTest {
     }
 
     private PostgreTableColumn mockDbColumn(String columnName, String columnType, int ordinalPosition) {
-        PostgreTableColumn mockPostgreTableColumn = mock(PostgreTableColumn.class);
+        PostgreTableColumn mockPostgreTableColumn = Mockito.mock(PostgreTableColumn.class);
         Mockito.when(mockPostgreTableColumn.getName()).thenReturn(columnName);
         Mockito.when(mockPostgreTableColumn.getTypeName()).thenReturn(columnType);
         Mockito.when(mockPostgreTableColumn.getOrdinalPosition()).thenReturn(ordinalPosition);

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
@@ -1,0 +1,280 @@
+package org.jkiss.dbeaver.ext.greenplum.model;
+
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableColumn;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GreenplumExternalTableTest {
+    @Mock
+    DBRProgressMonitor monitor;
+
+    @Mock
+    PostgreSchema mockSchema;
+
+    @Mock
+    PostgreDatabase mockDatabase;
+
+    @Mock
+    JDBCResultSet mockResults;
+
+    @Mock
+    PostgreDataSource mockDataSource;
+
+    @Mock
+    PostgreSchema.TableCache mockTableCache;
+
+    private final String exampleDatabaseName = "sampleDatabase";
+    private final String exampleSchemaName = "sampleSchema";
+    private final String exampleTableName = "sampleTable";
+    private final String exampleUriLocation = "gpfdist://filehost:8081/*.txt";
+    private final String exampleEncoding = "UTF8";
+    private final String exampleFormatOptions = "DELIMITER ','";
+    private final String exampleFormatType = "c";
+    private final int exampleRejectLimit = 100_000;
+    private final String exampleRejectLimitType = "r";
+    private final String exampleExecLocation = "ALL_SEGMENTS";
+
+    @Before
+    public void setup() throws SQLException {
+        Mockito.when(mockSchema.getDatabase()).thenReturn(mockDatabase);
+        Mockito.when(mockSchema.getDataSource()).thenReturn(mockDataSource);
+        Mockito.when(mockDatabase.getName()).thenReturn(exampleDatabaseName);
+        Mockito.when(mockSchema.getName()).thenReturn(exampleSchemaName);
+        Mockito.when(mockSchema.getTableCache()).thenReturn(mockTableCache);
+        Mockito.when(mockDataSource.isServerVersionAtLeast(Matchers.anyInt(), Matchers.anyInt())).thenReturn(false);
+
+        Mockito.when(mockResults.getString("relname")).thenReturn(exampleTableName);
+        Mockito.when(mockResults.getString("fmttype")).thenReturn(exampleFormatType);
+        Mockito.when(mockResults.getString("urilocation")).thenReturn(exampleUriLocation);
+        Mockito.when(mockResults.getString("fmtopts")).thenReturn(exampleFormatOptions);
+        Mockito.when(mockResults.getString("encoding")).thenReturn(exampleEncoding);
+        Mockito.when(mockResults.getString("execlocation")).thenReturn(exampleExecLocation);
+    }
+
+    @Test
+    public void onCreation_readsASingleUriLocationFromDbResult() throws SQLException {
+        Mockito.when(mockResults.getString("urilocation")).thenReturn("SOME_EXTERNAL_LOCATION");
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        Assert.assertEquals(Collections.singletonList("SOME_EXTERNAL_LOCATION"), table.getUriLocations());
+    }
+
+    @Test
+    public void onCreation_readsMultipleUriLocaitonsFromDbResult() throws SQLException {
+        Mockito.when(mockResults.getString("urilocation"))
+                .thenReturn("SOME_EXTERNAL_LOCATION,ANOTHER_EXTERNAL_LOCATION");
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        Assert.assertEquals(Arrays.asList("SOME_EXTERNAL_LOCATION", "ANOTHER_EXTERNAL_LOCATION"),
+                table.getUriLocations());
+    }
+
+    @Test
+    public void onCreation_readsExecLocationFromDbResult() throws SQLException {
+        Mockito.when(mockResults.getString("execlocation")).thenReturn("ALL_SEGMENTS");
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        String expectedUriLocation = "ALL_SEGMENTS";
+        Assert.assertEquals(expectedUriLocation, table.getExecLocation());
+    }
+
+    @Test
+    public void onCreation_readsFormatTypeFromDbResult() throws SQLException {
+        Mockito.when(mockResults.getString("fmttype")).thenReturn("t");
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        Assert.assertEquals(GreenplumExternalTable.FormatType.t, table.getFormatType());
+    }
+
+    @Test
+    public void onCreation_readsFormatOptionsFromDbResult() throws SQLException {
+        Mockito.when(mockResults.getString("fmtopts")).thenReturn("delimiter ',' null '' escape '\"' quote '\"' header");
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        String expectedUriLocation = "delimiter ',' null '' escape '\"' quote '\"' header";
+        Assert.assertEquals(expectedUriLocation, table.getFormatOptions());
+    }
+
+    @Test
+    public void onCreation_readsEncodingFromDBResult() throws SQLException {
+        Mockito.when(mockResults.getString("encoding")).thenReturn("UTF8");
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        String expectedUriLocation = "UTF8";
+        Assert.assertEquals(expectedUriLocation, table.getEncoding());
+    }
+
+    @Test
+    public void onCreation_readsRejectLimitTypeFromDBResult() throws SQLException {
+        Mockito.when(mockResults.getString("rejectlimittype")).thenReturn("r");
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        Assert.assertEquals(GreenplumExternalTable.RejectLimitType.r, table.getRejectLimitType());
+    }
+
+    @Test
+    public void onCreation_readsRejectLimitFromDBResult() throws SQLException {
+        Mockito.when(mockResults.getInt("rejectlimit")).thenReturn(50_000);
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        int expectedUriLocation = 50_000;
+        Assert.assertEquals(expectedUriLocation, table.getRejectLimit());
+    }
+
+    @Test
+    public void generateDDL_whenTableHasASingleColumn_returnsDDLStringForASingleColumn()
+            throws DBException {
+        PostgreTableColumn mockPostgreTableColumn = mockDbColumn("column1", "int4", 1);
+        List<PostgreTableColumn> tableColumns = Collections.singletonList(mockPostgreTableColumn);
+
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        addMockColumnsToTableCache(tableColumns, table);
+
+        String expectedDDL =
+                "CREATE EXTERNAL TABLE sampleDatabase.sampleSchema.sampleTable (\n\tcolumn1 int4\n)\n" +
+                        "LOCATION (\n" +
+                        "\t'gpfdist://filehost:8081/*.txt'\n" +
+                        ") ON ALL\n" +
+                        "FORMAT 'CSV' ( DELIMITER ',' )\n" +
+                        "ENCODING 'UTF8'";
+
+        Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
+    }
+
+    @Test
+    public void generateDDL_whenTableHasNoEncodingSet_returnsDDLStringWithNoEncoding()
+            throws DBException, SQLException {
+        PostgreTableColumn mockPostgreTableColumn = mockDbColumn("column1", "int4", 1);
+        List<PostgreTableColumn> tableColumns = Collections.singletonList(mockPostgreTableColumn);
+
+        Mockito.when(mockResults.getString("encoding")).thenReturn(null);
+
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        addMockColumnsToTableCache(tableColumns, table);
+
+        String expectedDDLWithNoEncodingSet =
+                "CREATE EXTERNAL TABLE sampleDatabase.sampleSchema.sampleTable (\n\tcolumn1 int4\n)\n" +
+                        "LOCATION (\n" +
+                        "\t'gpfdist://filehost:8081/*.txt'\n" +
+                        ") ON ALL\n" +
+                        "FORMAT 'CSV' ( DELIMITER ',' )";
+
+        Assert.assertEquals(expectedDDLWithNoEncodingSet, table.generateDDL(monitor));
+    }
+
+    @Test
+    public void generateDDL_whenTableHasMultiColumns_returnsDDLStringForMultiColumns()
+            throws DBException {
+        PostgreTableColumn mockPostgreTableColumn = mockDbColumn("column1", "int4", 1);
+        PostgreTableColumn mockPostgreTableColumn2 = mockDbColumn("column2", "int2", 2);
+        List<PostgreTableColumn> tableColumns = Arrays.asList(mockPostgreTableColumn, mockPostgreTableColumn2);
+
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        addMockColumnsToTableCache(tableColumns, table);
+
+        String expectedDDLWithMultiColumns =
+                "CREATE EXTERNAL TABLE sampleDatabase.sampleSchema.sampleTable (\n\tcolumn1 int4,\n\tcolumn2 int2\n)\n" +
+                        "LOCATION (\n" +
+                        "\t'gpfdist://filehost:8081/*.txt'\n" +
+                        ") ON ALL\n" +
+                        "FORMAT 'CSV' ( DELIMITER ',' )\n" +
+                        "ENCODING 'UTF8'";
+
+        Assert.assertEquals(expectedDDLWithMultiColumns, table.generateDDL(monitor));
+    }
+
+    @Test
+    public void generateDDL_whenTableHasASegmentRejectLimit_returnsDDLStringWithSegmentRejectLimit()
+            throws DBException, SQLException {
+        PostgreTableColumn mockPostgreTableColumn = mockDbColumn("column1", "int4", 1);
+        List<PostgreTableColumn> tableColumns = Collections.singletonList(mockPostgreTableColumn);
+
+        Mockito.when(mockResults.getInt("rejectlimit")).thenReturn(exampleRejectLimit);
+        Mockito.when(mockResults.getString("rejectlimittype")).thenReturn(exampleRejectLimitType);
+
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        addMockColumnsToTableCache(tableColumns, table);
+
+        String expectedDDL =
+                "CREATE EXTERNAL TABLE sampleDatabase.sampleSchema.sampleTable (\n\tcolumn1 int4\n)\n" +
+                        "LOCATION (\n" +
+                        "\t'gpfdist://filehost:8081/*.txt'\n" +
+                        ") ON ALL\n" +
+                        "FORMAT 'CSV' ( DELIMITER ',' )\n" +
+                        "ENCODING 'UTF8'\n" +
+                        "SEGMENT REJECT LIMIT 100000 ROWS";
+
+        Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
+    }
+
+    @Test
+    public void generateDDL_whenExecLocationIsMasterOnly_returnsDDLStringWithAMasterOnlyExecLocation()
+            throws DBException, SQLException {
+        PostgreTableColumn mockPostgreTableColumn = mockDbColumn("column1", "int4", 1);
+        List<PostgreTableColumn> tableColumns = Collections.singletonList(mockPostgreTableColumn);
+
+        Mockito.when(mockResults.getString("execlocation")).thenReturn("MASTER_ONLY");
+
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        addMockColumnsToTableCache(tableColumns, table);
+
+        String expectedDDL =
+                "CREATE EXTERNAL TABLE sampleDatabase.sampleSchema.sampleTable (\n\tcolumn1 int4\n)\n" +
+                        "LOCATION (\n" +
+                        "\t'gpfdist://filehost:8081/*.txt'\n" +
+                        ") ON MASTER\n" +
+                        "FORMAT 'CSV' ( DELIMITER ',' )\n" +
+                        "ENCODING 'UTF8'";
+
+        Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
+    }
+
+    @Test
+    public void generateDDL_whenTableHasMultipleUriLocations_returnsDDLStringForASingleColumn()
+            throws DBException, SQLException {
+        PostgreTableColumn mockPostgreTableColumn = mockDbColumn("column1", "int4", 1);
+        List<PostgreTableColumn> tableColumns = Collections.singletonList(mockPostgreTableColumn);
+
+        Mockito.when(mockResults.getString("urilocation"))
+                .thenReturn("gpfdist://filehost:8081/*.txt,gpfdist://filehost:8081/*.gz");
+
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        addMockColumnsToTableCache(tableColumns, table);
+
+        String expectedDDL =
+                "CREATE EXTERNAL TABLE sampleDatabase.sampleSchema.sampleTable (\n\tcolumn1 int4\n)\n" +
+                        "LOCATION (\n" +
+                        "\t'gpfdist://filehost:8081/*.txt',\n" +
+                        "\t'gpfdist://filehost:8081/*.gz'\n" +
+                        ") ON ALL\n" +
+                        "FORMAT 'CSV' ( DELIMITER ',' )\n" +
+                        "ENCODING 'UTF8'";
+
+        Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
+    }
+
+    private PostgreTableColumn mockDbColumn(String columnName, String columnType, int ordinalPosition) {
+        PostgreTableColumn mockPostgreTableColumn = mock(PostgreTableColumn.class);
+        Mockito.when(mockPostgreTableColumn.getName()).thenReturn(columnName);
+        Mockito.when(mockPostgreTableColumn.getTypeName()).thenReturn(columnType);
+        Mockito.when(mockPostgreTableColumn.getOrdinalPosition()).thenReturn(ordinalPosition);
+        return mockPostgreTableColumn;
+    }
+
+    private void addMockColumnsToTableCache(List<PostgreTableColumn> tableColumns, GreenplumExternalTable table)
+            throws DBException {
+        Mockito.when(mockTableCache.getChildren(monitor, mockSchema, table)).thenReturn(tableColumns);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplumTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplumTest.java
@@ -6,7 +6,6 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -16,12 +15,6 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.sql.SQLException;
-import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PostgreServerGreenplumTest {
@@ -42,8 +35,8 @@ public class PostgreServerGreenplumTest {
 
     @Before
     public void setup() throws SQLException {
-        when(mockSchema.getDataSource()).thenReturn(mockDataSource);
-        when(mockDataSource.isServerVersionAtLeast(Matchers.anyInt(), Matchers.anyInt())).thenReturn(false);
+        Mockito.when(mockSchema.getDataSource()).thenReturn(mockDataSource);
+        Mockito.when(mockDataSource.isServerVersionAtLeast(Matchers.anyInt(), Matchers.anyInt())).thenReturn(false);
         Mockito.when(mockResults.getString("fmttype")).thenReturn("c");
         Mockito.when(mockResults.getString("urilocation")).thenReturn("gpfdist://filehost:8081/*.txt");
     }
@@ -57,7 +50,7 @@ public class PostgreServerGreenplumTest {
     @Test
     public void createRelationOfClass_whenTableTypeIsRegularAndTableIsANonExternalGreenplumTable_returnsInstanceOfGreenplumTable()
             throws SQLException {
-        when(mockResults.getBoolean("is_ext_table")).thenReturn(false);
+        Mockito.when(mockResults.getBoolean("is_ext_table")).thenReturn(false);
         Assert.assertEquals(GreenplumTable.class,
                 server.createRelationOfClass(mockSchema, PostgreClass.RelKind.r, mockResults).getClass());
     }
@@ -65,7 +58,7 @@ public class PostgreServerGreenplumTest {
     @Test
     public void createRelationOfClass_whenTableTypeIsRegularAndTableIsAnExternalGreenplumTable_returnsInstanceOfGreenplumExternalTable()
             throws SQLException {
-        when(mockResults.getBoolean("is_ext_table")).thenReturn(true);
+        Mockito.when(mockResults.getBoolean("is_ext_table")).thenReturn(true);
         Assert.assertEquals(GreenplumExternalTable.class,
                 server.createRelationOfClass(mockSchema, PostgreClass.RelKind.r, mockResults).getClass());
     }
@@ -74,14 +67,14 @@ public class PostgreServerGreenplumTest {
     public void readTableDDL_whenTableIsNotAnInstanceOfGreenplumExternalTable_delegatesDDLcreationToParentClass()
             throws DBException {
         String expectedDelegatedResultFromParentClass = null;
-        PostgreTableBase table = mock(PostgreTableBase.class);
+        PostgreTableBase table = Mockito.mock(PostgreTableBase.class);
         Assert.assertEquals(expectedDelegatedResultFromParentClass, server.readTableDDL(monitor, table));
     }
 
     @Test
     public void readTableDDL_whenTableIsAnInstanceOfGreenplumExternalTable_delegatesToGpGenerateDDL()
             throws DBException {
-        GreenplumExternalTable table = mock(GreenplumExternalTable.class);
+        GreenplumExternalTable table = Mockito.mock(GreenplumExternalTable.class);
         server.readTableDDL(monitor, table);
         Mockito.verify(table).generateDDL(monitor);
     }

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplumTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplumTest.java
@@ -1,0 +1,88 @@
+package org.jkiss.dbeaver.ext.greenplum.model;
+
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.postgresql.model.*;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.sql.SQLException;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PostgreServerGreenplumTest {
+    @Mock
+    PostgreDataSource mockDataSource;
+
+    @Mock
+    PostgreSchema mockSchema;
+
+    @Mock
+    JDBCResultSet mockResults;
+
+    @Mock
+    DBRProgressMonitor monitor;
+
+    @InjectMocks
+    PostgreServerGreenplum server;
+
+    @Before
+    public void setup() throws SQLException {
+        when(mockSchema.getDataSource()).thenReturn(mockDataSource);
+        when(mockDataSource.isServerVersionAtLeast(Matchers.anyInt(), Matchers.anyInt())).thenReturn(false);
+        Mockito.when(mockResults.getString("fmttype")).thenReturn("c");
+        Mockito.when(mockResults.getString("urilocation")).thenReturn("gpfdist://filehost:8081/*.txt");
+    }
+
+    @Test
+    public void createRelationOfClass_whenTableIsNotAGreenplumTable_returnsInstanceOfPostgresTableBase() {
+        Assert.assertEquals(PostgreTableRegular.class,
+                server.createRelationOfClass(mockSchema, PostgreClass.RelKind.p, mockResults).getClass());
+    }
+
+    @Test
+    public void createRelationOfClass_whenTableTypeIsRegularAndTableIsANonExternalGreenplumTable_returnsInstanceOfGreenplumTable()
+            throws SQLException {
+        when(mockResults.getBoolean("is_ext_table")).thenReturn(false);
+        Assert.assertEquals(GreenplumTable.class,
+                server.createRelationOfClass(mockSchema, PostgreClass.RelKind.r, mockResults).getClass());
+    }
+
+    @Test
+    public void createRelationOfClass_whenTableTypeIsRegularAndTableIsAnExternalGreenplumTable_returnsInstanceOfGreenplumExternalTable()
+            throws SQLException {
+        when(mockResults.getBoolean("is_ext_table")).thenReturn(true);
+        Assert.assertEquals(GreenplumExternalTable.class,
+                server.createRelationOfClass(mockSchema, PostgreClass.RelKind.r, mockResults).getClass());
+    }
+
+    @Test
+    public void readTableDDL_whenTableIsNotAnInstanceOfGreenplumExternalTable_delegatesDDLcreationToParentClass()
+            throws DBException {
+        String expectedDelegatedResultFromParentClass = null;
+        PostgreTableBase table = mock(PostgreTableBase.class);
+        Assert.assertEquals(expectedDelegatedResultFromParentClass, server.readTableDDL(monitor, table));
+    }
+
+    @Test
+    public void readTableDDL_whenTableIsAnInstanceOfGreenplumExternalTable_delegatesToGpGenerateDDL()
+            throws DBException {
+        GreenplumExternalTable table = mock(GreenplumExternalTable.class);
+        server.readTableDDL(monitor, table);
+        Mockito.verify(table).generateDDL(monitor);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
@@ -217,6 +217,10 @@ public class PostgreSchema implements DBSSchema, DBPNamedObject2, DBPSaveableObj
         return null;
     }
 
+    public TableCache getTableCache() {
+        return this.tableCache;
+    }
+
     @Association
     public Collection<? extends JDBCTable> getTables(DBRProgressMonitor monitor)
         throws DBException {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableBase.java
@@ -90,7 +90,7 @@ public abstract class PostgreTableBase extends JDBCTable<PostgreDataSource, Post
     @Override
     public JDBCStructCache<PostgreSchema, ? extends PostgreClass, ? extends PostgreAttribute> getCache()
     {
-        return getContainer().tableCache;
+        return getContainer().getTableCache();
     }
 
     @NotNull
@@ -152,7 +152,7 @@ public abstract class PostgreTableBase extends JDBCTable<PostgreDataSource, Post
     public List<PostgreTableColumn> getAttributes(@NotNull DBRProgressMonitor monitor)
         throws DBException
     {
-        return getContainer().tableCache.getChildren(monitor, getContainer(), this);
+        return getContainer().getTableCache().getChildren(monitor, getContainer(), this);
     }
 
     public PostgreTableColumn getAttributeByPos(DBRProgressMonitor monitor, int position) throws DBException {
@@ -166,7 +166,7 @@ public abstract class PostgreTableBase extends JDBCTable<PostgreDataSource, Post
 
     public List<PostgreTableColumn> getCachedAttributes()
     {
-        final DBSObjectCache<PostgreTableBase, PostgreTableColumn> childrenCache = getContainer().tableCache.getChildrenCache(this);
+        final DBSObjectCache<PostgreTableBase, PostgreTableColumn> childrenCache = getContainer().getTableCache().getChildrenCache(this);
         if (childrenCache != null) {
             return childrenCache.getCachedObjects();
         }
@@ -177,7 +177,7 @@ public abstract class PostgreTableBase extends JDBCTable<PostgreDataSource, Post
     public PostgreTableColumn getAttribute(@NotNull DBRProgressMonitor monitor, @NotNull String attributeName)
         throws DBException
     {
-        return getContainer().tableCache.getChild(monitor, getContainer(), this, attributeName);
+        return getContainer().getTableCache().getChild(monitor, getContainer(), this, attributeName);
     }
 
     @Override
@@ -212,7 +212,7 @@ public abstract class PostgreTableBase extends JDBCTable<PostgreDataSource, Post
     {
         getContainer().constraintCache.clearObjectCache(this);
         getContainer().indexCache.clearObjectCache(this);
-        return getContainer().tableCache.refreshObject(monitor, getContainer(), this);
+        return getContainer().getTableCache().refreshObject(monitor, getContainer(), this);
     }
 
     @Override


### PR DESCRIPTION
- Greenplum has a concept of external tables that store data outside of the primary Greenplum store.
- DBeaver Greenplum plugin had no concept of DDL generation specifically for external tables
- This commit adds basic external table DDL generation

Example external table DDL:

```sql
CREATE EXTERNAL TABLE ext_customer
   (id int, name text, sponsor text)
   LOCATION ( 'gpfdist://filehost:8081/*.csv' )
   FORMAT 'CSV' ( DELIMITER ',' );
```