### PR TITLE
GP: Add Format Custom to External Table DDL generation

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
@@ -35,7 +35,8 @@ import java.util.stream.Collectors;
 public class GreenplumExternalTable extends PostgreTableRegular {
     public enum FormatType {
         c("CSV"),
-        t("TEXT");
+        t("TEXT"),
+        b("CUSTOM");
 
         private String formatType;
 
@@ -148,7 +149,8 @@ public class GreenplumExternalTable extends PostgreTableRegular {
             ddlBuilder.append("\n) " + determineExecutionLocation() + "\n");
         }
 
-        ddlBuilder.append("FORMAT '" + this.getFormatType().getValue() + "' ( " + this.getFormatOptions() + " )");
+        ddlBuilder.append("FORMAT '" + this.getFormatType().getValue() + "' ( "
+                + generateFormatOptions(this.getFormatType(), this.getFormatOptions()) + " )");
 
         if (this.getEncoding() != null && this.getEncoding().length() > 0) {
             ddlBuilder.append("\nENCODING '" + this.getEncoding() + "'");
@@ -159,6 +161,15 @@ public class GreenplumExternalTable extends PostgreTableRegular {
         }
 
         return ddlBuilder.toString();
+    }
+
+    private String generateFormatOptions(FormatType formatType, String formatOptions) {
+        if(formatType.equals(FormatType.b)){
+            String[] formatSpecTokens = formatOptions.split(" ");
+            String formatterSpec = formatSpecTokens.length >= 2 ? formatSpecTokens[1] : "";
+            return "FORMATTER=" + formatterSpec;
+        }
+        return formatOptions;
     }
 
     private String determineExecutionLocation() {

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
@@ -263,6 +263,29 @@ public class GreenplumExternalTableTest {
         Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
     }
 
+    @Test
+    public void generateDDL_whenTableHasACustomFormatType_returnsDDLStringWithACustomFormat()
+            throws DBException, SQLException {
+        PostgreTableColumn mockPostgreTableColumn = mockDbColumn("column1", "int4", 1);
+        List<PostgreTableColumn> tableColumns = Collections.singletonList(mockPostgreTableColumn);
+
+        Mockito.when(mockResults.getString("fmttype")).thenReturn("b");
+        Mockito.when(mockResults.getString("fmtopts")).thenReturn("FORMATTER 'formatter_export_s'");
+
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        addMockColumnsToTableCache(tableColumns, table);
+
+        String expectedDDL =
+                "CREATE EXTERNAL TABLE sampleDatabase.sampleSchema.sampleTable (\n\tcolumn1 int4\n)\n" +
+                        "LOCATION (\n" +
+                        "\t'gpfdist://filehost:8081/*.txt'\n" +
+                        ") ON ALL\n" +
+                        "FORMAT 'CUSTOM' ( FORMATTER='formatter_export_s' )\n" +
+                        "ENCODING 'UTF8'";
+
+        Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
+    }
+
     private PostgreTableColumn mockDbColumn(String columnName, String columnType, int ordinalPosition) {
         PostgreTableColumn mockPostgreTableColumn = Mockito.mock(PostgreTableColumn.class);
         Mockito.when(mockPostgreTableColumn.getName()).thenReturn(columnName);


### PR DESCRIPTION
This commit adds custom format of storage for an external table as part of external table DDL generation for Greenplum.