### PR TITLE
GP: Add 'WEB' keyword to external table DDL generation

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
@@ -119,8 +119,17 @@ public class GreenplumExternalTable extends PostgreTableRegular {
     }
 
     public String generateDDL(DBRProgressMonitor monitor) throws DBException {
-        StringBuilder ddlBuilder = new StringBuilder("CREATE EXTERNAL TABLE " + this.getDatabase().getName()
-                + "." + this.getSchema().getName() + "." + this.getName() + " (\n");
+        StringBuilder ddlBuilder = new StringBuilder();
+
+        ddlBuilder.append("CREATE EXTERNAL ")
+                .append(webUriLocationExists() ? "WEB " : "")
+                .append("TABLE ")
+                .append(this.getDatabase().getName())
+                .append(".")
+                .append(this.getSchema().getName())
+                .append(".")
+                .append(this.getName())
+                .append(" (\n");
 
         List<PostgreTableColumn> tableColumns = this.getAttributes(monitor)
                 .stream()
@@ -163,8 +172,12 @@ public class GreenplumExternalTable extends PostgreTableRegular {
         return ddlBuilder.toString();
     }
 
+    private boolean webUriLocationExists() {
+        return this.uriLocations.stream().anyMatch(location -> location.startsWith("http"));
+    }
+
     private String generateFormatOptions(FormatType formatType, String formatOptions) {
-        if(formatType.equals(FormatType.b)){
+        if (formatType.equals(FormatType.b)) {
             String[] formatSpecTokens = formatOptions.split(" ");
             String formatterSpec = formatSpecTokens.length >= 2 ? formatSpecTokens[1] : "";
             return "FORMATTER=" + formatterSpec;

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
@@ -78,7 +78,7 @@ public class PostgreServerGreenplum extends PostgreServerExtensionBase {
 
     @Override
     public void configureDialect(PostgreDialect dialect) {
-        dialect.addExtraKeywords("DISTRIBUTED", "SEGMENT", "REJECT", "FORMAT", "MASTER");
+        dialect.addExtraKeywords("DISTRIBUTED", "SEGMENT", "REJECT", "FORMAT", "MASTER", "WEB");
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
@@ -286,6 +286,28 @@ public class GreenplumExternalTableTest {
         Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
     }
 
+    @Test
+    public void generateDDL_whenTableIsAWebTable_returnsDDLStringForAWebTable()
+            throws DBException, SQLException {
+        PostgreTableColumn mockPostgreTableColumn = mockDbColumn("column1", "int4", 1);
+        List<PostgreTableColumn> tableColumns = Collections.singletonList(mockPostgreTableColumn);
+
+        Mockito.when(mockResults.getString("urilocation")).thenReturn("http://example.com/test.txt");
+
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        addMockColumnsToTableCache(tableColumns, table);
+
+        String expectedDDL =
+                "CREATE EXTERNAL WEB TABLE sampleDatabase.sampleSchema.sampleTable (\n\tcolumn1 int4\n)\n" +
+                        "LOCATION (\n" +
+                        "\t'http://example.com/test.txt'\n" +
+                        ") ON ALL\n" +
+                        "FORMAT 'CSV' ( DELIMITER ',' )\n" +
+                        "ENCODING 'UTF8'";
+
+        Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
+    }
+
     private PostgreTableColumn mockDbColumn(String columnName, String columnType, int ordinalPosition) {
         PostgreTableColumn mockPostgreTableColumn = Mockito.mock(PostgreTableColumn.class);
         Mockito.when(mockPostgreTableColumn.getName()).thenReturn(columnName);

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplumTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplumTest.java
@@ -90,5 +90,6 @@ public class PostgreServerGreenplumTest {
         Assert.assertTrue(!dialect.getMatchedKeywords("REJECT").isEmpty());
         Assert.assertTrue(!dialect.getMatchedKeywords("FORMAT").isEmpty());
         Assert.assertTrue(!dialect.getMatchedKeywords("MASTER").isEmpty());
+        Assert.assertTrue(!dialect.getMatchedKeywords("WEB").isEmpty());
     }
 }


### PR DESCRIPTION
If a URI Location of an external table has protocol of 'http' or
'https', then it should be prefixed with the 'WEB' keyword

Example DDL:

```
CREATE EXTERNAL WEB TABLE external_web_table ( a INT, b INT )
LOCATION ('http://example.com/stuff/test.txt')
FORMAT 'CSV';
```