### PR TITLE
Add `Unlogged` to Greenplum table DDL for Greenplum 6

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/plugin.xml
@@ -63,4 +63,10 @@
             </drivers>
         </datasource>
     </extension>
+
+    <extension point="org.jkiss.dbeaver.objectManager">
+        <manager class="org.jkiss.dbeaver.ext.greenplum.edit.GreenplumTableManager" objectType="org.jkiss.dbeaver.ext.greenplum.model.GreenplumTable"/>
+        <manager class="org.jkiss.dbeaver.ext.greenplum.edit.GreenplumTableManager" objectType="org.jkiss.dbeaver.ext.greenplum.model.GreenplumExternalTable"/>
+    </extension>
+
 </plugin>

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/edit/GreenplumTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/edit/GreenplumTableManager.java
@@ -1,0 +1,52 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
+ * Copyright (C) 2019 Dmitriy Dubson (ddubson@pivotal.io)
+ * Copyright (C) 2019 Gavin Shaw (gshaw@pivotal.io)
+ * Copyright (C) 2019 Zach Marcin (zmarcin@pivotal.io)
+ * Copyright (C) 2019 Nikhil Pawar (npawar@pivotal.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.greenplum.edit;
+
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.greenplum.model.GreenplumTable;
+import org.jkiss.dbeaver.ext.postgresql.edit.PostgreTableManager;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableBase;
+import org.jkiss.dbeaver.model.edit.DBEPersistAction;
+import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
+import org.jkiss.dbeaver.model.messages.ModelMessages;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Greenplum table manager
+ */
+public class GreenplumTableManager extends PostgreTableManager {
+
+    @Override
+    protected void addStructObjectCreateActions(DBRProgressMonitor monitor, List<DBEPersistAction> actions, StructCreateCommand command, Map<String, Object> options) throws DBException {
+        PostgreTableBase tableBase = command.getObject();
+
+        super.addStructObjectCreateActions(monitor, actions, command, options);
+
+        if (tableBase instanceof GreenplumTable && ((GreenplumTable) tableBase).isUnloggedTable()) {
+            actions.set(0,
+                    new SQLDatabasePersistAction(ModelMessages.model_jdbc_create_new_table,
+                            ((GreenplumTable) tableBase).addUnloggedClause(actions.get(0).getScript())));
+        }
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTableTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTableTest.java
@@ -1,0 +1,77 @@
+package org.jkiss.dbeaver.ext.greenplum.model;
+
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GreenplumTableTest {
+
+    @Mock
+    PostgreSchema mockSchema;
+
+    @Mock
+    PostgreDatabase mockDatabase;
+
+    @Mock
+    JDBCResultSet mockResults;
+
+    @Mock
+    PostgreDataSource mockDataSource;
+
+    @Mock
+    PostgreSchema.TableCache mockTableCache;
+
+    private GreenplumTable table;
+
+    private final String exampleDatabaseName = "sampleDatabase";
+    private final String exampleSchemaName = "sampleSchema";
+    private final String exampleTableName = "sampleTable";
+    private final String exampleUriLocation = "gpfdist://filehost:8081/*.txt";
+    private final String exampleEncoding = "UTF8";
+    private final String exampleFormatOptions = "DELIMITER ','";
+    private final String exampleFormatType = "c";
+    private final String exampleExecLocation = "ALL_SEGMENTS";
+
+    @Before
+    public void setUp() throws Exception {
+        Mockito.when(mockSchema.getDatabase()).thenReturn(mockDatabase);
+        Mockito.when(mockSchema.getDataSource()).thenReturn(mockDataSource);
+        Mockito.when(mockDatabase.getName()).thenReturn(exampleDatabaseName);
+        Mockito.when(mockSchema.getName()).thenReturn(exampleSchemaName);
+        Mockito.when(mockSchema.getTableCache()).thenReturn(mockTableCache);
+        Mockito.when(mockDataSource.isServerVersionAtLeast(Matchers.anyInt(), Matchers.anyInt())).thenReturn(false);
+
+        Mockito.when(mockResults.getString("relname")).thenReturn(exampleTableName);
+        Mockito.when(mockResults.getString("fmttype")).thenReturn(exampleFormatType);
+        Mockito.when(mockResults.getString("urilocation")).thenReturn(exampleUriLocation);
+        Mockito.when(mockResults.getString("fmtopts")).thenReturn(exampleFormatOptions);
+        Mockito.when(mockResults.getString("encoding")).thenReturn(exampleEncoding);
+        Mockito.when(mockResults.getString("execlocation")).thenReturn(exampleExecLocation);
+
+        table = new GreenplumTable(mockSchema, mockResults);
+    }
+
+    @Test
+    public void addUnloggedClause_whenTableDDLContainsCreateKeyword_itIsReplacedWithCreateUnlogged() {
+        String tableDdl = "CREATE TABLE";
+
+        Assert.assertEquals(table.addUnloggedClause(tableDdl), "CREATE UNLOGGED TABLE");
+    }
+
+    @Test
+    public void addUnloggedClause_whenTableDDLDoesNotContainCreateKeyword_itIsReplacedWithCreateUnlogged() {
+        String tableDdl = "SOME TABLE";
+
+        Assert.assertEquals(table.addUnloggedClause(tableDdl), tableDdl);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplumTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplumTest.java
@@ -67,7 +67,7 @@ public class PostgreServerGreenplumTest {
     public void readTableDDL_whenTableIsNotAnInstanceOfGreenplumExternalTable_delegatesDDLcreationToParentClass()
             throws DBException {
         String expectedDelegatedResultFromParentClass = null;
-        PostgreTableBase table = Mockito.mock(PostgreTableBase.class);
+        GreenplumTable table = Mockito.mock(GreenplumTable.class);
         Assert.assertEquals(expectedDelegatedResultFromParentClass, server.readTableDDL(monitor, table));
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/META-INF/MANIFEST.MF
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/META-INF/MANIFEST.MF
@@ -28,6 +28,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-ClassPath: .
 Bundle-Activator: org.jkiss.dbeaver.ext.postgresql.PostgreActivator
 Export-Package: org.jkiss.dbeaver.ext.postgresql,
+ org.jkiss.dbeaver.ext.postgresql.edit,
  org.jkiss.dbeaver.ext.postgresql.model,
  org.jkiss.dbeaver.ext.postgresql.model.impls,
  org.jkiss.dbeaver.ext.postgresql.ui,


### PR DESCRIPTION
- Created a GreenplumTableManager to handle Greenplum tables.
- Unlogged tables are available in Postgres 9.1 and later.