### PR TITLE
GP: Add `Replicated` keyword for tables in GP v6

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/pom.xml
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/pom.xml
@@ -11,20 +11,6 @@
   <artifactId>org.jkiss.dbeaver.ext.greenplum</artifactId>
   <version>1.0.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
-  <dependencies>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.7.4</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.7.4</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/pom.xml
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/pom.xml
@@ -11,6 +11,20 @@
   <artifactId>org.jkiss.dbeaver.ext.greenplum</artifactId>
   <version>1.0.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.7.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.7.4</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTable.java
@@ -103,7 +103,7 @@ public class GreenplumTable extends PostgreTableRegular {
         return columns;
     }
 
-    private List<PostgreTableColumn> getPostgreTableColumns(DBRProgressMonitor monitor, List<PostgreTableColumn> distributionColumns) throws DBException {
+    private List<PostgreTableColumn> getDistributionTableColumns(DBRProgressMonitor monitor, List<PostgreTableColumn> distributionColumns) throws DBException {
         // Get primary key
         PostgreTableConstraint pk = null;
         for (PostgreTableConstraint tc : getConstraints(monitor)) {
@@ -162,7 +162,7 @@ public class GreenplumTable extends PostgreTableRegular {
         try {
             List<PostgreTableColumn> distributionColumns = getDistributionPolicy(monitor);
             if (CommonUtils.isEmpty(distributionColumns)) {
-                distributionColumns = getPostgreTableColumns(monitor, distributionColumns);
+                distributionColumns = getDistributionTableColumns(monitor, distributionColumns);
             }
 
             ddl.append("\nDISTRIBUTED ");

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTableTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTableTest.java
@@ -42,11 +42,6 @@ public class GreenplumTableTest {
     private final String exampleDatabaseName = "sampleDatabase";
     private final String exampleSchemaName = "sampleSchema";
     private final String exampleTableName = "sampleTable";
-    private final String exampleUriLocation = "gpfdist://filehost:8081/*.txt";
-    private final String exampleEncoding = "UTF8";
-    private final String exampleFormatOptions = "DELIMITER ','";
-    private final String exampleFormatType = "c";
-    private final String exampleExecLocation = "ALL_SEGMENTS";
 
     @Before
     public void setUp() throws Exception {
@@ -58,11 +53,7 @@ public class GreenplumTableTest {
         Mockito.when(mockDataSource.isServerVersionAtLeast(Mockito.anyInt(), Mockito.anyInt())).thenReturn(false);
 
         Mockito.when(mockResults.getString("relname")).thenReturn(exampleTableName);
-        Mockito.when(mockResults.getString("fmttype")).thenReturn(exampleFormatType);
-        Mockito.when(mockResults.getString("urilocation")).thenReturn(exampleUriLocation);
-        Mockito.when(mockResults.getString("fmtopts")).thenReturn(exampleFormatOptions);
-        Mockito.when(mockResults.getString("encoding")).thenReturn(exampleEncoding);
-        Mockito.when(mockResults.getString("execlocation")).thenReturn(exampleExecLocation);
+        Mockito.when(mockResults.getString("relpersistence")).thenReturn("x");
     }
 
     @Test
@@ -141,7 +132,6 @@ public class GreenplumTableTest {
         DBRProgressMonitor monitor = Mockito.mock(DBRProgressMonitor.class);
         StringBuilder ddl = new StringBuilder();
 
-        Mockito.when(JDBCUtils.safeGetString(mockResults, "relpersistence")).thenReturn("x");
         Mockito.when(mockDataSource.isServerVersionAtLeast(Mockito.anyInt(), Mockito.anyInt())).thenReturn(true);
 
         mockSetupForEmptyDistributionColumnList();
@@ -154,12 +144,11 @@ public class GreenplumTableTest {
     }
 
     @Test
-    public void appendTableModifiers_whenServerVersion9_andIsReplicated_andNoColumnSetForDistribution_resultsInReplicated() throws Exception {
+    public void appendTableModifiers_whenServerVersion9_andIsReplicated_resultsInReplicated() throws Exception {
         PowerMockito.spy(JDBCUtils.class);
         DBRProgressMonitor monitor = Mockito.mock(DBRProgressMonitor.class);
         StringBuilder ddl = new StringBuilder();
 
-        Mockito.when(JDBCUtils.safeGetString(mockResults, "relpersistence")).thenReturn("x");
         Mockito.when(mockDataSource.isServerVersionAtLeast(Mockito.anyInt(), Mockito.anyInt())).thenReturn(true);
 
         mockSetupForEmptyDistributionColumnList();

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
@@ -221,6 +221,10 @@ public class PostgreSchema implements DBSSchema, DBPNamedObject2, DBPSaveableObj
         return this.tableCache;
     }
 
+    public ConstraintCache getConstraintCache() {
+        return this.constraintCache;
+    }
+
     @Association
     public Collection<? extends JDBCTable> getTables(DBRProgressMonitor monitor)
         throws DBException {
@@ -531,7 +535,7 @@ public class PostgreSchema implements DBSSchema, DBPNamedObject2, DBPSaveableObj
     /**
      * Constraint cache implementation
      */
-    class ConstraintCache extends JDBCCompositeCache<PostgreSchema, PostgreTableBase, PostgreTableConstraintBase, PostgreTableConstraintColumn> {
+    public class ConstraintCache extends JDBCCompositeCache<PostgreSchema, PostgreTableBase, PostgreTableConstraintBase, PostgreTableConstraintColumn> {
         protected ConstraintCache() {
             super(tableCache, PostgreTableBase.class, "tabrelname", "conname");
         }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableReal.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableReal.java
@@ -145,13 +145,13 @@ public abstract class PostgreTableReal extends PostgreTableBase
 
     @Override
     public Collection<PostgreTableConstraint> getConstraints(@NotNull DBRProgressMonitor monitor) throws DBException {
-        return getSchema().constraintCache.getTypedObjects(monitor, getSchema(), this, PostgreTableConstraint.class);
+        return getSchema().getConstraintCache().getTypedObjects(monitor, getSchema(), this, PostgreTableConstraint.class);
     }
 
     public PostgreTableConstraintBase getConstraint(@NotNull DBRProgressMonitor monitor, String ukName)
         throws DBException
     {
-        return getSchema().constraintCache.getObject(monitor, getSchema(), this, ukName);
+        return getSchema().getConstraintCache().getObject(monitor, getSchema(), this, ukName);
     }
 
     @Association


### PR DESCRIPTION
- Adds support for the `Replicated` keyword for Greenplum v6 table DDL generation.