### PR TITLE
GP: Add 'EXECUTE ON' clause for external web tables

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
@@ -182,7 +182,7 @@ public class GreenplumExternalTable extends PostgreTableRegular {
 
             ddlBuilder.append("\n) " + determineExecutionLocation() + "\n");
         } else if (tableHasCommand()) {
-            ddlBuilder.append("EXECUTE '" + this.getCommand() + "'\n");
+            ddlBuilder.append("EXECUTE '" + this.getCommand() + "' " + determineExecutionLocation() + "\n");
         }
 
         ddlBuilder.append("FORMAT '" +

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchema.java
@@ -70,6 +70,7 @@ public class GreenplumSchema extends PostgreSchema {
                                                     @Nullable String objectName) throws SQLException {
             String sqlQuery = "SELECT c.oid,d.description, c.*,\n" +
                     "CASE WHEN x.urilocation IS NOT NULL THEN array_to_string(x.urilocation, ',') ELSE '' END AS urilocation,\n" +
+                    "CASE WHEN x.command IS NOT NULL THEN x.command ELSE '' END AS command,\n" +
                     "x.fmttype, x.fmtopts,\n" +
                     "coalesce(x.rejectlimit, 0) AS rejectlimit,\n" +
                     "coalesce(x.rejectlimittype, '') AS rejectlimittype,\n" +

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
@@ -453,6 +453,28 @@ public class GreenplumExternalTableTest {
         Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
     }
 
+    @Test
+    public void generateDDL_whenAWebTableHasExecuteClause_returnsDDLWithTheExecuteClause() throws SQLException, DBException {
+        PostgreTableColumn mockPostgreTableColumn = mockDbColumn("column1", "int4", 1);
+        List<PostgreTableColumn> tableColumns = Collections.singletonList(mockPostgreTableColumn);
+
+        Mockito.when(mockResults.getString("command")).thenReturn("execute something");
+        Mockito.when(mockResults.getString("urilocation")).thenReturn("");
+        Mockito.when(mockResults.getString("fmttype")).thenReturn("t");
+        Mockito.when(mockResults.getString("fmtopts")).thenReturn("");
+
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        addMockColumnsToTableCache(tableColumns, table);
+
+        String expectedDDL =
+                "CREATE EXTERNAL WEB TABLE sampleDatabase.sampleSchema.sampleTable (\n\tcolumn1 int4\n)\n" +
+                        "EXECUTE 'execute something'\n" +
+                        "FORMAT 'TEXT'\n" +
+                        "ENCODING 'UTF8'";
+
+        Assert.assertEquals(expectedDDL, table.generateDDL(monitor));
+    }
+
     private PostgreTableColumn mockDbColumn(String columnName, String columnType, int ordinalPosition) {
         PostgreTableColumn mockPostgreTableColumn = Mockito.mock(PostgreTableColumn.class);
         Mockito.when(mockPostgreTableColumn.getName()).thenReturn(columnName);


### PR DESCRIPTION
External web tables in GP can possibly have an option to execute a command, which is stored as underlying metadata.