### PR TITLE
GP: Fix GPDB 6 bug in loading External Tables DDL

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
@@ -91,7 +91,8 @@ public class GreenplumExternalTable extends PostgreTableRegular {
         String rejectlimittype = JDBCUtils.safeGetString(dbResult, "rejectlimittype");
         this.writable = JDBCUtils.safeGetBoolean(dbResult, "writable");
         this.temporaryTable = JDBCUtils.safeGetBoolean(dbResult, "is_temp_table");
-        this.loggingErrors = JDBCUtils.safeGetBoolean(dbResult, "is_logging_errors");
+        this.loggingErrors = !getDataSource().isServerVersionAtLeast(9, 4)
+                && JDBCUtils.safeGetBoolean(dbResult, "is_logging_errors");
         this.command = JDBCUtils.safeGetString(dbResult, "command");
         if (rejectlimittype != null && rejectlimittype.length() > 0) {
             this.rejectLimitType = RejectLimitType.valueOf(rejectlimittype);

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
@@ -160,6 +160,14 @@ public class GreenplumExternalTableTest {
         Assert.assertTrue(table.isLoggingErrors());
     }
 
+    @Test
+    public void onCreation_setsDefaultLoggingErrorsToFalse_ifGreenplumServerVersionIs6andAbove() throws SQLException {
+        // Greenplum 6 runs on Postgre 9.4.x
+        Mockito.when(mockDataSource.isServerVersionAtLeast(9,4)).thenReturn(true);
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        Assert.assertFalse(table.isLoggingErrors());
+        Mockito.verify(mockResults, Mockito.times(0)).getBoolean("is_logging_errors");
+    }
 
     @Test
     public void generateDDL_whenTableHasASingleColumn_returnsDDLStringForASingleColumn()


### PR DESCRIPTION
- Upcoming GPDB 6 does not support error logging tables and so reading
from `pg_exttable.fmterrtbl` is no longer applicable in that version
- Retaining GPDB 5 functionality as is.