### PR TITLE
GP: Add 'EXECUTE ON' clause to Function declaration generation

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/plugin.xml
@@ -78,5 +78,7 @@
         <manager class="org.jkiss.dbeaver.ext.greenplum.edit.GreenplumExternalTableManager"
                  containerType="org.jkiss.dbeaver.ext.greenplum.model.GreenplumSchema"
                  objectType="org.jkiss.dbeaver.ext.greenplum.model.GreenplumExternalTable"/>
+        <manager class="org.jkiss.dbeaver.ext.greenplum.edit.GreenplumFunctionManager"
+                 objectType="org.jkiss.dbeaver.ext.greenplum.model.GreenplumFunction"/>
     </extension>
 </plugin>

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/edit/GreenplumFunctionManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/edit/GreenplumFunctionManager.java
@@ -1,0 +1,34 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2019 Serge Rider (serge@jkiss.org)
+ * Copyright (C) 2019 Dmitriy Dubson (ddubson@pivotal.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.greenplum.edit;
+
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.ext.greenplum.model.GreenplumSchema;
+import org.jkiss.dbeaver.ext.postgresql.edit.PostgreProcedureManager;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedure;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.model.impl.DBSObjectCache;
+
+public class GreenplumFunctionManager extends PostgreProcedureManager {
+    @Nullable
+    @Override
+    public DBSObjectCache<PostgreSchema, PostgreProcedure> getObjectsCache(PostgreProcedure object)
+    {
+        return ((GreenplumSchema) object.getContainer()).getGreenplumFunctionsCache();
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumFunction.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumFunction.java
@@ -1,0 +1,79 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2019 Serge Rider (serge@jkiss.org)
+ * Copyright (C) 2019 Dmitriy Dubson (ddubson@pivotal.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.greenplum.model;
+
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreLanguage;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedure;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.utils.CommonUtils;
+
+import java.sql.ResultSet;
+
+public class GreenplumFunction extends PostgreProcedure {
+    private FunctionExecLocation executionLocation;
+
+    public GreenplumFunction(PostgreSchema schema) {
+        super(schema);
+        this.executionLocation = getDataSource().isServerVersionAtLeast(9,4) ? FunctionExecLocation.a : null;
+    }
+
+    public GreenplumFunction(DBRProgressMonitor monitor, PostgreSchema schema, ResultSet dbResult) {
+        super(monitor, schema, dbResult);
+        this.executionLocation = readExecutionLocationIfSupported(dbResult);
+    }
+
+    public FunctionExecLocation getExecutionLocation() {
+        return executionLocation;
+    }
+
+    @Override
+    protected String generateFunctionDeclaration(PostgreLanguage language, String returnTypeName, String functionBody) {
+        String functionDeclaration = super.generateFunctionDeclaration(language, returnTypeName, functionBody);
+
+        if(this.executionLocation != null) {
+            StringBuilder def = new StringBuilder(functionDeclaration);
+            return def.append("EXECUTE ON ").append(this.executionLocation.getValue()).toString();
+        }
+
+        return functionDeclaration;
+    }
+
+    private FunctionExecLocation readExecutionLocationIfSupported(ResultSet dbResult) {
+        return getDataSource().isServerVersionAtLeast(9, 4) ?
+                CommonUtils.valueOf(FunctionExecLocation.class, JDBCUtils.safeGetString(dbResult, "proexeclocation"))
+                : null;
+    }
+
+    public enum FunctionExecLocation {
+        a("ANY"),
+        m("MASTER"),
+        s("ALL SEGMENTS");
+
+        private String execLocation;
+
+        FunctionExecLocation(String execLocationString) {
+            this.execLocation = execLocationString;
+        }
+
+        public String getValue() {
+            return execLocation;
+        }
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumFunctionTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumFunctionTest.java
@@ -1,0 +1,164 @@
+package org.jkiss.dbeaver.ext.greenplum.model;
+
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.postgresql.model.*;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCExecutionContext;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.sql.SQLException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GreenplumFunctionTest {
+    @Mock
+    PostgreSchema mockSchema;
+
+    @Mock
+    PostgreDatabase mockDatabase;
+
+    @Mock
+    JDBCResultSet mockResults;
+
+    @Mock
+    JDBCExecutionContext mockContext;
+
+    @Mock
+    PostgreDataSource mockDataSource;
+
+    @Mock
+    DBRProgressMonitor mockMonitor;
+
+    @Mock
+    PostgreSchema.TableCache mockTableCache;
+
+    @Mock
+    PostgreSchema.ConstraintCache mockConstraintCache;
+
+    private GreenplumTable table;
+
+    private final String exampleDatabaseName = "sampleDatabase";
+    private final String exampleSchemaName = "sampleSchema";
+    private final String exampleTableName = "sampleTable";
+    private PostgreLanguage postgreLanguage;
+
+    @Before
+    public void setUp() throws Exception {
+        Mockito.when(mockSchema.getDatabase()).thenReturn(mockDatabase);
+        Mockito.when(mockSchema.getDataSource()).thenReturn(mockDataSource);
+        Mockito.when(mockSchema.getName()).thenReturn(exampleSchemaName);
+        Mockito.when(mockSchema.getTableCache()).thenReturn(mockTableCache);
+        Mockito.when(mockSchema.getConstraintCache()).thenReturn(mockConstraintCache);
+
+        Mockito.when(mockDataSource.getSQLDialect()).thenReturn(new PostgreDialect());
+        Mockito.when(mockDataSource.isServerVersionAtLeast(Mockito.anyInt(), Mockito.anyInt())).thenReturn(false);
+        Mockito.when(mockDataSource.getDefaultInstance()).thenReturn(mockDatabase);
+
+        Mockito.when(mockDatabase.getName()).thenReturn(exampleDatabaseName);
+        Mockito.when(mockDatabase.getDefaultContext(true)).thenReturn(mockContext);
+
+        Mockito.when(mockResults.getString("proname")).thenReturn("sampleFunction");
+        postgreLanguage = new PostgreLanguage(mockDatabase, mockResults);
+    }
+
+    @Test
+    public void onCreationWithDbResult_whenGreenplumVersionIsSixAndAbove_thenExecutionLocationIsLoaded()
+            throws SQLException {
+        Mockito.when(mockResults.getString("proexeclocation")).thenReturn("a");
+
+        withGreenplumVersion6AndAbove(() -> {
+            GreenplumFunction function = new GreenplumFunction(mockMonitor, mockSchema, mockResults);
+            Assert.assertEquals(GreenplumFunction.FunctionExecLocation.a, function.getExecutionLocation());
+        });
+    }
+
+    @Test
+    public void onCreationWithDbResult_whenGreenplumVersionIsBelowSix_thenExecutionLocationIsNull()
+            throws SQLException {
+        withGreenplumVersionLessThan6(() -> {
+            GreenplumFunction function = new GreenplumFunction(mockMonitor, mockSchema, mockResults);
+            Assert.assertNull(function.getExecutionLocation());
+        });
+
+        Mockito.verify(mockResults, Mockito.times(0)).getString("proexeclocation");
+    }
+
+    @Test
+    public void onCreation_whenGreenplumVersionIsSixAndAbove_thenExecutionLocationDefaultsToANY() {
+        withGreenplumVersion6AndAbove(() -> {
+            GreenplumFunction function = new GreenplumFunction(mockSchema);
+            Assert.assertEquals(GreenplumFunction.FunctionExecLocation.a, function.getExecutionLocation());
+        });
+    }
+
+    @Test
+    public void onCreation_whenGreenplumVersionIsBelowSix_thenExecutionLocationIsNotSet() {
+        withGreenplumVersionLessThan6(() -> {
+            GreenplumFunction function = new GreenplumFunction(mockSchema);
+            Assert.assertNull(function.getExecutionLocation());
+        });
+    }
+
+    @Test
+    public void generateFunctionDeclaration_whenExecLocationIsNotSupported_thenShouldNotRetainAnyTypeOfExecutionLocationInDeclaration()
+            throws SQLException, DBException {
+        withGreenplumVersionLessThan6(() -> {
+            GreenplumFunction function = new GreenplumFunction(mockMonitor, mockSchema, mockResults);
+            Assert.assertFalse(function.generateFunctionDeclaration(postgreLanguage, "someName", "funcBody")
+                    .contains("EXECUTE ON"));
+        });
+    }
+
+    @Test
+    public void generateFunctionDeclaration_whenExecLocationIsSupportedAndSetToANY_thenShouldIncludeExecLocationClauseInDeclaration()
+            throws SQLException, DBException {
+        assertExecuteOnClauseExists("a", "EXECUTE ON ANY");
+    }
+
+    @Test
+    public void generateFunctionDeclaration_whenExecLocationIsSupportedAndSetToALL_thenShouldIncludeExecLocationClauseInDeclaration()
+            throws SQLException, DBException {
+        assertExecuteOnClauseExists("s", "EXECUTE ON ALL SEGMENTS");
+    }
+
+    @Test
+    public void generateFunctionDeclaration_whenExecLocationIsSupportedAndSetToMASTER_thenShouldIncludeExecLocationClauseInDeclaration()
+            throws SQLException, DBException {
+        assertExecuteOnClauseExists("m", "EXECUTE ON MASTER");
+    }
+
+    private void assertExecuteOnClauseExists(String executionLocationCode, String expectedClause) throws SQLException {
+        Mockito.when(mockResults.getString("proexeclocation")).thenReturn(executionLocationCode);
+        withGreenplumVersion6AndAbove(() -> {
+            GreenplumFunction function = new GreenplumFunction(mockMonitor, mockSchema, mockResults);
+            Assert.assertTrue(function.generateFunctionDeclaration(postgreLanguage, "someName", "funcBody")
+                    .endsWith(expectedClause));
+        });
+    }
+
+    private void withGreenplumVersion6AndAbove(Runnable testCase) {
+        setGreenplumToVersion6();
+        testCase.run();
+    }
+
+    private void withGreenplumVersionLessThan6(Runnable testCase) {
+        setGreenplumToVersionLessThan6();
+        testCase.run();
+    }
+
+    private void setGreenplumToVersionLessThan6() {
+        // Greenplum 6 runs on Postgre 9.4.x
+        Mockito.when(mockDataSource.isServerVersionAtLeast(9, 4)).thenReturn(false);
+    }
+
+    private void setGreenplumToVersion6() {
+        // Greenplum 6 runs on Postgre 9.4.x
+        Mockito.when(mockDataSource.isServerVersionAtLeast(9, 4)).thenReturn(true);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreProcedureManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreProcedureManager.java
@@ -54,7 +54,7 @@ public class PostgreProcedureManager extends SQLObjectEditor<PostgreProcedure, P
     @Override
     public DBSObjectCache<PostgreSchema, PostgreProcedure> getObjectsCache(PostgreProcedure object)
     {
-        return object.getContainer().proceduresCache;
+        return object.getContainer().getProceduresCache();
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
@@ -652,7 +652,7 @@ public class PostgreDatabase extends JDBCRemoteInstance<PostgreDataSource>
         throws DBException {
         final PostgreSchema schema = getSchema(monitor, schemaId);
         if (schema != null) {
-            return PostgreUtils.getObjectById(monitor, schema.proceduresCache, schema, procId);
+            return PostgreUtils.getObjectById(monitor, schema.getProceduresCache(), schema, procId);
         }
         return null;
     }
@@ -660,7 +660,7 @@ public class PostgreDatabase extends JDBCRemoteInstance<PostgreDataSource>
     public PostgreProcedure getProcedure(DBRProgressMonitor monitor, long procId)
         throws DBException {
         for (final PostgreSchema schema : getSchemas(monitor)) {
-            PostgreProcedure procedure = PostgreUtils.getObjectById(monitor, schema.proceduresCache, schema, procId);
+            PostgreProcedure procedure = PostgreUtils.getObjectById(monitor, schema.getProceduresCache(), schema, procId);
             if (procedure != null) {
                 return procedure;
             }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreProcedure.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreProcedure.java
@@ -378,13 +378,13 @@ public class PostgreProcedure extends AbstractProcedure<PostgreDataSource, Postg
             }
             PostgreDataType returnType = getReturnType();
             String returnTypeName = returnType == null ? null : returnType.getFullTypeName();
-            procDDL = omitHeader ? procSrc : generateFunctionDeclaration(monitor, getLanguage(monitor), returnTypeName, procSrc);
+            procDDL = omitHeader ? procSrc : generateFunctionDeclaration(getLanguage(monitor), returnTypeName, procSrc);
         } else {
             if (body == null) {
                 if (!isPersisted()) {
                     PostgreDataType returnType = getReturnType();
                     String returnTypeName = returnType == null ? null : returnType.getFullTypeName();
-                    body = generateFunctionDeclaration(monitor, getLanguage(monitor), returnTypeName, "\n\t-- Enter function body here\n");
+                    body = generateFunctionDeclaration(getLanguage(monitor), returnTypeName, "\n\t-- Enter function body here\n");
                 } else if (oid == 0 || isAggregate) {
                     // No OID so let's use old (bad) way
                     body = this.procSrc;
@@ -421,7 +421,7 @@ public class PostgreProcedure extends AbstractProcedure<PostgreDataSource, Postg
         return procDDL;
     }
 
-    private String generateFunctionDeclaration(DBRProgressMonitor monitor, PostgreLanguage language, String returnTypeName, String functionBody) throws DBException {
+    protected String generateFunctionDeclaration(PostgreLanguage language, String returnTypeName, String functionBody) {
         String lineSeparator = GeneralUtils.getDefaultLineSeparator();
 
         StringBuilder decl = new StringBuilder();
@@ -642,7 +642,7 @@ public class PostgreProcedure extends AbstractProcedure<PostgreDataSource, Postg
 
     @Override
     public DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException {
-        return getContainer().proceduresCache.refreshObject(monitor, getContainer(), this);
+        return getContainer().getProceduresCache().refreshObject(monitor, getContainer(), this);
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
@@ -73,7 +73,7 @@ public class PostgreSchema implements DBSSchema, DBPNamedObject2, DBPSaveableObj
     public final AggregateCache aggregateCache = new AggregateCache();
     public final TableCache tableCache = new TableCache();
     public final ConstraintCache constraintCache = new ConstraintCache();
-    public final ProceduresCache proceduresCache = new ProceduresCache();
+    private final ProceduresCache proceduresCache = new ProceduresCache();
     public final IndexCache indexCache = new IndexCache();
     public final PostgreDataTypeCache dataTypeCache = new PostgreDataTypeCache();
 
@@ -223,6 +223,10 @@ public class PostgreSchema implements DBSSchema, DBPNamedObject2, DBPSaveableObj
 
     public ConstraintCache getConstraintCache() {
         return this.constraintCache;
+    }
+
+    public ProceduresCache getProceduresCache() {
+        return this.proceduresCache;
     }
 
     @Association
@@ -796,9 +800,9 @@ public class PostgreSchema implements DBSSchema, DBPNamedObject2, DBPSaveableObj
     /**
      * Procedures cache implementation
      */
-    static class ProceduresCache extends JDBCObjectLookupCache<PostgreSchema, PostgreProcedure> {
+    public static class ProceduresCache extends JDBCObjectLookupCache<PostgreSchema, PostgreProcedure> {
 
-        ProceduresCache() {
+        public ProceduresCache() {
             super();
         }
 


### PR DESCRIPTION
- GPDB 6 has a concept of execution locations of functions, which can be
`MASTER`, `ALL SEGMENTS`, and `ANY`.
- GPDB 5 and below do not support this feature.