### PR TITLE
GP: Add 'ALTER EXTERNAL TABLE' fix to external table ddl generation

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTable.java
@@ -25,6 +25,8 @@ import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTable;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableColumn;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableRegular;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.meta.IPropertyValueListProvider;
 import org.jkiss.dbeaver.model.meta.IPropertyValueTransformer;
@@ -263,6 +265,13 @@ public class GreenplumExternalTable extends PostgreTable {
         }
 
         return ddlBuilder.toString();
+    }
+
+    @Override
+    public String generateChangeOwnerQuery(String owner) {
+        assert CommonUtils.isNotEmpty(owner);
+
+        return "ALTER EXTERNAL TABLE " + DBUtils.getObjectFullName(this, DBPEvaluationContext.DDL) + " OWNER TO " + owner;
     }
 
     private List<PostgreTableColumn> filterOutNonMetadataColumns(DBRProgressMonitor monitor) throws DBException {

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/tests/org/jkiss/dbeaver/ext/greenplum/model/GreenplumExternalTableTest.java
@@ -1,10 +1,7 @@
 package org.jkiss.dbeaver.ext.greenplum.model;
 
 import org.jkiss.dbeaver.DBException;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableColumn;
+import org.jkiss.dbeaver.ext.postgresql.model.*;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.junit.Assert;
@@ -59,6 +56,7 @@ public class GreenplumExternalTableTest {
         Mockito.when(mockDatabase.getName()).thenReturn(exampleDatabaseName);
         Mockito.when(mockSchema.getName()).thenReturn(exampleSchemaName);
         Mockito.when(mockSchema.getTableCache()).thenReturn(mockTableCache);
+        Mockito.when(mockDataSource.getSQLDialect()).thenReturn(new PostgreDialect());
         Mockito.when(mockDataSource.isServerVersionAtLeast(Matchers.anyInt(), Matchers.anyInt())).thenReturn(false);
 
         Mockito.when(mockResults.getString("relname")).thenReturn(exampleTableName);
@@ -594,6 +592,13 @@ public class GreenplumExternalTableTest {
         GreenplumExternalTable table = new GreenplumExternalTable(mockSchema);
         table.setFormatType("CUSTOM");
         Assert.assertEquals("CUSTOM", table.getFormatType());
+    }
+
+    @Test
+    public void generateChangeOwnerQuery_whenProvidedAValidOwner_thenShouldGenerateQuerySuccessfully() {
+        GreenplumExternalTable table = new GreenplumExternalTable(mockSchema, mockResults);
+        Assert.assertEquals("ALTER EXTERNAL TABLE sampleSchema.sampleTable OWNER TO someOwner",
+                table.generateChangeOwnerQuery("someOwner"));
     }
 
     private PostgreTableColumn mockDbColumn(String columnName, String columnType, int ordinalPosition) {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreUtils.java
@@ -620,7 +620,7 @@ public class PostgreUtils {
             if (owner != null) {
                 actions.add(new SQLDatabasePersistAction(
                     "Owner change",
-                    "ALTER " + getObjectTypeName(object) + " " + getObjectUniqueName(object) + " OWNER TO " + DBUtils.getQuotedIdentifier(owner)
+                    object.generateChangeOwnerQuery(DBUtils.getQuotedIdentifier(owner))
                 ));
             }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgrePermissionsOwner.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgrePermissionsOwner.java
@@ -18,6 +18,8 @@
 package org.jkiss.dbeaver.ext.postgresql.model;
 
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 
 import java.util.Collection;
@@ -37,4 +39,5 @@ public interface PostgrePermissionsOwner extends PostgreObject {
      */
     Collection<PostgrePermission> getPermissions(DBRProgressMonitor monitor, boolean includeNestedObjects) throws DBException;
 
+    String generateChangeOwnerQuery(String owner);
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreProcedure.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreProcedure.java
@@ -646,8 +646,12 @@ public class PostgreProcedure extends AbstractProcedure<PostgreDataSource, Postg
     }
 
     @Override
+    public String generateChangeOwnerQuery(String owner) {
+        return "ALTER " + this.getProcedureTypeName() + " " + this.getFullQualifiedSignature() + " OWNER TO " + owner;
+    }
+
+    @Override
     public String toString() {
         return overloadedName == null ? name : overloadedName;
     }
-
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreRole.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreRole.java
@@ -313,6 +313,11 @@ public class PostgreRole implements PostgreObject, PostgrePermissionsOwner, DBPP
         }
     }
 
+    @Override
+    public String generateChangeOwnerQuery(String owner) {
+        return null;
+    }
+
     private static Collection<PostgrePermission> getRolePermissions(PostgreRole role, PostgrePrivilege.Kind kind, JDBCPreparedStatement dbStat) throws SQLException {
         try (JDBCResultSet dbResult = dbStat.executeQuery()) {
             Map<String, List<PostgrePrivilege>> privs = new LinkedHashMap<>();

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSequence.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSequence.java
@@ -240,4 +240,7 @@ public class PostgreSequence extends PostgreTableBase implements DBSSequence, DB
         return sql.toString();
     }
 
+    public String generateChangeOwnerQuery(String owner) {
+        return "ALTER SEQUENCE " + DBUtils.getObjectFullName(this, DBPEvaluationContext.DDL) + " OWNER TO " + owner;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -325,5 +325,4 @@ public abstract class PostgreTable extends PostgreTableReal implements DBDPseudo
         }
         return result;
     }
-
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableBase.java
@@ -246,6 +246,10 @@ public abstract class PostgreTableBase extends JDBCTable<PostgreDataSource, Post
         // Nothing
     }
 
+    @Override
+    public String generateChangeOwnerQuery(String owner) {
+        return "ALTER TABLE " + DBUtils.getObjectFullName(this, DBPEvaluationContext.DDL) + " OWNER TO " + owner;
+    }
 
     public static class TablespaceListProvider implements IPropertyValueListProvider<PostgreTableBase> {
         @Override

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableColumn.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableColumn.java
@@ -62,6 +62,11 @@ public class PostgreTableColumn extends PostgreAttribute<PostgreTableBase> imple
     }
 
     @Override
+    public String generateChangeOwnerQuery(String owner) {
+        return null;
+    }
+
+    @Override
     public int getAttributeSRID(DBRProgressMonitor monitor) {
         if (srid == -1) {
             try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Load table inheritance info")) {


### PR DESCRIPTION
- `ALTER TABLE` is not applicable to external tables for changing owner
of a table.
- This commit transforms `ALTER TABLE` to `ALTER EXTERNAL TABLE` in DDL
view for external tables.