### PR TITLE
Hide SSH banner in JSCH implementation.

### DIFF
--- a/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationJsch.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationJsch.java
@@ -233,6 +233,11 @@ public class SSHImplementationJsch extends SSHImplementationAbstract {
             }
             return super.promptPassphrase(message);
         }
+
+        @Override
+        public void showMessage(String message) {
+            // do not show ssh banner
+        }
     }
 
 }


### PR DESCRIPTION
Currently, the SSH tunnel JSCH implementation displays the SSH banner in a separate popup window when connecting.
This change will suppress showing that SSH banner.

This is similar to the default behaviour in MySQL Workbench and other tools.