### PR TITLE
Update Elasticsearch 6.6 JDBC driver class name

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.es.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.es.ui/plugin.xml
@@ -19,7 +19,7 @@
                 <driver
                         id="elastic_search_jdbc"
                         label="Elasticsearch"
-                        class="org.elasticsearch.xpack.sql.jdbc.jdbc.JdbcDriver"
+                        class="org.elasticsearch.xpack.sql.jdbc.EsDriver"
                         icon="icons/elasticsearch_icon.png"
                         iconBig="icons/elasticsearch_icon_big.png"
                         sampleURL="jdbc:es://{host}:{port}/"
@@ -28,7 +28,7 @@
                         webURL="https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-jdbc.html"
                         categories="fulltext">
                     <replace provider="generic" driver="es_generic"/>
-                    <file type="jar" path="maven:/org.elasticsearch.plugin:x-pack-sql-jdbc:6.4.0"/>
+                    <file type="jar" path="maven:/org.elasticsearch.plugin:x-pack-sql-jdbc:6.6.0"/>
                     <parameter name="supports-references" value="false"/>
                     <parameter name="supports-indexes" value="false"/>
                     <parameter name="omit-catalog" value="true"/>


### PR DESCRIPTION
Elasticsearch 6.6 changed the JDBC driver class name. This PR fixes that and bumps the version number as well.
Thank you.