### PR TITLE
#5419 FIX of regnamespace error

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataType.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataType.java
@@ -62,6 +62,7 @@ public class PostgreDataType extends JDBCDataType<PostgreSchema> implements Post
         "regprocedure",
         "regoper",
         "regoperator",
+        "regnamespace",
         "regclass",
         "regtype",
         "regconfig",

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreGenericTypeCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreGenericTypeCache.java
@@ -47,6 +47,7 @@ public class PostgreGenericTypeCache extends JDBCBasicDataTypeCache<GenericStruc
         "regprocedure",
         "regoper",
         "regoperator",
+        "regnamespace",
         "regclass",
         "regtype",
         "regconfig",


### PR DESCRIPTION
Regnamespace is OID type => now the regnamespace is shown as string correctly.