### PR TITLE
Update plugin.xml to download latest version of Athena JDBC driver to support change workgroup

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.athena/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.athena/plugin.xml
@@ -28,10 +28,10 @@
                         description="%driver.athena.description"
                         category="AWS"
                         webURL="https://docs.aws.amazon.com/athena/latest/ug/connect-with-jdbc.html"
-                        propertiesURL="https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.5/docs/Simba+Athena+JDBC+Driver+Install+and+Configuration+Guide.pdf"
+                        propertiesURL="https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.7/docs/Simba+Athena+JDBC+Driver+Install+and+Configuration+Guide.pdf"
                         categories="bigdata">
                     <replace provider="generic" driver="aws_athena_42"/>
-                    <file type="jar" path="https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.5/AthenaJDBC42_2.0.5.jar"/>
+                    <file type="jar" path="https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.7/AthenaJDBC42_2.0.7.jar"/>
 
                     <parameter name="supports-references" value="false"/>
                     <parameter name="supports-indexes" value="false"/>


### PR DESCRIPTION
I've update `plugins/org.jkiss.dbeaver.ext.athena/plugin.xml` to link the latest version of Athena JDBC driver (`2.0.7`), which supports workgroup feature.

Current version of DBeaver does not support change workgroup because it just used the old one (`2.0.5`).

Since it just a simple change so I think it'll be fine to merge without test suite.

This PR also will resolve #5491 and resolve #5820.