### PR TITLE
Implementation of #6363 - add StringBuilder option to Copy as Source panel for Java

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
@@ -29,6 +29,8 @@ sql.convert.label.keep.formatting.discription = Keeps original formatting (white
 sql.convert.label.line.delimiter.name = Line delimiter
 sql.convert.label.line.delimiter.discription = Delimiter for source code lines. Usually \\n or space
 sql.convert.label.line.delimiter.delphi.discription = Delimiter for source code lines. Usually #13#10 or space
+sql.convert.label.use.string.builder.name = Use StringBuilder
+sql.convert.label.use.string.builder.description = Uses StringBuilder instead of String concatenation
 
 sql.plan.view.simple.name=Simple
 sql.plan.view.simple.tip=Simple execution plan presentation

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
@@ -56,6 +56,7 @@
         <target id="java" label="Java" description="%sql.convert.java.description" class="org.jkiss.dbeaver.ui.editors.sql.convert.impl.JavaSQLConverter">
             <property id="keep-formatting" label="%sql.convert.label.keep.formatting.name" type="boolean" description="%sql.convert.label.keep.formatting.discription" required="false" defaultValue="false"/>
             <property id="line-delimiter" label="%sql.convert.label.line.delimiter.name" type="string" description="%sql.convert.label.line.delimiter.discription" required="false" defaultValue=" "/>
+            <property id="use-string-builder" label="%sql.convert.label.use.string.builder.name" type="boolean" description="%sql.convert.label.use.string.builder.description" required="false" defaultValue="false"/>
         </target>
         <target id="cpp" label="C/C++" description="%sql.convert.c.description" class="org.jkiss.dbeaver.ui.editors.sql.convert.impl.CPPSQLConverter">
             <property id="keep-formatting" label="%sql.convert.label.keep.formatting.name" type="boolean" description="%sql.convert.label.keep.formatting.discription" required="false" defaultValue="false"/>

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/CPPSQLConverter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/CPPSQLConverter.java
@@ -19,13 +19,15 @@ package org.jkiss.dbeaver.ui.editors.sql.convert.impl;
 
 import org.jkiss.utils.CommonUtils;
 
+import java.util.Map;
+
 /**
  * CPPSQLConverter
  */
 public class CPPSQLConverter extends SourceCodeSQLConverter {
 
     @Override
-    protected void convertSourceLines(StringBuilder result, String[] sourceLines, String lineDelimiter) {
+    protected void convertSourceLines(StringBuilder result, String[] sourceLines, String lineDelimiter, Map<String, Object> options) {
         for (int i = 0; i < sourceLines.length; i++) {
             String line = sourceLines[i];
             result.append('"').append(CommonUtils.escapeJavaString(line)).append(lineDelimiter).append('"');

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/DelphiSQLConverter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/DelphiSQLConverter.java
@@ -19,13 +19,15 @@ package org.jkiss.dbeaver.ui.editors.sql.convert.impl;
 
 import org.jkiss.utils.CommonUtils;
 
+import java.util.Map;
+
 /**
  * DelphiSQLConverter
  */
 public class DelphiSQLConverter extends SourceCodeSQLConverter {
 
     @Override
-    protected void convertSourceLines(StringBuilder result, String[] sourceLines, String lineDelimiter) {
+    protected void convertSourceLines(StringBuilder result, String[] sourceLines, String lineDelimiter, Map<String, Object> options) {
         boolean trailingLineFeed = lineDelimiter.startsWith("#");
         for (int i = 0; i < sourceLines.length; i++) {
             String line = sourceLines[i];

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/JavaSQLConverter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/JavaSQLConverter.java
@@ -19,20 +19,32 @@ package org.jkiss.dbeaver.ui.editors.sql.convert.impl;
 
 import org.jkiss.utils.CommonUtils;
 
+import java.util.Map;
+
 /**
  * JavaSQLConverter
  */
 public class JavaSQLConverter extends SourceCodeSQLConverter {
 
+    public static final String OPTION_USE_STRING_BUILDER = "use-string-builder";
+
     @Override
-    protected void convertSourceLines(StringBuilder result, String[] sourceLines, String lineDelimiter) {
+    protected void convertSourceLines(StringBuilder result, String[] sourceLines, String lineDelimiter, Map<String, Object> options) {
+        boolean useStringBuilder = CommonUtils.toBoolean(options.get(OPTION_USE_STRING_BUILDER));
+        if (useStringBuilder)
+            result.append("StringBuilder query = new StringBuilder();\n");
         for (int i = 0; i < sourceLines.length; i++) {
-            String line = sourceLines[i];
-            result.append('"').append(CommonUtils.escapeJavaString(line)).append(lineDelimiter).append('"');
-            if (i < sourceLines.length - 1) {
-                result.append(" + \n");
-            } else {
-                result.append(";");
+            String escapedLine = CommonUtils.escapeJavaString(sourceLines[i]);
+            if (useStringBuilder) {
+              result.append("query.append(\"").append(escapedLine).append(lineDelimiter).append("\");\n");
+            }
+            else {
+                result.append('"').append(escapedLine).append(lineDelimiter).append('"');
+                if (i < sourceLines.length - 1) {
+                    result.append(" + \n");
+                } else {
+                    result.append(";");
+                }
             }
         }
     }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/SourceCodeSQLConverter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/SourceCodeSQLConverter.java
@@ -70,7 +70,7 @@ public abstract class SourceCodeSQLConverter implements ISQLTextConverter {
                 lineDelimiter = " "; // Space
             }
             StringBuilder result = new StringBuilder();
-            convertSourceLines(result, sourceLines, lineDelimiter);
+            convertSourceLines(result, sourceLines, lineDelimiter, options);
             return result.toString();
         } catch (BadLocationException e) {
             log.error(e);
@@ -78,6 +78,6 @@ public abstract class SourceCodeSQLConverter implements ISQLTextConverter {
         }
     }
 
-    protected abstract void convertSourceLines(StringBuilder result, String[] sourceLines, String lineDelimiter);
+    protected abstract void convertSourceLines(StringBuilder result, String[] sourceLines, String lineDelimiter, Map<String, Object> options);
 
 }


### PR DESCRIPTION
Implementation of #6363 

Quite straightforward implementation. I decided to change the method signature of convertSourceLines() in SourceCodeSqlConverter.java - this way makes the Copy as Source panel easily extensible with language-specific options.