### PR TITLE
Fbplanparser

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/plan/FireBirdPlanParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/plan/FireBirdPlanParser.java
@@ -183,7 +183,7 @@ class FireBirdPlanParser {
 					tokenMatch.checkToken(FireBirdPlanToken.IDENTIFICATOR);
 					String orderIndex = tokenMatch.getValue();
 					tokenMatch.jump();
-					String text = aliases + " ORDER " + orderIndex;
+					String text = aliases + " ORDER " + orderIndex + indexInfo(orderIndex);
 					if (tokenMatch.getToken() == FireBirdPlanToken.INDEX) {
 						String orderIndexes = collectIndexes();
 						text = text + " INDEX(" + orderIndexes + ")";

--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/plan/FireBirdPlanParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/plan/FireBirdPlanParser.java
@@ -76,7 +76,6 @@ class FireBirdPlanParser {
 						tokenMatch.jump();
 						planItem(parent);
 					} while (tokenMatch.token == FireBirdPlanToken.COMMA);
-					tokenMatch.jump();
 					tokenMatch.checkToken(FireBirdPlanToken.RIGHTPARENTHESE);
 					break;
 				case SORT:
@@ -115,7 +114,6 @@ class FireBirdPlanParser {
 			do {
 				tokenMatch.jump();
 				planItem(node);
-				tokenMatch.jump();
 			} while (tokenMatch.getToken() == FireBirdPlanToken.COMMA);
 			tokenMatch.checkToken(FireBirdPlanToken.RIGHTPARENTHESE);
 		}
@@ -159,6 +157,7 @@ class FireBirdPlanParser {
 			switch (tokenMatch.token) {
 				case NATURAL:
 					addPlanNode(parent, aliases + " NATURAL");
+					tokenMatch.jump();
 					break;
 				case INDEX:
 					String indexes = collectIndexes();

--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/plan/FireBirdPlanParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/plan/FireBirdPlanParser.java
@@ -84,6 +84,9 @@ class FireBirdPlanParser {
 				case JOIN:
 					joinedItem(parent);
 					break;
+				case HASH:
+					hashedItem(parent);
+					break;
 				case SORT_MERGE:
 					mergedItem(parent, true);
 					break;
@@ -109,6 +112,18 @@ class FireBirdPlanParser {
 		private void joinedItem(FireBirdPlanNode parent) throws FireBirdPlanException {
 			tokenMatch.checkToken(FireBirdPlanToken.JOIN);
 			FireBirdPlanNode node = addPlanNode(parent, "JOIN");
+			tokenMatch.jump();
+			tokenMatch.checkToken(FireBirdPlanToken.LEFTPARENTHESE);
+			do {
+				tokenMatch.jump();
+				planItem(node);
+			} while (tokenMatch.getToken() == FireBirdPlanToken.COMMA);
+			tokenMatch.checkToken(FireBirdPlanToken.RIGHTPARENTHESE);
+		}
+			
+		private void hashedItem(FireBirdPlanNode parent) throws FireBirdPlanException {
+			tokenMatch.checkToken(FireBirdPlanToken.HASH);
+			FireBirdPlanNode node = addPlanNode(parent, "HASH");
 			tokenMatch.jump();
 			tokenMatch.checkToken(FireBirdPlanToken.LEFTPARENTHESE);
 			do {

--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/plan/FireBirdPlanToken.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/plan/FireBirdPlanToken.java
@@ -26,6 +26,7 @@ enum FireBirdPlanToken {
 	SORT_MERGE("\\GSORT\\w+MERGE\\b"),
 	SORT("\\GSORT\\b"), 
 	MERGE("\\GMERGE\\b"), 
+	HASH("\\GHASH\\b"),
 	ORDER("\\GORDER\\b"), 
 	INDEX("\\GINDEX\\b"), 
 	LEFTPARENTHESE("\\G\\("), 


### PR DESCRIPTION
Hello,

1. I repaired error in parsing when navigation based on index in order by clause appeared in plan. 
like f.e. in the  following query:

SELECT FIRST 2 RDB$INDEX_NAME 
FROM RDB$INDEX_SEGMENTS
ORDER BY RDB$INDEX_NAME

plan is: 
PLAN(RDB$INDEX_SEGMENTS ORDER RDB$INDEX_6)

I added detailed info about index used in order by as well.


2. I added support for plan based on HASH combination of source streams.

f.e.:
SELECT F.RDB$FIELD_NAME, C.RDB$COLLATION_NAME FROM RDB$FIELDS F
JOIN RDB$COLLATIONS C ON C.RDB$COLLATION_ID+0 = F.RDB$COLLATION_ID+0

plan:
PLAN HASH(F NATURAL,C NATURAL)


regards
Tomas 



