### PR TITLE
#5453: compile Oracle package body and throw errors on save

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OraclePackage.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OraclePackage.java
@@ -157,7 +157,8 @@ public class OraclePackage extends OracleSchemaObject
     @Override
     public void refreshObjectState(@NotNull DBRProgressMonitor monitor) throws DBCException
     {
-        this.valid = OracleUtils.getObjectStatus(monitor, this, OracleObjectType.PACKAGE);
+        this.valid = OracleUtils.getObjectStatus(monitor, this, OracleObjectType.PACKAGE) &&
+        		OracleUtils.getObjectStatus(monitor, this, OracleObjectType.PACKAGE_BODY);
     }
 
     @Override
@@ -172,7 +173,7 @@ public class OraclePackage extends OracleSchemaObject
                     "ALTER PACKAGE " + getFullyQualifiedName(DBPEvaluationContext.DDL) + " COMPILE"
                 ));
         }
-        if (!CommonUtils.isEmpty(sourceDefinition)) {
+        /*if (!CommonUtils.isEmpty(sourceDefinition)) */ {
             actions.add(
                 new OracleObjectPersistAction(
                     OracleObjectType.PACKAGE_BODY,


### PR DESCRIPTION
Commenting line 175 is necessary because `sourceDefinition` is always `null` after saving a package, because after save and before compile the `refreshObject` method is called.

Alternatives to commenting line 175 are: 
- passing a `DBRProgressMonitor` object to `getCompileActions`, to allow calling `getExtendedDefinitionText`
- avoid calling `refreshObject`, or avoid setting `sourceDefinition` to null inside `refreshObject`, but this can lead to stale objects.

However, does a package without body even make sense? Stated otherwise, if you create a package without a body, and you get an error for that, you are unlikely to get angry.