### PR TITLE
SSH Auth: Add password as possible 2Factor AuthN when using Publickey AuthN

### DIFF
--- a/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationJsch.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationJsch.java
@@ -59,7 +59,7 @@ public class SSHImplementationJsch extends SSHImplementationAbstract {
             session.setConfig("StrictHostKeyChecking", "no");
             //session.setConfig("PreferredAuthentications", "password,publickey,keyboard-interactive");
             session.setConfig("PreferredAuthentications",
-                    privKeyFile != null ? "publickey,keyboard-interactive" : "password,keyboard-interactive");
+                    privKeyFile != null ? "publickey,keyboard-interactive,password" : "password,keyboard-interactive");
             session.setConfig("ConnectTimeout", String.valueOf(connectTimeout));
 
             // Use Eclipse standard prompter


### PR DESCRIPTION
Follow up of Issue #5164

Server might also ask for 'password' as second auth, not only 'keyboard-interactive'. 