### PR TITLE
Updates system table reckognition for Firebird Extension

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdMetaModel.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Locale;
 
 /**
  * FireBirdDataSource
@@ -179,8 +180,9 @@ public class FireBirdMetaModel extends GenericMetaModel
 
     @Override
     public boolean isSystemTable(GenericTableBase table) {
-        final String tableName = table.getName();
-        return tableName.contains("$");    // [JDBC: Firebird]
+        String tableName = table.getName();
+        tableName = tableName.toUpperCase(Locale.ENGLISH);
+        return tableName.startsWith("RDB$") || tableName.startsWith("MON$");    // [JDBC: Firebird]
     }
 
     @Override


### PR DESCRIPTION
Updates system table reckognition for Firebird Extension to only identify RDB$ and MON$ tables, rather than all tables with $ in the name.

MON$ tables are not described as system tables, but rather as monitoring tables. It makes sense to include them as system tables regardless.

Firebird reference manual states:

> System table identifiers all begin with the prefix RDB$

and
> [...] monitoring tables. The definitions of these tables are always present in the database, all named with the prefix MON$

Normal table names are allowed to contain $ too. Table names are restricted only by uniqueness and length:

> Name (identifier) for the table. It may consist of up to 31 characters and must be unique in the database.

The absolute best practice would be to lookup the RDB$SYSTEM_FLAG in RDB$RELATIONS for the table in question.

Links to the reference quotes:

- https://www.firebirdsql.org/file/documentation/reference_manuals/fblangref25-en/html/fblangref25-appx04-systables.html
- https://www.firebirdsql.org/file/documentation/reference_manuals/fblangref25-en/html/fblangref25-appx05-montables.html
- https://www.firebirdsql.org/file/documentation/reference_manuals/fblangref25-en/html/fblangref25-ddl-tbl.html