### PR TITLE
Changing HashSet to LinkedHashSet for deterministic iterations 

### DIFF
--- a/bundles/org.jkiss.utils/tests/org/jkiss/utils/CommonUtilsTest.java
+++ b/bundles/org.jkiss.utils/tests/org/jkiss/utils/CommonUtilsTest.java
@@ -9,6 +9,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 //@RunWith(PowerMockRunner.class)
@@ -431,7 +432,7 @@ public class CommonUtilsTest {
     collectionList.add("a");
     Assert.assertEquals("a", CommonUtils.getItem(collectionList, 0));
 
-    final HashSet<String> collectionSet = new HashSet<>();
+    final HashSet<String> collectionSet = new LinkedHashSet<>();
     collectionSet.add("a");
     collectionSet.add("b");
     Assert.assertEquals("b", CommonUtils.getItem(collectionSet, 1));


### PR DESCRIPTION
Test `org/jkiss/utils/CommonUtilsTest.java` uses a `HashSet` to test the functionalities of `CommonUtils.getItem`, which uses the iterator of the argument. Currently, the test depends on the iteration order of the `HashSet` (i.e., assuming the second object is `b`). However, `HashSet` does not guarantee any specific order of entries. Tests can fail if the iteration order changes.

This PR proposes to fix the test by changing `HashSet` to `LinkedHashSet` that make the iteration order deterministic.

