### PR TITLE
Quote identifiers in HANAMetaModel#getTableDDL

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAMetaModel.java
@@ -113,8 +113,8 @@ public class HANAMetaModel extends GenericMetaModel
             try (JDBCPreparedStatement dbStat = session.prepareCall(
                 "CALL get_object_definition(?,?)"))
             {
-                dbStat.setString(1, sourceObject.getContainer().getName());
-                dbStat.setString(2, sourceObject.getName());
+                dbStat.setString(1, DBUtils.getQuotedIdentifier(sourceObject.getContainer()));
+                dbStat.setString(2, DBUtils.getQuotedIdentifier(sourceObject));
                 try (JDBCResultSet dbResult = dbStat.executeQuery()) {
                     StringBuilder ddl = new StringBuilder();
                     while (dbResult.nextRow()) {


### PR DESCRIPTION
Identifiers must be quoted when calling get_object_definition.
Otherwise the DDL of tables with a name containing lower-case letters
(or other special characters) cannot be determined.