### PR TITLE
Fix initial datasource loading to refresh metadata folder contents

### DIFF
--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceRegistry.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceRegistry.java
@@ -78,7 +78,7 @@ public class DataSourceRegistry implements DBPDataSourceRegistry {
         this.platform = platform;
         this.project = project;
 
-        loadDataSources(false);
+        loadDataSources(true);
         DataSourceProviderRegistry.getInstance().fireRegistryChange(this, true);
 
         addDataSourceListener(modelChangeListener);


### PR DESCRIPTION
If the metadataFolder has been changed while DBeaver is closed, the changes will not be noticed without the refresh.