### PR TITLE
Format configureObject methods

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic.ui/src/org/jkiss/dbeaver/ext/generic/views/GenericTablePrimaryKeyConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic.ui/src/org/jkiss/dbeaver/ext/generic/views/GenericTablePrimaryKeyConfigurator.java
@@ -41,13 +41,16 @@ public class GenericTablePrimaryKeyConfigurator implements DBEObjectConfigurator
                 EditConstraintPage editPage = new EditConstraintPage(
                     "Create unique constraint",
                     primaryKey,
-                    new DBSEntityConstraintType[] {DBSEntityConstraintType.PRIMARY_KEY, DBSEntityConstraintType.UNIQUE_KEY} );
+                    new DBSEntityConstraintType[] {
+                            DBSEntityConstraintType.PRIMARY_KEY,
+                            DBSEntityConstraintType.UNIQUE_KEY});
                 if (!editPage.edit()) {
                     return null;
                 }
 
-                primaryKey.setConstraintType(editPage.getConstraintType());
                 primaryKey.setName(editPage.getConstraintName());
+                primaryKey.setConstraintType(editPage.getConstraintType());
+
                 int colIndex = 1;
                 for (DBSEntityAttribute tableColumn : editPage.getSelectedAttributes()) {
                     primaryKey.addColumn(
@@ -56,6 +59,7 @@ public class GenericTablePrimaryKeyConfigurator implements DBEObjectConfigurator
                             (GenericTableColumn) tableColumn,
                             colIndex++));
                 }
+
                 return primaryKey;
             }
         }.execute();

--- a/plugins/org.jkiss.dbeaver.ext.mssql.ui/src/org/jkiss/dbeaver/ext/mssql/ui/config/SQLServerUniqueKeyConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql.ui/src/org/jkiss/dbeaver/ext/mssql/ui/config/SQLServerUniqueKeyConfigurator.java
@@ -37,12 +37,16 @@ public class SQLServerUniqueKeyConfigurator implements DBEObjectConfigurator<SQL
             EditConstraintPage editPage = new EditConstraintPage(
                 "Create constraint",
                 primaryKey,
-                new DBSEntityConstraintType[] {DBSEntityConstraintType.PRIMARY_KEY, DBSEntityConstraintType.UNIQUE_KEY} );
+                new DBSEntityConstraintType[] {
+                        DBSEntityConstraintType.PRIMARY_KEY,
+                        DBSEntityConstraintType.UNIQUE_KEY});
             if (!editPage.edit()) {
                 return null;
             }
-            primaryKey.setConstraintType(editPage.getConstraintType());
+
             primaryKey.setName(editPage.getConstraintName());
+            primaryKey.setConstraintType(editPage.getConstraintType());
+
             int colIndex = 1;
             for (DBSEntityAttribute tableColumn : editPage.getSelectedAttributes()) {
                 primaryKey.addColumn(
@@ -51,6 +55,7 @@ public class SQLServerUniqueKeyConfigurator implements DBEObjectConfigurator<SQL
                         (SQLServerTableColumn) tableColumn,
                         colIndex++));
             }
+
             return primaryKey;
         });
     }

--- a/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/config/MySQLConstraintConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/config/MySQLConstraintConfigurator.java
@@ -41,14 +41,15 @@ public class MySQLConstraintConfigurator implements DBEObjectConfigurator<MySQLT
                 MySQLUIMessages.edit_constraint_manager_title,
                 constraint,
                 new DBSEntityConstraintType[] {
-                    DBSEntityConstraintType.PRIMARY_KEY,
-                    DBSEntityConstraintType.UNIQUE_KEY });
+                        DBSEntityConstraintType.PRIMARY_KEY,
+                        DBSEntityConstraintType.UNIQUE_KEY});
             if (!editPage.edit()) {
                 return null;
             }
 
             constraint.setName(editPage.getConstraintName());
             constraint.setConstraintType(editPage.getConstraintType());
+
             int colIndex = 1;
             for (DBSEntityAttribute tableColumn : editPage.getSelectedAttributes()) {
                 constraint.addColumn(
@@ -57,6 +58,7 @@ public class MySQLConstraintConfigurator implements DBEObjectConfigurator<MySQLT
                         (MySQLTableColumn) tableColumn,
                         colIndex++));
             }
+
             return constraint;
         });
     }

--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/config/OracleConstraintConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/config/OracleConstraintConfigurator.java
@@ -40,11 +40,12 @@ public class OracleConstraintConfigurator implements DBEObjectConfigurator<Oracl
                 OracleUIMessages.edit_oracle_constraint_manager_dialog_title,
                 constraint,
                 new DBSEntityConstraintType[] {
-                    DBSEntityConstraintType.PRIMARY_KEY,
-                    DBSEntityConstraintType.UNIQUE_KEY });
+                        DBSEntityConstraintType.PRIMARY_KEY,
+                        DBSEntityConstraintType.UNIQUE_KEY});
             if (!editPage.edit()) {
                 return null;
             }
+
             constraint.setName(editPage.getConstraintName());
             constraint.setConstraintType(editPage.getConstraintType());
 


### PR DESCRIPTION
A simple refactoring.
- format `configureObject()` methods.
- sort `setConstraintType()` and `setName()`.

--
Masayuki, Yoshiki, and Shinji