### PR TITLE
Fixed tablespace option selection in the PostgreSQL database creation…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/PostgreCreateDatabaseDialog.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/PostgreCreateDatabaseDialog.java
@@ -121,7 +121,7 @@ public class PostgreCreateDatabaseDialog extends BaseDialog
                     if (tablespaceCombo.getSelectionIndex() == 0) {
                         tablespace = null;
                     } else {
-                        tablespace = allTablespaces.get(tablespaceCombo.getSelectionIndex());
+                        tablespace = allTablespaces.get(tablespaceCombo.getSelectionIndex() - 1);
                     }
                 }
             });


### PR DESCRIPTION
When creating a new database, the selected table space is not used. This is due to the addition of an  default value to tablespaceCombo. ([here](https://github.com/dbeaver/dbeaver/blob/devel/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/PostgreCreateDatabaseDialog.java#L179))