### PR TITLE
Fixed closing the database selection dialog for PostgreSQL

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/dialogs/SelectDatabaseDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/dialogs/SelectDatabaseDialog.java
@@ -108,8 +108,6 @@ public class SelectDatabaseDialog extends SelectObjectDialog<DBNDatabaseNode>
                         objectList.loadData();
                     }
                 });
-
-                closeOnFocusLost(instanceCombo);
             }
         }
     }

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/dialogs/SelectObjectDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/dialogs/SelectObjectDialog.java
@@ -220,8 +220,6 @@ public class SelectObjectDialog<T extends DBPObject> extends AbstractPopupPanel 
 
         objectList.loadData();
 
-        closeOnFocusLost(objectList.getItemsViewer().getControl(), objectList.getSearchTextControl());
-
         return group;
     }
 


### PR DESCRIPTION
Hi. I think this is a dirty solution, but I don’t know Java, so I can’t offer something better.

When you try to select another base for the connection, the dialog just closes, because the main dialogue loses focus. I highlighted the problem element in red.

![dbeaver](https://user-images.githubusercontent.com/26214954/72210417-2c559380-34cc-11ea-837d-9542a220e14f.png)

This introduced by [commit](https://github.com/dbeaver/dbeaver/commit/e5a61f9c9242a14d0e762eb0b64a3e96f12793a5)
