### PR TITLE
Fix session comment string

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/SQLiteUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/SQLiteUtils.java
@@ -37,7 +37,7 @@ public class SQLiteUtils {
 
 
     public static String readMasterDefinition(DBRProgressMonitor monitor, DBSObject sourceObject, SQLiteObjectType objectType, String sourceObjectName, GenericTableBase table) {
-        try (JDBCSession session = DBUtils.openMetaSession(monitor, sourceObject, "Load PostgreSQL description")) {
+        try (JDBCSession session = DBUtils.openMetaSession(monitor, sourceObject, "Load SQLite description")) {
             try (JDBCPreparedStatement dbStat = session.prepareStatement(
                 "SELECT sql FROM sqlite_master WHERE type=? AND tbl_name=?" + (sourceObjectName != null ? " AND name=?" : "") + "\n" +
                     "UNION ALL\n" +


### PR DESCRIPTION
While looking into code how DBeaver managers to create Datetime types, I happen to see that this string is apparently a copy of the same class used by the Postgres driver.

It's trivial, I know, but thought to 'fix' it.