### PR TITLE
Fix WKB parsing issue in HANA plugin

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/data/wkb/HANAWKBParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/data/wkb/HANAWKBParser.java
@@ -172,9 +172,13 @@ public class HANAWKBParser {
         return factory.createPolygon(shell, holes);
     }
 
-    private MultiPoint parseMultiPoint() {
-        CoordinateSequence cs = readCoordinateSequence();
-        return factory.createMultiPoint(cs);
+    private MultiPoint parseMultiPoint() throws HANAWKBParserException {
+        int numPoints = data.getInt();
+        Point[] points = new Point[numPoints];
+        for (int i = 0; i < numPoints; ++i) {
+            points[i] = (Point) parseSubGeometry();
+        }
+        return factory.createMultiPoint(points);
     }
 
     private MultiLineString parseMultiLineString() throws HANAWKBParserException {

--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/data/wkb/HANAWKBWriter.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/data/wkb/HANAWKBWriter.java
@@ -108,7 +108,8 @@ public class HANAWKBWriter {
     }
 
     private static int computeMultiPointSize(MultiPoint multiPoint, XyzmMode xyzmMode) {
-        return HEADER_SIZE + COUNT_SIZE + multiPoint.getNumPoints() * xyzmMode.getCoordinatesPerPoint() * COORD_SIZE;
+        int pointSize = xyzmMode.getCoordinatesPerPoint() * COORD_SIZE;
+        return HEADER_SIZE + COUNT_SIZE + multiPoint.getNumPoints() * (HEADER_SIZE + pointSize);
     }
 
     private static int computeMultiLineStringSize(MultiLineString multiLineString, XyzmMode xyzmMode) {


### PR DESCRIPTION
MultiPoint WKBs are not parsed properly by the WKB parser in the HANA
plugin.

Instead of parsing each member of the multi-point as an independent
point, the parser interprets the following data as raw coordinates.

We had the same issue in geotools
(https://osgeo-org.atlassian.net/browse/GEOT-6509).