### PR TITLE
Fix issues with HANA geometry data transfer

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANASQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANASQLDialect.java
@@ -16,14 +16,25 @@
  */
 package org.jkiss.dbeaver.ext.hana.model;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.generic.model.GenericSQLDialect;
+import org.jkiss.dbeaver.model.DBPDataKind;
+import org.jkiss.dbeaver.model.DBPDataSource;
+import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCDatabaseMetaData;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCDataSource;
+import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
 import org.jkiss.dbeaver.model.sql.SQLConstants;
+import org.jkiss.dbeaver.model.struct.DBSTypedObject;
+import org.jkiss.utils.CommonUtils;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 public class HANASQLDialect extends GenericSQLDialect {
+
+    private static final Log log = Log.getLog(HANASQLDialect.class);
 
     public static final String[][] HANA_BEGIN_END_BLOCK = new String[][]{
         {SQLConstants.BLOCK_BEGIN, SQLConstants.BLOCK_END},
@@ -59,4 +70,22 @@ public class HANASQLDialect extends GenericSQLDialect {
     public String getDualTableName() {
         return "DUMMY";
     }
+
+    @Override
+    public String getColumnTypeModifiers(@NotNull DBPDataSource dataSource, @NotNull DBSTypedObject column,
+            @NotNull String typeName, @NotNull DBPDataKind dataKind) {
+        String ucTypeName = CommonUtils.notEmpty(typeName).toUpperCase(Locale.ENGLISH);
+        if (("ST_POINT".equals(ucTypeName) || "ST_GEOMETRY".equals(ucTypeName))
+                && (column instanceof HANATableColumn)) {
+            HANATableColumn hanaColumn = (HANATableColumn) column;
+            try {
+                int srid = hanaColumn.getAttributeGeometrySRID(new VoidProgressMonitor());
+                return "(" + Integer.toString(srid) + ")";
+            } catch (DBCException e) {
+                log.info("Could not determine SRID of column", e);
+            }
+        }
+        return super.getColumnTypeModifiers(dataSource, column, ucTypeName, dataKind);
+    }
+
 }

--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/data/HANAXyzmModeFinder.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/data/HANAXyzmModeFinder.java
@@ -78,8 +78,9 @@ public class HANAXyzmModeFinder {
             inspectPolygon((Polygon) g);
         } else if (g instanceof GeometryCollection) {
             inspectCollection((GeometryCollection) g);
+        } else {
+            throw new AssertionError("Unknown geometry type " + g.getClass());
         }
-        throw new AssertionError();
     }
 
     private void inspectPoint(Point p) {

--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/data/wkb/HANAWKBWriter.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/data/wkb/HANAWKBWriter.java
@@ -195,7 +195,7 @@ public class HANAWKBWriter {
 
         writeCoordinateSequence(shell.getCoordinateSequence(), xyzmMode, buffer);
         for (int i = 0; i < numHoles; ++i) {
-            LineString hole = polygon.getInteriorRingN(0);
+            LineString hole = polygon.getInteriorRingN(i);
             writeCoordinateSequence(hole.getCoordinateSequence(), xyzmMode, buffer);
         }
     }


### PR DESCRIPTION
There were three issues with HANA geometry data transfers:
 - Binding a geometry would always throw
 - Polygons with more than one hole would have a faulty serialization
 - The SRID would not be added to the type