### PR TITLE
FIX: Cast for PostgreSQL reg* types to avoid error of uncompatible varchar and reg* & OID types refactoring

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataType.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataType.java
@@ -270,6 +270,10 @@ public class PostgreDataType extends JDBCDataType<PostgreSchema> implements Post
         }
     }
 
+    public static String[] getOidTypes() {
+      return OID_TYPES;
+    }
+
     @Override
     @Property(viewable = true, order = 1)
     public String getName() {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDialect.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.postgresql.model;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataType;
 import org.jkiss.dbeaver.ext.postgresql.model.data.PostgreBinaryFormatter;
 import org.jkiss.dbeaver.model.data.DBDBinaryFormatter;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCDatabaseMetaData;
@@ -753,6 +754,15 @@ public class PostgreDialect extends JDBCSQLDialect {
     @Override
     public String[] getBlockHeaderStrings() {
         return new String[] { "DECLARE" };
+    }
+
+    @Override
+    public String cast(DBSAttributeBase attribute, String string) {
+        String typeName = attribute.getTypeName();
+        if (ArrayUtils.contains(PostgreDataType.getOidTypes(), typeName)) {
+            return string + "::" + typeName;
+        }
+        return string;
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreGenericTypeCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreGenericTypeCache.java
@@ -22,6 +22,7 @@ import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
 import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.PostgreUtils;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataType;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
@@ -42,17 +43,7 @@ public class PostgreGenericTypeCache extends JDBCBasicDataTypeCache<GenericStruc
 {
     private static final Log log = Log.getLog(PostgreGenericTypeCache.class);
 
-    private static String[] OID_TYPES = new String[] {
-        "regproc",
-        "regprocedure",
-        "regoper",
-        "regoperator",
-        "regnamespace",
-        "regclass",
-        "regtype",
-        "regconfig",
-        "regdictionary",
-    };
+    private static String[] OID_TYPES = PostgreDataType.getOidTypes();
 
     public PostgreGenericTypeCache(GenericStructContainer owner) {
         super(owner);

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCTable.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCTable.java
@@ -906,7 +906,7 @@ public abstract class JDBCTable<DATASOURCE extends DBPDataSource, CONTAINER exte
         if (DBUtils.isNullValue(value)) {
             query.append(" IS NULL"); //$NON-NLS-1$
         } else {
-            query.append("=?"); //$NON-NLS-1$
+            query.append(dialect.cast(attribute, "=?")); //$NON-NLS-1$
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/AbstractSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/AbstractSQLDialect.java
@@ -325,6 +325,12 @@ public abstract class AbstractSQLDialect implements SQLDialect {
 
     @NotNull
     @Override
+    public String cast(DBSAttributeBase attribute, String string) {
+        return string;
+    }
+
+    @NotNull
+    @Override
     public String escapeString(String string) {
         return string.replace("'", "''");
     }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/BasicSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/BasicSQLDialect.java
@@ -197,6 +197,12 @@ public class BasicSQLDialect extends AbstractSQLDialect implements RelationalSQL
 
     @NotNull
     @Override
+    public String cast(DBSAttributeBase attribute, String string) {
+        return string;
+    }
+
+    @NotNull
+    @Override
     public String escapeString(String string) {
         return string.replace("'", "''");
     }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
@@ -255,6 +255,15 @@ public interface SQLDialect {
     DBPIdentifierCase storesQuotedCase();
 
     /**
+     * Enables to call particular cast operator or function for special data types.
+     * @param attribute   attribute data to help decide whether cast and how to cast
+     * @param string      string representation for cast
+     * @return            casted string
+     */
+    @NotNull
+    String cast(DBSAttributeBase attribute, String string);
+
+    /**
      * Escapes string to make usable inside of SQL queries.
      * Basically it has to escape only ' character which delimits strings.
      * @param string string to escape


### PR DESCRIPTION
Fix for following bug [PostgreSQL], which occurred during saving changes in table which contains for example regclass primary key as same as for example some other regclass column, which is not primary key.

![regclass vs. varchar](https://user-images.githubusercontent.com/10884140/74769406-a2e36f00-528a-11ea-8efd-e75cfe518c1e.png)
