### PR TITLE
ERDiagram table nameLabel contrast color

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.erd/src/org/jkiss/dbeaver/ext/erd/figures/EntityFigure.java
+++ b/plugins/org.jkiss.dbeaver.ext.erd/src/org/jkiss/dbeaver/ext/erd/figures/EntityFigure.java
@@ -28,6 +28,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.ext.erd.ERDConstants;
 import org.jkiss.dbeaver.ext.erd.editor.ERDViewStyle;
 import org.jkiss.dbeaver.ext.erd.model.ERDEntity;
+import org.jkiss.dbeaver.ext.erd.model.EntityDiagram;
 import org.jkiss.dbeaver.ext.erd.part.EntityPart;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
@@ -163,7 +164,18 @@ public class EntityFigure extends Figure {
             setBackgroundColor(colorRegistry.get(ERDConstants.COLOR_ERD_ENTITY_REGULAR_BACKGROUND));
         }
         setForegroundColor(colorRegistry.get(ERDConstants.COLOR_ERD_ENTITY_NAME_FOREGROUND));
-        nameLabel.setForegroundColor(colorRegistry.get(ERDConstants.COLOR_ERD_ENTITY_NAME_FOREGROUND));
+        setNameLabelColor(colorRegistry.get(ERDConstants.COLOR_ERD_ENTITY_NAME_FOREGROUND));    
+    }
+    
+    private void setNameLabelColor(Color fallbackColor)
+    {
+        EntityDiagram diagram = part.getDiagram();        
+        EntityDiagram.NodeVisualInfo visualInfo = diagram.getVisualInfo(part.getEntity().getObject());
+        
+        if(visualInfo == null || visualInfo.bgColor == null)
+        	nameLabel.setForegroundColor(fallbackColor);
+        else
+	        nameLabel.setForegroundColor(UIUtils.getContrastColor(visualInfo.bgColor));
     }
 
     public void setSelected(boolean isSelected)

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIUtils.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIUtils.java
@@ -1969,6 +1969,22 @@ public class UIUtils {
     public static boolean isDark(RGB rgb) {
         return greyLevel(rgb) < 128;
     }
+    
+    /**
+     * Calculate the Contrast color based on Luma(brightness)
+     * https://en.wikipedia.org/wiki/Luma_(video)
+     */
+    public static Color getContrastColor(Color color)
+    {
+    	if(color == null)
+    		return new Color(null,0,0,0);
+    	
+    	double luminance = 1 - ( 0.299 * color.getRed() + 0.587 * color.getGreen() + 0.114 * color.getBlue()) / 255;
+
+        int c = (luminance > 0.5) ? 255 : 0;
+
+        return new Color(null,c,c,c);    	
+    }  
 
     public static void openWebBrowser(String url)
     {


### PR DESCRIPTION
Enhances visibility of table name.
Sets the table name label color to a contrast color based on the background color of the table.

Preview:
Label color is the same regardless of the background color:
![Digram-Before](https://user-images.githubusercontent.com/10381444/74974170-086b6300-5425-11ea-8b6b-2ba324d98110.png)
Label color is determined based on the background color:
![Digram-After](https://user-images.githubusercontent.com/10381444/74974191-10c39e00-5425-11ea-9ca7-a2a4f33d4847.png)

