### PR TITLE
Fix: generated SQL using new cast() (needed for pgsql reg* columns)

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
@@ -636,7 +636,7 @@ public final class SQLUtils {
                     strValue = sqlDialect.escapeString(strValue);
                 }
                 strValue = '\'' + strValue + '\'';
-                return sqlDialect.cast(attribute, strValue);
+                return sqlDialect.getTypeCastClause(attribute, strValue);
             default:
                 if (sqlDialect != null) {
                     return sqlDialect.escapeScriptValue(attribute, value, strValue);

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
@@ -635,7 +635,8 @@ public final class SQLUtils {
                 if (sqlDialect != null) {
                     strValue = sqlDialect.escapeString(strValue);
                 }
-                return '\'' + strValue + '\'';
+                strValue = '\'' + strValue + '\'';
+                return sqlDialect.cast(attribute, strValue);
             default:
                 if (sqlDialect != null) {
                     return sqlDialect.escapeScriptValue(attribute, value, strValue);
@@ -889,7 +890,7 @@ public final class SQLUtils {
                     String testLine = scriptLine.trim();
                     if (testLine.lastIndexOf(delimiter) != (testLine.length() - delimiter.length())) {
                         script.append(delimiter);
-                    }    
+                    }
                 } else {
                     script.append(lineSeparator);
                 }


### PR DESCRIPTION
Fix for generated queries for example for these cases:
* context menu above table -> Generate SQL -> INSERT
* context menu above row(s) -> Advanced Copy -> Copy As SQL

_[build on / using #7946]_