### PR TITLE
Enhancement for issue in Exasol plugin #8216

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/ExasolSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/ExasolSQLDialect.java
@@ -57,7 +57,7 @@ public class ExasolSQLDialect extends JDBCSQLDialect {
         	JDBCSession session = DBUtils.openMetaSession(new VoidProgressMonitor(), dataSource, "" );
         	try (JDBCStatement stmt = session.createStatement())
         	{
-        		try (JDBCResultSet dbResult = stmt.executeQuery("SELECT KEYWORD,RESERVED FROM  EXA_SQL_KEYWORDS")) 
+        		try (JDBCResultSet dbResult = stmt.executeQuery("/*snapshot execution*/ SELECT KEYWORD,RESERVED FROM  EXA_SQL_KEYWORDS")) 
         		{
         			
         			while(dbResult.next())

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolCurrentUserPrivileges.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolCurrentUserPrivileges.java
@@ -31,9 +31,9 @@ public class ExasolCurrentUserPrivileges {
 
     private static final Log LOG = Log.getLog(ExasolCurrentUserPrivileges.class);
 
-	private static final String C_QUERY_DICTIONARY = "SELECT CONNECTION_NAME FROM sys.EXA_DBA_CONNECTIONS WHERE false";
-    private static final String C_MAJOR_VERSION = "select TO_NUMBER(\"VALUE\") AS VERSION from \"$ODBCJDBC\".DB_METADATA WHERE name LIKE 'databaseMajorVersion'";
-    private static final String C_MINOR_VERSION = "select TO_NUMBER(\"VALUE\") AS VERSION from \"$ODBCJDBC\".DB_METADATA WHERE name LIKE 'databaseMinorVersion'";
+	private static final String C_QUERY_DICTIONARY = "/*snapshot execution*/ SELECT CONNECTION_NAME FROM sys.EXA_DBA_CONNECTIONS WHERE false";
+    private static final String C_MAJOR_VERSION = "/*snapshot execution*/ select TO_NUMBER(\"VALUE\") AS VERSION from \"$ODBCJDBC\".DB_METADATA WHERE name LIKE 'databaseMajorVersion'";
+    private static final String C_MINOR_VERSION = "/*snapshot execution*/ select TO_NUMBER(\"VALUE\") AS VERSION from \"$ODBCJDBC\".DB_METADATA WHERE name LIKE 'databaseMinorVersion'";
 
     private final Boolean userHasDictionaryAccess; 
     private final Integer majorVersion;

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolDataSource.java
@@ -120,7 +120,7 @@ public class ExasolDataSource extends JDBCDataSource implements DBCQueryPlanner,
 		} catch (SQLException e) {
 			LOG.warn("Error reading active schema", e);
 		}
-		String schemaSQL = "select schema_name as object_name,schema_owner as OWNER,CAST(NULL AS TIMESTAMP) AS created, schema_comment as OBJECT_COMMENT, SCHEMA_OBJECT_ID from SYS.EXA_SCHEMAS s  ";
+		String schemaSQL = "/*snapshot execution*/ select schema_name as object_name,schema_owner as OWNER,CAST(NULL AS TIMESTAMP) AS created, schema_comment as OBJECT_COMMENT, SCHEMA_OBJECT_ID from SYS.EXA_SCHEMAS s  ";
 		
 		if (exasolCurrentUserPrivileges.getatLeastV6()) {
 			
@@ -130,7 +130,7 @@ public class ExasolDataSource extends JDBCDataSource implements DBCQueryPlanner,
 			//build virtual schema cache for >V6 databases
 			virtualSchemaCache = new JDBCObjectSimpleCache<>(
 					ExasolVirtualSchema.class,
-					"select" + 
+					"/*snapshot execution*/ select" + 
 					"	s.SCHEMA_NAME as OBJECT_NAME," + 
 					"	s.SCHEMA_OWNER AS OWNER," + 
 					"CAST(NULL AS TIMESTAMP) AS created, " +
@@ -162,19 +162,19 @@ public class ExasolDataSource extends JDBCDataSource implements DBCQueryPlanner,
 		}
 
 		this.userCache = new JDBCObjectSimpleCache<>(ExasolUser.class,
-					"select * from SYS."+ this.exasolCurrentUserPrivileges.getTablePrefix(ExasolSysTablePrefix.USER)  +"_USERS ORDER BY USER_NAME");
+					"/*snapshot execution*/ select * from SYS."+ this.exasolCurrentUserPrivileges.getTablePrefix(ExasolSysTablePrefix.USER)  +"_USERS ORDER BY USER_NAME");
 		this.roleCache = new JDBCObjectSimpleCache<>(ExasolRole.class, "SELECT ROLE_NAME,CREATED,ROLE_PRIORITY AS USER_PRIORITY,ROLE_COMMENT FROM SYS." + this.exasolCurrentUserPrivileges.getTablePrefix(ExasolSysTablePrefix.SESSION)  +"_ROLES ORDER BY ROLE_NAME");
 		
 		this.connectionCache = new JDBCObjectSimpleCache<>(
-				ExasolConnection.class, "SELECT * FROM SYS."+ this.exasolCurrentUserPrivileges.getTablePrefix(ExasolSysTablePrefix.SESSION)  +"_CONNECTIONS ORDER BY CONNECTION_NAME");
+				ExasolConnection.class, "/*snapshot execution*/ SELECT * FROM SYS."+ this.exasolCurrentUserPrivileges.getTablePrefix(ExasolSysTablePrefix.SESSION)  +"_CONNECTIONS ORDER BY CONNECTION_NAME");
 		
 		if (exasolCurrentUserPrivileges.hasPriorityGroups()) {
 			this.priorityGroupCache = new JDBCObjectSimpleCache<>(
-				ExasolPriorityGroup.class, "SELECT * FROM SYS.EXA_PRIORITY_GROUPS ORDER BY PRIORITY_GROUP_NAME"
+				ExasolPriorityGroup.class, "/*snapshot execution*/ SELECT * FROM SYS.EXA_PRIORITY_GROUPS ORDER BY PRIORITY_GROUP_NAME"
 				);
 			
 			this.securityPolicyCache = new JDBCObjectSimpleCache<>(ExasolSecurityPolicy.class,
-					"SELECT SYSTEM_VALUE FROM sys.EXA_PARAMETERS WHERE PARAMETER_NAME = 'PASSWORD_SECURITY_POLICY'"
+					"/*snapshot execution*/ SELECT SYSTEM_VALUE FROM sys.EXA_PARAMETERS WHERE PARAMETER_NAME = 'PASSWORD_SECURITY_POLICY'"
 					);
 		} else {
 			this.priorityGroupCache = new DBSObjectCache<ExasolDataSource, ExasolPriorityGroup>() {
@@ -245,14 +245,14 @@ public class ExasolDataSource extends JDBCDataSource implements DBCQueryPlanner,
 		if (exasolCurrentUserPrivileges.getUserHasDictionaryAccess())
 		{
 			this.connectionGrantCache =  new JDBCObjectSimpleCache<>(
-					ExasolConnectionGrant.class,"SELECT c.*,P.ADMIN_OPTION,P.GRANTEE FROM SYS.EXA_DBA_CONNECTION_PRIVS P "
+					ExasolConnectionGrant.class,"/*snapshot execution*/ SELECT c.*,P.ADMIN_OPTION,P.GRANTEE FROM SYS.EXA_DBA_CONNECTION_PRIVS P "
 							+ "INNER JOIN SYS.EXA_DBA_CONNECTIONS C on P.GRANTED_CONNECTION = C.CONNECTION_NAME ORDER BY P.GRANTEE,C.CONNECTION_NAME ");
 		}
 		
 		if (exasolCurrentUserPrivileges.getUserHasDictionaryAccess())
 		{
 			this.baseTableGrantCache = new JDBCObjectSimpleCache<>(
-					ExasolBaseObjectGrant.class,"SELECT " + 
+					ExasolBaseObjectGrant.class,"/*snapshot execution*/ SELECT " + 
 							"	OBJECT_SCHEMA," + 
 							"	OBJECT_TYPE," + 
 							"	GRANTEE," + 
@@ -278,14 +278,14 @@ public class ExasolDataSource extends JDBCDataSource implements DBCQueryPlanner,
 		{
 			this.systemGrantCache = new JDBCObjectSimpleCache<>(
 					ExasolSystemGrant.class,
-					"SELECT GRANTEE,PRIVILEGE,ADMIN_OPTION FROM SYS.EXA_DBA_SYS_PRIVS ORDER BY GRANTEE,PRIVILEGE");
+					"/*snapshot execution*/ SELECT GRANTEE,PRIVILEGE,ADMIN_OPTION FROM SYS.EXA_DBA_SYS_PRIVS ORDER BY GRANTEE,PRIVILEGE");
 		}
 		
 		if (exasolCurrentUserPrivileges.getUserHasDictionaryAccess())
 		{
 			this.roleGrantCache = new JDBCObjectSimpleCache<>(
 					ExasolRoleGrant.class,
-					"select r.*,p.ADMIN_OPTION,p.GRANTEE from EXA_DBA_ROLES r "
+					"/*snapshot execution*/ select r.*,p.ADMIN_OPTION,p.GRANTEE from EXA_DBA_ROLES r "
 					+ "INNER JOIN  EXA_DBA_ROLE_PRIVS p ON p.GRANTED_ROLE = r.ROLE_NAME ORDER BY P.GRANTEE,R.ROLE_NAME"
 					);
 		}

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolExecutionContext.java
@@ -41,7 +41,7 @@ import java.sql.SQLException;
 public class ExasolExecutionContext extends JDBCExecutionContext implements DBCExecutionContextDefaults<DBSCatalog, ExasolSchema> {
     private static final Log log = Log.getLog(ExasolExecutionContext.class);
 
-    private static final String GET_CURRENT_SCHEMA = "SELECT CURRENT_SCHEMA";
+    private static final String GET_CURRENT_SCHEMA = "/*snapshot execution*/ SELECT CURRENT_SCHEMA";
     private static final String SET_CURRENT_SCHEMA = "OPEN SCHEMA \"%s\"";
 
     private String activeSchemaName;

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolSchema.java
@@ -87,7 +87,7 @@ public class ExasolSchema extends ExasolGlobalObject implements DBSSchema, DBPNa
         this.owner = owner;
         this.scriptCache = new ExasolJDBCObjectSimpleCacheLiterals<>(
         		ExasolScript.class,
-        		"select "
+        		"/*snapshot execution*/ select "
         		+ "script_name,script_owner,script_language,script_type,script_result_type,script_text,script_comment,b.created "
         		+ "from SYS." + tablePrefix + "_SCRIPTS a inner join SYS." + tablePrefix + "_OBJECTS b "
         		+ "on a.SCRIPT_OBJECT_ID  = b.object_id and b.object_type = 'SCRIPT' where a.script_schema = '%s' "
@@ -95,7 +95,7 @@ public class ExasolSchema extends ExasolGlobalObject implements DBSSchema, DBPNa
         		name);
 
         this.functionCache = new ExasolJDBCObjectSimpleCacheLiterals<>(ExasolFunction.class,
-                "SELECT\n" + 
+                "/*snapshot execution*/ SELECT\n" + 
                 "    F.*,\n" + 
                 "    O.CREATED\n" + 
                 "FROM\n" + 
@@ -294,7 +294,7 @@ public class ExasolSchema extends ExasolGlobalObject implements DBSSchema, DBPNa
     {
     	if (!refreshed && this.objectId != null) {
 	    	JDBCSession session = DBUtils.openMetaSession(monitor, this, ExasolMessages.read_schema_details );
-	    	try (JDBCPreparedStatement stmt = session.prepareStatement("SELECT * FROM SYS."+getDataSource().getTablePrefix(ExasolSysTablePrefix.ALL)+"_OBJECT_SIZES WHERE OBJECT_ID = ?"))
+	    	try (JDBCPreparedStatement stmt = session.prepareStatement("/*snapshot execution*/ SELECT * FROM SYS."+getDataSource().getTablePrefix(ExasolSysTablePrefix.ALL)+"_OBJECT_SIZES WHERE OBJECT_ID = ?"))
 	    	{
 	    		stmt.setInt(1, this.objectId);
 	    		try (JDBCResultSet dbResult = stmt.executeQuery()) 

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolStructureAssistant.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolStructureAssistant.java
@@ -55,10 +55,10 @@ public class ExasolStructureAssistant implements DBSStructureAssistant<ExasolExe
 
 
 
-    private static final String SQL_TABLES_ALL = "SELECT table_schem,table_name,table_type from \"$ODBCJDBC\".ALL_TABLES WHERE TABLE_NAME = '%s' AND TABLE_TYPE IN (%s)";
-    private static final String SQL_TABLES_SCHEMA = "SELECT table_schem,table_name,table_type from \"$ODBCJDBC\".ALL_TABLES WHERE TABLE_SCHEM = '%s' AND TABLE_NAME LIKE ? AND TABLE_TYPE IN (%s)";
+    private static final String SQL_TABLES_ALL = "/*snapshot execution*/ SELECT table_schem,table_name,table_type from \"$ODBCJDBC\".ALL_TABLES WHERE TABLE_NAME = '%s' AND TABLE_TYPE IN (%s)";
+    private static final String SQL_TABLES_SCHEMA = "/*snapshot execution*/ SELECT table_schem,table_name,table_type from \"$ODBCJDBC\".ALL_TABLES WHERE TABLE_SCHEM = '%s' AND TABLE_NAME LIKE '%%%s%%' AND TABLE_TYPE IN (%s)";
     //private static final String SQL_COLS_ALL = "SELECT TABLE_SCHEM,TABLE_NAME,COLUMN_NAME from \"$ODBCJDBC\".ALL_COLUMNS WHERE COLUMN_NAME LIKE '%s'";
-    private static final String SQL_COLS_SCHEMA = "SELECT TABLE_SCHEM,TABLE_NAME,COLUMN_NAME from \"$ODBCJDBC\".ALL_COLUMNS WHERE TABLE_SCHEM = '%s' and COLUMN_NAME LIKE '%s'";
+    private static final String SQL_COLS_SCHEMA = "/*snapshot execution*/ SELECT TABLE_SCHEM,TABLE_NAME,COLUMN_NAME from \"$ODBCJDBC\".ALL_COLUMNS WHERE TABLE_SCHEM = '%s' and COLUMN_NAME LIKE '%%%s%%'";
 
 
     private ExasolDataSource dataSource;

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolTable.java
@@ -64,7 +64,7 @@ public class ExasolTable extends ExasolTableBase implements DBPRefreshableObject
     private Boolean hasPartitionKey;
     private ExasolTablePartitionColumnCache tablePartitionColumnCache = new ExasolTablePartitionColumnCache();
     
-    private static String readAdditionalTableInfo = "SELECT" + 
+    private static String readAdditionalTableInfo = "/*snapshot execution*/ SELECT" + 
             "    * " + 
             "FROM" + 
             "    (" + 
@@ -110,7 +110,7 @@ public class ExasolTable extends ExasolTableBase implements DBPRefreshableObject
             "    table_schema," + 
             "    o.table_name" + 
             "";
-    private static String readTableSize =         "SELECT " + 
+    private static String readTableSize =         "/*snapshot execution*/ SELECT " + 
             "    * " + 
             "FROM " + 
             "    ( " + 

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolView.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolView.java
@@ -101,7 +101,7 @@ public class ExasolView extends ExasolTableBase implements ExasolSourceObject, D
             JDBCSession session = DBUtils.openMetaSession(new VoidProgressMonitor(), this, "Read Table Details");
             try (JDBCStatement stmt = session.createStatement())
             {
-                String sql = String.format("SELECT VIEW_OWNER,VIEW_TEXT FROM SYS.EXA_ALL_VIEWS WHERE VIEW_SCHEMA = '%s' and VIEW_NAME = '%s'",
+                String sql = String.format("/*snapshot execution*/ SELECT VIEW_OWNER,VIEW_TEXT FROM SYS.EXA_ALL_VIEWS WHERE VIEW_SCHEMA = '%s' and VIEW_NAME = '%s'",
                         ExasolUtils.quoteString(this.getSchema().getName()),
                         ExasolUtils.quoteString(this.getName())
                         );

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolVirtualSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolVirtualSchema.java
@@ -56,7 +56,7 @@ public class ExasolVirtualSchema extends ExasolSchema  {
 		
 		virtualSchemaParameterCache = new JDBCObjectSimpleCache<>(
 				ExasolVirtualSchemaParameter.class, 
-				"select\r\n" + 
+				"/*snapshot execution*/ select\r\n" + 
 				"	property_name,\r\n" + 
 				"	property_value\r\n" + 
 				"from\r\n" + 

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolDataTypeCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolDataTypeCache.java
@@ -36,7 +36,7 @@ public final class ExasolDataTypeCache
     private LongKeyMap<ExasolDataType> dataTypeMap = new LongKeyMap<>();
 	
 	private static final String SQL_TYPE_CACHE =
-        "select * from SYS.EXA_SQL_TYPES";
+        "/*snapshot execution*/ select * from SYS.EXA_SQL_TYPES";
 
 	@NotNull
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolTableCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolTableCache.java
@@ -36,7 +36,7 @@ import java.sql.SQLException;
 public final class ExasolTableCache
 		extends JDBCStructCache<ExasolSchema, ExasolTable, ExasolTableColumn> {
 
-	private static final String SQL_COLS_TAB = "SELECT " + 
+	private static final String SQL_COLS_TAB = "/*snapshot execution*/ SELECT " + 
 			"c.* " + 
 			"FROM " + 
 			"SYS.%s_COLUMNS c " + 
@@ -45,7 +45,7 @@ public final class ExasolTableCache
 			"AND COLUMN_TABLE = '%s' " + 
 			"ORDER BY " + 
 			"COLUMN_ORDINAL_POSITION ";
-	private static final String SQL_COLS_ALL = "SELECT " + 
+	private static final String SQL_COLS_ALL = "/*snapshot execution*/ SELECT " + 
 			"c.* " + 
 			"FROM " + 
 			"SYS.%s_COLUMNS c " + 
@@ -54,7 +54,7 @@ public final class ExasolTableCache
 			"ORDER BY " + 
 			"COLUMN_ORDINAL_POSITION ";
 	
-	private static final String SQL_TABLES = "SELECT * FROM \"$ODBCJDBC\".ALL_TABLES WHERE TABLE_SCHEM = '%s' and TABLE_TYPE = 'TABLE' order by TABLE_NAME";
+	private static final String SQL_TABLES = "/*snapshot execution*/ SELECT * FROM \"$ODBCJDBC\".ALL_TABLES WHERE TABLE_SCHEM = '%s' and TABLE_TYPE = 'TABLE' order by TABLE_NAME";
 
 	public ExasolTableCache()
 	{

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolTableForeignKeyCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolTableForeignKeyCache.java
@@ -41,7 +41,7 @@ public final class ExasolTableForeignKeyCache
     extends JDBCCompositeCache<ExasolSchema, ExasolTable, ExasolTableForeignKey, ExasolTableKeyColumn> {
 
     private static final String SQL_FK_TAB =
-        "select\r\n" +
+        "/*snapshot execution*/ select\r\n" +
             "		CONSTRAINT_NAME,CONSTRAINT_TABLE,CONSTRAINT_SCHEMA,constraint_owner,c.constraint_enabled,constraint_Type," +
             "cc.column_name,cc.ordinal_position,cc.referenced_schema,cc.referenced_table,cc.referenced_column" +
             "	from\r\n" +
@@ -68,7 +68,7 @@ public final class ExasolTableForeignKeyCache
             "	order by\r\n" +
             "		ORDINAL_POSITION";
     private static final String SQL_FK_ALL =
-        "select\r\n" +
+        "/*snapshot execution*/ select\r\n" +
             "		CONSTRAINT_NAME,CONSTRAINT_TABLE,CONSTRAINT_SCHEMA,constraint_owner,c.constraint_enabled,constraint_Type," +
             "cc.column_name,cc.ordinal_position,cc.referenced_schema,cc.referenced_table,cc.referenced_column" +
             "	from\r\n" +

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolTableUniqueKeyCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolTableUniqueKeyCache.java
@@ -39,7 +39,7 @@ public final class ExasolTableUniqueKeyCache
     extends JDBCCompositeCache<ExasolSchema, ExasolTable, ExasolTableUniqueKey, ExasolTableKeyColumn> {
 
     private static final String SQL_UK_TAB =
-        "SELECT\r\n" + 
+        "/*snapshot execution*/ SELECT\r\n" + 
         "	C.CONSTRAINT_SCHEMA,\r\n" + 
         "	c.CONSTRAINT_TABLE,\r\n" + 
         "	c.CONSTRAINT_NAME,\r\n" + 
@@ -75,7 +75,7 @@ public final class ExasolTableUniqueKeyCache
         "	ORDINAL_POSITION";
     
     private static final String SQL_UK_ALL =
-    		"SELECT\r\n" + 
+    		"/*snapshot execution*/ SELECT\r\n" + 
     		"	C.CONSTRAINT_SCHEMA,\r\n" + 
     		"	c.CONSTRAINT_TABLE,\r\n" + 
     		"	c.CONSTRAINT_NAME,\r\n" + 

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolViewCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolViewCache.java
@@ -41,7 +41,7 @@ import java.sql.SQLException;
  */
 public class ExasolViewCache extends JDBCStructCache<ExasolSchema, ExasolView, ExasolTableColumn> {
 
-	private static final String SQL_COLS_VIEW = "SELECT " + 
+	private static final String SQL_COLS_VIEW = "/*snapshot execution*/ SELECT " + 
 			"c.* " + 
 			"FROM " + 
 			"SYS.%s_COLUMNS c " + 
@@ -50,7 +50,7 @@ public class ExasolViewCache extends JDBCStructCache<ExasolSchema, ExasolView, E
 			"AND COLUMN_TABLE = '%s' " + 
 			"ORDER BY " + 
 			"COLUMN_ORDINAL_POSITION ";
-	private static final String SQL_COLS_ALL = "SELECT " + 
+	private static final String SQL_COLS_ALL = "/*snapshot execution*/ SELECT " + 
 			"c.* " + 
 			"FROM " + 
 			"SYS.%s_COLUMNS c " + 
@@ -60,7 +60,7 @@ public class ExasolViewCache extends JDBCStructCache<ExasolSchema, ExasolView, E
 			"COLUMN_ORDINAL_POSITION ";
 
 	private static final String SQL_COLS_SYS_VIEW = ""
-			+ "SELECT OBJECT_ID as COLUMN_OBJECT_ID, " + 
+			+ "/*snapshot execution*/ SELECT OBJECT_ID as COLUMN_OBJECT_ID, " + 
 			"	TABLE_CAT, " + 
 			"	TABLE_SCHEM as COLUMN_SCHEMA, " + 
 			"	TABLE_NAME as COLUMN_TABLE, " + 
@@ -93,7 +93,7 @@ public class ExasolViewCache extends JDBCStructCache<ExasolSchema, ExasolView, E
 			"WHERE table_schem = '%s' AND table_name = '%s'";
 
 	private static final String SQL_COLS_SYS_ALL = ""
-			+ "SELECT OBJECT_ID as COLUMN_OBJECT_ID, " + 
+			+ "/*snapshot execution*/ SELECT OBJECT_ID as COLUMN_OBJECT_ID, " + 
 			"	TABLE_CAT, " + 
 			"	TABLE_SCHEM as COLUMN_SCHEMA, " + 
 			"	TABLE_NAME as COLUMN_TABLE, " + 

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/lock/ExasolLockManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/lock/ExasolLockManager.java
@@ -37,7 +37,7 @@ public class ExasolLockManager extends LockGraphManager
 		implements DBAServerLockManager<ExasolLock, ExasolLockItem> {
 	
 	public static final String LOCK_QUERY = 
-			"WITH LOCKED AS (\r\n" + 
+			"/*snapshot execution*/ WITH LOCKED AS (\r\n" + 
 			"SELECT \r\n" + 
 			"w.SESSION_ID AS w_session_id,w.login_time as w_login_time,\r\n" + 
 			"w.user_name AS w_user_name,\r\n" + 
@@ -93,7 +93,7 @@ public class ExasolLockManager extends LockGraphManager
 			;
 	
 	public static final String LOCK_ITEM_QUERY = 
-			"with\r\n" + 
+			"/*snapshot execution*/ with\r\n" + 
 			"	EXA_SQL as (\r\n" + 
 			"		select\r\n" + 
 			"			SESSION_ID,\r\n" + 

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/plan/ExasolPlanAnalyser.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/plan/ExasolPlanAnalyser.java
@@ -56,7 +56,7 @@ public class ExasolPlanAnalyser extends AbstractExecutionPlan {
 
     @Override
     public String getPlanQueryString() {
-        return "SELECT * FROM EXA_USER_PROFILE_LAST_DAY WHERE SESSION_ID = CURRENT_SESSION AND STMT_ID = (select max(stmt_id) from EXA_USER_PROFILE_LAST_DAY where sql_text = ?)";
+        return "/*snapshot execution*/ SELECT * FROM EXA_USER_PROFILE_LAST_DAY WHERE SESSION_ID = CURRENT_SESSION AND STMT_ID = (select max(stmt_id) from EXA_USER_PROFILE_LAST_DAY where sql_text = ?)";
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/tools/ExasolUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/tools/ExasolUtils.java
@@ -46,11 +46,11 @@ import java.util.stream.Collectors;
 public class ExasolUtils {
 
     // select columns of tables
-    private static final String TABLE_QUERY_COLUMNS = "SELECT * FROM EXA_ALL_COLUMNS WHERE COLUMN_SCHEMA='%s' AND COLUMN_TABLE='%s' ORDER BY COLUMN_ORDINAL_POSITION";
+    private static final String TABLE_QUERY_COLUMNS = "/*snapshot execution*/ SELECT * FROM EXA_ALL_COLUMNS WHERE COLUMN_SCHEMA='%s' AND COLUMN_TABLE='%s' ORDER BY COLUMN_ORDINAL_POSITION";
 
     // list sessions
-    private static final String SESS_DBA_QUERY = "select * from exa_dba_sessions";
-    private static final String SESS_ALL_QUERY = "select * from exa_ALL_sessions";
+    private static final String SESS_DBA_QUERY = "/*snapshot execution*/ select * from exa_dba_sessions";
+    private static final String SESS_ALL_QUERY = "/*snapshot execution*/ select * from exa_ALL_sessions";
 
     private static final Log LOG = Log.getLog(ExasolUtils.class);
 


### PR DESCRIPTION
This is an enhancement  for #8216 

When using separate connection for every editor window meta data queries are executed in the data connection of that editor.

As of Exasol Version >= 6.2.5  there is a special comment that will start the sql in snapshot transaction mode in Exasol. In older versions this will just be ignored like a regular comment.

[EXASOL-2646](https://www.exasol.com/support/browse/EXASOL-2646)