### PR TITLE
Fix typo in datatransfer bundle_de.properties

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/OSGI-INF/l10n/bundle_de.properties
+++ b/plugins/org.jkiss.dbeaver.data.transfer/OSGI-INF/l10n/bundle_de.properties
@@ -54,7 +54,7 @@ dataTransfer.processor.markdownTable.property.nullString.name                   
 dataTransfer.processor.markdownTable.property.showHeaderSeparator.description   = Druckkopf-Trennzeichen (---). Erforderlich f\u00FCr den GitHub-Abschlag.
 dataTransfer.processor.markdownTable.property.showHeaderSeparator.name          = Header-Trennzeichen anzeigen
 dataTransfer.processor.markdownTable.propertyGroup.general.label                = Allgemein
-dataTransfer.processor.sql.description                                          = Exportieren als SQL-Insertefehle
+dataTransfer.processor.sql.description                                          = Exportieren als SQL-Insertbefehle
 dataTransfer.processor.sql.name                                                 = SQL
 dataTransfer.processor.sql.property.escape.description                          = Zeichen, das aus einem einfachen Anf\u00FChrungszeichen hervorgeht.
 dataTransfer.processor.sql.property.escape.name                                 = Escape-Zeichen


### PR DESCRIPTION
Fix typo "Exportieren als SQL-Insertefehle" -> "Exportieren als SQL-Insertbefehle"