### PR TITLE
#8711 tables with an exclusively digital name get an alias "t"

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
@@ -745,7 +745,13 @@ public final class SQLUtils {
             }
             prevChar = c;
         }
-        String alias = buf.toString().toLowerCase(Locale.ENGLISH);
+        String alias;
+        if(!CommonUtils.isEmpty(buf)) {
+            alias = buf.toString().toLowerCase(Locale.ENGLISH);
+        }
+        else{
+            alias = "t";
+        }
 
         String result = alias;
         for (int i = 2; i < 500; i++) {


### PR DESCRIPTION
in order to avoid syntax error when requesting