### PR TITLE
#8795: Option "Force object refresh on editor open" does not work on …

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerObjectOpen.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerObjectOpen.java
@@ -202,11 +202,7 @@ public class NavigatorHandlerObjectOpen extends NavigatorHandlerObjectBase imple
                     } else {
                         DatabaseNodeEditorInput editorInput = new DatabaseNodeEditorInput(dnNode);
                         if (DBWorkbench.getPlatform().getPreferenceStore().getBoolean(NavigatorPreferences.NAVIGATOR_REFRESH_EDITORS_ON_OPEN)) {
-                            if (databaseObject instanceof DBSObjectContainer) {
-                                // do not auto-refresh object containers (too expensive)
-                            } else {
-                                refreshDatabaseNode(dnNode);
-                            }
+                            refreshDatabaseNode(dnNode);
                         }
                         setInputAttributes(editorInput, defaultPageId, defaultFolderId, attributes);
                         return workbenchWindow.getActivePage().openEditor(


### PR DESCRIPTION
…Oracle packages: Removed exclusion of DBSObjectContainer from refresh

I don't see a problem when refreshing DBSObjectContainer . We have very large Packages in Oracle and I didn't found an issue.