### PR TITLE
Default to using MySQL's longer connection timeout var

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLDataSourceProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLDataSourceProvider.java
@@ -65,6 +65,11 @@ public class MySQLDataSourceProvider extends JDBCDataSourceProvider implements D
         // Set utf-8 as default charset
         connectionsProps.put("characterEncoding", GeneralUtils.UTF8_ENCODING);
         connectionsProps.put("tinyInt1isBit", "false");
+        // Tell MySQL to use the (typically longer) interactive_timeout variable as the connection timeout
+        // instead of wait_timeout.
+        // This longer timeout is for connections directly in use by a human, who'd prefer MySQL not 
+        // kill their connection while they were on a coffee break.
+        connectionsProps.put("interactiveClient", "true");
         // Auth plugins
 //        connectionsProps.put("authenticationPlugins",
 //            "com.mysql.jdbc.authentication.MysqlClearPasswordPlugin," +


### PR DESCRIPTION
MySQL and MariaDB have a connection property called `interactiveClient`, which is intended to be set on connections that are in direct use by a human, and causes MySQL to make the connection timeout be the (typically longer) `interactive_timeout` variable instead of `wait_timeout`.

As an example, our database has `wait_timeout` as 10 minutes, and `interactive_timeout` as 8 hours. Since DBeaver wasn't setting `interactiveClient` by default, my connection was being killed after 10 minutes, causing my temporary table I was working with to be dropped, which is pretty annoying and unnecessary.

A stock install of MySQL  has both `interactive_timeout` and `wait_timeout` set as 8 hours, so many people probably don't run into this snag until they start tweaking some of the database defaults, set `wait_timeout` lower to keep so fewer connections sitting around, then don't realize it's the cause of their frustrations that DBeaver's connections die very quickly.