### PR TITLE
#8892 remove truncate function from FireBird, Oracle and DB2

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.db2.i/src/org/jkiss/dbeaver/ext/db2/i/model/DB2ISQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.db2.i/src/org/jkiss/dbeaver/ext/db2/i/model/DB2ISQLDialect.java
@@ -33,6 +33,7 @@ public class DB2ISQLDialect extends GenericSQLDialect {
 
     public void initDriverSettings(JDBCDataSource dataSource, JDBCDatabaseMetaData metaData) {
         super.initDriverSettings(dataSource, metaData);
+        turnFunctionIntoKeyword("TRUNCATE");
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.db2.zos/src/org/jkiss/dbeaver/ext/db2/zos/model/DB2ZOSSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.db2.zos/src/org/jkiss/dbeaver/ext/db2/zos/model/DB2ZOSSQLDialect.java
@@ -33,6 +33,7 @@ public class DB2ZOSSQLDialect extends GenericSQLDialect {
 
     public void initDriverSettings(JDBCDataSource dataSource, JDBCDatabaseMetaData metaData) {
         super.initDriverSettings(dataSource, metaData);
+        turnFunctionIntoKeyword("TRUNCATE");
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.db2/src/org/jkiss/dbeaver/ext/db2/DB2SQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.db2/src/org/jkiss/dbeaver/ext/db2/DB2SQLDialect.java
@@ -48,6 +48,7 @@ public class DB2SQLDialect extends JDBCSQLDialect {
         for (String kw : DB2Constants.ADVANCED_KEYWORDS) {
             this.addSQLKeyword(kw);
         }
+        turnFunctionIntoKeyword("TRUNCATE");
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdSQLDialect.java
@@ -61,6 +61,7 @@ public class FireBirdSQLDialect extends GenericSQLDialect {
 
     public void initDriverSettings(JDBCDataSource dataSource, JDBCDatabaseMetaData metaData) {
         super.initDriverSettings(dataSource, metaData);
+        turnFunctionIntoKeyword("TRUNCATE");
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
@@ -337,6 +337,7 @@ class OracleSQLDialect extends JDBCSQLDialect {
         }
 
         addKeywords(Arrays.asList(OTHER_TYPES_FUNCTIONS), DBPKeywordType.OTHER);
+        turnFunctionIntoKeyword("TRUNCATE");
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/AbstractSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/AbstractSQLDialect.java
@@ -127,6 +127,11 @@ public abstract class AbstractSQLDialect implements SQLDialect {
         addKeywords(allFunctions, DBPKeywordType.FUNCTION);
     }
 
+    protected void turnFunctionIntoKeyword(String function) {
+        functions.remove(function);
+        addKeywords(Collections.singletonList(function), DBPKeywordType.KEYWORD);
+    }
+
     protected void addDataTypes(Collection<String> allTypes) {
         for (String type : allTypes) {
             types.add(type.toUpperCase(Locale.ENGLISH));


### PR DESCRIPTION
in this case TRUNCATE as a function with parentheses remain in other db