### PR TITLE
#8892 remove truncate as function from everywhere

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCSQLDialect.java
@@ -202,6 +202,7 @@ public class JDBCSQLDialect extends BasicSQLDialect {
         }
 
         loadDriverKeywords(metaData);
+        turnFunctionIntoKeyword("TRUNCATE");
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/AbstractSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/AbstractSQLDialect.java
@@ -127,6 +127,11 @@ public abstract class AbstractSQLDialect implements SQLDialect {
         addKeywords(allFunctions, DBPKeywordType.FUNCTION);
     }
 
+    protected void turnFunctionIntoKeyword(String function) {
+        functions.remove(function);
+        addKeywords(Collections.singletonList(function), DBPKeywordType.KEYWORD);
+    }
+
     protected void addDataTypes(Collection<String> allTypes) {
         for (String type : allTypes) {
             types.add(type.toUpperCase(Locale.ENGLISH));


### PR DESCRIPTION
in this case TRUNCATE as a function with parentheses remove from everywhere, including MySQL and H2 databases, where she actually works