### PR TITLE
Check data kind while matching column for query result

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
@@ -673,6 +673,7 @@ public class DBExecUtils {
                     }
 
                     if (tableColumn != null &&
+                        tableColumn.getDataKind().isComplex() == attrMeta.getDataKind().isComplex() &&
                         bindingMeta.setEntityAttribute(
                             tableColumn,
                             ((sqlQuery == null || tableColumn.getTypeID() != attrMeta.getTypeID()) && rows != null)))


### PR DESCRIPTION
This was reported on #postgresql IRC channel and I felt like fixing it.
The following query shows an empty result in DBeaver
```sql
create table post (post_id integer generated by default as identity);
ALTER TABLE post ADD tags _text NOT NULL DEFAULT '{}'::text[];
insert into post values (1, array['Apples']);
select tags[1] from post
```
https://www.db-fiddle.com/f/hDNfD3uVQXwYhTyvVB7T6G/1
But `select tags[1] as foo from post` works.
Before
![image](https://user-images.githubusercontent.com/413384/84585258-8b009f80-add3-11ea-814d-fd52082fe18a.png)
After
![image](https://user-images.githubusercontent.com/413384/84585250-77553900-add3-11ea-9004-b8a19daf9ae9.png)
