### PR TITLE
#9043 trim unwanted spaces in connection settings tabs: SSH, Proxy, SSL

### DIFF
--- a/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHTunnelConfiguratorUI.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHTunnelConfiguratorUI.java
@@ -305,15 +305,15 @@ public class SSHTunnelConfiguratorUI implements IObjectPropertyConfigurator<DBWH
     @Override
     public void saveSettings(DBWHandlerConfiguration configuration)
     {
-        configuration.setProperty(SSHConstants.PROP_HOST, hostText.getText());
+        configuration.setProperty(SSHConstants.PROP_HOST, hostText.getText().trim());
         configuration.setProperty(SSHConstants.PROP_PORT, portText.getSelection());
         switch (authMethodCombo.getSelectionIndex()) {
             case 0: configuration.setProperty(SSHConstants.PROP_AUTH_TYPE, SSHConstants.AuthType.PASSWORD.name()); break;
             case 1: configuration.setProperty(SSHConstants.PROP_AUTH_TYPE, SSHConstants.AuthType.PUBLIC_KEY.name()); break;
             case 2: configuration.setProperty(SSHConstants.PROP_AUTH_TYPE, SSHConstants.AuthType.AGENT.name()); break;
         }
-        configuration.setProperty(SSHConstants.PROP_KEY_PATH, privateKeyText.getText());
-        configuration.setUserName(userNameText.getText());
+        configuration.setProperty(SSHConstants.PROP_KEY_PATH, privateKeyText.getText().trim());
+        configuration.setUserName(userNameText.getText().trim());
         configuration.setPassword(passwordText.getText());
         configuration.setSavePassword(savePasswordCheckbox.getSelection());
 
@@ -325,7 +325,7 @@ public class SSHTunnelConfiguratorUI implements IObjectPropertyConfigurator<DBWH
             }
         }
 
-        configuration.setProperty(SSHConstants.PROP_LOCAL_HOST, localHostText.getText());
+        configuration.setProperty(SSHConstants.PROP_LOCAL_HOST, localHostText.getText().trim());
         int localPort = localPortSpinner.getSelection();
         if (localPort <= 0) {
             configuration.setProperty(SSHConstants.PROP_LOCAL_PORT, null);
@@ -333,7 +333,7 @@ public class SSHTunnelConfiguratorUI implements IObjectPropertyConfigurator<DBWH
             configuration.setProperty(SSHConstants.PROP_LOCAL_PORT, localPort);
         }
 
-        configuration.setProperty(SSHConstants.PROP_REMOTE_HOST, remoteHostText.getText());
+        configuration.setProperty(SSHConstants.PROP_REMOTE_HOST, remoteHostText.getText().trim());
         int remotePort = remotePortSpinner.getSelection();
         if (remotePort <= 0) {
             configuration.setProperty(SSHConstants.PROP_REMOTE_PORT, null);

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/net/SSLConfiguratorTrustStoreUI.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/net/SSLConfiguratorTrustStoreUI.java
@@ -90,9 +90,9 @@ public class SSLConfiguratorTrustStoreUI extends SSLConfiguratorAbstractUI
     @Override
     public void saveSettings(DBWHandlerConfiguration configuration) {
         if (caCertPath != null) {
-            configuration.setProperty(SSLHandlerTrustStoreImpl.PROP_SSL_CA_CERT, caCertPath.getText());
+            configuration.setProperty(SSLHandlerTrustStoreImpl.PROP_SSL_CA_CERT, caCertPath.getText().trim());
         }
-        configuration.setProperty(SSLHandlerTrustStoreImpl.PROP_SSL_CLIENT_CERT, clientCertPath.getText());
-        configuration.setProperty(SSLHandlerTrustStoreImpl.PROP_SSL_CLIENT_KEY, clientKeyPath.getText());
+        configuration.setProperty(SSLHandlerTrustStoreImpl.PROP_SSL_CLIENT_CERT, clientCertPath.getText().trim());
+        configuration.setProperty(SSLHandlerTrustStoreImpl.PROP_SSL_CLIENT_KEY, clientKeyPath.getText().trim());
     }
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/net/SocksProxyConfiguratorUI.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/net/SocksProxyConfiguratorUI.java
@@ -88,9 +88,9 @@ public class SocksProxyConfiguratorUI implements IObjectPropertyConfigurator<DBW
     @Override
     public void saveSettings(DBWHandlerConfiguration configuration)
     {
-        configuration.setProperty(SocksConstants.PROP_HOST, hostText.getText());
+        configuration.setProperty(SocksConstants.PROP_HOST, hostText.getText().trim());
         configuration.setProperty(SocksConstants.PROP_PORT, portText.getSelection());
-        configuration.setUserName(userNameText.getText());
+        configuration.setUserName(userNameText.getText().trim());
         configuration.setPassword(passwordText.getText());
         configuration.setSavePassword(savePasswordCheckbox.getSelection());
     }


### PR DESCRIPTION
It works for hostnames, usernames, keys and for certificates.