### PR TITLE
#9124 segment size text in export setting replaced

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseProducerPageExtractSettings.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseProducerPageExtractSettings.java
@@ -107,7 +107,7 @@ public class DatabaseProducerPageExtractSettings extends ActiveWizardPage<DataTr
                 });
 
                 segmentSizeLabel = UIUtils.createControlLabel(generalSettings, DTMessages.data_transfer_wizard_output_label_segment_size);
-                segmentSizeLabel.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_END, GridData.VERTICAL_ALIGN_BEGINNING, false, false, 1, 1));
+                segmentSizeLabel.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING, GridData.VERTICAL_ALIGN_BEGINNING, false, false, 3, 1));
                 segmentSizeText = new Text(generalSettings, SWT.BORDER);
                 segmentSizeText.addModifyListener(e -> {
                     try {
@@ -116,7 +116,7 @@ public class DatabaseProducerPageExtractSettings extends ActiveWizardPage<DataTr
                         // just skip it
                     }
                 });
-                segmentSizeText.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_END, GridData.VERTICAL_ALIGN_BEGINNING, false, false, 1, 1));
+                segmentSizeText.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING, GridData.VERTICAL_ALIGN_BEGINNING, false, false, 3, 1));
             }
 
             newConnectionCheckbox = UIUtils.createCheckbox(generalSettings, DTMessages.data_transfer_wizard_output_checkbox_new_connection, DTUIMessages.database_producer_page_extract_settings_new_connection_checkbox_tooltip, true, 4);
@@ -211,11 +211,11 @@ public class DatabaseProducerPageExtractSettings extends ActiveWizardPage<DataTr
         if (rowsExtractType != null) {
             int selectionIndex = rowsExtractType.getSelectionIndex();
             if (selectionIndex == EXTRACT_TYPE_SEGMENTS) {
-                segmentSizeLabel.setVisible(true);
-                segmentSizeText.setVisible(true);
+                segmentSizeLabel.setEnabled(true);
+                segmentSizeText.setEnabled(true);
             } else {
-                segmentSizeLabel.setVisible(false);
-                segmentSizeText.setVisible(false);
+                segmentSizeLabel.setEnabled(false);
+                segmentSizeText.setEnabled(false);
             }
         }
         return true;

--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseProducerPageExtractSettings.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseProducerPageExtractSettings.java
@@ -92,6 +92,7 @@ public class DatabaseProducerPageExtractSettings extends ActiveWizardPage<DataTr
 
                 UIUtils.createControlLabel(generalSettings, DTMessages.data_transfer_wizard_output_label_extract_type);
                 rowsExtractType = new Combo(generalSettings, SWT.DROP_DOWN | SWT.READ_ONLY);
+                rowsExtractType.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING, GridData.VERTICAL_ALIGN_BEGINNING, false, false, 3, 1));
                 rowsExtractType.setItems(
                     DTMessages.data_transfer_wizard_output_combo_extract_type_item_single_query,
                     DTMessages.data_transfer_wizard_output_combo_extract_type_item_by_segments);
@@ -107,7 +108,7 @@ public class DatabaseProducerPageExtractSettings extends ActiveWizardPage<DataTr
                 });
 
                 segmentSizeLabel = UIUtils.createControlLabel(generalSettings, DTMessages.data_transfer_wizard_output_label_segment_size);
-                segmentSizeLabel.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING, GridData.VERTICAL_ALIGN_BEGINNING, false, false, 3, 1));
+                segmentSizeLabel.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING, GridData.VERTICAL_ALIGN_BEGINNING, false, false, 1, 1));
                 segmentSizeText = new Text(generalSettings, SWT.BORDER);
                 segmentSizeText.addModifyListener(e -> {
                     try {
@@ -116,7 +117,7 @@ public class DatabaseProducerPageExtractSettings extends ActiveWizardPage<DataTr
                         // just skip it
                     }
                 });
-                segmentSizeText.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING, GridData.VERTICAL_ALIGN_BEGINNING, false, false, 3, 1));
+                segmentSizeText.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING, GridData.VERTICAL_ALIGN_BEGINNING, false, false, 1, 1));
             }
 
             newConnectionCheckbox = UIUtils.createCheckbox(generalSettings, DTMessages.data_transfer_wizard_output_checkbox_new_connection, DTUIMessages.database_producer_page_extract_settings_new_connection_checkbox_tooltip, true, 4);


### PR DESCRIPTION
segment size text and label under Extract type in Export settings placed, their visibility settings are changed
![2020-06-30 18_29_51-DBeaver 7 1 2 - _localhost_ Script-29](https://user-images.githubusercontent.com/45152336/86146003-52b1ce80-bb00-11ea-8236-376ee658b1df.png)
