### PR TITLE
#8941 keyword "ILIKE" to Snowflake SQL Dialect added

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
@@ -32,7 +32,8 @@ public class SnowflakeSQLDialect extends GenericSQLDialect {
         super.initDriverSettings(dataSource, metaData);
         addSQLKeywords(
                 Arrays.asList(
-                        "QUALIFY"
+                        "QUALIFY",
+                        "ILIKE"
                 ));
     }
 }


### PR DESCRIPTION
![2020-07-06 11_45_21-DBeaver 7 1 2 - _SNOWFLAKE_SAMPLE_DATA_ Script-20](https://user-images.githubusercontent.com/45152336/86574257-3b4e6780-bf7e-11ea-98a1-8e466e2ca911.png)
keyword, not function https://docs.snowflake.com/en/sql-reference/functions/ilike.html