### PR TITLE
Execute in new tab: create a new tab if current query processor has jobs running

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -1916,7 +1916,7 @@ public class SQLEditor extends SQLEditorBase implements
             for (int i = 0; i < queries.size(); i++) {
                 SQLScriptElement query = queries.get(i);
                 QueryProcessor queryProcessor;
-                if (i == 0 && (extraTabsClosed || !curQueryProcessor.getFirstResults().hasData())) {
+                if (i == 0 && curQueryProcessor.getRunningJobs() <= 0 && (extraTabsClosed || !curQueryProcessor.getFirstResults().hasData())) {
                     queryProcessor = curQueryProcessor;
                 } else {
                     queryProcessor = createQueryProcessor(queries.size() == 1, false);
@@ -2520,6 +2520,10 @@ public class SQLEditor extends SQLEditorBase implements
                 queryProcessors.add(this);
             }
             createResultsProvider(0, makeDefault);
+        }
+
+        int getRunningJobs() {
+            return curJobRunning.get();
         }
 
         private QueryResultsContainer createResultsProvider(int resultSetNumber, boolean makeDefault) {


### PR DESCRIPTION
When the user issues an "Execute in new tab" command, we need to check if the current query processor is running a query. If it is, we want to create a new tab.