### PR TITLE
#9010 error status for tasks on deleted objects added

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/task/SQLToolExecuteHandler.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/task/SQLToolExecuteHandler.java
@@ -85,14 +85,14 @@ public abstract class SQLToolExecuteHandler<OBJECT_TYPE extends DBSObject, SETTI
 
         List<OBJECT_TYPE> objectList = settings.getObjectList();
         Exception lastError = null;
-        if(objectList.isEmpty()){
-            logStream.write("Object(s) for tool execution not found");
-            log.debug("Object(s) for tool execution not found");
-        }
 
         listener.taskStarted(settings);
         try {
             monitor.beginTask("Execute tool '" + task.getType().getName() + "'", objectList.size());
+            if(objectList.isEmpty()){
+                log.debug("Object(s) for tool execution not found");
+                throw new DBException("Object(s) for tool execution not found");
+            }
             for (OBJECT_TYPE object : objectList) {
                 monitor.subTask("Process [" + DBUtils.getObjectFullName(object, DBPEvaluationContext.UI) + "]");
                 try (DBCSession session = DBUtils.openUtilSession(monitor, object, "Execute " + task.getType().getName())) {


### PR DESCRIPTION
Success status is not displayed anymore if a table, mentioned in the task, is deleted
![2020-07-13 21_41_47-DBeaver 7 1 3 - run_202007132135_2 log](https://user-images.githubusercontent.com/45152336/87341582-8ce48c80-c552-11ea-98c5-34b8bcc00799.png)
