### PR TITLE
#9055 MySQL. Password change without flush privileges

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/config/MySQLUserManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/config/MySQLUserManager.java
@@ -99,6 +99,16 @@ public class MySQLUserManager extends AbstractObjectManager<MySQLUser> implement
     {
         if (!queue.isEmpty() && !MySQLUtils.isAlterUSerSupported(queue.getObject().getDataSource())) {
             // Add privileges flush to the tail
+            for(DBECommand<MySQLUser> user : queue) {
+                if (user instanceof MySQLCommandChangeUser) {
+                    Map<Object, Object> properties = ((MySQLCommandChangeUser) user).getProperties();
+                    if (properties.size() == 2) {
+                        if (properties.containsKey(UserPropertyHandler.PASSWORD_CONFIRM.name()) && properties.containsKey(UserPropertyHandler.PASSWORD.name())) {
+                            return;
+                        }
+                    }
+                }
+            }
             queue.add(
                 new DBECommandAbstract<MySQLUser>(
                     queue.getObject(),


### PR DESCRIPTION
use of the "SET PASSWORD FOR" command in case of user password change. without flush privileges
![2020-07-14 18_01_10-DBeaver 7 1 3 - tesrtazzz@%](https://user-images.githubusercontent.com/45152336/87441708-1308dd80-c5fc-11ea-9b63-ec4a1daef190.png)
