### PR TITLE
Postgre inheritance ddl

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -298,7 +298,7 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
                 superTables = Collections.emptyList();
             }
         }
-        isSuperTablesInitialized = true;
+        isSuperTablesInitialized = true; //that means we don't need to try to initialise superTables anymore
     }
 
     @Nullable

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -247,7 +247,7 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
     }
 
     @Nullable
-    public List<PostgreTableInheritance> getSuperInheritance(DBRProgressMonitor monitor) throws DBException {
+    public synchronized List<PostgreTableInheritance> getSuperInheritance(DBRProgressMonitor monitor) throws DBException {
         if (superTables == null && getDataSource().getServerType().supportsInheritance()) {
             try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Load table inheritance info")) {
                 try (JDBCPreparedStatement dbStat = session.prepareStatement(


### PR DESCRIPTION
Fixed issue when child table DDL statement sometimes shows parent table name two times.
I think sometimes 2 threads go to method getSuperInheritance(it is a getter of superTables) at the same time. I have extracted initialization of superTables  and  added "synchronized" on it. Initialization is used only one time.