### PR TITLE
Incorrectly quoting values of a UUID array #8823

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreArrayValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreArrayValueHandler.java
@@ -148,7 +148,7 @@ public class PostgreArrayValueHandler extends JDBCArrayValueHandler {
                     // Multi-dimensional arrays case
                     itemString = getValueDisplayString(column, item, format);
                 } else {
-                    itemString = valueHandler.getValueDisplayString(collection.getComponentType(), item, DBDDisplayFormat.NATIVE);
+                    itemString = valueHandler.getValueDisplayString(collection.getComponentType(), item, format);
                 }
                 if (format == DBDDisplayFormat.NATIVE) {
                     str.append(SQLUtils.escapeString(collection.getComponentType().getDataSource(), itemString));


### PR DESCRIPTION
Deleted unnecessary quotes when copying an array of uuids from a column
Connected issues : #798 , #1623
This "if" is unnecessary in this case:
![image](https://user-images.githubusercontent.com/61096732/88058465-2e2f9c00-cb6c-11ea-8709-595c3a8b9b5a.png)

Before/After this PR
![image](https://user-images.githubusercontent.com/61096732/88059079-03921300-cb6d-11ea-8de2-020048d27201.png)

