### PR TITLE
Task configuration: hide empty properties #9343

### DIFF
--- a/plugins/org.jkiss.dbeaver.tasks.sql.ui/src/org/jkiss/dbeaver/tasks/ui/sql/SQLToolTaskWizardPageSettings.java
+++ b/plugins/org.jkiss.dbeaver.tasks.sql.ui/src/org/jkiss/dbeaver/tasks/ui/sql/SQLToolTaskWizardPageSettings.java
@@ -224,7 +224,7 @@ class SQLToolTaskWizardPageSettings extends ActiveWizardPage<SQLToolTaskWizard> 
 
         loadSettings();
 
-        if (taskOptionsViewer.getTree().getItems().length == 0) {
+        if (taskOptionsViewer.getTree().getItemCount() == 0) {
             settingsPanel.setMaximizedControl(objectsPanel);
         }
 

--- a/plugins/org.jkiss.dbeaver.tasks.sql.ui/src/org/jkiss/dbeaver/tasks/ui/sql/SQLToolTaskWizardPageSettings.java
+++ b/plugins/org.jkiss.dbeaver.tasks.sql.ui/src/org/jkiss/dbeaver/tasks/ui/sql/SQLToolTaskWizardPageSettings.java
@@ -91,9 +91,9 @@ class SQLToolTaskWizardPageSettings extends ActiveWizardPage<SQLToolTaskWizard> 
         previewSplitter.setLayoutData(new GridData(GridData.FILL_BOTH));
 
         SashForm settingsPanel = new SashForm(previewSplitter, SWT.HORIZONTAL);
-
+        Group objectsPanel;
         {
-            Group objectsPanel = UIUtils.createControlGroup(settingsPanel, TasksSQLUIMessages.sql_tool_task_wizard_page_settings_group_label_objects, 2, GridData.FILL_BOTH, 0);
+            objectsPanel = UIUtils.createControlGroup(settingsPanel, TasksSQLUIMessages.sql_tool_task_wizard_page_settings_group_label_objects, 2, GridData.FILL_BOTH, 0);
             objectsViewer = new TableViewer(objectsPanel, SWT.BORDER | SWT.MULTI | SWT.FULL_SELECTION);
             objectsViewer.setContentProvider(new ListContentProvider());
             objectsViewer.setLabelProvider(new ColumnLabelProvider() {
@@ -223,6 +223,10 @@ class SQLToolTaskWizardPageSettings extends ActiveWizardPage<SQLToolTaskWizard> 
         getWizard().createTaskSaveButtons(controlsPanel, true, 1);
 
         loadSettings();
+
+        if (taskOptionsViewer.getTree().getItems().length == 0) {
+            settingsPanel.setMaximizedControl(objectsPanel);
+        }
 
         setControl(composite);
     }


### PR DESCRIPTION
taskOptionsViewer is invisible if there are no item options

![image](https://user-images.githubusercontent.com/61096732/88284891-dbceb680-ccf6-11ea-93d2-98c8ef439fa8.png)
