### PR TITLE
[#9387] Fixed generating ddl logic to show comment for postgres

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -22,6 +22,7 @@ import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.PostgreUtils;
+import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.data.DBDPseudoAttribute;
 import org.jkiss.dbeaver.model.data.DBDPseudoAttributeContainer;
@@ -161,6 +162,10 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
 
     @Override
     public String getObjectDefinitionText(DBRProgressMonitor monitor, Map<String, Object> options) throws DBException {
+    	if(!options.containsKey(DBPScriptObject.OPTION_DDL_SOURCE)) {
+    	    options.put(DBPScriptObject.OPTION_DDL_SOURCE, true);
+    		options.put(PostgreConstants.OPTION_DDL_SHOW_COLUMN_COMMENTS, true);
+    	}
         return DBStructUtils.generateTableDDL(monitor, this, options, false);
     }
 


### PR DESCRIPTION
This logic works well without disturbing existing logic (DDL tab + Show comments toggle).

I tried to create a show comment tab in the Generated SQL viewer, but Oracle shows the comment when schema contains the comment. So I referenced that. 

# DDL tab
![image](https://user-images.githubusercontent.com/6668548/88863727-7589ec80-d23e-11ea-9ea7-f69146f0e73a.png)

# DDL tab (with Show comments)
![image](https://user-images.githubusercontent.com/6668548/88863745-8175ae80-d23e-11ea-9327-ac2eaeddfb6f.png)

# Generate DDL
![image](https://user-images.githubusercontent.com/6668548/88863770-92262480-d23e-11ea-972f-ad68755cecc3.png)

