### PR TITLE
Oracle: Use URL template for custom connections

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/views/OracleConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/views/OracleConnectionPage.java
@@ -244,7 +244,7 @@ public class OracleConnectionPage extends ConnectionPageWithAuth implements ICom
         targetContainer.setLayoutData(new GridData(GridData.FILL_BOTH));
         protocolTabCustom.setControl(targetContainer);
 
-        final Label urlLabel = UIUtils.createControlLabel(targetContainer, "JDBC URL"); //$NON-NLS-1$
+        final Label urlLabel = UIUtils.createControlLabel(targetContainer, "JDBC URL Template"); //$NON-NLS-1$
         urlLabel.setLayoutData(new GridData(GridData.VERTICAL_ALIGN_BEGINNING));
 
         connectionUrlText = new Text(targetContainer, SWT.BORDER | SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/OracleDataSourceProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/OracleDataSourceProvider.java
@@ -33,6 +33,7 @@ import org.jkiss.dbeaver.model.connection.DBPNativeClientLocation;
 import org.jkiss.dbeaver.model.connection.DBPNativeClientLocationManager;
 import org.jkiss.dbeaver.model.impl.auth.AuthModelDatabaseNative;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCDataSourceProvider;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCURL;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.utils.CommonUtils;
 
@@ -65,7 +66,7 @@ public class OracleDataSourceProvider extends JDBCDataSourceProvider implements 
             connectionType = OracleConstants.ConnectionType.BASIC;
         }
         if (connectionType == OracleConstants.ConnectionType.CUSTOM) {
-            return connectionInfo.getUrl();
+            return JDBCURL.generateUrlByTemplate(connectionInfo.getUrl(), connectionInfo);
         }
         StringBuilder url = new StringBuilder(100);
         url.append("jdbc:oracle:thin:@"); //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCURL.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCURL.java
@@ -38,6 +38,11 @@ public class JDBCURL {
     private static final char URL_OPTIONAL_END = ']'; //$NON-NLS-1$
 
     public static String generateUrlByTemplate(DBPDriver driver, DBPConnectionConfiguration connectionInfo) {
+        String urlTemplate = driver.getSampleURL();
+        return JDBCURL.generateUrlByTemplate(urlTemplate, connectionInfo);
+    }
+
+    public static String generateUrlByTemplate(String urlTemplate, DBPConnectionConfiguration connectionInfo) {
         if (!CommonUtils.isEmpty(connectionInfo.getUrl()) &&
             CommonUtils.isEmpty(connectionInfo.getHostPort()) &&
             CommonUtils.isEmpty(connectionInfo.getHostName()) &&
@@ -48,7 +53,6 @@ public class JDBCURL {
             return connectionInfo.getUrl();
         }
         try {
-            String urlTemplate = driver.getSampleURL();
             if (CommonUtils.isEmptyTrimmed(urlTemplate)) {
                 return connectionInfo.getUrl();
             }


### PR DESCRIPTION
This allows you to use {host} and {port} so dynamically-assigned local SSH ports work.

I need this in my context because we use an Oracle database with an SSL connection but which we can only access through an SSH tunnel. We need a horrible looking TNS connection string as part of the JDBC URL with the host and port embedded in it: `jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(PORT={port})(HOST=localhost))(CONNECT_DATA=(SID=ORCL)))`

Using this string, I can set the remote endpoint of the tunnel to the database host and port, and leave the local end with port 0 for a dynamically chosen free one, and the Oracle driver connects to the allocated port.