### PR TITLE
PostgreSQL table comment  DDL. #9387

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -22,6 +22,7 @@ import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.PostgreUtils;
+import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.data.DBDPseudoAttribute;
 import org.jkiss.dbeaver.model.data.DBDPseudoAttributeContainer;
@@ -161,6 +162,11 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
 
     @Override
     public String getObjectDefinitionText(DBRProgressMonitor monitor, Map<String, Object> options) throws DBException {
+        if (!CommonUtils.getBoolean(options.get(OPTION_SCRIPT_FORMAT_COMPACT), true)) {
+            options.put(DBPScriptObject.OPTION_DDL_SOURCE, true);
+            options.put(PostgreConstants.OPTION_DDL_SHOW_COLUMN_COMMENTS, true);
+            return DBStructUtils.generateTableDDL(monitor, this, options, false);
+        }
         return DBStructUtils.generateTableDDL(monitor, this, options, false);
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -165,7 +165,6 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
         if (!CommonUtils.getBoolean(options.get(OPTION_SCRIPT_FORMAT_COMPACT), true)) {
             options.put(DBPScriptObject.OPTION_DDL_SOURCE, true);
             options.put(PostgreConstants.OPTION_DDL_SHOW_COLUMN_COMMENTS, true);
-            return DBStructUtils.generateTableDDL(monitor, this, options, false);
         }
         return DBStructUtils.generateTableDDL(monitor, this, options, false);
     }


### PR DESCRIPTION
Added table and column comments to ddl, they can be turned off by pressing "Compact"-button.

This PR was inspired by https://github.com/dbeaver/dbeaver/pull/9401 .

![image](https://user-images.githubusercontent.com/61096732/89536084-05600580-d800-11ea-9b54-00b50e21d513.png)

![image](https://user-images.githubusercontent.com/61096732/89536558-c41c2580-d800-11ea-810a-516832ef4fa0.png)

