### PR TITLE
SQL Server: use empty string for name if can't obtain

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql.ui/src/org/jkiss/dbeaver/ext/mssql/ui/SQLServerConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql.ui/src/org/jkiss/dbeaver/ext/mssql/ui/SQLServerConnectionPage.java
@@ -247,7 +247,7 @@ public class SQLServerConnectionPage extends ConnectionPageAbstract implements I
             if (getSite().isNew() && CommonUtils.isEmpty(databaseName)) {
                 databaseName = CommonUtils.notEmpty(site.getDriver().getDefaultDatabase());
             }
-            dbText.setText(databaseName);
+            dbText.setText(CommonUtils.notEmpty(databaseName));
         }
         if (userNameText != null) {
             if (site.isNew() && CommonUtils.isEmpty(connectionInfo.getUserName())) {


### PR DESCRIPTION
.