### PR TITLE
MySQL 8: fix duplicates in foreign keys

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
@@ -494,7 +494,14 @@ public class MySQLTable extends MySQLTableBase implements DBPObjectStatistics
                             fkList.add(fk);
                         }
                         MySQLTableForeignKeyColumn fkColumnInfo = new MySQLTableForeignKeyColumn(fk, fkColumn, keySeq, pkColumn);
-                        fk.addColumn(fkColumnInfo);
+                        if (fk.hasColumn(fkColumnInfo)) {
+                            // Known MySQL bug, metaData.getImportedKeys() can return duplicates
+                            // https://bugs.mysql.com/bug.php?id=95280
+                            log.debug("FK "+ fkName +" has already been added, skip");
+                        }
+                        else {
+                            fk.addColumn(fkColumnInfo);
+                        }
                     }
                 }
             } finally {

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTableForeignKey.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTableForeignKey.java
@@ -89,6 +89,20 @@ public class MySQLTableForeignKey extends JDBCTableForeignKey<MySQLTable, MySQLT
         columns.add(column);
     }
 
+    public boolean hasColumn(MySQLTableForeignKeyColumn column) {
+        if (columns != null) {
+            String columnName = column.getName();
+            String refName = column.getReferencedColumn().getName();
+            for (MySQLTableForeignKeyColumn col : columns) {
+                if (columnName.equals(col.getName()) &&
+                    refName.equals(col.getReferencedColumn().getName())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     @NotNull
     @Override
     public String getFullyQualifiedName(DBPEvaluationContext context)


### PR DESCRIPTION
In MySQL 8, the function metaData.getImportedKeys() may return twice the same column in the result set.
This is a known bug that has been reported here: https://bugs.mysql.com/bug.php?id=95280.

This issue can be a bit annoying in the case of DBeaver, especially because it breaks the foreign key link feature in the data viewer (It shows an error dialog with message "Entity <db.table> association <fk> columns differs from referenced constraint"). Cf issue #4768 which is exactly what I'm referring to.

I just created a patch to fix this issue. Basically when building the FK list, it checks if the column is already in the list before registering it. Hopefully this pull request gets accepted :)