### PR TITLE
#10266 (Hana) Public Synonyms

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
@@ -66,6 +66,7 @@ public class GenericDataSource extends JDBCDataSource implements DBPTermProvider
     private List<GenericSchema> schemas;
     private final GenericMetaModel metaModel;
     private GenericObjectContainer structureContainer;
+    private GenericSchema publicSchema;
 
     private String queryGetActiveDB;
     private String querySetActiveDB;

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericSchema.java
@@ -25,18 +25,23 @@ import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSEntity;
 import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.dbeaver.model.struct.rdb.DBSPublicSynonymSchema;
 import org.jkiss.dbeaver.model.struct.rdb.DBSSchema;
 
 /**
  * GenericSchema
  */
-public class GenericSchema extends GenericObjectContainer implements DBSSchema, DBPSystemObject, DBPVirtualObject
+public class GenericSchema extends GenericObjectContainer implements DBSSchema, DBPSystemObject, DBPVirtualObject, DBSPublicSynonymSchema
 {
     @Nullable
     private GenericCatalog catalog;
     @NotNull
     private String schemaName;
     private boolean virtualSchema;
+    /**
+     * A
+     */
+    private boolean isPublicSynonymSchema;
 
     public GenericSchema(@NotNull GenericDataSource dataSource, @Nullable GenericCatalog catalog, @NotNull String schemaName)
     {
@@ -107,5 +112,13 @@ public class GenericSchema extends GenericObjectContainer implements DBSSchema, 
     public void setVirtual(boolean nullSchema) {
         this.virtualSchema = nullSchema;
     }
+
+	public boolean isPublicSynonymSchema() {
+		return isPublicSynonymSchema;
+	}
+
+	public void setPublicSynonymSchema(boolean isPublicSchema) {
+		this.isPublicSynonymSchema = isPublicSchema;
+	}
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAMetaModel.java
@@ -67,12 +67,14 @@ public class HANAMetaModel extends GenericMetaModel
     @Override
     public List<GenericSchema> loadSchemas(JDBCSession session, GenericDataSource dataSource, GenericCatalog catalog) throws DBException {
         List<GenericSchema> schemas = super.loadSchemas(session, dataSource, catalog);
-        GenericSchema publicSchema = new GenericSchema(dataSource, catalog, PUBLIC_SCHEMA_NAME);
+        GenericSchema publicSchema = new HANAPublicSchema(dataSource, catalog, PUBLIC_SCHEMA_NAME);
+        /*
+         * Placee the PUBLIC schema at the top, not ordered by name 
         int i;
         for (i = 0; i < schemas.size(); i++)
             if (schemas.get(i).getName().compareTo(PUBLIC_SCHEMA_NAME) > 0)
-                break;
-        schemas.add(i, publicSchema);
+                break; */
+        schemas.add(0, publicSchema);
         return schemas;
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAPublicSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAPublicSchema.java
@@ -1,0 +1,34 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2020 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.hana.model;
+
+import org.jkiss.dbeaver.ext.generic.model.GenericCatalog;
+import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
+import org.jkiss.dbeaver.ext.generic.model.GenericSchema;
+
+/**
+ * This is just a simple placeholder for the Hana PUBLIC schema with all its synonyms
+ *
+ */
+public class HANAPublicSchema extends GenericSchema {
+
+	public HANAPublicSchema(GenericDataSource dataSource, GenericCatalog catalog, String schemaName) {
+		super(dataSource, catalog, schemaName);
+		super.setPublicSynonymSchema(true);
+	}
+
+}

--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAStructureAssistant.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAStructureAssistant.java
@@ -65,10 +65,7 @@ public class HANAStructureAssistant extends JDBCStructureAssistant<JDBCExecution
         GenericSchema parentSchema = parentObject instanceof GenericSchema ? (GenericSchema) parentObject : null;
 
         if (objectType == RelationalObjectType.TYPE_TABLE)
-        	/* 
-        	 * A TYPE_TABLE is requested in any kind of select statement. Hence it should return tables, views and (public) synonyms
-        	 */
-        	findObjectsByMask(session, parentSchema, objectNameMask, caseSensitive, maxResults, result);
+        	findTablesByMask(session, parentSchema, objectNameMask, caseSensitive, maxResults, result);
         if (objectType == RelationalObjectType.TYPE_VIEW)
             findViewsByMask(session, parentSchema, objectNameMask, caseSensitive, maxResults, result);
         if (objectType == RelationalObjectType.TYPE_PROCEDURE)

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/rdb/DBSPublicSynonymSchema.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/rdb/DBSPublicSynonymSchema.java
@@ -1,0 +1,27 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2020 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jkiss.dbeaver.model.struct.rdb;
+
+/**
+ * PublicSynonymSchema is a marker telling that this schema contains public synonyms.
+ * These are important when queries with out a schema qualifier are executed.
+ */
+public interface DBSPublicSynonymSchema
+{
+	boolean isPublicSynonymSchema();
+}


### PR DESCRIPTION
I had multiple issues with Hana around public synonyms and the case did spread a bit into the Generic* package.

The starting point was the following: Hana supports synonyms and public synonyms. Public synonyms are used a lot for data dictionary, e.g. PUBLIC.TABLES points to SYS.TABLES. A normal synonyms are used often for cross schema access.

Examples:
1 select * from PUBLIC.TABLES; (schema + **synonym**)
2 select * from SYS.TABLES; (schema + table/view)
3 select * from TABLES; (public **synonym**)
4 select * from MYSCHEMA.TABLE1; (schema + table/view)
5 select * from TABLE1; (table/view in selectedschema)
6 select * from MYSCHEMA.REMOTETABLE1; (schema + **synonym**)
7 select * from REMOTETABLE1; (**synonym** in selectedschema)

For all these cases
* auto complete
* column binding (when executing the query);

must work.

When testing only case 2), 4) and 5) did work, and these are the ones where neither a local nor a public synonym had been involved.

The first required change was to add an indication what the public schema is. When a query without a schema is executed, the logic tries to find the table in the selected schema and if not found, must now try for public synonyms. So we must know what schema the public synonym is.

For that I followed the isVirtual() approach and added an interface DBSPublicSynonymSchema and GenericSchema implements it.
Next is the getChildren() and getChild(). They return the TableCache only but must return synonyms as well. Hence I modified the GenericObjectContainer. Problem is, the variables tableCache and synonyms are different. In Oracle a SynonymCache class was added. Instead I changed the synonyms from ArrayList to Map (sorted). This is sort of a poor man's cache. If an ArrayList is fine, a simple Map should be as well.
Finally I had to modify the autocomplete code in certain points to support the missing 4 combinations from above list of seven queries.

One thing I did not however: When a object name without a schema is typed, e.g. "select * from tab..." I do not add the public synonyms to the list. It depends on the persona. An administrator will hate to be forced typing "select * from public.tab..." because he is using these mostly. A normal developer would hate to get the 2000 synonyms shown, all with generic names, instead of the objects in his schema. I decided to focus on the latter persona.


Regarding side effects, I have tested as much as I can. Hana builds on the Generic classes so does SQL Server and two more. As they do not add a public synonym schema (yet), there shouldn't be a negative side effect. Does any of these databases even support public synonyms? For local synonyms it depends on how those database supporting those (SQL Server only) behave. It might actually be that they lack from the same issue as Hana did with synonyms and then this PR would allow the same enhancement there as well.
