### PR TITLE
Fix navigate association not working on mysql 8 in some cases

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
@@ -443,21 +443,26 @@ public class MySQLTable extends MySQLTableBase implements DBPObjectStatistics
 
                     // Find PK
                     MySQLTableConstraint pk = null;
-                    if (pkTable != null && pkName != null) {
-                        pk = DBUtils.findObject(pkTable.getConstraints(monitor), pkName);
-                        if (pk == null) {
-                            log.warn("Unique key '" + pkName + "' not found in table " + pkTable.getFullyQualifiedName(DBPEvaluationContext.DDL));
-                        }
-                    }
-                    if (pk == null && pkTable != null) {
+                    if (pkTable != null) {
+                    	// Find pk based on referenced columns
                         Collection<MySQLTableConstraint> constraints = pkTable.getConstraints(monitor);
                         if (constraints != null) {
                             for (MySQLTableConstraint pkConstraint : constraints) {
                                 if (pkConstraint.getConstraintType().isUnique() && DBUtils.getConstraintAttribute(monitor, pkConstraint, pkColumn) != null) {
                                     pk = pkConstraint;
-                                    break;
+                                    if (pkConstraint.getName().equals(pkName))
+                                    	break;
+                                    // If pk name does not match, keep searching (actual pk might not be this one)
                                 }
                             }
+                        }
+                    }
+                    if (pk == null && pkTable != null && pkName != null) {
+                    	// Find pk based on name
+                    	Collection<MySQLTableConstraint> constraints = pkTable.getConstraints(monitor);
+                    	pk = DBUtils.findObject(constraints, pkName);
+                        if (pk == null) {
+                            log.warn("Unique key '" + pkName + "' not found in table " + pkTable.getFullyQualifiedName(DBPEvaluationContext.DDL));
                         }
                     }
                     if (pk == null && pkTable != null) {


### PR DESCRIPTION
In mysql 8 driver, navigation association does not work well when the foreign key is not referencing to the primary key of the target table. You can reproduce it by creating a MySQL 8 database and running [this script](https://timothe.malahieude.net/dbeaver-bug-mysql8.sql). The foreign key link for customer_bill_id in table product does not work.
This is due to a bug in mysql 8 driver itself, (it always return PRIMARY as PK_NAME in getImportedKeys method).
I managed to fix this by changing the way the referenced pk is retreived in DBeaver. I basically switched 2 blocks of code and added an extra check to increase the chance of actually retreiving the right pk.
Feel free to merge :)
