### PR TITLE
improve exception forwarding if !isSchemasOptional()

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
@@ -526,7 +526,10 @@ public class GenericDataSource extends JDBCDataSource implements DBPTermProvider
                     if (metaModel.isSchemasOptional()) {
                         log.warn("Can't read schema list", e);
                     } else {
-                        throw new DBException("Error reading schema list", e);
+                        if (e instanceof DBException) {
+                            throw (DBException) e;
+                        }
+                        throw new DBException("Error reading schema list", e, this);
                     }
                 }
 

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/GenericMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/GenericMetaModel.java
@@ -155,9 +155,13 @@ public class GenericMetaModel {
                             dataSource.getAllObjectsPattern());
                     catalogSchemas = true;
                 } catch (Throwable e) {
-                    // This method not supported (may be old driver version)
-                    // Use general schema reading method
-                    log.debug("Error reading schemas in catalog '" + catalog.getName() + "' - " + e.getClass().getSimpleName() + " - " + e.getMessage());
+                    if (isSchemasOptional()) {
+                        // This method not supported (may be old driver version)
+                        // Use general schema reading method
+                        log.debug("Error reading schemas in catalog '" + catalog.getName() + "' - " + e.getClass().getSimpleName() + " - " + e.getMessage());
+                    } else {
+                        throw e;
+                    }
                 }
             } else if (dataSource.isSchemaFiltersEnabled()) {
                 // In some drivers (e.g. jt400) reading schemas with empty catalog leads to
@@ -169,7 +173,11 @@ public class GenericMetaModel {
                             schemaFilters.getSingleMask() :
                             dataSource.getAllObjectsPattern());
                 } catch (Throwable e) {
-                    log.debug("Error reading global schemas " + " - " + e.getMessage());
+                    if (isSchemasOptional()) {
+                        log.debug("Error reading global schemas " + " - " + e.getMessage());
+                    } else {
+                        throw e;
+                    }
                 }
             }
             if (dbResult == null) {
@@ -244,9 +252,14 @@ public class GenericMetaModel {
             log.debug("Can't read schema list: " + e.getMessage());
             return null;
         } catch (Throwable ex) {
-            // Schemas do not supported - just ignore this error
-            log.warn("Can't read schema list", ex);
-            return null;
+            if (isSchemasOptional()) {
+                // Schemas are not supported - just ignore this error
+                log.warn("Can't read schema list", ex);
+                return null;
+            } else {
+                log.error("Can't read schema list", ex);
+                throw new DBException(ex, dataSource);
+            }
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana/src/org/jkiss/dbeaver/ext/hana/model/HANAMetaModel.java
@@ -72,6 +72,8 @@ public class HANAMetaModel extends GenericMetaModel
     @Override
     public List<GenericSchema> loadSchemas(JDBCSession session, GenericDataSource dataSource, GenericCatalog catalog) throws DBException {
         List<GenericSchema> schemas = super.loadSchemas(session, dataSource, catalog);
+        // throws exception if password or license expired
+
         GenericSchema publicSchema = new GenericSchema(dataSource, catalog, PUBLIC_SCHEMA_NAME);
         int i;
         for (i = 0; i < schemas.size(); i++)

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
@@ -887,6 +887,7 @@ public class DataSourceDescriptor
                         dataSource.initialize(monitor);
                     } catch (Throwable e) {
                         log.error("Error initializing datasource", e);
+                        throw e;
                     }
                 }
 


### PR DESCRIPTION
replaces PR #10165

Implemented on top of #10510. I changed some more places that discarded the exception. Without change in `DataSourceDescriptor.java` the error dialog is only shown when refreshing schema list with F5, but not on initial connect.

You can easilily reproduce this with HANA by creating a new user with `CREATE USER <name> PASSWORD <passwd>`. The new user does not return schemas, but an error that it requires an initial password change:
![grafik](https://user-images.githubusercontent.com/25850372/100550726-1be10f80-327c-11eb-87be-c4c8683b1cc7.png)

