### PR TITLE
use recent version of mariadb-connector-j

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
@@ -241,7 +241,7 @@
                     description="MariaDB JDBC driver"
                     promoted="1"
                     categories="sql">
-                    <file type="jar" path="maven:/org.mariadb.jdbc:mariadb-java-client:RELEASE[2.4.3]" bundle="!drivers.mariadb"/>
+                    <file type="jar" path="maven:/org.mariadb.jdbc:mariadb-java-client:RELEASE[2.7.1]" bundle="!drivers.mariadb"/>
 
                     <file type="license" path="drivers/mariadb/LICENSE.txt" bundle="drivers.mariadb"/>
                     <file type="jar" path="drivers/mariadb" bundle="drivers.mariadb"/>


### PR DESCRIPTION
The MariaDB connector used to select an odd collation for the
connection when the server is configured to use non-mb4 utf8.
This was fixed upstream [0] and made its way into version
2.6.1. That's the minimum version I need, but let's just bump to the
recent version 2.7.1.

[0] https://github.com/mariadb-corporation/mariadb-connector-j/commit/6edc091e7e034b6ba3a764f30391de827179c96a