### PR TITLE
Fix error when pasting more rows than current number of rows in ResultSetViewer

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/LightGrid.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/LightGrid.java
@@ -4254,7 +4254,9 @@ public abstract class LightGrid extends Canvas {
         }
         List<GridCell> cells = new ArrayList<>(selectedCells.size());
         for (GridPos pos : selectedCells) {
-            cells.add(posToCell(pos));
+        	GridCell cell = posToCell(pos);
+        	if (cell != null)
+        		cells.add(cell);
         }
         return cells;
     }

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/LightGrid.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/LightGrid.java
@@ -671,6 +671,9 @@ public abstract class LightGrid extends Canvas {
         if (pos.col < 0 || pos.row < 0) {
             return null;
         }
+        if (pos.col >= columnElements.length || pos.row >= rowElements.length) {
+            return null;
+        }
         return new GridCell(columnElements[pos.col], rowElements[pos.row]);
     }
 


### PR DESCRIPTION
When I use Advanced Paste in a table to add new rows, I have to ensure that I leave enough room for the rows I am creating, otherwise it shows me an error dialog:
![image](https://user-images.githubusercontent.com/32641321/106333786-aef0f280-6289-11eb-9a30-7bb0ab1c0477.png)
It was not the case in 7.3.2 version of dbeaver. The error seams to come from this commt: https://github.com/dbeaver/dbeaver/commit/f740fb41e970a382eddefd3c49465cb8144f1e25

I found a way to fix it by adding an out of bounds check in LightGrid.posToCell (make sure that target position is less than grid length). Not sure if it's the most relevant fix but it seams to make sense since there is already a check in the other way (make sure that position is greater than 0).
