### PR TITLE
chore: update official driver name and status of community driver

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.spanner/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ext.spanner/OSGI-INF/l10n/bundle.properties
@@ -1,3 +1,3 @@
 Bundle-Vendor = DBeaver Corp
-Bundle-Name = DBeaver Google Spanner Extension
+Bundle-Name = DBeaver Google Cloud Spanner Extension
 datasource.spanner.description = Spanner datasource

--- a/plugins/org.jkiss.dbeaver.ext.spanner/OSGI-INF/l10n/bundle_pt_BR.properties
+++ b/plugins/org.jkiss.dbeaver.ext.spanner/OSGI-INF/l10n/bundle_pt_BR.properties
@@ -1,5 +1,5 @@
 
-Bundle-Name = DBeaver Google Spanner Extens\u00E3o 
+Bundle-Name = DBeaver Google Cloud Spanner Extens\u00E3o 
 
 Bundle-Vendor = DBeaver Corp
 

--- a/plugins/org.jkiss.dbeaver.ext.spanner/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.spanner/plugin.xml
@@ -19,7 +19,7 @@
 
                 <driver
                         id="spanner_jdbc_official"
-                        label="Google Spanner"
+                        label="Google Cloud Spanner"
                         icon="icons/spanner_icon.png"
                         iconBig="icons/spanner_icon_big.png"
                         class="com.google.cloud.spanner.jdbc.JdbcDriver"
@@ -35,13 +35,13 @@
                 
                 <driver
                         id="spanner_jdbc"
-                        label="Google Spanner (Community)"
+                        label="Google Cloud Spanner (Deprecated)"
                         icon="icons/spanner_icon.png"
                         iconBig="icons/spanner_icon_big.png"
                         class="nl.topicus.jdbc.CloudSpannerDriver"
                         sampleURL="jdbc:cloudspanner://localhost"
                         defaultPort=""
-                        description="Google Spanner JDBC community (Topicus) driver"
+                        description="Google Spanner JDBC community (Topicus) driver (Deprecated, use the officially supported driver instead)"
                         webURL="https://github.com/olavloite/spanner-jdbc"
                         categories="sql,bigdata,cloud">
                     <parameter name="omit-catalog" value="true"/>
@@ -55,7 +55,7 @@
     </extension>
 
     <extension point="org.jkiss.dbeaver.sqlDialect">
-        <dialect id="spanner" parent="generic" class="org.jkiss.dbeaver.ext.spanner.model.SpannerSQLDialect" label="Spanner" description="Google Spanner SQL dialect." icon="icons/spanner_icon.png">
+        <dialect id="spanner" parent="generic" class="org.jkiss.dbeaver.ext.spanner.model.SpannerSQLDialect" label="Spanner" description="Google Cloud Spanner SQL dialect." icon="icons/spanner_icon.png">
         </dialect>
     </extension>
 


### PR DESCRIPTION
The official driver name should be `Google Cloud Spanner` to correspond with the name of the database and the corresponding JDBC driver.

The community driver has been deprecated and does not receive any updates anymore. Users should therefore whenever possible use the offically supported driver instead of the community driver. See also https://github.com/olavloite/spanner-jdbc#deprecated