### PR TITLE
#7032 read index DDL for Oracle tables

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleTableBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleTableBase.java
@@ -39,6 +39,7 @@ import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSObjectState;
+import org.jkiss.dbeaver.model.struct.DBStructUtils;
 import org.jkiss.dbeaver.model.struct.rdb.DBSTableForeignKey;
 import org.jkiss.dbeaver.model.struct.rdb.DBSTableIndex;
 import org.jkiss.utils.CommonUtils;
@@ -288,7 +289,11 @@ public abstract class OracleTableBase extends JDBCTable<OracleDataSource, Oracle
     public String getDDL(DBRProgressMonitor monitor, OracleDDLFormat ddlFormat, Map<String, Object> options)
         throws DBException
     {
-        return OracleUtils.getDDL(monitor, getTableTypeName(), this, ddlFormat, options);
+        if (isPersisted()) {
+            return OracleUtils.getDDL(monitor, getTableTypeName(), this, ddlFormat, options);
+        } else {
+            return DBStructUtils.generateTableDDL(monitor, this, options, true);
+        }
     }
 
     @NotNull


### PR DESCRIPTION
- use DBeaver DDL generator for new tables
![2021-04-02 01_01_12-DBeaver Enterprise 21 0 2 - NewTable](https://user-images.githubusercontent.com/45152336/113359165-e2b2cc00-934f-11eb-83f3-0b554e0738b1.png)

![2021-04-02 01_02_08-DBeaver Enterprise 21 0 2 - PK](https://user-images.githubusercontent.com/45152336/113359167-e3e3f900-934f-11eb-8516-208c1f61b5db.png)

![2021-04-02 01_02_31-DBeaver Enterprise 21 0 2 - PK](https://user-images.githubusercontent.com/45152336/113359168-e3e3f900-934f-11eb-9d3b-d5673ad5dfb4.png)