### PR TITLE
changed url for debeaver license text.

### DIFF
--- a/features/org.jkiss.dbeaver.ui.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.ui.feature/feature.properties
@@ -2,5 +2,5 @@ featureName=DBeaver Desktop UI
 providerName=JKISS
 description=DBeaver Desktop UI
 copyright=(C) 2010-2021, DBeaver Corp
-licenseURL=https://dbeaver.io/files/dbeaver_license.txt
+licenseURL=https://dbeaver.io/product/dbeaver_license.txt
 


### PR DESCRIPTION
1. I noticed that license url doesn't exist. (https://dbeaver.io/files/dbeaver_license.txt)
3. found new url on dbeaver.io, changed it. 