### PR TITLE
Updated colortheme url

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.ui.colortheme/pom.xml
+++ b/plugins/org.jkiss.dbeaver.ext.ui.colortheme/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>eclipse-color-theme</id>
-            <url>https://eclipse-color-theme.github.com/update</url>
+            <url>https://eclipse-color-theme.github.io/update</url>
             <layout>p2</layout>
         </repository>
     </repositories>


### PR DESCRIPTION
when trying to build from source the build fails when trying to get to `https://eclipse-color-theme.github.com/update` when going to that link it throws a 404.  Changing the link to `https://eclipse-color-theme-github.io/update` fixes the build and allows it to proceed to completion. 