### PR TITLE
#12206 [Sybase] remove space after double dash in Dialect

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDialect.java
@@ -275,8 +275,8 @@ public class SQLServerDialect extends JDBCSQLDialect {
     @Override
     public String[] getSingleLineComments() {
         if (!isSqlServer) {
-            // Sybase support also double slash as comment indicator (and "%" - but not recommend to use it in documentation)
-            return new String[]{"-- ", "//"};
+            // Sybase supports double dash and double slash as single line comment indicators (and "%" - but not recommend to use it in documentation)
+            return new String[]{SQLConstants.SL_COMMENT, "//"};
         } else {
             return super.getSingleLineComments();
         }


### PR DESCRIPTION
remove space after double dash (single line comment indicator in Sybase)

![2021-04-22 13_02_37-DBeaver Enterprise 21 0 3 - _none_ Script-44](https://user-images.githubusercontent.com/45152336/115696311-3a4ec100-a36b-11eb-9732-b64e3e9e1904.png)
