### PR TITLE
Redshift missing columns when view is configured as a non-binding.

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreConstants.java
@@ -103,6 +103,8 @@ public class PostgreConstants {
     public static final String TYPE_INTERVAL = "interval";
     public static final String TYPE_TIME = "time";
     public static final String TYPE_TIMESTAMP = "timestamp";
+    public static final String TYPE_TIMETZ = "timetz";
+    public static final String TYPE_TIMESTAMPTZ = "timestamptz";
 
     public static final String HANDLER_SSL = "postgre_ssl";
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
@@ -254,6 +254,10 @@ public class PostgreServerRedshift extends PostgreServerExtensionBase implements
         Map<String, String> aliasMap = new LinkedHashMap<>(super.getDataTypeAliases());
         aliasMap.put("character", PostgreConstants.TYPE_BPCHAR);
         aliasMap.put("character varying", PostgreConstants.TYPE_VARCHAR);
+        aliasMap.put("time with time zone", PostgreConstants.TYPE_TIMETZ);
+        aliasMap.put("time without time zone", PostgreConstants.TYPE_TIME);
+        aliasMap.put("timestamp with time zone", PostgreConstants.TYPE_TIMESTAMPTZ);
+        aliasMap.put("timestamp without time zone", PostgreConstants.TYPE_TIMESTAMP);        
         return aliasMap;
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftView.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftView.java
@@ -81,7 +81,7 @@ public class RedshiftView extends PostgreView
     private boolean isViewVwithNoSchemaBinding(DBRProgressMonitor monitor) throws DBException {
         getObjectDefinitionText(monitor, Collections.emptyMap());
         String viewDefinition = getSource();
-        return viewDefinition.contains("with no schema binding");
+        return viewDefinition.toLowerCase().contains("with no schema binding");
     }
 
     private List<PostgreTableColumn> readLateBindingColumns(DBRProgressMonitor monitor) throws DBException {


### PR DESCRIPTION
This change address two issues: 

- #12372 View columns not visible with 'NO SCHEMA BINDING' views on Redshift connection
- #12396 DBeaver 21.0.4: Not all columns showing in DB Navigation Pane/Generated SQL - View

It address a few aspects, first it will allow the column to display in the navigator and also allow the columns to show in 'generate sql' functions. 