### PR TITLE
Added a new test case to check Long values when importing CSV file

### DIFF
--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/tools/transfer/CSVImporterTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/tools/transfer/CSVImporterTest.java
@@ -85,6 +85,23 @@ public class CSVImporterTest {
         Assert.assertEquals(DBPDataKind.STRING, columnsInfo.get(2).getDataKind());
         Assert.assertEquals(DBPDataKind.BOOLEAN, columnsInfo.get(3).getDataKind());
     }
+  
+    @Test
+    public void guessColumnTypesWithLongData() throws DBException, IOException {
+    	List<StreamDataImporterColumnInfo> columnsInfo = readColumnsInfo("2147483648,-9223372036854775808", false);
+    	Assert.assertEquals(2,  columnsInfo.size());
+    	Assert.assertEquals(DBPDataKind.NUMERIC, columnsInfo.get(0).getDataKind());
+    	Assert.assertEquals("INTEGER", columnsInfo.get(0).getTypeName());
+    	Assert.assertEquals(DBPDataKind.NUMERIC, columnsInfo.get(1).getDataKind());
+    	Assert.assertEquals("INTEGER", columnsInfo.get(1).getTypeName());
+    }
+    
+    @Test
+    public void returnsEmptyListWithEmptyFile() throws DBException, IOException {
+    	List<StreamDataImporterColumnInfo> columnsInfo = readColumnsInfo("", false);
+    	Assert.assertEquals(0,  columnsInfo.size());
+    }
+    
 
     @Test
     public void guessColumnTypesOverSamples() throws DBException, IOException {


### PR DESCRIPTION
Added a new test to correctly guess data types for Long input corresponding to the fixed Issue dbeaver#11561 and another new test case for importing an empty CSV file.