### PR TITLE
Fixed issue#10734 HTML file showing HTML entities

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterHTML.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterHTML.java
@@ -167,6 +167,7 @@ public class DataExporterHTML extends StreamExporterAbstract {
         if (value == null) {
             out.write("&nbsp;");
         } else {
+        	value = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
             out.write(value);
         }
         out.write("</th>");
@@ -178,6 +179,7 @@ public class DataExporterHTML extends StreamExporterAbstract {
         if (value == null) {
             out.write("&nbsp;");
         } else {
+        	value = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
             out.write(value);
         }
         out.write(header ? "</th>" : "</td>");

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterHTML.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterHTML.java
@@ -167,7 +167,6 @@ public class DataExporterHTML extends StreamExporterAbstract {
         if (value == null) {
             out.write("&nbsp;");
         } else {
-            value = value.replace("<", "&lt;").replace(">", "&gt;").replace("&", "&amp;");
             out.write(value);
         }
         out.write("</th>");
@@ -179,7 +178,6 @@ public class DataExporterHTML extends StreamExporterAbstract {
         if (value == null) {
             out.write("&nbsp;");
         } else {
-            value = value.replace("<", "&lt;").replace(">", "&gt;").replace("&", "&amp;");
             out.write(value);
         }
         out.write(header ? "</th>" : "</td>");

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterHTML.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterHTML.java
@@ -167,7 +167,7 @@ public class DataExporterHTML extends StreamExporterAbstract {
         if (value == null) {
             out.write("&nbsp;");
         } else {
-        	value = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+            value = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
             out.write(value);
         }
         out.write("</th>");
@@ -179,7 +179,7 @@ public class DataExporterHTML extends StreamExporterAbstract {
         if (value == null) {
             out.write("&nbsp;");
         } else {
-        	value = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+            value = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
             out.write(value);
         }
         out.write(header ? "</th>" : "</td>");


### PR DESCRIPTION
Hi DBeaver Community,

This is a fix for issue #10734. Exported HTML file is now able to display <, &, and >. I could not reproduce the same issue on the JSON file. JSON file actually works fine on my end. 

![after](https://user-images.githubusercontent.com/25361923/121417575-ea2dbd00-c91e-11eb-9cd0-f8d832c628fa.png)

