### PR TITLE
Fixed Issue#12676 Different column is exported to CSV when columns have the same name

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.office.ui/src/org/jkiss/dbeaver/data/office/ui/handlers/OpenSpreadsheetHandler.java
+++ b/plugins/org.jkiss.dbeaver.data.office.ui/src/org/jkiss/dbeaver/data/office/ui/handlers/OpenSpreadsheetHandler.java
@@ -69,12 +69,16 @@ public class OpenSpreadsheetHandler extends AbstractHandler
                 selectedRows.add((long) selectedRow.getRowNumber());
             }
             List<String> selectedAttributes = new ArrayList<>();
+            // this list stores the ordinal positions of the selected columns
+            List<Integer> selectedAttributesOrdinalPositions = new ArrayList<>();
             for (DBDAttributeBinding attributeBinding : rsSelection.getSelectedAttributes()) {
                 selectedAttributes.add(attributeBinding.getName());
+                selectedAttributesOrdinalPositions.add(attributeBinding.getOrdinalPosition());
             }
 
             options.setSelectedRows(selectedRows);
             options.setSelectedColumns(selectedAttributes);
+            options.setSelectedColumnsOrdinalPositions(selectedAttributesOrdinalPositions);
         }
         ResultSetDataContainer dataContainer = new ResultSetDataContainer(resultSet, options);
         if (dataContainer.getDataSource() == null) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetDataContainer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetDataContainer.java
@@ -167,9 +167,12 @@ public class ResultSetDataContainer implements DBSDataContainer, DBPContextProvi
             if (ac != null && !ac.isVisible()) {
                 continue;
             }
-            if (!filterAttributes || options.getSelectedColumns().contains(attr.getName())) {
+            // add column to the list of selected columns if either no filtering is to be done
+            // or the attribute name matches the selected column name and they are in the same ordinal position in the table
+            if (!filterAttributes || (options.getSelectedColumns().contains(attr.getName()) && options.getSelectedColumnsOrdinalPositions().contains(attr.getOrdinalPosition()))) {
                 filtered.add(attr);
             }
+            
         }
         filtered.sort((o1, o2) -> {
             DBDAttributeConstraint c1 = dataFilter.getConstraint(o1, true);

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetDataContainerOptions.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetDataContainerOptions.java
@@ -22,6 +22,9 @@ public class ResultSetDataContainerOptions {
 
     private List<Long> selectedRows;
     private List<String> selectedColumns;
+    // this keeps track of what are the indices of the columns selected. 
+    // This is needed to arbitrate in case two columns with same exist in a ResultSet but only one is selected
+    private List<Integer> selectedColumnsOrdinalPositions;
 
     public List<Long> getSelectedRows() {
         return selectedRows;
@@ -37,5 +40,13 @@ public class ResultSetDataContainerOptions {
 
     public void setSelectedColumns(List<String> selectedColumns) {
         this.selectedColumns = selectedColumns;
+    }
+    
+    public List<Integer> getSelectedColumnsOrdinalPositions() {
+    	return selectedColumnsOrdinalPositions;
+    }
+    
+    public void setSelectedColumnsOrdinalPositions(List<Integer> selectedColumnsOrdinalPositions) {
+    	this.selectedColumnsOrdinalPositions = selectedColumnsOrdinalPositions;
     }
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetDataContainerOptions.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetDataContainerOptions.java
@@ -23,7 +23,7 @@ public class ResultSetDataContainerOptions {
     private List<Long> selectedRows;
     private List<String> selectedColumns;
     // this keeps track of what are the indices of the columns selected. 
-    // This is needed to arbitrate in case two columns with same exist in a ResultSet but only one is selected
+    // This is needed to arbitrate in case two columns with same name exist in a ResultSet but only one is selected
     private List<Integer> selectedColumnsOrdinalPositions;
 
     public List<Long> getSelectedRows() {

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerCopyAs.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerCopyAs.java
@@ -104,18 +104,23 @@ public class ResultSetHandlerCopyAs extends AbstractHandler implements IElementU
         IResultSetSelection rsSelection = resultSet.getSelection();
         List<ResultSetRow> rsSelectedRows = rsSelection.getSelectedRows();
         List<DBDAttributeBinding> rsSelectedAttributes = rsSelection.getSelectedAttributes();
+
         if (rsSelectedRows.size() > 1 || rsSelectedAttributes.size() > 1) {
             List<Long> selectedRows = new ArrayList<>();
             for (ResultSetRow selectedRow : rsSelectedRows) {
                 selectedRows.add((long) selectedRow.getRowNumber());
             }
             List<String> selectedAttributes = new ArrayList<>();
+            // this list stores the ordinal positions of the selected columns
+            List<Integer> selectedAttributesOrdinalPositions = new ArrayList<>();
             for (DBDAttributeBinding attributeBinding : rsSelectedAttributes) {
                 selectedAttributes.add(attributeBinding.getName());
+                selectedAttributesOrdinalPositions.add(attributeBinding.getOrdinalPosition());
             }
 
             options.setSelectedRows(selectedRows);
             options.setSelectedColumns(selectedAttributes);
+            options.setSelectedColumnsOrdinalPositions(selectedAttributesOrdinalPositions);
         }
         ResultSetDataContainer dataContainer = new ResultSetDataContainer(resultSet, options);
         if (dataContainer.getDataSource() == null) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerMain.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerMain.java
@@ -486,13 +486,18 @@ public class ResultSetHandlerMain extends AbstractHandler {
                     selectedRows.add(Long.valueOf(selectedRow.getRowNumber()));
                 }
                 List<String> selectedAttributes = new ArrayList<>();
+                // this list stores the ordinal positions of the selected columns
+                List<Integer> selectedAttributesOrdinalPositions = new ArrayList<>();
+                
                 for (DBDAttributeBinding attributeBinding : rsv.getSelection().getSelectedAttributes()) {
                     selectedAttributes.add(attributeBinding.getName());
+                    selectedAttributesOrdinalPositions.add(attributeBinding.getOrdinalPosition());
                 }
 
                 ResultSetDataContainerOptions options = new ResultSetDataContainerOptions();
                 options.setSelectedRows(selectedRows);
                 options.setSelectedColumns(selectedAttributes);
+                options.setSelectedColumnsOrdinalPositions(selectedAttributesOrdinalPositions);
 
                 ResultSetDataContainer dataContainer = new ResultSetDataContainer(rsv, options);
                 DataTransferWizard.openWizard(

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerOpenWith.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerOpenWith.java
@@ -130,12 +130,16 @@ public class ResultSetHandlerOpenWith extends AbstractHandler implements IElemen
                 selectedRows.add((long) selectedRow.getRowNumber());
             }
             List<String> selectedAttributes = new ArrayList<>();
+            // this list stores the ordinal positions of the selected columns
+            List<Integer> selectedAttributesOrdinalPositions = new ArrayList<>();
             for (DBDAttributeBinding attributeBinding : rsSelectedAttributes) {
                 selectedAttributes.add(attributeBinding.getName());
+                selectedAttributesOrdinalPositions.add(attributeBinding.getOrdinalPosition());
             }
 
             options.setSelectedRows(selectedRows);
             options.setSelectedColumns(selectedAttributes);
+            options.setSelectedColumnsOrdinalPositions(selectedAttributesOrdinalPositions);
         }
         ResultSetDataContainer dataContainer = new ResultSetDataContainer(resultSet, options);
         if (dataContainer.getDataSource() == null) {


### PR DESCRIPTION
Hi,
I found out that the root cause of the issue #12676 was that in ResultSetDataContainer.java, the filtering of the ResultSet based on the selected columns was being done only based on column name. This caused any column that had the same name as a selected column to be put inside the filtered array. 
I put in an additional condition to compare the ordinal positions of a candidate attribute against those of the selected columns. Now only the columns in the selected positions are exported.
To make this change, I added a new private member List to the ResultSetDataContainerOptions.java and added get and set methods for the same. I also updated the code wherever a ResultSetDataContainerOptions object was being created to set the new member List so that no existing code calls filterAttributeBindings() without setting the list of selected column ordinal positions and raises an exception. 
Please review if the changes are appropriate. I have attached some screenshots validating the fix here.

---------------
_ResultSet= [1,2,3]_. Select only the first column containing 1.
![2](https://user-images.githubusercontent.com/68994510/121473107-03faee80-c977-11eb-9b53-a28a0f343214.png)
---------------
![3](https://user-images.githubusercontent.com/68994510/121473117-078e7580-c977-11eb-9577-5b4f0fd21dc3.png)
---------------

New expected behaviour
![4](https://user-images.githubusercontent.com/68994510/121473126-0b21fc80-c977-11eb-9e69-6058d107c469.png)

Earlier behaviour with the same input
![previous](https://user-images.githubusercontent.com/68994510/121473165-170dbe80-c977-11eb-8333-1370878a6e05.png)
---------------
This also corrects the behaviour of OpenWith option.
![browserSelection](https://user-images.githubusercontent.com/68994510/121473541-afa43e80-c977-11eb-863f-72413575b150.png)

---------------
![ViewOnBrowser](https://user-images.githubusercontent.com/68994510/121473559-b632b600-c977-11eb-9bde-8ed19ecf0484.png)
