### PR TITLE
Bug fix. Can not get TNS alias

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/tasks/OracleScriptExecuteHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/tasks/OracleScriptExecuteHandler.java
@@ -62,7 +62,7 @@ public class OracleScriptExecuteHandler extends AbstractNativeToolHandler<Oracle
         DBPConnectionConfiguration conInfo = settings.getDataSourceContainer().getActualConnectionConfiguration();
         String url;
         if ("TNS".equals(conInfo.getProviderProperty(OracleConstants.PROP_CONNECTION_TYPE))) { //$NON-NLS-1$
-            url = conInfo.getServerName();
+            url = conInfo.getServerName() != null ? conInfo.getServerName() : conInfo.getDatabaseName();
         }
         else {
             boolean isSID = OracleConnectionType.SID.name().equals(conInfo.getProviderProperty(OracleConstants.PROP_SID_SERVICE));


### PR DESCRIPTION
DBCE, Oracle. Can not get TNS alias in feature "Execute in SQL*Plus".

C:\program\oracleIC\instantclient_19_6\sqlplus.exe test/test@null
Task 'Oracle SQL*Plus script' started at Wed Jun 16 11:18:47 CST 2021


SQL*Plus: Release 19.0.0.0.0 - Production on Wed Jun 16 11:18:47 2021

Version 19.6.0.0.0



Copyright (c) 1982, 2019, Oracle.  All rights reserved.



ERROR:

ORA-12154: TNS:could not resolve the connect identifier specified