### PR TITLE
#12124 set primary child for better table manager search

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSchema.java
@@ -28,6 +28,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSEntity;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -94,4 +95,9 @@ public class ClickhouseSchema extends GenericSchema implements DBPObjectStatisti
         }
     }
 
+    @NotNull
+    @Override
+    public Class<? extends DBSEntity> getPrimaryChildType(@Nullable DBRProgressMonitor monitor) throws DBException {
+        return ClickhouseTable.class;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdDataSource.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.ext.firebird.model;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.firebird.model.plan.FireBirdPlanAnalyser;
@@ -34,6 +35,7 @@ import org.jkiss.dbeaver.model.exec.plan.DBCQueryPlanner;
 import org.jkiss.dbeaver.model.exec.plan.DBCQueryPlannerConfiguration;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.utils.IntKeyMap;
 
 import java.sql.SQLException;
@@ -161,4 +163,9 @@ public class FireBirdDataSource extends GenericDataSource
         return (List<FireBirdProcedure>) super.getProcedures(monitor);
     }
 
+    @NotNull
+    @Override
+    public Class<? extends DBSObject> getPrimaryChildType(@Nullable DBRProgressMonitor monitor) throws DBException {
+        return FireBirdTable.class;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/model/SQLiteDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/model/SQLiteDataSource.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.ext.sqlite.model;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSourceInfo;
@@ -30,6 +31,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCDatabaseMetaData;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCExecutionContext;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSDataType;
+import org.jkiss.dbeaver.model.struct.DBSObject;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -90,4 +92,9 @@ public class SQLiteDataSource extends GenericDataSource {
         return connectionsProps;
     }
 
+    @NotNull
+    @Override
+    public Class<? extends DBSObject> getPrimaryChildType(@Nullable DBRProgressMonitor monitor) throws DBException {
+        return SQLiteTable.class;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaSchema.java
@@ -37,6 +37,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCObjectLookupCache;
 import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCStructLookupCache;
 import org.jkiss.dbeaver.model.meta.Association;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSEntity;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.utils.ArrayUtils;
 
@@ -190,6 +191,12 @@ public class VerticaSchema extends GenericSchema implements DBPSystemObject, DBP
         } finally {
             hasStatistics = true;
         }
+    }
+
+    @NotNull
+    @Override
+    public Class<? extends DBSEntity> getPrimaryChildType(@Nullable DBRProgressMonitor monitor) throws DBException {
+        return VerticaTable.class;
     }
 
     public class ProjectionCache extends JDBCStructLookupCache<VerticaSchema, VerticaProjection, VerticaProjectionColumn> {


### PR DESCRIPTION
for getPrimaryChildType method which is using in generateStructTableDDL in DatabaseTransferUtils

![2021-06-22 15_55_31-Target DDL](https://user-images.githubusercontent.com/45152336/122928400-81106580-d372-11eb-9058-e462842e7f4b.png)
