### PR TITLE
Fix a typo

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/OSGI-INF/l10n/bundle_zh.properties
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/OSGI-INF/l10n/bundle_zh.properties
@@ -3,7 +3,7 @@
 dialog.connection.header=\u8FDE\u63A5\u8BBE\u7F6E
 
 editor.session_manager.name=\u4F1A\u8BDD\u7BA1\u7406\u5668
-editor.lock_manager.name=\u9501\u53E4\u7BA1\u7406\u5668
+editor.lock_manager.name=\u9501\u7BA1\u7406\u5668
 
 # database editor #
 db.editor.role.permission.name=\u6743\u9650


### PR DESCRIPTION
Translation of "Lock Manager" should be "锁管理器", not "锁古管理器".