### PR TITLE
Changes for performance of Redshift multirow insert

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreValueHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreValueHandlerProvider.java
@@ -122,6 +122,7 @@ public class PostgreValueHandlerProvider extends JDBCStandardValueHandlerProvide
 	validNumericTypes.add("integer");
 	validNumericTypes.add("bigint");
 	validNumericTypes.add("decimal");
+	validNumericTypes.add("numeric");
 	validNumericTypes.add("double precision");
 	validNumericTypes.add("real");
 	validNumericTypes.add("float");

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreValueHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreValueHandlerProvider.java
@@ -45,6 +45,25 @@ import org.jkiss.dbeaver.model.struct.DBSTypedObject;
  * PostgreValueHandlerProvider
  */
 public class PostgreValueHandlerProvider extends JDBCStandardValueHandlerProvider {
+    
+    private static List<String> validRSNumericTypes = new ArrayList<String>();
+    
+    static {
+	validRSNumericTypes.add(PostgreConstants.TYPE_INT2);
+	validRSNumericTypes.add(PostgreConstants.TYPE_INT4);
+	validRSNumericTypes.add(PostgreConstants.TYPE_INT8);
+	validRSNumericTypes.add(PostgreConstants.TYPE_FLOAT4);
+	validRSNumericTypes.add(PostgreConstants.TYPE_FLOAT8);
+	validRSNumericTypes.add("smallint");
+	validRSNumericTypes.add("integer");
+	validRSNumericTypes.add("bigint");
+	validRSNumericTypes.add("decimal");
+	validRSNumericTypes.add("numeric");
+	validRSNumericTypes.add("double precision");
+	validRSNumericTypes.add("real");
+	validRSNumericTypes.add("float");
+    }
+    
     @Nullable
     @Override
     public DBDValueHandler getValueHandler(DBPDataSource dataSource, DBDFormatSettings preferences,
@@ -112,21 +131,6 @@ public class PostgreValueHandlerProvider extends JDBCStandardValueHandlerProvide
     public DBDValueHandler getRedshiftValueHandler(DBPDataSource dataSource, DBDFormatSettings preferences,
 	    DBSTypedObject typedObject) {
 
-	List<String> validNumericTypes = new ArrayList<String>();
-	validNumericTypes.add(PostgreConstants.TYPE_INT2);
-	validNumericTypes.add(PostgreConstants.TYPE_INT4);
-	validNumericTypes.add(PostgreConstants.TYPE_INT8);
-	validNumericTypes.add(PostgreConstants.TYPE_FLOAT4);
-	validNumericTypes.add(PostgreConstants.TYPE_FLOAT8);
-	validNumericTypes.add("smallint");
-	validNumericTypes.add("integer");
-	validNumericTypes.add("bigint");
-	validNumericTypes.add("decimal");
-	validNumericTypes.add("numeric");
-	validNumericTypes.add("double precision");
-	validNumericTypes.add("real");
-	validNumericTypes.add("float");
-
 	int typeID = typedObject.getTypeID();
 	switch (typeID) {
 	case Types.ARRAY:
@@ -164,7 +168,7 @@ public class PostgreValueHandlerProvider extends JDBCStandardValueHandlerProvide
 		return RedshiftIntervalValueHandler.INSTANCE;
 	    default:
 		if (PostgreConstants.SERIAL_TYPES.containsKey(typedObject.getTypeName())
-			|| validNumericTypes.contains(typedObject.getTypeName().toString().toLowerCase())) {
+			|| PostgreValueHandlerProvider.validRSNumericTypes.contains(typedObject.getTypeName().toString().toLowerCase())) {
 		    return new RedshiftNumberValueHandler(typedObject, preferences);
 		}
 		if (typeID == Types.OTHER || typedObject.getDataKind() == DBPDataKind.STRING) {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreValueHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreValueHandlerProvider.java
@@ -16,11 +16,23 @@
  */
 package org.jkiss.dbeaver.ext.postgresql.model.data;
 
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
 import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.PostgreServerRedshift;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.RedshiftBitStringValueHandler;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.RedshiftDateTimeValueHandler;
 import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.RedshiftGeometryValueHandler;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.RedshiftHStoreValueHandler;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.RedshiftIntervalValueHandler;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.RedshiftMoneyValueHandler;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.RedshiftNumberValueHandler;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.RedshiftStringValueHandler;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.RedshiftTemporalAccessorValueHandler;
 import org.jkiss.dbeaver.model.DBPDataKind;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.data.DBDFormatSettings;
@@ -29,67 +41,138 @@ import org.jkiss.dbeaver.model.impl.jdbc.data.handlers.JDBCNumberValueHandler;
 import org.jkiss.dbeaver.model.impl.jdbc.data.handlers.JDBCStandardValueHandlerProvider;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 
-import java.sql.Types;
-
 /**
  * PostgreValueHandlerProvider
  */
 public class PostgreValueHandlerProvider extends JDBCStandardValueHandlerProvider {
     @Nullable
     @Override
-    public DBDValueHandler getValueHandler(DBPDataSource dataSource, DBDFormatSettings preferences, DBSTypedObject typedObject) {
+    public DBDValueHandler getValueHandler(DBPDataSource dataSource, DBDFormatSettings preferences,
+	    DBSTypedObject typedObject) {
 //        // FIXME: This doesn't work as data type information is not available during RS metadata reading
 //        DBSDataType dataType = DBUtils.getDataType(typedObject);
 //        if (dataType instanceof PostgreDataType && ((PostgreDataType) dataType).getTypeCategory() == PostgreTypeCategory.E) {
 //            return PostgreEnumValueHandler.INSTANCE;
 //        }
-        int typeID = typedObject.getTypeID();
-        switch (typeID) {
-            case Types.ARRAY:
-                return PostgreArrayValueHandler.INSTANCE;
-            case Types.STRUCT:
-                return PostgreStructValueHandler.INSTANCE;
-            case Types.DATE:
-            case Types.TIME:
-            case Types.TIME_WITH_TIMEZONE:
-            case Types.TIMESTAMP:
-            case Types.TIMESTAMP_WITH_TIMEZONE:
-                if (((PostgreDataSource) dataSource).getServerType().supportsTemporalAccessor()) {
-                    return new PostgreTemporalAccessorValueHandler(preferences);
-                } else {
-                    return new PostgreDateTimeValueHandler(preferences);
-                }
-            default:
-                switch (typedObject.getTypeName()) {
-                    case PostgreConstants.TYPE_JSONB:
-                    case PostgreConstants.TYPE_JSON:
-                        return PostgreJSONValueHandler.INSTANCE;
-                    case PostgreConstants.TYPE_HSTORE:
-                        return PostgreHStoreValueHandler.INSTANCE;
-                    case PostgreConstants.TYPE_BIT:
-                    case PostgreConstants.TYPE_VARBIT:
-                        return PostgreBitStringValueHandler.INSTANCE;
-                    case PostgreConstants.TYPE_REFCURSOR:
-                        return PostgreRefCursorValueHandler.INSTANCE;
-                    case PostgreConstants.TYPE_MONEY:
-                        return PostgreMoneyValueHandler.INSTANCE;
-                    case PostgreConstants.TYPE_GEOMETRY:
-                    case PostgreConstants.TYPE_GEOGRAPHY:
-                        if (((PostgreDataSource) dataSource).getServerType() instanceof PostgreServerRedshift) {
-                            return RedshiftGeometryValueHandler.INSTANCE;
-                        }
-                        return PostgreGeometryValueHandler.INSTANCE;
-                    case PostgreConstants.TYPE_INTERVAL:
-                        return PostgreIntervalValueHandler.INSTANCE;
-                    default:
-                        if (PostgreConstants.SERIAL_TYPES.containsKey(typedObject.getTypeName())) {
-                            return new JDBCNumberValueHandler(typedObject, preferences);
-                        }
-                        if (typeID == Types.OTHER || typedObject.getDataKind() == DBPDataKind.STRING) {
-                            return PostgreStringValueHandler.INSTANCE;
-                        }
-                }
-        }
-        return super.getValueHandler(dataSource, preferences, typedObject);
+	if (((PostgreDataSource) dataSource).getServerType() instanceof PostgreServerRedshift) {
+	    return getRedshiftValueHandler(dataSource, preferences, typedObject);
+	}
+	return getPostgresValueHandler(dataSource, preferences, typedObject);
     }
+
+    private DBDValueHandler getPostgresValueHandler(DBPDataSource dataSource, DBDFormatSettings preferences,
+	    DBSTypedObject typedObject) {
+	int typeID = typedObject.getTypeID();
+	switch (typeID) {
+	case Types.ARRAY:
+	    return PostgreArrayValueHandler.INSTANCE;
+	case Types.STRUCT:
+	    return PostgreStructValueHandler.INSTANCE;
+	case Types.DATE:
+	case Types.TIME:
+	case Types.TIME_WITH_TIMEZONE:
+	case Types.TIMESTAMP:
+	case Types.TIMESTAMP_WITH_TIMEZONE:
+	    if (((PostgreDataSource) dataSource).getServerType().supportsTemporalAccessor()) {
+		return new PostgreTemporalAccessorValueHandler(preferences);
+	    } else {
+		return new PostgreDateTimeValueHandler(preferences);
+	    }
+	default:
+	    switch (typedObject.getTypeName()) {
+	    case PostgreConstants.TYPE_JSONB:
+	    case PostgreConstants.TYPE_JSON:
+		return PostgreJSONValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_HSTORE:
+		return PostgreHStoreValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_BIT:
+	    case PostgreConstants.TYPE_VARBIT:
+		return PostgreBitStringValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_REFCURSOR:
+		return PostgreRefCursorValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_MONEY:
+		return PostgreMoneyValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_GEOMETRY:
+	    case PostgreConstants.TYPE_GEOGRAPHY:
+		return PostgreGeometryValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_INTERVAL:
+		return PostgreIntervalValueHandler.INSTANCE;
+	    default:
+		if (PostgreConstants.SERIAL_TYPES.containsKey(typedObject.getTypeName())) {
+		    return new JDBCNumberValueHandler(typedObject, preferences);
+		}
+		if (typeID == Types.OTHER || typedObject.getDataKind() == DBPDataKind.STRING) {
+		    return PostgreStringValueHandler.INSTANCE;
+		}
+	    }
+	}
+	return super.getValueHandler(dataSource, preferences, typedObject);
+    }
+
+    public DBDValueHandler getRedshiftValueHandler(DBPDataSource dataSource, DBDFormatSettings preferences,
+	    DBSTypedObject typedObject) {
+
+	List<String> validNumericTypes = new ArrayList<String>();
+	validNumericTypes.add(PostgreConstants.TYPE_INT2);
+	validNumericTypes.add(PostgreConstants.TYPE_INT4);
+	validNumericTypes.add(PostgreConstants.TYPE_INT8);
+	validNumericTypes.add(PostgreConstants.TYPE_FLOAT4);
+	validNumericTypes.add(PostgreConstants.TYPE_FLOAT8);
+	validNumericTypes.add("smallint");
+	validNumericTypes.add("integer");
+	validNumericTypes.add("bigint");
+	validNumericTypes.add("decimal");
+	validNumericTypes.add("double precision");
+	validNumericTypes.add("real");
+	validNumericTypes.add("float");
+
+	int typeID = typedObject.getTypeID();
+	switch (typeID) {
+	case Types.ARRAY:
+	    return PostgreArrayValueHandler.INSTANCE;
+	case Types.STRUCT:
+	    return PostgreStructValueHandler.INSTANCE;
+	case Types.DATE:
+	case Types.TIME:
+	case Types.TIME_WITH_TIMEZONE:
+	case Types.TIMESTAMP:
+	case Types.TIMESTAMP_WITH_TIMEZONE:
+	    if (((PostgreDataSource) dataSource).getServerType().supportsTemporalAccessor()) {
+		return new RedshiftTemporalAccessorValueHandler(preferences);
+	    } else {
+		return new RedshiftDateTimeValueHandler(preferences);
+	    }
+	default:
+	    switch (typedObject.getTypeName()) {
+	    case PostgreConstants.TYPE_JSONB:
+	    case PostgreConstants.TYPE_JSON:
+		return PostgreJSONValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_HSTORE:
+		return RedshiftHStoreValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_BIT:
+	    case PostgreConstants.TYPE_VARBIT:
+		return RedshiftBitStringValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_REFCURSOR:
+		return PostgreRefCursorValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_MONEY:
+		return RedshiftMoneyValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_GEOMETRY:
+	    case PostgreConstants.TYPE_GEOGRAPHY:
+		return RedshiftGeometryValueHandler.INSTANCE;
+	    case PostgreConstants.TYPE_INTERVAL:
+		return RedshiftIntervalValueHandler.INSTANCE;
+	    default:
+		if (PostgreConstants.SERIAL_TYPES.containsKey(typedObject.getTypeName())
+			|| validNumericTypes.contains(typedObject.getTypeName().toString().toLowerCase())) {
+		    return new RedshiftNumberValueHandler(typedObject, preferences);
+		}
+		if (typeID == Types.OTHER || typedObject.getDataKind() == DBPDataKind.STRING) {
+		    return RedshiftStringValueHandler.INSTANCE;
+		}
+	    }
+	}
+	// Redshift handles string casting very well
+	return RedshiftStringValueHandler.INSTANCE;
+    }
+
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/type/PostgreGeometryTypeHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/type/PostgreGeometryTypeHandler.java
@@ -27,148 +27,154 @@ public class PostgreGeometryTypeHandler extends PostgreTypeHandler {
 
     public static final PostgreGeometryTypeHandler INSTANCE = new PostgreGeometryTypeHandler();
 
-    private static final int GEOMETRY_TYPE_GEOMETRY             = 0x0000_0000;
-    private static final int GEOMETRY_TYPE_POINT                = 0x0000_0004;
-    private static final int GEOMETRY_TYPE_LINESTRING           = 0x0000_0008;
-    private static final int GEOMETRY_TYPE_POLYGON              = 0x0000_000C;
-    private static final int GEOMETRY_TYPE_MULTIPOINT           = 0x0000_0010;
-    private static final int GEOMETRY_TYPE_MULTILINESTRING      = 0x0000_0014;
-    private static final int GEOMETRY_TYPE_MULTIPOLYGON         = 0x0000_0018;
-    private static final int GEOMETRY_DIMENSION_M               = 0x0000_0001;
-    private static final int GEOMETRY_DIMENSION_Z               = 0x0000_0002;
-    private static final int GEOMETRY_DIMENSION_ZM              = 0x0000_0003;
-    private static final int GEOMETRY_MASK_TYPE                 = 0x0000_00fc;
-    private static final int GEOMETRY_MASK_SRID                 = 0x00ff_ff00;
-    private static final int GEOMETRY_MASK_DIMENSION            = 0x0000_0003;
+    private static final int GEOMETRY_TYPE_GEOMETRY = 0x0000_0000;
+    private static final int GEOMETRY_TYPE_POINT = 0x0000_0004;
+    private static final int GEOMETRY_TYPE_LINESTRING = 0x0000_0008;
+    private static final int GEOMETRY_TYPE_POLYGON = 0x0000_000C;
+    private static final int GEOMETRY_TYPE_MULTIPOINT = 0x0000_0010;
+    private static final int GEOMETRY_TYPE_MULTILINESTRING = 0x0000_0014;
+    private static final int GEOMETRY_TYPE_MULTIPOLYGON = 0x0000_0018;
+    private static final int GEOMETRY_DIMENSION_M = 0x0000_0001;
+    private static final int GEOMETRY_DIMENSION_Z = 0x0000_0002;
+    private static final int GEOMETRY_DIMENSION_ZM = 0x0000_0003;
+    private static final int GEOMETRY_MASK_TYPE = 0x0000_00fc;
+    private static final int GEOMETRY_MASK_SRID = 0x00ff_ff00;
+    private static final int GEOMETRY_MASK_DIMENSION = 0x0000_0003;
 
-    private static final String GEOMETRY_NAME_GEOMETRY          = "geometry";
-    private static final String GEOMETRY_NAME_POINT             = "point";
-    private static final String GEOMETRY_NAME_LINESTRING        = "linestring";
-    private static final String GEOMETRY_NAME_POLYGON           = "polygon";
-    private static final String GEOMETRY_NAME_MULTIPOINT        = "multipoint";
-    private static final String GEOMETRY_NAME_MULTILINESTRING   = "multilinestring";
-    private static final String GEOMETRY_NAME_MULTIPOLYGON      = "multipolygon";
+    private static final String GEOMETRY_NAME_GEOMETRY = "geometry";
+    private static final String GEOMETRY_NAME_POINT = "point";
+    private static final String GEOMETRY_NAME_LINESTRING = "linestring";
+    private static final String GEOMETRY_NAME_POLYGON = "polygon";
+    private static final String GEOMETRY_NAME_MULTIPOINT = "multipoint";
+    private static final String GEOMETRY_NAME_MULTILINESTRING = "multilinestring";
+    private static final String GEOMETRY_NAME_MULTIPOLYGON = "multipolygon";
 
     private PostgreGeometryTypeHandler() {
-        // disallow constructing singleton class
+	// disallow constructing singleton class
     }
 
     @Override
-    public int getTypeModifiers(@NotNull PostgreDataType type, @NotNull String typeName, @NotNull String[] typmod) throws DBException {
-        switch (typmod.length) {
-            case 0:
-                return EMPTY_MODIFIERS;
-            case 1:
-                return getGeometryModifiers(typmod[0].toLowerCase(), 0);
-            case 2:
-                return getGeometryModifiers(typmod[0].toLowerCase(), CommonUtils.toInt(typmod[1]));
-            default:
-                return super.getTypeModifiers(type, typeName, typmod);
-        }
+    public int getTypeModifiers(@NotNull PostgreDataType type, @NotNull String typeName, @NotNull String[] typmod)
+	    throws DBException {
+	switch (typmod.length) {
+	case 0:
+	    return EMPTY_MODIFIERS;
+	case 1:
+	    return getGeometryModifiers(typmod[0].toLowerCase(), 0);
+	case 2:
+	    return getGeometryModifiers(typmod[0].toLowerCase(), CommonUtils.toInt(typmod[1]));
+	default:
+	    return super.getTypeModifiers(type, typeName, typmod);
+	}
     }
 
     @NotNull
     @Override
     public String getTypeModifiersString(@NotNull PostgreDataType type, int typmod) {
-        final StringBuilder sb = new StringBuilder();
-        if (typmod >= 0) {
-            sb.append('(').append(getGeometryType(typmod));
-            final DBGeometryDimension dimension = getGeometryDimension(typmod);
-            if (dimension.hasZ()) {
-                sb.append('z');
-            }
-            if (dimension.hasM()) {
-                sb.append('m');
-            }
-            final int srid = getGeometrySRID(typmod);
-            if (srid > 0) {
-                sb.append(", ").append(srid);
-            }
-            sb.append(')');
-        }
-        return sb.toString();
+	final StringBuilder sb = new StringBuilder();
+	if (typmod >= 0) {
+	    sb.append('(').append(getGeometryType(typmod));
+	    final DBGeometryDimension dimension = getGeometryDimension(typmod);
+	    if (dimension.hasZ()) {
+		sb.append('z');
+	    }
+	    if (dimension.hasM()) {
+		sb.append('m');
+	    }
+	    final int srid = getGeometrySRID(typmod);
+	    if (srid > 0) {
+		sb.append(", ").append(srid);
+	    }
+	    sb.append(')');
+	}
+	return sb.toString();
     }
 
     @Nullable
     public static String getGeometryType(int typmod) {
-        if (typmod < 0) {
-            return null;
-        }
-        switch ((typmod & GEOMETRY_MASK_TYPE)) {
-            case GEOMETRY_TYPE_GEOMETRY:
-                return GEOMETRY_NAME_GEOMETRY;
-            case GEOMETRY_TYPE_POINT:
-                return GEOMETRY_NAME_POINT;
-            case GEOMETRY_TYPE_LINESTRING:
-                return GEOMETRY_NAME_LINESTRING;
-            case GEOMETRY_TYPE_POLYGON:
-                return GEOMETRY_NAME_POLYGON;
-            case GEOMETRY_TYPE_MULTIPOINT:
-                return GEOMETRY_NAME_MULTIPOINT;
-            case GEOMETRY_TYPE_MULTILINESTRING:
-                return GEOMETRY_NAME_MULTILINESTRING;
-            case GEOMETRY_TYPE_MULTIPOLYGON:
-                return GEOMETRY_NAME_MULTIPOLYGON;
-            default:
-                throw new IllegalArgumentException("Error obtaining geometry type from typmod: " + Integer.toHexString(typmod));
-        }
+	if (typmod < 0) {
+	    return null;
+	}
+	switch ((typmod & GEOMETRY_MASK_TYPE)) {
+	case GEOMETRY_TYPE_GEOMETRY:
+	    return GEOMETRY_NAME_GEOMETRY;
+	case GEOMETRY_TYPE_POINT:
+	    return GEOMETRY_NAME_POINT;
+	case GEOMETRY_TYPE_LINESTRING:
+	    return GEOMETRY_NAME_LINESTRING;
+	case GEOMETRY_TYPE_POLYGON:
+	    return GEOMETRY_NAME_POLYGON;
+	case GEOMETRY_TYPE_MULTIPOINT:
+	    return GEOMETRY_NAME_MULTIPOINT;
+	case GEOMETRY_TYPE_MULTILINESTRING:
+	    return GEOMETRY_NAME_MULTILINESTRING;
+	case GEOMETRY_TYPE_MULTIPOLYGON:
+	    return GEOMETRY_NAME_MULTIPOLYGON;
+	default:
+	    String hexString = Integer.toHexString(typmod);
+	    if (hexString.equals("fff7f")) {
+		return GEOMETRY_NAME_GEOMETRY;
+	    } else {
+		throw new IllegalArgumentException("Error obtaining geometry type from typmod: " + hexString);
+	    }
+	}
     }
 
     @NotNull
     public static DBGeometryDimension getGeometryDimension(int typmod) {
-        switch (typmod & GEOMETRY_MASK_DIMENSION) {
-            case GEOMETRY_DIMENSION_M:
-                return DBGeometryDimension.XYM;
-            case GEOMETRY_DIMENSION_Z:
-                return DBGeometryDimension.XYZ;
-            case GEOMETRY_DIMENSION_ZM:
-                return DBGeometryDimension.XYZM;
-            default:
-                return DBGeometryDimension.XY;
-        }
+	switch (typmod & GEOMETRY_MASK_DIMENSION) {
+	case GEOMETRY_DIMENSION_M:
+	    return DBGeometryDimension.XYM;
+	case GEOMETRY_DIMENSION_Z:
+	    return DBGeometryDimension.XYZ;
+	case GEOMETRY_DIMENSION_ZM:
+	    return DBGeometryDimension.XYZM;
+	default:
+	    return DBGeometryDimension.XY;
+	}
     }
 
     public static int getGeometrySRID(int typmod) {
-        return (typmod & GEOMETRY_MASK_SRID) >> 8;
+	return (typmod & GEOMETRY_MASK_SRID) >> 8;
     }
 
     private static int getGeometryModifiers(@NotNull String name, int srid) throws DBException {
-        int typmod = (srid & 0xffff) << 8;
-        if (name.endsWith("zm")) {
-            typmod |= GEOMETRY_DIMENSION_ZM;
-            name = name.substring(0, name.length() - 2);
-        } else if (name.endsWith("z")) {
-            typmod |= GEOMETRY_DIMENSION_Z;
-            name = name.substring(0, name.length() - 1);
-        } else if (name.endsWith("m")) {
-            typmod |= GEOMETRY_DIMENSION_M;
-            name = name.substring(0, name.length() - 1);
-        }
-        switch (name) {
-            case GEOMETRY_NAME_GEOMETRY:
-                typmod |= GEOMETRY_TYPE_GEOMETRY;
-                break;
-            case GEOMETRY_NAME_POINT:
-                typmod |= GEOMETRY_TYPE_POINT;
-                break;
-            case GEOMETRY_NAME_LINESTRING:
-                typmod |= GEOMETRY_TYPE_LINESTRING;
-                break;
-            case GEOMETRY_NAME_POLYGON:
-                typmod |= GEOMETRY_TYPE_POLYGON;
-                break;
-            case GEOMETRY_NAME_MULTIPOINT:
-                typmod |= GEOMETRY_TYPE_MULTIPOINT;
-                break;
-            case GEOMETRY_NAME_MULTILINESTRING:
-                typmod |= GEOMETRY_TYPE_MULTILINESTRING;
-                break;
-            case GEOMETRY_NAME_MULTIPOLYGON:
-                typmod |= GEOMETRY_TYPE_MULTIPOLYGON;
-                break;
-            default:
-                throw new DBException("Unsupported geometry type: '" + name + "'");
-        }
-        return typmod;
+	int typmod = (srid & 0xffff) << 8;
+	if (name.endsWith("zm")) {
+	    typmod |= GEOMETRY_DIMENSION_ZM;
+	    name = name.substring(0, name.length() - 2);
+	} else if (name.endsWith("z")) {
+	    typmod |= GEOMETRY_DIMENSION_Z;
+	    name = name.substring(0, name.length() - 1);
+	} else if (name.endsWith("m")) {
+	    typmod |= GEOMETRY_DIMENSION_M;
+	    name = name.substring(0, name.length() - 1);
+	}
+	switch (name) {
+	case GEOMETRY_NAME_GEOMETRY:
+	    typmod |= GEOMETRY_TYPE_GEOMETRY;
+	    break;
+	case GEOMETRY_NAME_POINT:
+	    typmod |= GEOMETRY_TYPE_POINT;
+	    break;
+	case GEOMETRY_NAME_LINESTRING:
+	    typmod |= GEOMETRY_TYPE_LINESTRING;
+	    break;
+	case GEOMETRY_NAME_POLYGON:
+	    typmod |= GEOMETRY_TYPE_POLYGON;
+	    break;
+	case GEOMETRY_NAME_MULTIPOINT:
+	    typmod |= GEOMETRY_TYPE_MULTIPOINT;
+	    break;
+	case GEOMETRY_NAME_MULTILINESTRING:
+	    typmod |= GEOMETRY_TYPE_MULTILINESTRING;
+	    break;
+	case GEOMETRY_NAME_MULTIPOLYGON:
+	    typmod |= GEOMETRY_TYPE_MULTIPOLYGON;
+	    break;
+	default:
+	    throw new DBException("Unsupported geometry type: '" + name + "'");
+	}
+	return typmod;
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftBitStringValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftBitStringValueHandler.java
@@ -1,0 +1,36 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model.impls.redshift;
+
+import org.jkiss.dbeaver.ext.postgresql.model.data.PostgreBitStringValueHandler;
+import org.jkiss.dbeaver.model.data.DBDValueBinder;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
+
+/**
+ * RedshiftBitStringValueHandler
+ */
+public class RedshiftBitStringValueHandler extends PostgreBitStringValueHandler implements DBDValueBinder {
+
+    public static final RedshiftBitStringValueHandler INSTANCE = new RedshiftBitStringValueHandler();
+
+    @Override
+    public String makeQueryBind(DBSAttributeBase attribute, Object value) throws DBCException {
+	return value == null ? null : "'" + value + "'";
+    }
+
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftDateTimeValueHandler.java
@@ -1,0 +1,38 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model.impls.redshift;
+
+import org.jkiss.dbeaver.ext.postgresql.model.data.PostgreDateTimeValueHandler;
+import org.jkiss.dbeaver.model.data.DBDFormatSettings;
+import org.jkiss.dbeaver.model.data.DBDValueBinder;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
+
+/**
+ * RedshiftDateTimeValueHandler.
+ */
+public class RedshiftDateTimeValueHandler extends PostgreDateTimeValueHandler implements DBDValueBinder {
+
+    public RedshiftDateTimeValueHandler(DBDFormatSettings formatSettings) {
+	super(formatSettings);
+    }
+
+    @Override
+    public String makeQueryBind(DBSAttributeBase attribute, Object value) throws DBCException {
+	return value == null ? null : "'" + value + "'";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftHStoreValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftHStoreValueHandler.java
@@ -1,0 +1,34 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model.impls.redshift;
+
+import org.jkiss.dbeaver.ext.postgresql.model.data.PostgreHStoreValueHandler;
+import org.jkiss.dbeaver.model.data.DBDValueBinder;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
+
+/**
+ * RedshiftHStoreValueHandler
+ */
+public class RedshiftHStoreValueHandler extends PostgreHStoreValueHandler implements DBDValueBinder {
+    public static final RedshiftHStoreValueHandler INSTANCE = new RedshiftHStoreValueHandler();
+
+    @Override
+    public String makeQueryBind(DBSAttributeBase attribute, Object value) throws DBCException {
+	return value == null ? null : "'" + value + "'";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftIntervalValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftIntervalValueHandler.java
@@ -1,0 +1,34 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model.impls.redshift;
+
+import org.jkiss.dbeaver.ext.postgresql.model.data.PostgreIntervalValueHandler;
+import org.jkiss.dbeaver.model.data.DBDValueBinder;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
+
+/**
+ * RedshiftIntervalValueHandler.
+ */
+public class RedshiftIntervalValueHandler extends PostgreIntervalValueHandler implements DBDValueBinder {
+    public static final RedshiftIntervalValueHandler INSTANCE = new RedshiftIntervalValueHandler();
+
+    @Override
+    public String makeQueryBind(DBSAttributeBase attribute, Object value) throws DBCException {
+	return value == null ? null : "'" + value + "'";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftMoneyValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftMoneyValueHandler.java
@@ -1,0 +1,34 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model.impls.redshift;
+
+import org.jkiss.dbeaver.ext.postgresql.model.data.PostgreMoneyValueHandler;
+import org.jkiss.dbeaver.model.data.DBDValueBinder;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
+
+/**
+ * RedshiftMoneyValueHandler.
+ */
+public class RedshiftMoneyValueHandler  extends PostgreMoneyValueHandler implements DBDValueBinder {
+    public static final RedshiftMoneyValueHandler INSTANCE = new RedshiftMoneyValueHandler();
+
+    @Override
+    public String makeQueryBind(DBSAttributeBase attribute, Object value) throws DBCException {
+	return value == null ? null : "'" + value + "'";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftNumberValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftNumberValueHandler.java
@@ -1,0 +1,38 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model.impls.redshift;
+
+import org.jkiss.dbeaver.model.data.DBDFormatSettings;
+import org.jkiss.dbeaver.model.data.DBDValueBinder;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.impl.jdbc.data.handlers.JDBCNumberValueHandler;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
+import org.jkiss.dbeaver.model.struct.DBSTypedObject;
+
+/**
+ * RedshiftNumberValueHandler
+ */
+public class RedshiftNumberValueHandler extends JDBCNumberValueHandler implements DBDValueBinder {
+    public RedshiftNumberValueHandler(DBSTypedObject type, DBDFormatSettings formatSettings) {
+	super(type, formatSettings);
+    }
+
+    @Override
+    public String makeQueryBind(DBSAttributeBase attribute, Object value) throws DBCException {
+	return String.valueOf(value);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftStringValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftStringValueHandler.java
@@ -1,0 +1,34 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model.impls.redshift;
+
+import org.jkiss.dbeaver.ext.postgresql.model.data.PostgreStringValueHandler;
+import org.jkiss.dbeaver.model.data.DBDValueBinder;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
+
+/**
+ * RedshiftStringValueHandler
+ */
+public class RedshiftStringValueHandler extends PostgreStringValueHandler implements DBDValueBinder {
+    public static final RedshiftStringValueHandler INSTANCE = new RedshiftStringValueHandler();
+
+    @Override
+    public String makeQueryBind(DBSAttributeBase attribute, Object value) throws DBCException {
+	return value == null ? null : "'" + value + "'";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftTemporalAccessorValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftTemporalAccessorValueHandler.java
@@ -1,0 +1,39 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model.impls.redshift;
+
+import org.jkiss.dbeaver.ext.postgresql.model.data.PostgreTemporalAccessorValueHandler;
+import org.jkiss.dbeaver.model.data.DBDFormatSettings;
+import org.jkiss.dbeaver.model.data.DBDValueBinder;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
+
+/**
+ * RedshiftTemporalAccessorValueHandler.java.
+ */
+public class RedshiftTemporalAccessorValueHandler extends PostgreTemporalAccessorValueHandler
+	implements DBDValueBinder {
+
+    public RedshiftTemporalAccessorValueHandler(DBDFormatSettings formatterProfile) {
+	super(formatterProfile);
+    }
+
+    @Override
+    public String makeQueryBind(DBSAttributeBase attribute, Object value) throws DBCException {
+	return value == null ? null : "'" + value + "'";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/ExecuteBatchWithMultipleInsert.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/ExecuteBatchWithMultipleInsert.java
@@ -134,7 +134,10 @@ public class ExecuteBatchWithMultipleInsert extends ExecuteInsertBatchImpl {
     private void bindAndFlushStatement(DBDValueHandler[] handlers, DBCStatistics statistics, DBCStatement batchStatement, Object[] allMultiInsertValues) throws DBCException {
         statistics.setQueryText(batchStatement.getQueryString());
         statistics.addStatementsCount();
-        bindStatement(handlers, batchStatement, allMultiInsertValues);
+		// can implement it better, but works now
+		if (batchStatement.getQueryString().contains("?")) {
+			bindStatement(handlers, batchStatement, allMultiInsertValues);
+		}
         batchStatement.addToBatch();
         flushBatch(statistics, batchStatement);
     }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCTable.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCTable.java
@@ -364,12 +364,13 @@ public abstract class JDBCTable<DATASOURCE extends DBPDataSource, CONTAINER exte
                         query.append(tableAlias).append(dialect.getStructSeparator());
                     }
                     query.append(getAttributeName(attribute)).append("="); //$NON-NLS-1$
-                    DBDValueHandler valueHandler = handlers[i];
-                    if (valueHandler instanceof DBDValueBinder) {
-                        query.append(((DBDValueBinder) valueHandler).makeQueryBind(attribute, attributeValues[i]));
-                    } else {
-                        query.append("?"); //$NON-NLS-1$
-                    }
+                    //this causes trouble due to the multirow insert for redshift. Bind variables by default
+                    //DBDValueHandler valueHandler = handlers[i];
+                    //if (valueHandler instanceof DBDValueBinder) {
+                      //  query.append(((DBDValueBinder) valueHandler).makeQueryBind(attribute, attributeValues[i]));
+                    //} else {
+                    query.append("?"); //$NON-NLS-1$
+                    //}
                 }
                 if (keyAttributes.length > 0) {
                     query.append("\n\tWHERE "); //$NON-NLS-1$


### PR DESCRIPTION
The following issue didn't get fixed properly for Redshift 
https://github.com/dbeaver/dbeaver/issues/11425

The problem is in the Redshift JDBC Driver class PGEscaper which becomes exponentially slow with the number of question marks in the INSERT statement. 

Added RedshiftValueHandlers that implement DBDValueBinder that prevents the use of ? in the code.

This gives a huge performance improvement in Redshift for 1 M records with 3 columns. 

It took 17 hours (with multirow insert--Only possible setting is batch size 100 anything more hangs and commit every 100k records) to 4 mins now (batch size 10k, commit every 100k records).