### PR TITLE
Resolved the data type names and column type length, precision/scale for Redshift

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
@@ -20,7 +20,6 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
-import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.model.*;
 import org.jkiss.dbeaver.ext.postgresql.model.impls.PostgreServerExtensionBase;
 import org.jkiss.dbeaver.model.DBPErrorAssistant;
@@ -40,7 +39,6 @@ import org.osgi.framework.Version;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -294,14 +292,6 @@ public class PostgreServerRedshift extends PostgreServerExtensionBase implements
     @Override
     public boolean supportSerialTypes() {
         return false;
-    }
-
-    @Override
-    public Map<String, String> getDataTypeAliases() {
-        Map<String, String> aliasMap = new LinkedHashMap<>(super.getDataTypeAliases());
-        aliasMap.put("character", PostgreConstants.TYPE_BPCHAR);
-        aliasMap.put("character varying", PostgreConstants.TYPE_VARCHAR);
-        return aliasMap;
     }
 
     @Override


### PR DESCRIPTION
Fix for https://github.com/dbeaver/dbeaver/issues/13536

Use the below scripts
CREATE TABLE IF NOT EXISTS test_all_types_2
(
	c1 SMALLINT   ENCODE az64
	,c2 INTEGER   ENCODE az64
	,c3 BIGINT   ENCODE az64
	,c4 NUMERIC(18,0)   ENCODE az64
	,c5 REAL   ENCODE RAW
	,c6 DOUBLE PRECISION   ENCODE RAW
	,c7 BOOLEAN   ENCODE RAW
	,c8 CHAR(1)   ENCODE lzo
	,c9 VARCHAR(256)   ENCODE lzo
	,c10 DATE   ENCODE az64
	,c11 TIMESTAMP WITHOUT TIME ZONE   ENCODE az64
	,c12 TIMESTAMP WITH TIME ZONE   ENCODE az64
	,c15 TIME WITHOUT TIME ZONE   ENCODE az64
	,c16 TIME WITH TIME ZONE   ENCODE az64
	,c17 NUMERIC(18,7)   ENCODE az64
)
DISTSTYLE AUTO
;

CREATE VIEW usr_senthidx.v_test_all_types_b AS
SELECT a.c1, a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8, a.c9, a.c10, a.c11, a.c12, a.c15, a.c16,a.c17 FROM test_all_types_2 a;

CREATE VIEW usr_senthidx.v_test_all_types_nb AS
SELECT a.c1, a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8, a.c9, a.c10, a.c11, a.c12, a.c15, a.c16,a.c17 FROM test_all_types_2 a
WITH no SCHEMA binding;



After applying the fix table, binding view, no schema binding view-all look the same!

Table:
![image](https://user-images.githubusercontent.com/36084950/129494728-cddfed8c-59f8-47b6-8706-5f21ff1848e3.png)

![image](https://user-images.githubusercontent.com/36084950/129494742-a8c36353-0206-49f3-a030-d262354a8321.png)


It's a simple fix of using viewColumn.setFullTypeName to get the column length/precision, scale!
