### PR TITLE
Fix for Redshift data import issues #13542

### DIFF
--- a/bundles/org.jkiss.utils/src/org/jkiss/utils/CommonUtils.java
+++ b/bundles/org.jkiss.utils/src/org/jkiss/utils/CommonUtils.java
@@ -983,4 +983,27 @@ public class CommonUtils {
         }
         return grouped;
     }
+    
+    /**
+     * Returns lower case of ASCII characters in the string.
+     * 
+     * @param str input string
+     * @return lower case ASCII string
+     */
+    @Nullable
+    public static String toLowerCaseASCII(@Nullable String str) {
+        if (!isEmptyTrimmed(str)) {
+            char[] chars = str.toCharArray();
+            for (int i = 0; i < chars.length; i++) {
+                // 97-a, 122-z handles a-z in lower case
+                // 65-A, 90-Z converts to A-Z in upper case
+                // leaves other characters alone
+                if (chars[i] >= 'A' && chars[i] <= 'Z') {
+                    chars[i] = (char) (chars[i] + 32);
+                }
+            }
+            return new String(chars);
+        }
+        return str;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/RedshiftSchema.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.ext.postgresql.model.impls.redshift;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.postgresql.model.*;
@@ -25,7 +26,9 @@ import org.jkiss.dbeaver.model.exec.DBCSession;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTable;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.utils.CommonUtils;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -47,6 +50,14 @@ public class RedshiftSchema extends PostgreSchema {
     @Override
     public String getTableColumnsQueryExtraParameters(PostgreTableContainer owner, PostgreTableBase forTable) {
         return ",format_encoding(a.attencodingtype::integer) AS \"encoding\"";
+    }
+    
+    @Override
+    public JDBCTable getChild(@NotNull DBRProgressMonitor monitor, @NotNull String childName)
+        throws DBException {
+	// https://docs.aws.amazon.com/redshift/latest/dg/r_names.html
+	// Redshift converts ASCII characters to lower case
+	return super.getChild(monitor, CommonUtils.toLowerCaseASCII(childName));
     }
 
     @Override

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/utils/CommonUtilsTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/utils/CommonUtilsTest.java
@@ -572,4 +572,14 @@ public class CommonUtilsTest {
     Assert.assertEquals(Arrays.asList("bbb", "bab"), groups.get('b'));
     Assert.assertEquals(Arrays.asList("ccc"), groups.get('c'));
   }
+  
+  @Test
+  public void testToLowerCaseASCII() {
+    Assert.assertEquals(CommonUtils.toLowerCaseASCII("aaaa"), "aaaa");
+    Assert.assertEquals(CommonUtils.toLowerCaseASCII("AAAA"), "aaaa");
+    Assert.assertEquals(CommonUtils.toLowerCaseASCII("aaAA"), "aaaa");
+    // cyrillic
+    Assert.assertEquals(CommonUtils.toLowerCaseASCII("ABC ТЕСТ abc"), "abc ТЕСТ abc");
+  }
+  
 }


### PR DESCRIPTION
Fix for https://github.com/dbeaver/dbeaver/issues/13542
1. Redshift uses lower case for table name. Added logic to handle the conversion that happens at Redshift end.
2. Special characters in column names are escaped using double quotes. Added logic to escape special characters using double quote when the resolution without double quote doesn't return anything. 