### PR TITLE
Security Definer Get DDL fix for Redshift

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreProcedure.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreProcedure.java
@@ -456,6 +456,9 @@ public class PostgreProcedure extends AbstractProcedure<PostgreDataSource, Postg
         if (language != null) {
             decl.append("\tLANGUAGE ").append(language).append(lineSeparator);
         }
+        if (isSecurityDefiner()) {
+            decl.append("\tSECURITY DEFINER").append(lineSeparator);
+        }
         if (isWindow()) {
             decl.append("\tWINDOW").append(lineSeparator);
         }


### PR DESCRIPTION
Fix for the issue
Security Definer is missing for a Redshift procedure in the Generate SQL>DDL statement #13559 