### PR TITLE
Fix for Redshift Data Editor-Editing of Date/Timestamp column

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreDateTimeValueHandler.java
@@ -17,6 +17,8 @@
 package org.jkiss.dbeaver.ext.postgresql.model.data;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.PostgreServerRedshift;
 import org.jkiss.dbeaver.model.data.DBDFormatSettings;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.DBCSession;
@@ -66,9 +68,12 @@ public class PostgreDateTimeValueHandler extends JDBCDateTimeValueHandler {
     public void bindValueObject(@NotNull DBCSession session, @NotNull DBCStatement statement, @NotNull DBSTypedObject type, int index, Object value) throws DBCException {
         if (value instanceof String) {
             try {
-                ((JDBCPreparedStatement)statement).setObject(index + 1, value.toString(), Types.OTHER);
-            }
-            catch (SQLException e) {
+                if (((PostgreDataSource) session.getDataSource()).getServerType() instanceof PostgreServerRedshift) {
+                    ((JDBCPreparedStatement) statement).setObject(index + 1, value.toString(), Types.VARCHAR);
+                } else {
+                    ((JDBCPreparedStatement) statement).setObject(index + 1, value.toString(), Types.OTHER);
+                }
+            } catch (SQLException e) {
                 throw new DBCException(ModelMessages.model_jdbc_exception_could_not_bind_statement_parameter, e);
             }
             return;


### PR DESCRIPTION
https://github.com/dbeaver/dbeaver/issues/13544

The Date/Timestamp columns are fixed now. Redshift doesn't know about Types.OTHER, it has to be Types.VARCHAR.

The 1.x Redshift JDBC driver doesn't work fine for timestamp with timezone, time, timetz columns edits from data editor