### PR TITLE
Redshift also returns 500150 on timed out sessions

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
@@ -50,6 +50,7 @@ public class PostgreServerRedshift extends PostgreServerExtensionBase implements
 
     private static final Log log = Log.getLog(PostgreServerRedshift.class);
     public static final int RS_ERROR_CODE_CHANNEL_CLOSE = 500366;
+    public static final int RS_ERROR_CODE_NOT_CONNECTED = 500150;
 
     private Version redshiftVersion;
 
@@ -284,7 +285,7 @@ public class PostgreServerRedshift extends PostgreServerExtensionBase implements
     @Override
     public ErrorType discoverErrorType(@NotNull Throwable error) {
         int errorCode = SQLState.getCodeFromException(error);
-        if (errorCode == RS_ERROR_CODE_CHANNEL_CLOSE) {
+        if (errorCode == RS_ERROR_CODE_CHANNEL_CLOSE || errorCode == RS_ERROR_CODE_NOT_CONNECTED) {
             return ErrorType.CONNECTION_LOST;
         }
         return null;


### PR DESCRIPTION
Fix for #13695 

Redshift also returns a 500150 error code on timed-out sessions. Adding it.

Scenario now handled:
SQL Error [500150] [HY000]: [Amazon](500150) Error setting/closing connection: Not Connected.
org.jkiss.dbeaver.model.sql.DBSQLException: SQL Error [500150] [HY000]: [Amazon](500150) Error setting/closing connection: Not Connected.
	at org.jkiss.dbeaver.model.impl.jdbc.exec.JDBCStatementImpl.executeStatement(JDBCStatementImpl.java:133)
	at org.jkiss.dbeaver.ui.editors.sql.execute.SQLQueryJob.executeStatement(SQLQueryJob.java:513)

Previous code was only handling below scenario.

org.jkiss.dbeaver.model.sql.DBSQLException: SQL Error [500366] [HY000]: [Amazon](500366) Channel is not open. Connection is lost.
	at org.jkiss.dbeaver.model.impl.jdbc.exec.JDBCStatementImpl.executeStatement(JDBCStatementImpl.java:133)
	at org.jkiss.dbeaver.ui.editors.sql.execute.SQLQueryJob.executeStatement(SQLQueryJob.java:513)
