### PR TITLE
#13283 Redshift geometry type handling fix

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/type/PostgreEmptyTypeHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/type/PostgreEmptyTypeHandler.java
@@ -1,0 +1,50 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model.data.type;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataType;
+
+/**
+ * Handler for types that don't support modifiers.
+ * <p>
+ * Displays base type name without {@code (...)} after
+ * it and does not accept any modifiers when editing.
+ */
+public class PostgreEmptyTypeHandler extends PostgreTypeHandler {
+
+    public static final PostgreEmptyTypeHandler INSTANCE = new PostgreEmptyTypeHandler();
+
+    private PostgreEmptyTypeHandler() {
+        // disallow constructing singleton class
+    }
+
+    @Override
+    public int getTypeModifiers(@NotNull PostgreDataType type, @NotNull String typeName, @NotNull String[] typmod) throws DBException {
+        if (typmod.length == 0) {
+            return EMPTY_MODIFIERS;
+        }
+        return super.getTypeModifiers(type, typeName, typmod);
+    }
+
+    @NotNull
+    @Override
+    public String getTypeModifiersString(@NotNull PostgreDataType type, int typmod) {
+        return "";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/type/PostgreTypeHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/type/PostgreTypeHandlerProvider.java
@@ -21,6 +21,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.postgresql.PostgreUtils;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataType;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreOid;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.PostgreServerRedshift;
 
 public class PostgreTypeHandlerProvider {
 
@@ -31,7 +32,11 @@ public class PostgreTypeHandlerProvider {
     @Nullable
     public static PostgreTypeHandler getTypeHandler(@NotNull PostgreDataType type) {
         if (PostgreUtils.isGISDataType(type.getTypeName().toLowerCase())) {
-            return PostgreGeometryTypeHandler.INSTANCE;
+            if (type.getDataSource().getServerType() instanceof PostgreServerRedshift) {
+                return PostgreEmptyTypeHandler.INSTANCE;
+            } else {
+                return PostgreGeometryTypeHandler.INSTANCE;
+            }
         }
         switch ((int) type.getObjectId()) {
             case PostgreOid.NUMERIC:


### PR DESCRIPTION
I don't really like this approach, but it's simple. Postgres plugin must not know about its concrete extensions. 

In future, after we move Redshift into separate plugin, we can add logic for retrieving type handler provider from the data source instead of accessing it via static method.