### PR TITLE
Fix for Unsupported vector type exception while using 2.x redshift

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreUtils.java
@@ -28,6 +28,7 @@ import org.jkiss.dbeaver.ext.postgresql.model.*;
 import org.jkiss.dbeaver.ext.postgresql.model.impls.PostgreServerPostgreSQL;
 import org.jkiss.dbeaver.ext.postgresql.model.impls.PostgreServerType;
 import org.jkiss.dbeaver.ext.postgresql.model.impls.PostgreServerTypeRegistry;
+import org.jkiss.dbeaver.ext.postgresql.model.impls.redshift.PostgreServerRedshift;
 import org.jkiss.dbeaver.model.DBPDataKind;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.DBPScriptObject;
@@ -115,7 +116,8 @@ public class PostgreUtils {
         if (pgObject == null) {
             return null;
         }
-        if (!pgObject.getClass().getName().equals(PostgreConstants.PG_OBJECT_CLASS)) {
+        if (!pgObject.getClass().getName().equals(PostgreConstants.PG_OBJECT_CLASS)
+                && !pgObject.getClass().getName().equals(PostgreServerRedshift.RS_OBJECT_CLASS)) {
             return pgObject;
         }
         try {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
@@ -53,6 +53,7 @@ public class PostgreServerRedshift extends PostgreServerExtensionBase implements
     private static final Log log = Log.getLog(PostgreServerRedshift.class);
     public static final int RS_ERROR_CODE_CHANNEL_CLOSE = 500366;
     public static final int RS_ERROR_CODE_NOT_CONNECTED = 500150;
+    public static final String RS_OBJECT_CLASS = "com.amazon.redshift.util.RedshiftObject";
 
     private Version redshiftVersion;
 


### PR DESCRIPTION
Fix for Unsupported vector type: com.amazon.redshift.util.RedshiftObject
When there is a unique constraint in a table

This is not the most efficient fix, but a good enough solution I guess. 