### PR TITLE
Use returned value

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
@@ -599,7 +599,7 @@ public class MySQLTable extends MySQLTableBase implements DBPObjectStatistics, D
     @Override
     public void enableReferentialIntegrity(@NotNull DBRProgressMonitor monitor, boolean enable) throws DBException {
         String sql = getChangeReferentialIntegrityStatement(monitor, enable);
-        sql.replace("?", getFullyQualifiedName(DBPEvaluationContext.DDL));
+        sql = sql.replace("?", getFullyQualifiedName(DBPEvaluationContext.DDL));
         try {
             DBUtils.executeInMetaSession(monitor, this, "Changing referential integrity", sql);
         } catch (SQLException e) {


### PR DESCRIPTION
The method replace() returns the expected results instead of modifying the current string.