### PR TITLE
Update OracleCLOBValueHandler.java

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleCLOBValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleCLOBValueHandler.java
@@ -36,7 +36,7 @@ import java.io.Writer;
 public class OracleCLOBValueHandler extends JDBCContentValueHandler {
 
     public static final OracleCLOBValueHandler INSTANCE = new OracleCLOBValueHandler();
-    public static final int MAX_PART_SIZE = 4000;
+    public static final int MAX_PART_SIZE = 2000;
 
     @Override
     public void writeStreamValue(DBRProgressMonitor monitor, @NotNull DBPDataSource dataSource, @NotNull DBSTypedObject type, @NotNull DBDContent object, @NotNull Writer writer) throws DBCException, IOException {


### PR DESCRIPTION
2000 is safer in case there are multibyte characters. interpolates just twice as many ')||TO_CLOB(' in worst case scenario.