### PR TITLE
#13481 avoid schemas names duplicates for reference query

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -238,7 +238,7 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
             CommonUtils.safeList(getSubInheritance(monitor)));
         // Obtain a list of schemas containing references to this table to avoid fetching everything
         try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Read referencing schemas")) {
-            try (JDBCPreparedStatement dbStat = session.prepareStatement("SELECT connamespace FROM pg_catalog.pg_constraint WHERE confrelid=?")) {
+            try (JDBCPreparedStatement dbStat = session.prepareStatement("SELECT DISTINCT connamespace FROM pg_catalog.pg_constraint WHERE confrelid=?")) {
                 dbStat.setLong(1, getObjectId());
                 try (JDBCResultSet dbResult = dbStat.executeQuery()) {
                     while (dbResult.next()) {


### PR DESCRIPTION
Was:
![2021-10-06 17_33_37-DBeaver Ultimate 21 2 2 - customer](https://user-images.githubusercontent.com/45152336/136224412-a67a1986-8a92-411a-a051-5217f10b46c9.png)

Now:
![2021-10-06 17_33_10-DBeaver Ultimate 21 2 2 - customer](https://user-images.githubusercontent.com/45152336/136224434-a1d57892-b02a-430b-83e3-3f60b7bcc97a.png)


