### PR TITLE
Add background color option for HTML export

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.data.transfer/OSGI-INF/l10n/bundle.properties
@@ -27,6 +27,10 @@ dataTransfer.processor.html.property.header.name=Output table header
 dataTransfer.processor.html.property.header.description=Output query or table name as first row in generated table
 dataTransfer.processor.html.property.columnHeaders.name = Output column headers
 dataTransfer.processor.html.property.columnHeaders.description = Output column names as extra row in generated table
+dataTransfer.processor.html.property.backgroundColorHeader.name=Header background color
+dataTransfer.processor.html.property.backgroundColorHeader.description=Background color of table's header. Search 'HTML colors' for format details.
+dataTransfer.processor.html.property.backgroundColorDocument.name=Document background color
+dataTransfer.processor.html.property.backgroundColorDocument.description=Background color of HTML document. Search 'HTML colors' for format details.
 
 dataTransfer.processor.csv.name=CSV
 dataTransfer.processor.csv.description=Export to CSV file(s)

--- a/plugins/org.jkiss.dbeaver.data.transfer/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.data.transfer/plugin.xml
@@ -122,6 +122,8 @@
                     <property id="tableHeader" label="%dataTransfer.processor.html.property.header.name" type="boolean" description="%dataTransfer.processor.html.property.header.description" defaultValue="true"/>
                     <property id="columnHeaders" label="%dataTransfer.processor.html.property.columnHeaders.name" type="boolean" description="%dataTransfer.processor.html.property.columnHeaders.description" defaultValue="true"/>
                     <property id="extractImages" label="%dataTransfer.processor.html.property.images.name" type="boolean" description="%dataTransfer.processor.html.property.images.description" defaultValue="true"/>
+                    <property id="backgroundColorHeader" label="%dataTransfer.processor.html.property.backgroundColorHeader.name" description="%dataTransfer.processor.html.property.backgroundColorHeader.description" defaultValue="#D0E3FA" required="false"/>
+                    <property id="backgroundColorDocument" label="%dataTransfer.processor.html.property.backgroundColorDocument.name" description="%dataTransfer.processor.html.property.backgroundColorDocument.description" defaultValue="#FFFFFF" required="false"/>
                 </propertyGroup>
             </processor>
             <processor

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterHTML.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterHTML.java
@@ -41,6 +41,8 @@ public class DataExporterHTML extends StreamExporterAbstract {
 
     private static final String PROP_HEADER = "tableHeader";
     private static final String PROP_COLUMN_HEADERS = "columnHeaders";
+    private static final String PROP_BACKGROUND_COLOR_HEADER = "backgroundColorHeader";
+    private static final String PROP_BACKGROUND_COLOR_DOCUMENT = "backgroundColorDocument";
 
     private String name;
     private static final int IMAGE_FRAME_SIZE = 200;
@@ -50,7 +52,9 @@ public class DataExporterHTML extends StreamExporterAbstract {
 
     private boolean outputHeader = true;
     private boolean outputColumnHeaders = true;
-
+    private String backgroundColorHeader = "#D0E3FA";
+    private String backgroundColorDocument = "#000000";
+    
     @Override
     public void init(IStreamDataExporterSite site) throws DBException {
         super.init(site);
@@ -58,6 +62,8 @@ public class DataExporterHTML extends StreamExporterAbstract {
         Map<String, Object> properties = site.getProperties();
         outputHeader = CommonUtils.getBoolean(properties.get(PROP_HEADER), outputHeader);
         outputColumnHeaders = CommonUtils.getBoolean(properties.get(PROP_COLUMN_HEADERS), outputColumnHeaders);
+        backgroundColorHeader = CommonUtils.toString(properties.get(PROP_BACKGROUND_COLOR_HEADER), backgroundColorHeader);
+        backgroundColorDocument = CommonUtils.toString(properties.get(PROP_BACKGROUND_COLOR_DOCUMENT), backgroundColorDocument);
     }
 
     @Override
@@ -78,6 +84,7 @@ public class DataExporterHTML extends StreamExporterAbstract {
         out.write("<head>\n" +
             "<meta charset=\"" + getSite().getOutputEncoding() + "\"/>" +
             "<style>\n" +
+            "body {background-color: " + backgroundColorDocument + "}\n"+
             "table {border: medium solid #6495ed;" +
             "border-collapse: collapse;" +
             "width: 100%;} " +
@@ -85,7 +92,7 @@ public class DataExporterHTML extends StreamExporterAbstract {
             "border: thin solid #6495ed;" +
 //              "width: 50%;" +
             "padding: 5px;" +
-            "background-color: #D0E3FA;}" +
+            "background-color: " + backgroundColorHeader + ";}" +
             "td{font-family: sans-serif;" +
             "border: thin solid #6495ed;" +
 //              "width: 50%;" +


### PR DESCRIPTION
Add background color option for the whole document
Add background color option for the table's header

![изображение](https://user-images.githubusercontent.com/34656435/137355795-c3c31526-a032-4046-94ed-dfc64420eb17.png)
