### PR TITLE
#13044 GIS viewer properties display fix

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/GeometryDataUtils.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/GeometryDataUtils.java
@@ -17,11 +17,17 @@
 
 package org.jkiss.dbeaver.ui.gis;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.widgets.Display;
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.data.DBDAttributeBinding;
 import org.jkiss.dbeaver.model.gis.DBGeometry;
 import org.jkiss.dbeaver.model.gis.GisConstants;
+import org.jkiss.dbeaver.ui.UIColors;
 import org.jkiss.dbeaver.ui.controls.resultset.IResultSetController;
 import org.jkiss.dbeaver.ui.controls.resultset.ResultSetModel;
 import org.jkiss.dbeaver.ui.controls.resultset.ResultSetRow;
@@ -77,21 +83,28 @@ public class GeometryDataUtils {
         return result;
     }
 
-    public static void setGeometryProperties(IResultSetController controller, GeomAttrs geomAttrs, DBGeometry geometry, ResultSetRow row) {
-        // Now extract all geom values from data
-        ResultSetModel model = controller.getModel();
-        if (row != null) {
-            // Now get description
-            if (!geomAttrs.descAttrs.isEmpty()) {
-                Map<String, Object> properties = new LinkedHashMap<>();
-                for (DBDAttributeBinding da : geomAttrs.descAttrs) {
-                    Object descValue = model.getCellValue(da, row);
-                    if (!DBUtils.isNullValue(descValue)) {
-                        properties.put(da.getName(), descValue);
-                    }
-                }
-                geometry.setProperties(properties);
+    public static void setGeometryProperties(@NotNull IResultSetController controller, @NotNull GeomAttrs geomAttrs, @NotNull DBGeometry geometry, @NotNull RGB geometryColor, @NotNull ResultSetRow row) {
+        final ResultSetModel model = controller.getModel();
+        final Map<String, Object> info = new LinkedHashMap<>();
+        for (DBDAttributeBinding binding : geomAttrs.descAttrs) {
+            final Object description = model.getCellValue(binding, row);
+            if (!DBUtils.isNullValue(description) && !(description instanceof String && ((String) description).isEmpty())) {
+                info.put(binding.getName(), description);
             }
+        }
+        final Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("id", DBUtils.getObjectFullName(geomAttrs.geomAttr, DBPEvaluationContext.UI));
+        properties.put("color", String.format("#%02x%02x%02x", geometryColor.red, geometryColor.green, geometryColor.blue));
+        properties.put("info", info);
+        geometry.setProperties(properties);
+    }
+
+    @NotNull
+    public static RGB makeGeometryColor(int index) {
+        if (index == 0) {
+            return Display.getCurrent().getSystemColor(SWT.COLOR_BLUE).getRGB();
+        } else {
+            return UIColors.getColor(index).getRGB();
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/panel/GISBrowserViewer.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/panel/GISBrowserViewer.java
@@ -113,9 +113,6 @@ public class GISBrowserViewer extends BaseValueEditor<Browser> implements IGeome
                             }
                         }
                     }
-                    if (geometry.getProperties() == null) {
-                        geometry.setProperties(Collections.singletonMap("Object", geometry.getSRID()));
-                    }
                 }
             }
         }

--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/panel/GISBrowserViewer.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/panel/GISBrowserViewer.java
@@ -105,9 +105,10 @@ public class GISBrowserViewer extends BaseValueEditor<Browser> implements IGeome
 
                     // Set properties
                     if (valueType instanceof DBSAttributeBase) {
-                        for (GeometryDataUtils.GeomAttrs ga : geomAttrs) {
+                        for (int i = 0; i < geomAttrs.size(); i++) {
+                            final GeometryDataUtils.GeomAttrs ga = geomAttrs.get(i);
                             if (ga.geomAttr.matches(attr, false)) {
-                                GeometryDataUtils.setGeometryProperties(resultSetController, ga, geometry, row);
+                                GeometryDataUtils.setGeometryProperties(resultSetController, ga, geometry, GeometryDataUtils.makeGeometryColor(i), row);
                                 break;
                             }
                         }

--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/panel/GISLeafletViewer.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/panel/GISLeafletViewer.java
@@ -324,19 +324,7 @@ public class GISLeafletViewer implements IGeometryValueEditor {
                 if (CommonUtils.isEmpty(value.getProperties())) {
                     geomTipValues.add("null");
                 } else {
-                    Map<String, Object> simplifiedProperties = new LinkedHashMap<>();
-                    for (Map.Entry<String, Object> pe : value.getProperties().entrySet()) {
-                        Object pv = pe.getValue();
-                        if (pv instanceof String || pv instanceof Number || pv instanceof Boolean || pv == null) {
-                            // No changes
-                        } else if (pv instanceof Map) {
-                            simplifiedProperties.putAll((Map<? extends String, ?>) pv);
-                        } else {
-                            pv = CommonUtils.toString(pv);
-                        }
-                        simplifiedProperties.put(pe.getKey(), pv);
-                    }
-                    geomTipValues.add(gson.toJson(simplifiedProperties));
+                    geomTipValues.add(gson.toJson(value.getProperties()));
                 }
             } catch (Exception e) {
                 log.debug(e);

--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/presentation/GeometryPresentation.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/presentation/GeometryPresentation.java
@@ -19,25 +19,18 @@ package org.jkiss.dbeaver.ui.gis.presentation;
 
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.Transfer;
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.themes.ITheme;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
-import org.jkiss.dbeaver.model.DBPEvaluationContext;
-import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.data.DBDAttributeBinding;
 import org.jkiss.dbeaver.model.gis.DBGeometry;
 import org.jkiss.dbeaver.model.gis.GisTransformUtils;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
-import org.jkiss.dbeaver.ui.UIColors;
 import org.jkiss.dbeaver.ui.controls.resultset.*;
 import org.jkiss.dbeaver.ui.gis.GeometryDataUtils;
 import org.jkiss.dbeaver.ui.gis.panel.GISLeafletViewer;
@@ -136,15 +129,6 @@ public class GeometryPresentation extends AbstractPresentation {
         List<DBGeometry> geometries = new ArrayList<>();
         for (int i = 0; i < result.size(); i++) {
             GeometryDataUtils.GeomAttrs geomAttrs = result.get(i);
-            Color attrColor;
-            if (i == 0) {
-                attrColor = Display.getCurrent().getSystemColor(SWT.COLOR_BLUE);
-            } else {
-                attrColor = UIColors.getColor(i);
-            }
-            RGB rgb = attrColor.getRGB();
-            String colorCode = String.format("#%02x%02x%02x", rgb.red, rgb.green, rgb.blue);
-
             for (ResultSetRow row : model.getAllRows()) {
                 Object value = model.getCellValue(geomAttrs.geomAttr, row);
 
@@ -156,21 +140,7 @@ public class GeometryPresentation extends AbstractPresentation {
 
                 if (geometry != null && !(geometry.getSRID() != 0 && geometry.isEmpty())) {
                     geometries.add(geometry);
-                    // Now get description
-                    Map<String, Object> properties = new LinkedHashMap<>();
-                    properties.put("id", DBUtils.getObjectFullName(geomAttrs.geomAttr, DBPEvaluationContext.UI));
-                    properties.put("color", colorCode);
-                    if (!geomAttrs.descAttrs.isEmpty()) {
-                        Map<String, Object> infoMap = new LinkedHashMap<>();
-                        properties.put("info", infoMap);
-                        for (DBDAttributeBinding da : geomAttrs.descAttrs) {
-                            Object descValue = model.getCellValue(da, row);
-                            if (!DBUtils.isNullValue(descValue) && !(descValue instanceof String && ((String) descValue).isEmpty())) {
-                                infoMap.put(da.getName(), descValue);
-                            }
-                        }
-                    }
-                    geometry.setProperties(properties);
+                    GeometryDataUtils.setGeometryProperties(getController(), geomAttrs, geometry, GeometryDataUtils.makeGeometryColor(i), row);
                 }
             }
         }

--- a/plugins/org.jkiss.dbeaver.data.gis.view/web/view_template.html
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/web/view_template.html
@@ -80,15 +80,17 @@
                     if (color == null) color = "black";
                     tipText += "<h3 style='color:" + color + "'>" + tip.id + "</h3>";
                 }
-                tipText += "<table>";
                 var objInfo = tip.info;
                 if (objInfo == null) objInfo = tip;
-                if (objInfo != null) {
+                if (objInfo != null && Object.keys(objInfo).length > 0) {
+                    tipText += "<table>";
                     for (var propName in objInfo) {
                         tipText += "<tr><td>" + propName + "</td><td>" + objInfo[propName] + "</td></tr>";
                     }
+                    tipText += "</table>";
+                } else {
+                    tipText += "<i>No information present</i>";
                 }
-                tipText += "</table>";
                 layer.bindPopup(tipText, popupOption);
             }
         }


### PR DESCRIPTION
Fixed:
1. Attributes with name like `id` and `color` would override layer's color and title
1. Different attributes would have the same color in value panel
1. An empty layer would display if no description columns are present
  
![idea64_Mnv9istCWE](https://user-images.githubusercontent.com/35821147/138698626-7ed9b9a9-4f1f-451c-a640-8c8429bd0fa1.png)

![idea64_0HmxFx0tfq](https://user-images.githubusercontent.com/35821147/138698621-f7030237-4ef7-44b0-826b-5440c61dcec5.png)
