### PR TITLE
#11922 add recreate object action

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreForeignKeyManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreForeignKeyManager.java
@@ -109,9 +109,8 @@ public class PostgreForeignKeyManager extends SQLForeignKeyManager<PostgreTableF
     @Override
     protected void addObjectModifyActions(DBRProgressMonitor monitor, DBCExecutionContext executionContext, List<DBEPersistAction> actionList, ObjectChangeCommand command, Map<String, Object> options)
     {
-        if (command.getProperty(DBConstants.PROP_ID_DESCRIPTION) != null) {
-            PostgreConstraintManager.addConstraintCommentAction(actionList, command.getObject());
-        }
+        addObjectDeleteActions(monitor, executionContext, actionList, new ObjectDeleteCommand(command.getObject(), command.getTitle()), options);
+        addObjectCreateActions(monitor, executionContext, actionList, makeCreateCommand(command.getObject(), options), options);
     }
 
     @Override
@@ -134,5 +133,12 @@ public class PostgreForeignKeyManager extends SQLForeignKeyManager<PostgreTableF
                         "ALTER TABLE " + foreignKey.getTable().getFullyQualifiedName(DBPEvaluationContext.DDL) + //$NON-NLS-1$
                                 " RENAME CONSTRAINT " + DBUtils.getQuotedIdentifier(foreignKey) + " TO " + DBUtils.getQuotedIdentifier(foreignKey.getDataSource(), command.getNewName())) //$NON-NLS-1$
         );
+    }
+
+    @Override
+    protected void addObjectExtraActions(DBRProgressMonitor monitor, DBCExecutionContext executionContext, List<DBEPersistAction> actions, NestedObjectCommand<PostgreTableForeignKey, PropertyHandler> command, Map<String, Object> options) throws DBException {
+        if (command.getProperty(DBConstants.PROP_ID_DESCRIPTION) != null) {
+            PostgreConstraintManager.addConstraintCommentAction(actions, command.getObject());
+        }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableForeignKey.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableForeignKey.java
@@ -25,6 +25,7 @@ import org.jkiss.dbeaver.model.DBPNamedObject;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.meta.IPropertyValueListProvider;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSEntityConstraint;
@@ -153,7 +154,7 @@ public class PostgreTableForeignKey extends PostgreTableConstraintBase implement
 
     @NotNull
     @Override
-    @Property(viewable = true, specific = true, order = 55)
+    @Property(viewable = true, specific = true, updatable = true, editable = true, listProvider = PostgreConstraintModifyRuleListProvider.class, order = 55)
     public DBSForeignKeyModifyRule getDeleteRule() {
         return deleteRule;
     }
@@ -164,7 +165,7 @@ public class PostgreTableForeignKey extends PostgreTableConstraintBase implement
 
     @NotNull
     @Override
-    @Property(viewable = true, specific = true, order = 56)
+    @Property(viewable = true, specific = true, updatable = true, editable = true, listProvider = PostgreConstraintModifyRuleListProvider.class, order = 56)
     public DBSForeignKeyModifyRule getUpdateRule() {
         return updateRule;
     }
@@ -202,5 +203,25 @@ public class PostgreTableForeignKey extends PostgreTableConstraintBase implement
 
     public void addColumn(PostgreTableForeignKeyColumn column) {
         this.columns.add(column);
+    }
+
+    public static class PostgreConstraintModifyRuleListProvider implements IPropertyValueListProvider<PostgreTableForeignKey> {
+
+        @Override
+        public boolean allowCustomValue()
+        {
+            return false;
+        }
+
+        @Override
+        public Object[] getPossibleValues(PostgreTableForeignKey foreignKey)
+        {
+            return new DBSForeignKeyModifyRule[] {
+                DBSForeignKeyModifyRule.NO_ACTION,
+                DBSForeignKeyModifyRule.CASCADE,
+                DBSForeignKeyModifyRule.RESTRICT,
+                DBSForeignKeyModifyRule.SET_NULL,
+                DBSForeignKeyModifyRule.SET_DEFAULT };
+        }
     }
 }


### PR DESCRIPTION
for the ability to change delete/update foreign key rules

![2021-11-01 11_33_01-DBeaver Ultimate 21 2 4 - child_b](https://user-images.githubusercontent.com/45152336/139645369-eaa94b1e-0c80-4d1d-922b-f7bd780b0171.png)

