### PR TITLE
#14522 Allow cancelling SSH tunnel setup via monitor

### DIFF
--- a/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationJsch.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationJsch.java
@@ -62,6 +62,10 @@ public class SSHImplementationJsch extends SSHImplementationAbstract {
             final SSHAuthConfiguration auth = host.getAuthConfiguration();
             final Session session;
 
+            if (monitor.isCanceled()) {
+                break;
+            }
+
             if (auth.getType() == AuthType.PUBLIC_KEY) {
                 log.debug("Adding identity key");
                 try {


### PR DESCRIPTION
May not be a very elegant solution since we don't have a way to forcibly terminate ongoing socket connection, but it works.