### PR TITLE
#14474 Fix check component for privilege roles of postgresql

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/editors/PostgresRolePrivilegesEditor.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/editors/PostgresRolePrivilegesEditor.java
@@ -309,7 +309,7 @@ public class PostgresRolePrivilegesEditor extends AbstractDatabaseObjectEditor<P
                                 currentObject.getName(),
                                 Collections.singletonList(privGrant));
                     } else {
-                    	permission.setPermission(privilegeType, grant);
+                    	permission.setPermission(privilegeType, grant, currentUser);
                     }
                     
                 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/editors/PostgresRolePrivilegesEditor.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/editors/PostgresRolePrivilegesEditor.java
@@ -423,7 +423,7 @@ public class PostgresRolePrivilegesEditor extends AbstractDatabaseObjectEditor<P
             for (TableItem item : permissionTable.getItems()) {
                 PostgrePrivilegeType privType = (PostgrePrivilegeType) item.getData();
                 short perm = currentPermissions[0] == null ? PostgrePrivilege.NONE : currentPermissions[0].getPermission(privType);
-                item.setChecked((perm & PostgrePrivilege.GRANTED) != 0 );
+                item.setChecked(CommonUtils.isBitSet(perm, PostgrePrivilege.GRANTED));
                 if ((perm & PostgrePrivilege.WITH_GRANT_OPTION) != 0) {
                     item.setText(1, "X");
                 } else {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgrePrivilege.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgrePrivilege.java
@@ -163,6 +163,19 @@ public abstract class PostgrePrivilege implements DBAPrivilege, Comparable<Postg
 
     public void setPermission(PostgrePrivilegeType privilegeType, boolean permit) {
         for (ObjectPermission permission : permissions) {
+            if (permission.privilegeType == privilegeType) {
+                if (permit) {
+                    permission.permissions |= GRANTED;
+                } else {
+                    permission.permissions = 0;
+                }
+            }
+        }
+    }
+    
+    
+    public void setPermission(PostgrePrivilegeType privilegeType, boolean permit, String grantor) {
+        for (ObjectPermission permission : permissions) {
             if (permission.privilegeType != privilegeType) {
                 if (permit) {
                     permission.permissions |= GRANTED;
@@ -170,7 +183,7 @@ public abstract class PostgrePrivilege implements DBAPrivilege, Comparable<Postg
                     for(int i = 0; i < this.permissions.length; i++) {
                 	tempPermission[i] = this.permissions[i];
                     }
-                    tempPermission[this.permissions.length] = new ObjectPermission(privilegeType, permission.getGrantor(), permission.permissions);
+                    tempPermission[this.permissions.length] = new ObjectPermission(privilegeType, grantor, permission.permissions);
                     this.permissions = tempPermission;
                     
                 } else {
@@ -179,7 +192,6 @@ public abstract class PostgrePrivilege implements DBAPrivilege, Comparable<Postg
             }
         }
     }
-
     // Properties for permissions viewer
 
 /*

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgrePrivilege.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgrePrivilege.java
@@ -25,6 +25,7 @@ import org.jkiss.dbeaver.model.access.DBAPrivilegeGrant;
 import org.jkiss.dbeaver.model.access.DBARole;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.utils.ArrayUtils;
 
 import java.util.List;
 
@@ -179,13 +180,7 @@ public abstract class PostgrePrivilege implements DBAPrivilege, Comparable<Postg
             if (permission.privilegeType != privilegeType) {
                 if (permit) {
                     permission.permissions |= GRANTED;
-                    ObjectPermission[] tempPermission = new ObjectPermission[this.permissions.length+1];
-                    for(int i = 0; i < this.permissions.length; i++) {
-                	tempPermission[i] = this.permissions[i];
-                    }
-                    tempPermission[this.permissions.length] = new ObjectPermission(privilegeType, grantor, permission.permissions);
-                    this.permissions = tempPermission;
-                    
+                    ArrayUtils.add(ObjectPermission.class, this.permissions, new ObjectPermission(privilegeType, grantor, permission.permissions));
                 } else {
                     permission.permissions = 0;
                 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgrePrivilege.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgrePrivilege.java
@@ -163,9 +163,16 @@ public abstract class PostgrePrivilege implements DBAPrivilege, Comparable<Postg
 
     public void setPermission(PostgrePrivilegeType privilegeType, boolean permit) {
         for (ObjectPermission permission : permissions) {
-            if (permission.privilegeType == privilegeType) {
+            if (permission.privilegeType != privilegeType) {
                 if (permit) {
                     permission.permissions |= GRANTED;
+                    ObjectPermission[] tempPermission = new ObjectPermission[this.permissions.length+1];
+                    for(int i = 0; i < this.permissions.length; i++) {
+                	tempPermission[i] = this.permissions[i];
+                    }
+                    tempPermission[this.permissions.length] = new ObjectPermission(privilegeType, permission.getGrantor(), permission.permissions);
+                    this.permissions = tempPermission;
+                    
                 } else {
                     permission.permissions = 0;
                 }


### PR DESCRIPTION
This is proposed solution to #14474 
the issue was added to the 21.3.5 milestone

- Changed the `setPermission` method from `PostgrePrivilege` so it not overwrite the permissions anymore.
- Changed the `updateCurrentPrivileges` method from `PostgresRolePrivilegesEditor` so the `if(permission == null)` doesn't skip the addition of new permissions before user add the first permission.