### PR TITLE
#12335 fix join autocomplete

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
@@ -932,8 +932,16 @@ public class SQLCompletionAnalyzer implements DBRRunnableParametrized<DBRProgres
                     continue;
                 }
                 if (state == InlineState.TABLE_DOT) {
-                    if (CommonUtils.isEmpty(tableAlias)) {
+                    if (CommonUtils.isEmpty(tableAlias) && !isTableQueryToken(tok, value)) {
                         state = InlineState.MATCHED;
+                    } else if (isTableQueryToken(tok, value)) {
+                        /*
+                            Sometimes we can have table without alias, it will reset state to table_name because there is no alias to check
+                            See #12335
+                         */
+                        matchedTableName = null;
+                        state = InlineState.TABLE_NAME;
+                        continue;
                     } else {
                         state = InlineState.ALIAS_AS;
                     }

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/SQLCompletionAnalyzerTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/SQLCompletionAnalyzerTest.java
@@ -148,6 +148,30 @@ public class SQLCompletionAnalyzerTest {
     }
 
     @Test
+    public void testColumnWithNonExistingAliases() throws DBException {
+        final RequestResult request = RequestBuilder.tables(s-> {
+            s.table("Table1", t -> {
+                t.attribute("Col1");
+                t.attribute("Col2");
+            });
+            s.table("Table2", t -> {
+                t.attribute("Col4");
+                t.attribute("Col5");
+            });
+        }).prepare();
+        {
+            final List<SQLCompletionProposalBase> proposals = request.request("SELECT * FROM Table1 join Table2 t on t.|", false);
+            Assert.assertEquals("Col4", proposals.get(0).getReplacementString());
+            Assert.assertEquals("Col5", proposals.get(1).getReplacementString());
+        }
+        {
+            final List<SQLCompletionProposalBase> proposals = request.request("SELECT * FROM Table1 b join Table2 on b.|", false);
+            Assert.assertEquals("Col1", proposals.get(0).getReplacementString());
+            Assert.assertEquals("Col2", proposals.get(1).getReplacementString());
+        }
+    }
+
+    @Test
     public void testColumnNamesExpandCompletion() throws DBException {
         final RequestResult request = RequestBuilder
             .tables(s -> {


### PR DESCRIPTION
The problem was in the state machine which after not finding the alias skipped the JOIN statement entirely and was not able to work correctly afterward. 