### PR TITLE
#14729 avoid returning the null column name in the ResultSet

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
@@ -2324,7 +2324,7 @@ public class SpreadsheetPresentation extends AbstractPresentation implements IRe
             if (element instanceof DBDAttributeBinding) {
                 DBDAttributeBinding attributeBinding = (DBDAttributeBinding) element;
                 if (CommonUtils.isEmpty(attributeBinding.getLabel())) {
-                    return attributeBinding.getName();
+                    return CommonUtils.notEmpty(attributeBinding.getName());
                 } else {
                     return attributeBinding.getLabel();
                 }


### PR DESCRIPTION
Most of the drivers can return an empty string as a label/name in special cases. But MySQL driver can return null instead. And null will crash everything. Let's avoid this situation.