### PR TITLE
#14187 Add confirmation dialog for old rows update

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetPreferences.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetPreferences.java
@@ -87,6 +87,7 @@ public final class ResultSetPreferences {
     // Confirmations
     public static final String CONFIRM_ORDER_RESULTSET = "order_resultset"; //$NON-NLS-1$
     public static final String CONFIRM_FILTER_RESULTSET = "filter_resultset"; //$NON-NLS-1$
+    public static final String CONFIRM_UPDATE_RESULTSET = "update_resultset";
     public static final String CONFIRM_RS_FETCH_ALL = "fetch_all_rows"; //$NON-NLS-1$
     public static final String CONFIRM_RS_EDIT_CLOSE = "close_resultset_edit"; //$NON-NLS-1$
     public static final String CONFIRM_RS_PANEL_RESET = "reset_panels_content"; //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
@@ -2256,8 +2256,17 @@ public class ResultSetViewer extends Viewer
     }
 
     void appendData(List<Object[]> rows, boolean resetOldRows) {
-        model.appendData(rows, resetOldRows);
-
+        if (model.isDirty() && resetOldRows) {
+            UIUtils.syncExec(() -> {
+                model.appendData(rows, ConfirmationDialog.showConfirmDialog(
+                        ResourceBundle.getBundle(ResultSetMessages.BUNDLE_NAME),
+                        null,
+                        ResultSetPreferences.CONFIRM_UPDATE_RESULTSET,
+                        ConfirmationDialog.QUESTION) == IDialogConstants.YES_ID);
+            });
+        } else {
+            model.appendData(rows, resetOldRows);
+        }
         UIUtils.asyncExec(() -> {
             setStatus(NLS.bind(ResultSetMessages.controls_resultset_viewer_status_rows_size, model.getRowCount(), rows.size()) + getExecutionTimeMessage());
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.java
@@ -29,6 +29,11 @@ public class ResultSetMessages extends NLS {
     public static String confirm_filter_resultset_message;
     public static String confirm_filter_resultset_toggleMessage;
 
+    public static String confirm_update_resultset_message_toggleMessage;
+    public static String confirm_update_resultset_message;
+    public static String confirm_update_resultset_title;
+
+
     public static String confirm_fetch_all_rows_title;
     public static String confirm_fetch_all_rows_message;
     public static String confirm_fetch_all_rows_toggleMessage;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
@@ -18,6 +18,10 @@ confirm_order_resultset_message = Ordering of the result set can take substantia
 confirm_order_resultset_title = Order result set
 confirm_order_resultset_toggleMessage = Do not ask me again
 
+confirm_update_resultset_title = Confirm update
+confirm_update_resultset_message = You are trying to update resultset when having unconfirmed changes this will cause them to be lost. \n\n Are you sure you want to update old rows?
+confirm_update_resultset_toggleMessage = Do not ask me again
+
 confirm_filter_resultset_title = Filter resultset
 confirm_filter_resultset_message = Loading distinct values from database table can take substantial time for large tables when there is no appropriate index for this column.\n\nAre you sure you want to load possible values column {0}?
 confirm_filter_resultset_toggleMessage = Do not ask me again


### PR DESCRIPTION
Shows dialog if you try to get more elements from the database when scrolling, have an active checkbox to update old rows, and If you have any unconfirmed changes to prevent them from being lost.