### PR TITLE
#14010 Fix retrieval of array data when `getResultSet` is not supported

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/handlers/JDBCArrayValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/handlers/JDBCArrayValueHandler.java
@@ -65,7 +65,7 @@ public class JDBCArrayValueHandler extends JDBCComplexValueHandler {
         } else if (object instanceof String) {
             return JDBCCollection.makeCollectionFromString((JDBCSession) session, (String)object);
         } else if (object.getClass().isArray()) {
-            return JDBCCollection.makeCollectionFromJavaArray((JDBCSession) session, type, object);
+            return JDBCCollection.makeCollectionFromJavaArray((JDBCSession) session, object);
         } else if (object instanceof Collection) {
             return JDBCCollection.makeCollectionFromJavaCollection((JDBCSession) session, type, (Collection) object);
         } else {


### PR DESCRIPTION
Unfortunately, the driver itself returns bad data:

![image](https://user-images.githubusercontent.com/35821147/146009106-72cc898f-e596-4bf4-b4ae-c35a631d1883.png)
