### PR TITLE
#14669 Hide new table creation command for non-default non-initial db…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerTableManager.java
@@ -18,17 +18,21 @@ package org.jkiss.dbeaver.ext.mssql.edit;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.mssql.SQLServerUtils;
 import org.jkiss.dbeaver.ext.mssql.model.*;
 import org.jkiss.dbeaver.model.DBConstants;
+import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.edit.DBECommandContext;
 import org.jkiss.dbeaver.model.edit.DBEPersistAction;
 import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
+import org.jkiss.dbeaver.model.exec.DBCExecutionContextDefaults;
 import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
 import org.jkiss.dbeaver.model.impl.sql.edit.SQLObjectEditor;
 import org.jkiss.dbeaver.model.impl.sql.edit.SQLStructEditor;
 import org.jkiss.dbeaver.model.messages.ModelMessages;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
 import org.jkiss.dbeaver.model.struct.rdb.DBSTableIndex;
 import org.jkiss.utils.CommonUtils;
 
@@ -100,6 +104,36 @@ public class SQLServerTableManager extends SQLServerBaseTableManager<SQLServerTa
                     (!object.isView() && CommonUtils.getOption(options, OPTION_DELETE_CASCADE) ? " CASCADE CONSTRAINTS" : "")
             )
         );
+    }
+
+    @Override
+    public boolean canCreateObject(Object container) {
+        if (container instanceof SQLServerSchema) {
+            SQLServerSchema schema = (SQLServerSchema)container;
+            if (SQLServerUtils.isDriverBabelfish(schema.getDataSource().getContainer().getDriver()) && isNonDefaultNonInitialDatabase(schema.getDatabase())) {
+               return false;
+            }
+        }
+
+        return super.canCreateObject(container);
+    }
+
+    private boolean isNonDefaultNonInitialDatabase(SQLServerDatabase database) {
+        SQLServerDataSource dataSource = database.getDataSource();
+        DBPDataSourceContainer dataSourceContainer = dataSource.getContainer();
+
+        String configuredDatabaseName = dataSourceContainer.getConnectionConfiguration().getDatabaseName();
+        String initialDatabaseName = CommonUtils.isNotEmpty(configuredDatabaseName) ? configuredDatabaseName
+                                                                                    : dataSourceContainer.getDriver().getDefaultDatabase();
+        SQLServerDatabase initialDatabase = dataSource.getDatabase(initialDatabaseName);
+
+        if (database != initialDatabase) {
+            return true;
+        } else {
+            DBCExecutionContext defaultContext = dataSource.getDefaultInstance().getDefaultContext(new VoidProgressMonitor(), false);
+            DBCExecutionContextDefaults contextDefaults = defaultContext.getContextDefaults();
+            return contextDefaults != null && contextDefaults.getDefaultCatalog() != database;
+        }
     }
 
     @NotNull


### PR DESCRIPTION
… for babelfish connections using mssql datasource

Babelfish connection always creates table in default database, but non-initial database doesn't display database objects. So new table creation command was made accessible only for initial (specified in connection properties) database when it is set as default.