### PR TITLE
#13784 introduce new version of jdbc driver for athena

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.athena/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.athena/plugin.xml
@@ -30,10 +30,10 @@
                         description="%driver.athena.description"
                         category="AWS"
                         webURL="https://docs.aws.amazon.com/athena/latest/ug/connect-with-jdbc.html"
-                        propertiesURL="https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.16.1000/docs/Simba+Athena+JDBC+Driver+Install+and+Configuration+Guide.pdf"
+                        propertiesURL="https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.25.1001/doc/Simba+Athena+JDBC+Connector+Install+and+Configuration+Guide.pdf"
                         categories="bigdata,aws">
                     <replace provider="generic" driver="aws_athena_42"/>
-                    <file type="jar" path="https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.16.1000/AthenaJDBC42.jar" bundle="!drivers.athena"/>
+                    <file type="jar" path="https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.25.1001/SimbaAthenaJDBC-2.0.25.1001.zip" bundle="!drivers.athena"/>
                     <file type="jar" path="drivers/athena" bundle="drivers.athena"/>
 
                     <parameter name="supports-references" value="false"/>

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverUtils.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverUtils.java
@@ -137,6 +137,10 @@ public class DriverUtils {
             // Already extracted
             return;
         }
+        File localDir = localFile.getParentFile();
+        if (!localDir.exists() && !localDir.mkdirs()) { // in case of localFile located in subdirectory inside zip archive
+            throw new IOException("Can't create local file directory in the cache '" + localDir.getAbsolutePath() + "'");
+        }
         try (FileOutputStream os = new FileOutputStream(localFile)) {
             copyZipStream(zipStream, os);
         }


### PR DESCRIPTION
JDBC driver of a newer version (2.0.25) eliminates the syntax error related to the fact that AJQueryExecutor (internal class of JDBC driver) of a previously used JDBC driver (2.0.16) tried to execute prepared statement with not filled parameters in its constructor to estimate a size of ResultSet.

The Athena JDBC driver version 2.0.25 is available in zip-archive through nested folder, so we need to add this folder in zip-cache for JDBC drivers available by zip archive with such structure.

It may need to update some permissions policy according to https://docs.aws.amazon.com/athena/latest/ug/connect-with-jdbc.html (Migration from Previous Version of the JDBC Driver)