### PR TITLE
#13924 Fix filter result set on computed aliased columns

### DIFF
--- a/bundles/org.jkiss.utils/src/org/jkiss/utils/CommonUtils.java
+++ b/bundles/org.jkiss.utils/src/org/jkiss/utils/CommonUtils.java
@@ -1028,4 +1028,9 @@ public class CommonUtils {
         matcher.appendTail(sb);
         return sb.toString();
     }
+
+    @NotNull
+    public static <T> Optional<T> optionalIfInstanceOf(@NotNull Class<T> type, Object obj) {
+        return obj != null && type.isAssignableFrom(obj.getClass()) ? Optional.of((T)obj) : Optional.empty();
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/DBDAttributeAssociatedExpressionConstraint.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/DBDAttributeAssociatedExpressionConstraint.java
@@ -1,0 +1,32 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2021 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql;
+
+import org.jkiss.dbeaver.model.data.DBDAttributeConstraint;
+
+public class DBDAttributeAssociatedExpressionConstraint extends DBDAttributeConstraint {
+    private String valueExpressionString;
+
+    public DBDAttributeAssociatedExpressionConstraint(DBDAttributeConstraint source, String valueExpressionString) {
+        super(source);
+        this.valueExpressionString = valueExpressionString;
+    }
+
+    public String getValueExpressionString() {
+        return this.valueExpressionString;
+    }
+}


### PR DESCRIPTION
The [previously proposed solution](https://github.com/dbeaver/dbeaver/pull/14957) did not work for computed columns and was revised.

The current solution offers to patch query with aliased columns and replace alias with aliased expression. I didn't find any possibility in current model to add custom expression as constraint. So, a new attribute constraint was proposed for that.