### PR TITLE
#15011 Fix result set release operation was executed before data read

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParser.java
@@ -141,14 +141,14 @@ public class PostgreValueParser {
                 if(firstAttempt){
                     return itemValues;
                 } else {
-                    return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), itemValues, session.getProgressMonitor());
+                    return new JDBCCollection(session.getProgressMonitor(), itemType, DBUtils.findValueHandler(session, itemType), itemValues);
                 }
             }
         }
         if (firstAttempt) {
             return values;
         } else {
-            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), values, session.getProgressMonitor());
+            return new JDBCCollection(session.getProgressMonitor(), itemType, DBUtils.findValueHandler(session, itemType), values);
 
         }
     }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParser.java
@@ -141,14 +141,14 @@ public class PostgreValueParser {
                 if(firstAttempt){
                     return itemValues;
                 } else {
-                    return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), itemValues);
+                    return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), itemValues, session.getProgressMonitor());
                 }
             }
         }
         if (firstAttempt) {
             return values;
         } else {
-            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), values);
+            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), values, session.getProgressMonitor());
 
         }
     }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreArrayValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreArrayValueHandler.java
@@ -86,10 +86,10 @@ public class PostgreArrayValueHandler extends JDBCArrayValueHandler {
                     } else {
                         log.error("Can't parse array");
                         return new JDBCCollection(
-                            itemType,
+                                session.getProgressMonitor(), itemType,
                             DBUtils.findValueHandler(session, itemType),
-                            value == null ? null : new Object[]{value},
-                            session.getProgressMonitor());
+                            value == null ? null : new Object[]{value}
+                        );
                     }
                 } else {
                     return convertStringToCollection(session, type, itemType, (String) object);
@@ -118,24 +118,24 @@ public class PostgreArrayValueHandler extends JDBCArrayValueHandler {
                 Object itemValue = itemValueHandler.getValueFromObject(session, itemType, itemString, false, false);
                 itemValues[i] = itemValue;
             }
-            return new JDBCCollection(itemType, itemValueHandler, itemValues, session.getProgressMonitor());
+            return new JDBCCollection(session.getProgressMonitor(), itemType, itemValueHandler, itemValues);
         } else {
             List<Object> strings = PostgreValueParser.parseArrayString(value, delimiter);
             Object[] contents = new Object[strings.size()];
             for (int i = 0; i < strings.size(); i++) {
                 contents[i] = PostgreValueParser.convertStringToValue(session, itemType, String.valueOf(strings.get(i)));
             }
-            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), contents, session.getProgressMonitor());
+            return new JDBCCollection(session.getProgressMonitor(), itemType, DBUtils.findValueHandler(session, itemType), contents);
         }
     }
 
     private JDBCCollection convertStringArrayToCollection(@NotNull DBCSession session, @NotNull PostgreDataType arrayType, @NotNull PostgreDataType itemType, @NotNull String strValue) throws DBCException {
         Object parsedArray = PostgreValueParser.convertStringToValue(session, arrayType, strValue);
         if (parsedArray instanceof Object[]){
-            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), (Object[]) parsedArray, session.getProgressMonitor());
+            return new JDBCCollection(session.getProgressMonitor(), itemType, DBUtils.findValueHandler(session, itemType), (Object[]) parsedArray);
         } else {
             log.error("Can't parse array");
-            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), new Object[]{parsedArray}, session.getProgressMonitor());
+            return new JDBCCollection(session.getProgressMonitor(), itemType, DBUtils.findValueHandler(session, itemType), new Object[]{parsedArray});
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreArrayValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreArrayValueHandler.java
@@ -88,7 +88,8 @@ public class PostgreArrayValueHandler extends JDBCArrayValueHandler {
                         return new JDBCCollection(
                             itemType,
                             DBUtils.findValueHandler(session, itemType),
-                            value == null ? null : new Object[]{value});
+                            value == null ? null : new Object[]{value},
+                            session.getProgressMonitor());
                     }
                 } else {
                     return convertStringToCollection(session, type, itemType, (String) object);
@@ -117,24 +118,24 @@ public class PostgreArrayValueHandler extends JDBCArrayValueHandler {
                 Object itemValue = itemValueHandler.getValueFromObject(session, itemType, itemString, false, false);
                 itemValues[i] = itemValue;
             }
-            return new JDBCCollection(itemType, itemValueHandler, itemValues);
+            return new JDBCCollection(itemType, itemValueHandler, itemValues, session.getProgressMonitor());
         } else {
             List<Object> strings = PostgreValueParser.parseArrayString(value, delimiter);
             Object[] contents = new Object[strings.size()];
             for (int i = 0; i < strings.size(); i++) {
                 contents[i] = PostgreValueParser.convertStringToValue(session, itemType, String.valueOf(strings.get(i)));
             }
-            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), contents);
+            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), contents, session.getProgressMonitor());
         }
     }
 
     private JDBCCollection convertStringArrayToCollection(@NotNull DBCSession session, @NotNull PostgreDataType arrayType, @NotNull PostgreDataType itemType, @NotNull String strValue) throws DBCException {
         Object parsedArray = PostgreValueParser.convertStringToValue(session, arrayType, strValue);
         if (parsedArray instanceof Object[]){
-            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), (Object[]) parsedArray);
+            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), (Object[]) parsedArray, session.getProgressMonitor());
         } else {
             log.error("Can't parse array");
-            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), new Object[]{parsedArray});
+            return new JDBCCollection(itemType, DBUtils.findValueHandler(session, itemType), new Object[]{parsedArray}, session.getProgressMonitor());
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCollection.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCollection.java
@@ -57,7 +57,7 @@ public class JDBCCollection extends AbstractDatabaseList implements DBDValueClon
     public JDBCCollection() {
     }
 
-    public JDBCCollection(DBSDataType type, DBDValueHandler valueHandler, @Nullable Object[] contents, @NotNull DBRProgressMonitor monitor) {
+    public JDBCCollection(@NotNull DBRProgressMonitor monitor, DBSDataType type, DBDValueHandler valueHandler, @Nullable Object[] contents) {
         this.type = type;
         this.valueHandler = valueHandler;
         if (contents != null) {
@@ -92,7 +92,7 @@ public class JDBCCollection extends AbstractDatabaseList implements DBDValueClon
 
     @Override
     public DBDValueCloneable cloneValue(DBRProgressMonitor monitor) {
-        return new JDBCCollection(type, valueHandler, contents, monitor);
+        return new JDBCCollection(monitor, type, valueHandler, contents);
     }
 
     @Override
@@ -255,7 +255,7 @@ public class JDBCCollection extends AbstractDatabaseList implements DBDValueClon
                 String defDataTypeName = dataSource.getDefaultDataTypeName(DBPDataKind.OBJECT);
                 DBSDataType defDataType = dataSource.getLocalDataType(defDataTypeName);
                 DBDValueHandler defValueHandler = session.getDefaultValueHandler();
-                return new JDBCCollection(defDataType, defValueHandler, null, monitor);
+                return new JDBCCollection(monitor, defDataType, defValueHandler, null);
             }
 
             if (elementType != null) {
@@ -342,7 +342,7 @@ public class JDBCCollection extends AbstractDatabaseList implements DBDValueClon
             }
             final DBDValueHandler elementValueHandler = DBUtils.findValueHandler(session, elementType);
             if (array == null) {
-                return new JDBCCollection(elementType, elementValueHandler, null, session.getProgressMonitor());
+                return new JDBCCollection(session.getProgressMonitor(), elementType, elementValueHandler, null);
             }
             return makeCollectionFromJavaArray(session, elementType, elementValueHandler, array);
         } catch (DBException e) {
@@ -401,7 +401,7 @@ public class JDBCCollection extends AbstractDatabaseList implements DBDValueClon
                     // Fetch second column - it contains value
                     data.add(valueHandler.fetchValueObject(session, resultSet, elementType, 1));
                 }
-                return new JDBCCollection(elementType, valueHandler, data.toArray(), session.getProgressMonitor());
+                return new JDBCCollection(session.getProgressMonitor(), elementType, valueHandler, data.toArray());
             }
         } finally {
             try {
@@ -416,7 +416,7 @@ public class JDBCCollection extends AbstractDatabaseList implements DBDValueClon
     private static JDBCCollection makeCollectionFromArray(@NotNull JDBCSession session, @Nullable Array array, @NotNull DBSDataType elementType) throws SQLException, DBCException {
         final DBDValueHandler elementValueHandler = DBUtils.findValueHandler(session, elementType);
         if (array == null) {
-            return new JDBCCollection(elementType, elementValueHandler, null, session.getProgressMonitor());
+            return new JDBCCollection(session.getProgressMonitor(), elementType, elementValueHandler, null);
         }
         Object arrObject = array.getArray();
         return makeCollectionFromJavaArray(session, elementType, elementValueHandler, arrObject);
@@ -443,7 +443,7 @@ public class JDBCCollection extends AbstractDatabaseList implements DBDValueClon
             }
             contents[i] = itemValue;
         }
-        return new JDBCCollection(elementType, elementValueHandler, contents, session.getProgressMonitor());
+        return new JDBCCollection(session.getProgressMonitor(), elementType, elementValueHandler, contents);
     }
 
     @NotNull
@@ -473,10 +473,10 @@ public class JDBCCollection extends AbstractDatabaseList implements DBDValueClon
                     items.add(token);
                 }
 
-                return new JDBCCollectionString(dataType, valueHandler, value, items.toArray(), session.getProgressMonitor());
+                return new JDBCCollectionString(session.getProgressMonitor(), dataType, valueHandler, value, items.toArray());
             }
         }
-        return new JDBCCollectionString(dataType, valueHandler, value, session.getProgressMonitor());
+        return new JDBCCollectionString(session.getProgressMonitor(), dataType, valueHandler, value);
     }
 
     //////////////////////////////////////////

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCollection.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCollection.java
@@ -60,17 +60,21 @@ public class JDBCCollection extends AbstractDatabaseList implements DBDValueClon
     public JDBCCollection(DBSDataType type, DBDValueHandler valueHandler, @Nullable Object[] contents, @NotNull DBRProgressMonitor monitor) {
         this.type = type;
         this.valueHandler = valueHandler;
-        this.contents = new Object[contents.length];
-        for (int i = 0; i < contents.length; i++) {
-            Object value = contents[i];
-            if (value instanceof DBDValueCloneable) {
-                try {
-                    value = ((DBDValueCloneable) value).cloneValue(monitor);
-                } catch (DBCException ex) {
-                    log.warn("Failed to clone value of type " + value.getClass().getName(), ex);
+        if (contents != null) {
+            this.contents = new Object[contents.length];
+            for (int i = 0; i < contents.length; i++) {
+                Object value = contents[i];
+                if (value instanceof DBDValueCloneable) {
+                    try {
+                        value = ((DBDValueCloneable) value).cloneValue(monitor);
+                    } catch (DBCException ex) {
+                        log.warn("Failed to clone value of type " + value.getClass().getName(), ex);
+                    }
                 }
+                this.contents[i] = value;
             }
-            this.contents[i] = value;
+        } else {
+            this.contents = null;
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCollectionString.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCollectionString.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.model.impl.jdbc.data;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.data.DBDDisplayFormat;
 import org.jkiss.dbeaver.model.data.DBDValueHandler;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSDataType;
 
 /**
@@ -29,13 +30,13 @@ public class JDBCCollectionString extends JDBCCollection {
 
     private String value;
 
-    JDBCCollectionString(DBSDataType type, DBDValueHandler valueHandler, String value) {
-        super(type, valueHandler, value == null ? null : new Object[] { value });
+    JDBCCollectionString(DBSDataType type, DBDValueHandler valueHandler, String value, @NotNull DBRProgressMonitor monitor) {
+        super(type, valueHandler, value == null ? null : new Object[] { value }, monitor);
         this.value = value;
     }
 
-    JDBCCollectionString(DBSDataType type, DBDValueHandler valueHandler, String value, Object[] contents) {
-        super(type, valueHandler, contents);
+    JDBCCollectionString(DBSDataType type, DBDValueHandler valueHandler, String value, Object[] contents, @NotNull DBRProgressMonitor monitor) {
+        super(type, valueHandler, contents, monitor);
         this.value = value;
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCollectionString.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCollectionString.java
@@ -30,13 +30,13 @@ public class JDBCCollectionString extends JDBCCollection {
 
     private String value;
 
-    JDBCCollectionString(DBSDataType type, DBDValueHandler valueHandler, String value, @NotNull DBRProgressMonitor monitor) {
-        super(type, valueHandler, value == null ? null : new Object[] { value }, monitor);
+    JDBCCollectionString(@NotNull DBRProgressMonitor monitor, DBSDataType type, DBDValueHandler valueHandler, String value) {
+        super(monitor, type, valueHandler, value == null ? null : new Object[] { value });
         this.value = value;
     }
 
-    JDBCCollectionString(DBSDataType type, DBDValueHandler valueHandler, String value, Object[] contents, @NotNull DBRProgressMonitor monitor) {
-        super(type, valueHandler, contents, monitor);
+    JDBCCollectionString(@NotNull DBRProgressMonitor monitor, DBSDataType type, DBDValueHandler valueHandler, String value, Object[] contents) {
+        super(monitor, type, valueHandler, contents);
         this.value = value;
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCComposite.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCComposite.java
@@ -65,7 +65,7 @@ public abstract class JDBCComposite implements DBDComposite, DBDValueCloneable {
         this.rawStruct = rawStruct;
     }
 
-    protected JDBCComposite(@NotNull JDBCComposite struct, @NotNull DBRProgressMonitor monitor) throws DBCException {
+    protected JDBCComposite(@NotNull DBRProgressMonitor monitor, @NotNull JDBCComposite struct) throws DBCException {
         this.type = struct.type;
         this.attributes = Arrays.copyOf(struct.attributes, struct.attributes.length);
         this.values = new Object[struct.values.length];

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCompositeDynamic.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCompositeDynamic.java
@@ -41,7 +41,7 @@ public class JDBCCompositeDynamic extends JDBCComposite {
 
 
     public JDBCCompositeDynamic(@NotNull JDBCComposite struct, @NotNull DBRProgressMonitor monitor) throws DBCException {
-        super(struct, monitor);
+        super(monitor, struct);
     }
 
     public JDBCCompositeDynamic(@NotNull DBCSession session, @Nullable Struct contents, @Nullable ResultSetMetaData metaData) throws DBCException

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCompositeStatic.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCompositeStatic.java
@@ -44,7 +44,7 @@ public class JDBCCompositeStatic extends JDBCComposite {
     private static final Log log = Log.getLog(JDBCCompositeStatic.class);
 
     public JDBCCompositeStatic(@NotNull JDBCComposite struct, @NotNull DBRProgressMonitor monitor) throws DBCException {
-        super(struct, monitor);
+        super(monitor, struct);
     }
 
     public JDBCCompositeStatic(DBCSession session, @NotNull DBSDataType type, @Nullable Struct contents) throws DBCException {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCompositeUnknown.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCCompositeUnknown.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 public class JDBCCompositeUnknown extends JDBCComposite {
 
     public JDBCCompositeUnknown(@NotNull JDBCComposite struct, @NotNull DBRProgressMonitor monitor) throws DBCException {
-        super(struct, monitor);
+        super(monitor, struct);
     }
 
     public JDBCCompositeUnknown(@NotNull DBCSession session, @Nullable Object structData) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetModel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetModel.java
@@ -624,6 +624,7 @@ public class ResultSetModel {
 
     public void setData(@NotNull List<Object[]> rows) {
         // Clear previous data
+        this.releaseAllData();
         this.clearData();
 
         {

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
@@ -4831,7 +4831,6 @@ public class ResultSetViewer extends Viewer
 
             model.setUpdateInProgress(this);
             model.setStatistics(null);
-            model.releaseAllData();
             if (filtersPanel != null) {
                 UIUtils.asyncExec(() -> filtersPanel.enableFilters(false));
             }

--- a/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParserTest.java
+++ b/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParserTest.java
@@ -108,16 +108,19 @@ public class PostgreValueParserTest {
 
         JDBCCollection innerCollection1 = new JDBCCollection(doubleItemType,
                 new JDBCNumberValueHandler(doubleItemType, dbdFormatSettings),
-                new Double[]{1.1, 22.22});
+                new Double[]{1.1, 22.22},
+                session.getProgressMonitor());
         JDBCCollection innerCollection2 = new JDBCCollection(doubleItemType,
                 new JDBCNumberValueHandler(doubleItemType, dbdFormatSettings),
-                new Double[]{3.3, 44.44});
+                new Double[]{3.3, 44.44},
+                session.getProgressMonitor());
         Assert.assertArrayEquals(new Object[]{innerCollection1, innerCollection2},
                 (Object[]) PostgreValueParser.convertStringToValue(session, arrayDoubleItemType, "{{1.1,22.22},{3.3,44.44}}"));
 
         JDBCCollection innerCollection3 = new JDBCCollection(doubleItemType,
                 new JDBCNumberValueHandler(doubleItemType, dbdFormatSettings),
-                new Object[]{innerCollection1, innerCollection2});
+                new Object[]{innerCollection1, innerCollection2},
+                session.getProgressMonitor());
         Assert.assertArrayEquals(new Object[]{ innerCollection3, innerCollection3 },
                 (Object[]) PostgreValueParser.convertStringToValue(session, arrayDoubleItemType, "{{{1.1,22.22},{3.3,44.44}},{{1.1,22.22},{3.3,44.44}}}"));
         Assert.assertEquals("{{{1.1,22.22},{3.3,44.44}},{1.1,22.22},{3.3,44.44}}}",
@@ -174,8 +177,8 @@ public class PostgreValueParserTest {
         String[] stringItems = new String[] {
             "one", "two", " four with spaces ", "f{i,v}e"
         };
-        JDBCCollection array = new JDBCCollection(stringItemType, arrayVH, stringItems);
-        JDBCCollection array3D = new JDBCCollection(stringItemType, arrayVH, new Object[] { array, array} );
+        JDBCCollection array = new JDBCCollection(stringItemType, arrayVH, stringItems, session.getProgressMonitor());
+        JDBCCollection array3D = new JDBCCollection(stringItemType, arrayVH, new Object[] { array, array}, session.getProgressMonitor());
         String arrayString = arrayVH.getValueDisplayString(arrayStringItemType, array, DBDDisplayFormat.NATIVE);
         Assert.assertEquals("'{\"one\",\"two\",\" four with spaces \",\"f{i,v}e\"}'", arrayString);
         String arrayString3D = arrayVH.getValueDisplayString(arrayStringItemType, array3D, DBDDisplayFormat.NATIVE);

--- a/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParserTest.java
+++ b/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParserTest.java
@@ -106,21 +106,18 @@ public class PostgreValueParserTest {
                 (Object[]) PostgreValueParser.convertStringToValue(session, arrayIntItemType, "{1,22}"));
 
 
-        JDBCCollection innerCollection1 = new JDBCCollection(doubleItemType,
+        JDBCCollection innerCollection1 = new JDBCCollection(session.getProgressMonitor(), doubleItemType,
                 new JDBCNumberValueHandler(doubleItemType, dbdFormatSettings),
-                new Double[]{1.1, 22.22},
-                session.getProgressMonitor());
-        JDBCCollection innerCollection2 = new JDBCCollection(doubleItemType,
+                new Double[]{1.1, 22.22});
+        JDBCCollection innerCollection2 = new JDBCCollection(session.getProgressMonitor(), doubleItemType,
                 new JDBCNumberValueHandler(doubleItemType, dbdFormatSettings),
-                new Double[]{3.3, 44.44},
-                session.getProgressMonitor());
+                new Double[]{3.3, 44.44});
         Assert.assertArrayEquals(new Object[]{innerCollection1, innerCollection2},
                 (Object[]) PostgreValueParser.convertStringToValue(session, arrayDoubleItemType, "{{1.1,22.22},{3.3,44.44}}"));
 
-        JDBCCollection innerCollection3 = new JDBCCollection(doubleItemType,
+        JDBCCollection innerCollection3 = new JDBCCollection(session.getProgressMonitor(), doubleItemType,
                 new JDBCNumberValueHandler(doubleItemType, dbdFormatSettings),
-                new Object[]{innerCollection1, innerCollection2},
-                session.getProgressMonitor());
+                new Object[]{innerCollection1, innerCollection2});
         Assert.assertArrayEquals(new Object[]{ innerCollection3, innerCollection3 },
                 (Object[]) PostgreValueParser.convertStringToValue(session, arrayDoubleItemType, "{{{1.1,22.22},{3.3,44.44}},{{1.1,22.22},{3.3,44.44}}}"));
         Assert.assertEquals("{{{1.1,22.22},{3.3,44.44}},{1.1,22.22},{3.3,44.44}}}",
@@ -177,8 +174,8 @@ public class PostgreValueParserTest {
         String[] stringItems = new String[] {
             "one", "two", " four with spaces ", "f{i,v}e"
         };
-        JDBCCollection array = new JDBCCollection(stringItemType, arrayVH, stringItems, session.getProgressMonitor());
-        JDBCCollection array3D = new JDBCCollection(stringItemType, arrayVH, new Object[] { array, array}, session.getProgressMonitor());
+        JDBCCollection array = new JDBCCollection(session.getProgressMonitor(), stringItemType, arrayVH, stringItems);
+        JDBCCollection array3D = new JDBCCollection(session.getProgressMonitor(), stringItemType, arrayVH, new Object[] { array, array});
         String arrayString = arrayVH.getValueDisplayString(arrayStringItemType, array, DBDDisplayFormat.NATIVE);
         Assert.assertEquals("'{\"one\",\"two\",\" four with spaces \",\"f{i,v}e\"}'", arrayString);
         String arrayString3D = arrayVH.getValueDisplayString(arrayStringItemType, array3D, DBDDisplayFormat.NATIVE);


### PR DESCRIPTION
JDBCCollection implements DBDValueCloneable, but copyValue method didn't clone value of array while creating new JDBCCollection. So, array copying was added in constructor (inspired by JDBCComposite).

Release operation was moved to another time of filter applying execution sequence.