### PR TITLE
#15042 Forbid appending to binary files

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/stream/StreamConsumerPageOutput.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/stream/StreamConsumerPageOutput.java
@@ -256,7 +256,7 @@ public class StreamConsumerPageOutput extends DataTransferPageNodeSettings {
         fileNameText.setEnabled(!clipboard);
         compressCheckbox.setEnabled(!clipboard && !addToEnd);
         splitFilesCheckbox.setEnabled(!clipboard);
-        appendToEndOfFileCheck.setEnabled(!clipboard && !compress);
+        appendToEndOfFileCheck.setEnabled(!isBinary && !clipboard && !compress);
         maximumFileSizeLabel.setEnabled(!clipboard && splitFilesCheckbox.getSelection());
         maximumFileSizeText.setEnabled(!clipboard && splitFilesCheckbox.getSelection());
         encodingCombo.setEnabled(!isBinary && !clipboard);


### PR DESCRIPTION
Forbid enabling `append to file end`  when XLSX file is selected