### PR TITLE
#13436 fix wrong delphi code generation

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/DelphiSQLConverter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/convert/impl/DelphiSQLConverter.java
@@ -40,6 +40,7 @@ public class DelphiSQLConverter extends SourceCodeSQLConverter {
                 result.append("Query.Add(");
             }
             String line = sourceLines[i];
+            line = line.replace("'", "''");
             result.append('\'').append(CommonUtils.escapeJavaString(line));
             if (!trailingLineFeed) {
                 result.append(lineDelimiter);
@@ -48,9 +49,9 @@ public class DelphiSQLConverter extends SourceCodeSQLConverter {
             if (trailingLineFeed) {
                 result.append(lineDelimiter);
             }
-            if ((i < sourceLines.length - 1) && (!useStringBuilder)) {
+            if (i < sourceLines.length - 1 && !useStringBuilder) {
                 result.append(" + \n");
-            } else {
+            } else if (useStringBuilder){
                 result.append(");\n");
             }
         }


### PR DESCRIPTION
Previously we had 2 known incorrect parts when generation Delphi code:
1 - We had wrong closing parentheses when StringBuilder was not checkek
2 - `'` was not escaped properly
I fixed logic for generating bracket and added escaping to symbol