### PR TITLE
#15042 unselect append to file if already selected

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/stream/StreamConsumerPageOutput.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/stream/StreamConsumerPageOutput.java
@@ -276,7 +276,7 @@ public class StreamConsumerPageOutput extends DataTransferPageNodeSettings {
 
         clipboardCheck.setSelection(settings.isOutputClipboard());
         singleFileCheck.setSelection(settings.isUseSingleFile());
-        appendToEndOfFileCheck.setSelection(settings.isAppendToFileEnd());
+        appendToEndOfFileCheck.setSelection(!settings.isAppendToFileEnd() && !settings.isCompressResults() && settings.isOutputClipboard());
         directoryText.setText(CommonUtils.toString(settings.getOutputFolder()));
         fileNameText.setText(CommonUtils.toString(settings.getOutputFilePattern()));
         compressCheckbox.setSelection(settings.isCompressResults());
@@ -287,6 +287,7 @@ public class StreamConsumerPageOutput extends DataTransferPageNodeSettings {
         encodingBOMCheckbox.setSelection(settings.isOutputEncodingBOM());
 
         if (isBinary) {
+            appendToEndOfFileCheck.setSelection(false);
             clipboardCheck.setSelection(false);
             encodingBOMCheckbox.setSelection(false);
             settings.setOutputClipboard(false);


### PR DESCRIPTION
unselects `append to file` if no longer valid to be used