### PR TITLE
dbeaver/dbeaver-ee#1365 DBTTaskRunStatus refactored to hold DBCStatistics instead of preformatted text message

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskRunStatus.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskRunStatus.java
@@ -25,40 +25,45 @@ import java.util.StringJoiner;
 
 public class DBTTaskRunStatus {
 
-    private String resultMessage;
+    private DBCStatistics statistics;
 
     public DBTTaskRunStatus(){
     }
 
     @Nullable
-    public String getResultMessage() {
-        return resultMessage;
+    public DBCStatistics getStatistics() {
+        return statistics;
     }
 
-    public void setResultMessage(String message) {
-        resultMessage = message;
+    public void setStatistics(DBCStatistics statistics) {
+        this.statistics = statistics;
+    }
+
+    @Nullable
+    public String makeStatisticsMessage() {
+        if (statistics.getRowsFetched() == 0 && 
+            statistics.getRowsUpdated() == 0 &&
+            statistics.getStatementsCount() == 0) {
+            return null;
+        }
+
+        StringJoiner joiner = new StringJoiner(", ");
+        if (statistics.getRowsFetched() > 0) {
+            joiner.add(NLS.bind(ModelMessages.task_rows_fetched_message_part, statistics.getRowsFetched()));
+        }
+        if (statistics.getRowsUpdated() > 0) {
+            joiner.add(NLS.bind(ModelMessages.task_rows_modified_message_part, statistics.getRowsUpdated()));
+        }
+        if (statistics.getStatementsCount() > 0) {
+            joiner.add(NLS.bind(ModelMessages.task_statements_executed_message_part, statistics.getStatementsCount()));
+        }
+
+        return joiner.toString();
     }
 
     public static DBTTaskRunStatus makeStatisticsStatus(DBCStatistics statistics) {
         DBTTaskRunStatus taskResultStatus = new DBTTaskRunStatus();
-
-        if (statistics.getRowsFetched() > 0 ||
-            statistics.getRowsUpdated() > 0 ||
-            statistics.getStatementsCount() > 0) {
-
-            StringJoiner joiner = new StringJoiner(", ");
-            if (statistics.getRowsFetched() > 0) {
-                joiner.add(NLS.bind(ModelMessages.task_rows_fetched_message_part, statistics.getRowsFetched()));
-            }
-            if (statistics.getRowsUpdated() > 0) {
-                joiner.add(NLS.bind(ModelMessages.task_rows_modified_message_part, statistics.getRowsUpdated()));
-            }
-            if (statistics.getStatementsCount() > 0) {
-                joiner.add(NLS.bind(ModelMessages.task_statements_executed_message_part, statistics.getStatementsCount()));
-            }
-            taskResultStatus.setResultMessage(joiner.toString());
-        }
-
+        taskResultStatus.setStatistics(statistics);
         return taskResultStatus;
     }
 }

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
@@ -92,7 +92,7 @@ public class TaskRunJob extends AbstractJob implements DBRRunnableContext {
             monitor.beginTask("Run task '" + task.getName() + " (" + task.getType().getName() + ")", 1);
             try {
                 DBTTaskRunStatus runResultStatus = executeTask(new LoggingProgressMonitor(monitor), logStream);
-                taskRun.setExtraMessage(runResultStatus.getResultMessage());
+                taskRun.setExtraMessage(runResultStatus.makeStatisticsMessage());
             } catch (Throwable e) {
                 taskError = e;
                 taskLog.error("Task fatal error", e);


### PR DESCRIPTION
We need it to accumulate a few task run statistics for composite tasks from a number of nested task runs.
