### PR TITLE
#15158 Fix case for quoted table name in result set export

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DTUtils.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DTUtils.java
@@ -103,7 +103,7 @@ public class DTUtils {
     public static String getTableNameFromQuery(DBPDataSource dataSource, SQLQueryContainer queryContainer, boolean shortName) {
         SQLScriptElement query = queryContainer.getQuery();
         if (query instanceof SQLQuery) {
-            DBCEntityMetaData singleSource = ((SQLQuery) query).getSingleSource();
+            DBCEntityMetaData singleSource = ((SQLQuery) query).getEntityMetadata(true);
             if (singleSource != null) {
                 SQLDialect dialect = dataSource.getSQLDialect();
                 String entity = transformName(dialect, singleSource.getEntityName());

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
@@ -312,7 +312,7 @@ public class SQLServerUtils {
     }
 
     public static SQLServerTableBase getTableFromQuery(DBCSession session, SQLQuery sqlQuery, SQLServerDataSource dataSource) throws DBException, SQLException {
-        DBCEntityMetaData singleSource = sqlQuery.getSingleSource();
+        DBCEntityMetaData singleSource = sqlQuery.getEntityMetadata(false);
         String catalogName = null;
         if (singleSource != null) {
             catalogName = singleSource.getCatalogName();

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
@@ -640,7 +640,7 @@ public class DBExecUtils {
                         Object sourceDescriptor = executionSource.getSourceDescriptor();
                         if (sourceDescriptor instanceof SQLQuery) {
                             sqlQuery = (SQLQuery) sourceDescriptor;
-                            entityMeta = sqlQuery.getSingleSource();
+                            entityMeta = sqlQuery.getEntityMetadata(false);
                         }
                         if (entityMeta != null) {
                             entity = DBUtils.getEntityFromMetaData(monitor, session.getExecutionContext(), entityMeta);

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQuery.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQuery.java
@@ -73,7 +73,7 @@ public class SQLQuery implements SQLScriptElement {
     @NotNull
     private SQLQueryType type;
     private Statement statement;
-    private SingleTableMeta singleTableMeta;
+    private SingleTableMeta singleTableMeta, rawSingleTableMetadata;
     private List<SQLSelectItem> selectItems;
     private String queryTitle;
 
@@ -214,18 +214,27 @@ public class SQLQuery implements SQLScriptElement {
     }
 
     private void fillSingleSource(Table fromItem) {
-        singleTableMeta = createTableMetaData(fromItem);
+        rawSingleTableMetadata = createOriginalSourceTableMetaData(fromItem);
+        singleTableMeta = createUnquotedTableMetaData(rawSingleTableMetadata);
     }
 
     SingleTableMeta createTableMetaData(Table fromItem) {
+        return createUnquotedTableMetaData(createOriginalSourceTableMetaData(fromItem));
+    }
+
+    private SingleTableMeta createOriginalSourceTableMetaData(Table fromItem) {
         Database database = fromItem.getDatabase();
         String catalogName = database == null ? null : database.getDatabaseName();
         String schemaName = fromItem.getSchemaName();
         String tableName = fromItem.getName();
+        return new SingleTableMeta(catalogName, schemaName, tableName);
+    }
+
+    private SingleTableMeta createUnquotedTableMetaData(SingleTableMeta tableMeta) {
         return new SingleTableMeta(
-            unquoteIdentifier(catalogName),
-            unquoteIdentifier(schemaName),
-            unquoteIdentifier(tableName));
+            unquoteIdentifier(tableMeta.getCatalogName()),
+            unquoteIdentifier(tableMeta.getSchemaName()),
+            unquoteIdentifier(tableMeta.getEntityName()));
     }
 
     private String unquoteIdentifier(String name) {
@@ -345,9 +354,9 @@ public class SQLQuery implements SQLScriptElement {
         return type;
     }
 
-    public DBCEntityMetaData getSingleSource() {
+    public DBCEntityMetaData getEntityMetadata(boolean raw) {
         parseQuery();
-        return singleTableMeta;
+        return raw? rawSingleTableMetadata : singleTableMeta;
     }
 
     public void setParameters(List<SQLQueryParameter> parameters) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -2295,8 +2295,8 @@ public class SQLEditor extends SQLEditorBase implements
             SQLQuery query = (SQLQuery) queries.get(0);
             if (query.isDeleteUpdateDangerous()) {
                 String targetName = "multiple tables";
-                if (query.getSingleSource() != null) {
-                    targetName = query.getSingleSource().getEntityName();
+                if (query.getEntityMetadata(false) != null) {
+                    targetName = query.getEntityMetadata(false).getEntityName();
                 }
                 if (ConfirmationDialog.showConfirmDialogEx(
                     ResourceBundle.getBundle(SQLEditorMessages.BUNDLE_NAME),


### PR DESCRIPTION
Preserving original entity name for export "as is" from result set based on custom query.