### PR TITLE
#13860 Fix folding disappeared after reenabling or file rename

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
@@ -333,6 +333,11 @@ public abstract class SQLEditorBase extends BaseTextEditor implements DBPContext
     @Override
     public void updatePartControl(IEditorInput input) {
         super.updatePartControl(input);
+        
+        ProjectionViewer viewer = ((ProjectionViewer) getSourceViewer());
+        if (viewer != null) {
+            annotationModel = viewer.getProjectionAnnotationModel();
+        }
     }
 
     protected IOverviewRuler createOverviewRuler(ISharedTextColors sharedColors) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -62,6 +62,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     @Override
     public void setDocument(IDocument document) {
         this.document = document;
+        this.cache.clear();
     }
 
     @Override
@@ -159,6 +160,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
 
     private void reconcile(int damagedRegionOffset, int damagedRegionLength, boolean restoreCollapsedAnnotations) {
         if (!editor.isFoldingEnabled()) {
+            cache.clear(); // underlying annotation model being cleared, so reset the cache too
             return;
         }
         ProjectionAnnotationModel model = editor.getAnnotationModel();


### PR DESCRIPTION
Case 1:
After unset folding enabled it can't be enabled again, because cash wasn't cleared while set/unset folding. Now it works.

Case 2:
Folding disappeared after file renaming. Annotation model of the document wasn't transferred while renaming file, but new IDocument was recreated by eclipse. So, old annotation model was used for new document.