### PR TITLE
Fixed PostgreInsertReplaceMethod not quoting the column in CONFLICT

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreInsertReplaceMethod.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreInsertReplaceMethod.java
@@ -62,7 +62,7 @@ public class PostgreInsertReplaceMethod implements DBDInsertReplaceMethod {
                             if (hasKey) pkNames.append(",");
                             DBSEntityAttribute attribute = column.getAttribute();
                             if (attribute == null) continue;
-                            pkNames.append(attribute.getName());
+                            pkNames.append(String.format("\"%s\"", attribute.getName()));
                             hasKey = true;
                         }
                         StringBuilder updateExpression = new StringBuilder();


### PR DESCRIPTION
When using the import data wizard (in my case, a CSV) on a Postgres table that had capitalized column names (like `HelloWorld` rather than `helloworld`) this caused the insert/replace function to error out, because it did not properly quote the column name, and Postgres defaults capitalized column names to all-lowercase when they are unquoted. This fixes that.

I'm not really a Java programmer, so I just did the most straight-forward fix.