### PR TITLE
#15069 Add QueryTransformerLimit for Clickhouse

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMetaModel.java
@@ -24,11 +24,15 @@ import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaModel;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformProvider;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformType;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformer;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCBasicDataTypeCache;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCDataType;
+import org.jkiss.dbeaver.model.impl.sql.QueryTransformerLimit;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 
@@ -38,7 +42,7 @@ import java.util.Map;
 /**
  * ClickhouseMetaModel
  */
-public class ClickhouseMetaModel extends GenericMetaModel
+public class ClickhouseMetaModel extends GenericMetaModel implements DBCQueryTransformProvider
 {
     public ClickhouseMetaModel() {
         super();
@@ -127,4 +131,14 @@ public class ClickhouseMetaModel extends GenericMetaModel
     public boolean supportsNotNullColumnModifiers(DBSObject object) {
         return false;
     }
+
+    @Override
+    @Nullable
+    public DBCQueryTransformer createQueryTransformer(@NotNull DBCQueryTransformType type) {
+        if (type == DBCQueryTransformType.RESULT_SET_LIMIT) {
+            return new QueryTransformerLimit(false, false);
+        }
+        return null;
+    }
+
 }

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSQLDialect.java
@@ -70,6 +70,10 @@ public class ClickhouseSQLDialect extends GenericSQLDialect {
         "toLowCardinality",
         "formatRow"
     };
+    private static final String[] CLICKHOUSE_NONKEYWORDS = {
+            "DEFAULT",
+            "SYSTEM"
+    };
 
     public ClickhouseSQLDialect() {
         super("Clickhouse SQL", "clickhouse");
@@ -82,8 +86,9 @@ public class ClickhouseSQLDialect extends GenericSQLDialect {
 
     public void initDriverSettings(JDBCSession session, JDBCDataSource dataSource, JDBCDatabaseMetaData metaData) {
         super.initDriverSettings(session, dataSource, metaData);
-        removeSQLKeyword("DEFAULT");
-        removeSQLKeyword("SYSTEM");
+        for (String word : CLICKHOUSE_NONKEYWORDS) {
+            removeSQLKeyword(word);
+        }
         addFunctions(Arrays.asList(CLICKHOUSE_FUNCTIONS));
     }
 
@@ -103,5 +108,16 @@ public class ClickhouseSQLDialect extends GenericSQLDialect {
     @Override
     public boolean supportsNestedComments() {
         return true;
+    }
+
+    //We should quote keywords which is not keywords for clickhouse, otherwise JSQLParser can't parse statements
+    @Override
+    public boolean mustBeQuoted(@NotNull String str, boolean forceCaseSensitive) {
+        for (String word : CLICKHOUSE_NONKEYWORDS) {
+            if (word.equalsIgnoreCase(str)) {
+                return true;
+            }
+        }
+        return super.mustBeQuoted(str, forceCaseSensitive);
     }
 }


### PR DESCRIPTION
QueryTransformerLimit was added, so now it's possible to use 'Use SQL to limit fetch size' option.
Also quotation was added for `DEFAULT` and `SYSTEM` keywords which is not keywords for Clickhouse, but leads to errors in JSQLParser when it's unquoted and meet, for example, in identifier names.