### PR TITLE
#1397 Add host key verification for ssh

### DIFF
--- a/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationJsch.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationJsch.java
@@ -101,7 +101,12 @@ public class SSHImplementationJsch extends SSHImplementationAbstract {
                 }
 
                 session.setUserInfo(userInfo);
-                session.setConfig("StrictHostKeyChecking", "no");
+
+                File knownHosts = SSHUtils.getKnownSshHostsFileOrNull();
+                if (knownHosts != null) {
+                    jsch.setKnownHosts(knownHosts.getAbsolutePath());
+                }
+                session.setConfig("StrictHostKeyChecking", "ask");
                 session.setConfig("ConnectTimeout", String.valueOf(configuration.getIntProperty(SSHConstants.PROP_CONNECT_TIMEOUT)));
                 session.setConfig("ServerAliveInterval", String.valueOf(configuration.getIntProperty(SSHConstants.PROP_ALIVE_INTERVAL)));
 

--- a/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/KnownHostsVerifier.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/KnownHostsVerifier.java
@@ -1,0 +1,91 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2022 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.net.ssh;
+
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.common.SecurityUtils;
+import net.schmizz.sshj.transport.verification.OpenSSHKnownHosts;
+import org.jkiss.dbeaver.runtime.ui.DBPPlatformUI;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.PublicKey;
+
+public class KnownHostsVerifier extends OpenSSHKnownHosts {
+
+    private DBPPlatformUI platformUI;
+
+    public KnownHostsVerifier(File khFile, DBPPlatformUI platformUI) throws IOException {
+        super(khFile);
+        this.platformUI = platformUI;
+    }
+
+    protected boolean hostKeyUnverifiableAction(String hostname, PublicKey key) {
+        KeyType type = KeyType.fromKey(key);
+
+        String confirmationMessage = new StringBuilder()
+                .append("The authenticity of host can't be established.")
+                .append("host: '").append(hostname).append("'\n")
+                .append(type).append("key fingerprint: ").append(SecurityUtils.getFingerprint(key)).append("\n")
+                .append("Are you sure you want to continue connecting?").toString();
+
+        boolean isConfirmed = platformUI.confirmAction("Connection confirmation", confirmationMessage);
+
+        if(isConfirmed) {
+            try {
+                this.entries().add(new HostEntry((Marker)null, hostname, KeyType.fromKey(key), key));
+                this.write();
+                String warnMessage = new StringBuilder()
+                        .append("'").append(hostname).append("' (").append(type).append(") ")
+                        .append("permanently added to the list of known hosts.\n").toString();
+                platformUI.showWarningMessageBox("Warning",  warnMessage);
+                return true;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return false;
+        }
+    }
+
+    protected boolean hostKeyChangedAction(String hostname, PublicKey key) {
+        KeyType type = KeyType.fromKey(key);
+        String fp = SecurityUtils.getFingerprint(key);
+        String path = this.getFile().getAbsolutePath();
+        String warnMessage = new StringBuilder()
+                .append("Remote host identification has changed. It could be man-in-the-middle attack or the host key has just been changed \n")
+                .append("The fingerprint for the ").append(type).append("key sent by the remote host is ").append(fp).append("\n")
+                .append("Please contact your system administrator or add correct host key in ").append(path).append("to get rid of this message.")
+                .append("\n").toString();
+        platformUI.showWarningMessageBox("Warning",warnMessage);
+        return false;
+    }
+
+    @Override
+    public void write(KnownHostEntry entry) throws IOException {
+        this.khFile.getParentFile().mkdirs();
+        super.write(entry);
+        SSHUtils.forcePlatformReloadKnownHostsPreferences();
+    }
+
+    @Override
+    public void write() throws IOException {
+        this.khFile.getParentFile().mkdirs();
+        super.write();
+        SSHUtils.forcePlatformReloadKnownHostsPreferences();
+    }
+}

--- a/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/KnownHostsVerifier.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/KnownHostsVerifier.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.model.net.ssh;
 import net.schmizz.sshj.common.KeyType;
 import net.schmizz.sshj.common.SecurityUtils;
 import net.schmizz.sshj.transport.verification.OpenSSHKnownHosts;
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.runtime.ui.DBPPlatformUI;
 
 import java.io.File;
@@ -29,11 +30,12 @@ public class KnownHostsVerifier extends OpenSSHKnownHosts {
 
     private DBPPlatformUI platformUI;
 
-    public KnownHostsVerifier(File khFile, DBPPlatformUI platformUI) throws IOException {
+    public KnownHostsVerifier(@NotNull File khFile, @NotNull DBPPlatformUI platformUI) throws IOException {
         super(khFile);
         this.platformUI = platformUI;
     }
 
+    @Override
     protected boolean hostKeyUnverifiableAction(String hostname, PublicKey key) {
         KeyType type = KeyType.fromKey(key);
 
@@ -62,6 +64,7 @@ public class KnownHostsVerifier extends OpenSSHKnownHosts {
         }
     }
 
+    @Override
     protected boolean hostKeyChangedAction(String hostname, PublicKey key) {
         KeyType type = KeyType.fromKey(key);
         String fp = SecurityUtils.getFingerprint(key);

--- a/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationSshj.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationSshj.java
@@ -21,7 +21,6 @@ import net.schmizz.sshj.DefaultConfig;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.LoggerFactory;
 import net.schmizz.sshj.connection.channel.direct.LocalPortForwarder;
-import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
 import net.schmizz.sshj.userauth.method.AuthMethod;
 import net.schmizz.sshj.userauth.password.PasswordUtils;
@@ -33,9 +32,11 @@ import org.jkiss.dbeaver.model.net.ssh.config.SSHAuthConfiguration;
 import org.jkiss.dbeaver.model.net.ssh.config.SSHHostConfiguration;
 import org.jkiss.dbeaver.model.net.ssh.config.SSHPortForwardConfiguration;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.utils.RuntimeUtils;
 import org.jkiss.utils.CommonUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
@@ -62,10 +63,10 @@ public class SSHImplementationSshj extends SSHImplementationAbstract {
             Config clientConfig = new DefaultConfig();
             clientConfig.setLoggerFactory(LoggerFactory.DEFAULT);
             sshClient = new SSHClient(clientConfig);
-            // TODO: make real host verifier
-            sshClient.addHostKeyVerifier(new PromiscuousVerifier());
 
             try {
+                File knownHostsFile = SSHUtils.getKnownSshHostsFileOrDefault();
+                sshClient.addHostKeyVerifier(new KnownHostsVerifier(knownHostsFile, DBWorkbench.getPlatformUI()));
                 sshClient.loadKnownHosts();
             } catch (IOException e) {
                 log.debug("Error loading known hosts: " + e.getMessage());

--- a/plugins/org.jkiss.dbeaver.net.ssh/META-INF/MANIFEST.MF
+++ b/plugins/org.jkiss.dbeaver.net.ssh/META-INF/MANIFEST.MF
@@ -15,10 +15,12 @@ Bundle-ClassPath: .,
 Require-Bundle: org.eclipse.equinox.security,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
+ org.eclipse.jsch.core,
  org.jkiss.dbeaver.model;visibility:=reexport,
  org.jkiss.dbeaver.registry,
  com.sun.jna,
  com.sun.jna.platform,
  com.jcraft.jsch
+Import-Package: org.eclipse.jsch.internal.core
 Bundle-Localization: OSGI-INF/l10n/bundle
 Automatic-Module-Name: org.jkiss.dbeaver.net.ssh

--- a/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
@@ -29,7 +29,6 @@ import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
 import org.jkiss.dbeaver.utils.RuntimeUtils;
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.IOUtils;
-import org.jkiss.utils.StandardConstants;
 
 import java.io.File;
 import java.nio.file.InvalidPathException;
@@ -43,6 +42,12 @@ import java.util.List;
 public class SSHUtils {
 
     private static final Log log = Log.getLog(SSHUtils.class);
+
+    private static final String PLATFORM_SSH_PREFERENCES_NODE = "org.eclipse.jsch.core"; //$NON-NLS-1$
+    private static final String PLATFORM_SSH_PREFERENCES_SSH2HOME_KEY = IConstants.KEY_SSH2HOME;
+    private static final String DEFAULT_SSH_HOME_DIR_NAME = IConstants.SSH_DEFAULT_HOME;
+    private static final String DEFAULT_SSH_HOME_DIR_NAME_WIN_OLD = IConstants.SSH_OLD_DEFAULT_WIN32_HOME;
+    private static final String KNOWN_SSH_HOSTS_FILE_NAME = "known_hosts";
 
     static int findFreePort(DBPPlatform platform)
     {
@@ -90,11 +95,6 @@ public class SSHUtils {
         return false;
     }
 
-    private static final String PLATFORM_SSH_PREFERENCES_NODE = "org.eclipse.jsch.core"; //$NON-NLS-1$
-    private static final String PLATFORM_SSH_PREFERENCES_SSH2HOME_KEY = IConstants.KEY_SSH2HOME;
-    private static final String DEFAULT_SSH_HOME_DIR_NAME = IConstants.SSH_DEFAULT_HOME;
-    private static final String DEFAULT_SSH_HOME_DIR_NAME_WIN_OLD = IConstants.SSH_OLD_DEFAULT_WIN32_HOME;
-    private static final String KNOWN_SSH_HOSTS_FILE_NAME = "known_hosts";
 
     @NotNull
     public static File getKnownSshHostsFileOrDefault() {
@@ -115,7 +115,7 @@ public class SSHUtils {
                 log.warn("Failed to resolve SSH known hosts file location at " + sshHomePathString, e);
                 if (forceFileObjectOnFail) {
                     return new File(sshHomePathString + File.pathSeparator + KNOWN_SSH_HOSTS_FILE_NAME);
-                } else{
+                } else {
                     return null;
                 }
             }
@@ -148,12 +148,11 @@ public class SSHUtils {
 
                         if (updatePreferences) {
                             Platform.getPreferencesService()
-                                    .getRootNode().node(PLATFORM_SSH_PREFERENCES_NODE)
-                                    .put(PLATFORM_SSH_PREFERENCES_SSH2HOME_KEY, sshHomeDir.getAbsolutePath());
+                                .getRootNode().node(PLATFORM_SSH_PREFERENCES_NODE)
+                                .put(PLATFORM_SSH_PREFERENCES_SSH2HOME_KEY, sshHomeDir.getAbsolutePath());
                         }
 
-                        Path knownSshHostsFilePath = sshHomeDirPath.resolve(KNOWN_SSH_HOSTS_FILE_NAME);
-                        return knownSshHostsFilePath.toFile();
+                        return sshHomeDirPath.resolve(KNOWN_SSH_HOSTS_FILE_NAME).toFile();
                     } else {
                         log.warn("Failed to resolve default SSH known hosts file location due to invalid SSH home directory " + sshHomeDirPath.toAbsolutePath());
                     }
@@ -174,6 +173,7 @@ public class SSHUtils {
             return null;
         }
     }
+
     public static void forcePlatformReloadKnownHostsPreferences() {
         JSchCorePlugin.getPlugin().setNeedToLoadKnownHosts(true);
         JSchCorePlugin.getPlugin().getJSch().setHostKeyRepository(null);

--- a/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
@@ -26,6 +26,7 @@ import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ModelPreferences;
 import org.jkiss.dbeaver.model.app.DBPPlatform;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
+import org.jkiss.dbeaver.utils.RuntimeUtils;
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.IOUtils;
 import org.jkiss.utils.StandardConstants;
@@ -124,11 +125,6 @@ public class SSHUtils {
         }
     }
 
-    private static boolean isOnWindows() {
-        String osName = System.getProperty(StandardConstants.ENV_OS_NAME);
-        return osName != null && osName.startsWith("Windows");
-    }
-
     private static File resolveDefaultKnownSshHostsFile(boolean forceFileObjectOnFail, boolean updatePreferences) {
         try {
             String userHomePathString = System.getProperty(IConstants.SYSTEM_PROPERTY_USER_HOME);
@@ -138,7 +134,7 @@ public class SSHUtils {
                     Path sshHomeDirPath = userHomeDirPath.resolve(DEFAULT_SSH_HOME_DIR_NAME);
                     File sshHomeDir = sshHomeDirPath.toFile();
 
-                    if (isOnWindows() && (!sshHomeDir.isDirectory() || !sshHomeDir.exists())) {
+                    if (RuntimeUtils.isWindows() && (!sshHomeDir.isDirectory() || !sshHomeDir.exists())) {
                         Path sshHomeOldDirPath = userHomeDirPath.resolve(DEFAULT_SSH_HOME_DIR_NAME_WIN_OLD);
                         File sshHomeOldDir = sshHomeDirPath.toFile();
                         if (sshHomeOldDir.isDirectory()) {
@@ -172,7 +168,7 @@ public class SSHUtils {
         }
 
         if (forceFileObjectOnFail) {
-            Path forcedUserProfilePath = Paths.get(isOnWindows() ? "%USERPROFILE%" : "~"); // let's pretend it'll resolve itself
+            Path forcedUserProfilePath = Paths.get(RuntimeUtils.isWindows() ? "%USERPROFILE%" : "~"); // let's pretend it'll resolve itself
             return forcedUserProfilePath.resolve(DEFAULT_SSH_HOME_DIR_NAME).resolve(KNOWN_SSH_HOSTS_FILE_NAME).toFile();
         } else {
             return null;

--- a/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
@@ -17,18 +17,29 @@
 package org.jkiss.dbeaver.model.net.ssh;
 
 import com.jcraft.jsch.*;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jsch.internal.core.IConstants;
+import org.eclipse.jsch.internal.core.JSchCorePlugin;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ModelPreferences;
 import org.jkiss.dbeaver.model.app.DBPPlatform;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
+import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.IOUtils;
+import org.jkiss.utils.StandardConstants;
 
+import java.io.File;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 /**
  * SSH utils
  */
-class SSHUtils {
+public class SSHUtils {
 
     private static final Log log = Log.getLog(SSHUtils.class);
 
@@ -76,6 +87,100 @@ class SSHUtils {
             }
         }
         return false;
+    }
+
+    private static final String PLATFORM_SSH_PREFERENCES_NODE = "org.eclipse.jsch.core"; //$NON-NLS-1$
+    private static final String PLATFORM_SSH_PREFERENCES_SSH2HOME_KEY = IConstants.KEY_SSH2HOME;
+    private static final String DEFAULT_SSH_HOME_DIR_NAME = IConstants.SSH_DEFAULT_HOME;
+    private static final String DEFAULT_SSH_HOME_DIR_NAME_WIN_OLD = IConstants.SSH_OLD_DEFAULT_WIN32_HOME;
+    private static final String KNOWN_SSH_HOSTS_FILE_NAME = "known_hosts";
+
+    @NotNull
+    public static File getKnownSshHostsFileOrDefault() {
+        return  getKnownSshHostsFileImpl(true);
+    }
+
+    @Nullable
+    public static File getKnownSshHostsFileOrNull() {
+        return  getKnownSshHostsFileImpl(false);
+    }
+
+    private static File getKnownSshHostsFileImpl(boolean forceFileObjectOnFail) {
+        String sshHomePathString = Platform.getPreferencesService().getString(PLATFORM_SSH_PREFERENCES_NODE, PLATFORM_SSH_PREFERENCES_SSH2HOME_KEY, null, null);
+        if (CommonUtils.isNotEmpty(sshHomePathString)) {
+            try {
+                return Paths.get(sshHomePathString, KNOWN_SSH_HOSTS_FILE_NAME).toFile();
+            } catch (InvalidPathException e) {
+                log.warn("Failed to resolve SSH known hosts file location at " + sshHomePathString, e);
+                if (forceFileObjectOnFail) {
+                    return new File(sshHomePathString + File.pathSeparator + KNOWN_SSH_HOSTS_FILE_NAME);
+                } else{
+                    return null;
+                }
+            }
+        } else {
+            // seems preference path not set at all, so try to resolve it and preserve
+            return resolveDefaultKnownSshHostsFile(forceFileObjectOnFail, true);
+        }
+    }
+
+    private static boolean isOnWindows() {
+        String osName = System.getProperty(StandardConstants.ENV_OS_NAME);
+        return osName != null && osName.startsWith("Windows");
+    }
+
+    private static File resolveDefaultKnownSshHostsFile(boolean forceFileObjectOnFail, boolean updatePreferences) {
+        try {
+            String userHomePathString = System.getProperty(IConstants.SYSTEM_PROPERTY_USER_HOME);
+            if (userHomePathString != null) {
+                Path userHomeDirPath = Paths.get(userHomePathString);
+                if (userHomeDirPath.toFile().isDirectory()) {
+                    Path sshHomeDirPath = userHomeDirPath.resolve(DEFAULT_SSH_HOME_DIR_NAME);
+                    File sshHomeDir = sshHomeDirPath.toFile();
+
+                    if (isOnWindows() && (!sshHomeDir.isDirectory() || !sshHomeDir.exists())) {
+                        Path sshHomeOldDirPath = userHomeDirPath.resolve(DEFAULT_SSH_HOME_DIR_NAME_WIN_OLD);
+                        File sshHomeOldDir = sshHomeDirPath.toFile();
+                        if (sshHomeOldDir.isDirectory()) {
+                            sshHomeDirPath = sshHomeOldDirPath;
+                            sshHomeDir = sshHomeOldDir;
+                        }
+                    }
+
+                    if (sshHomeDir.isDirectory() || !sshHomeDir.exists()) {
+                        // don't need to create it until we'll need to write known hosts file
+
+                        if (updatePreferences) {
+                            Platform.getPreferencesService()
+                                    .getRootNode().node(PLATFORM_SSH_PREFERENCES_NODE)
+                                    .put(PLATFORM_SSH_PREFERENCES_SSH2HOME_KEY, sshHomeDir.getAbsolutePath());
+                        }
+
+                        Path knownSshHostsFilePath = sshHomeDirPath.resolve(KNOWN_SSH_HOSTS_FILE_NAME);
+                        return knownSshHostsFilePath.toFile();
+                    } else {
+                        log.warn("Failed to resolve default SSH known hosts file location due to invalid SSH home directory " + sshHomeDirPath.toAbsolutePath());
+                    }
+                } else {
+                    log.warn("Failed to resolve default SSH known hosts file location due to missing user home directory " + userHomeDirPath.toAbsolutePath());
+                }
+            } else {
+                log.warn("Failed to resolve default SSH known hosts file location due to missing user home system property.");
+            }
+        } catch (Throwable e) {
+            log.warn("Failed to resolve default SSH known hosts file location.", e);
+        }
+
+        if (forceFileObjectOnFail) {
+            Path forcedUserProfilePath = Paths.get(isOnWindows() ? "%USERPROFILE%" : "~"); // let's pretend it'll resolve itself
+            return forcedUserProfilePath.resolve(DEFAULT_SSH_HOME_DIR_NAME).resolve(KNOWN_SSH_HOSTS_FILE_NAME).toFile();
+        } else {
+            return null;
+        }
+    }
+    public static void forcePlatformReloadKnownHostsPreferences() {
+        JSchCorePlugin.getPlugin().setNeedToLoadKnownHosts(true);
+        JSchCorePlugin.getPlugin().getJSch().setHostKeyRepository(null);
     }
 
 }


### PR DESCRIPTION
With a new ssh connection DBeaver will ask user to confirm and write key to ".ssh/known-hosts" file. For further connections it assumed as already confirmed while key verification with remembered key in "known-hosts" file pass. If key is not matched with key in "known-hosts" file than user will be alarmed and connection will be refused due to possible man-in-the-middle attack.

It was done for both sshj and jsch.

Also "known-hosts" is observable in eclipse preferences, but Eclipse itself does not support some host key types (like ed25519, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=520927 and https://bugs.eclipse.org/bugs/show_bug.cgi?id=567109) so they are not displayed in the SSH2 known hosts preferences page.