### PR TITLE
dbeaver/dbeaver-ee#1400 Remove 'create database' option in erd for mongo

### DIFF
--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/model/ERDObjectAdapter.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/model/ERDObjectAdapter.java
@@ -35,6 +35,7 @@ import org.jkiss.dbeaver.model.navigator.meta.DBXTreeItem;
 import org.jkiss.dbeaver.model.navigator.meta.DBXTreeNode;
 import org.jkiss.dbeaver.model.preferences.DBPPropertySource;
 import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSDocumentContainer;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSObjectContainer;
 import org.jkiss.dbeaver.model.struct.DBSStructContainer;
@@ -68,7 +69,9 @@ public class ERDObjectAdapter implements IAdapterFactory {
             }
             if (object instanceof ERDObject) {
                 object = ((ERDObject<?>) object).getObject();
-                if (object instanceof DBSObject && adaptableObject instanceof DiagramPart && ((DBSObject) object).getParentObject() instanceof DBSStructContainer) {
+                if (object instanceof DBSDocumentContainer) {
+                    unwrapParentNode = false;
+                } else if (object instanceof DBSObject && adaptableObject instanceof DiagramPart && ((DBSObject) object).getParentObject() instanceof DBSStructContainer) {
                     object = ((DBSObject) object).getParentObject();
                 }
             }


### PR DESCRIPTION
There is no such option anymore as in other databases.
![image](https://user-images.githubusercontent.com/28875055/155995357-0751a19d-7135-408f-9ca4-378a7ff5c0b5.png)
