### PR TITLE
dbeaver/dbeaver-ee#1302 Support 2fa with pam for mariadb

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.mysql.ui/plugin.xml
@@ -224,4 +224,8 @@
         <configurator type="mysqlScriptExecute" class="org.jkiss.dbeaver.ext.mysql.tools.MySQLTaskConfigurator"/>
     </extension>
 
+	<extension point="org.jkiss.dbeaver.ext.mysql.auth.secondaryStepDialogProvider">
+        <provider class="org.jkiss.dbeaver.ext.mysql.ui.SecondaryStepAuthDialogProvider"/>
+    </extension>
+	
 </plugin>

--- a/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/SecondaryStepAuthDialogProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/SecondaryStepAuthDialogProvider.java
@@ -1,0 +1,78 @@
+package org.jkiss.dbeaver.ext.mysql.ui;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.jkiss.dbeaver.ext.mysql.SecondaryStepAuthProvider;
+import org.jkiss.dbeaver.ext.mysql.ui.internal.MySQLUIMessages;
+import org.jkiss.dbeaver.model.runtime.RunnableWithResult;
+import org.jkiss.dbeaver.ui.UIUtils;
+import org.jkiss.dbeaver.ui.dialogs.BaseDialog;
+
+public class SecondaryStepAuthDialogProvider implements SecondaryStepAuthProvider {
+
+    @Override
+    public String obtainSecondaryPassword(String reason) {
+        return UIUtils.syncExec(new RunnableWithResult<String>() {
+            @Override
+            public String runWithResult()  {
+                InputPasswordDialog  dialog = new InputPasswordDialog(UIUtils.getActiveWorkbenchShell(), reason);
+                if (dialog.open() == IDialogConstants.OK_ID) {
+                    return dialog.getPasswordString();
+                } else {
+                    return null;
+                }
+            }
+        });
+    }
+
+    private class InputPasswordDialog extends BaseDialog {
+        private String passwordText;
+        private Text passwordTextControl;
+        private String reason;
+        
+        public InputPasswordDialog(Shell parentShell, String reason) {
+            super(parentShell, MySQLUIMessages.two_factor_auth_secondary_password_dialog_title, null);
+            this.reason = reason;
+        }
+        
+        @Override
+        protected boolean isResizable() {
+            return false;
+        }
+
+        public String getPasswordString() {
+            return passwordText;
+        }
+
+        @Override
+        protected Composite createDialogArea(Composite parent) {
+            Composite composite = super.createDialogArea(parent);
+            
+            GridData gd = new GridData(GridData.FILL_BOTH);
+            gd.widthHint = 300;
+            gd.minimumWidth = 100;
+
+            passwordTextControl = UIUtils.createLabelText(composite, NLS.bind(MySQLUIMessages.two_factor_auth_secondary_password_dialog_message, reason), "", SWT.BORDER | SWT.PASSWORD, gd);
+
+            return composite;
+        }
+
+        @Override
+        protected void createButtonsForButtonBar(Composite parent) {
+            createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
+            createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
+        }
+        
+        @Override
+        protected void okPressed() {
+            passwordText = passwordTextControl.getText();
+            super.okPressed();
+        }
+    }
+
+}

--- a/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/internal/MySQLUIMessages.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/internal/MySQLUIMessages.java
@@ -158,6 +158,9 @@ public final class MySQLUIMessages extends NLS {
     public static String controls_privilege_table_push_button_check_all;
     public static String controls_privilege_table_push_button_clear_all;
 
+    public static String two_factor_auth_secondary_password_dialog_title;
+    public static String two_factor_auth_secondary_password_dialog_message;
+
     private MySQLUIMessages() {
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/internal/MySQLUIMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/internal/MySQLUIMessages.properties
@@ -129,3 +129,6 @@ controls_privilege_table_column_privilege_description = Description
 controls_privilege_table_column_privilege_description_tip = Privilege description
 controls_privilege_table_push_button_check_all = Check All
 controls_privilege_table_push_button_clear_all = Clear All
+
+two_factor_auth_secondary_password_dialog_title = Secondary authentication step
+two_factor_auth_secondary_password_dialog_message = Secondary password for session {0}

--- a/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/internal/MySQLUIMessages_ru.properties
+++ b/plugins/org.jkiss.dbeaver.ext.mysql.ui/src/org/jkiss/dbeaver/ext/mysql/ui/internal/MySQLUIMessages_ru.properties
@@ -125,3 +125,6 @@ controls_privilege_table_column_privilege_description = \u041E\u043F\u0438\u0441
 controls_privilege_table_column_privilege_description_tip = \u041E\u043F\u0438\u0441\u0430\u043D\u0438\u0435 \u043F\u0440\u0438\u0432\u0438\u043B\u0435\u0433\u0438\u0438
 controls_privilege_table_push_button_check_all = \u041E\u0442\u043C\u0435\u0442\u0438\u0442\u044C \u0432\u0441\u0435
 controls_privilege_table_push_button_clear_all = \u041E\u0447\u0438\u0441\u0442\u0438\u0442\u044C \u0432\u0441\u0435
+
+two_factor_auth_secondary_password_dialog_title = \u0412\u0442\u043E\u0440\u0438\u0447\u043D\u044B\u0439 \u043F\u0430\u0440\u043E\u043B\u044C
+two_factor_auth_secondary_password_dialog_message = \u0412\u0442\u043E\u0440\u0438\u0447\u043D\u044B\u0439 \u043F\u0430\u0440\u043E\u043B\u044C \u0434\u043B\u044F \u0441\u0435\u0441\u0441\u0438\u0438 {0}

--- a/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
@@ -18,7 +18,6 @@
   -->
 
 <plugin>
-
     <extension point="org.jkiss.dbeaver.dataSourceProvider">
         <datasource
             class="org.jkiss.dbeaver.ext.mysql.MySQLDataSourceProvider"
@@ -442,4 +441,5 @@
 
     </extension>
 
+    <extension-point id="org.jkiss.dbeaver.ext.mysql.auth.secondaryStepDialogProvider" name="Secondary authentication step dialog provider" schema="schema/org.jkiss.dbeaver.ext.mysql.auth.secondaryStepDialogProvider.exsd"/>
 </plugin>

--- a/plugins/org.jkiss.dbeaver.ext.mysql/schema/org.jkiss.dbeaver.ext.mysql.auth.secondaryStepDialogProvider.exsd
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/schema/org.jkiss.dbeaver.ext.mysql.auth.secondaryStepDialogProvider.exsd
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.jkiss.dbeaver.ext.mysql" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.jkiss.dbeaver.ext.mysql" id="org.jkiss.dbeaver.ext.mysql.auth.secondaryStepDialogProvider" name="Secondary authentication step dialog provider"/>
+      </appInfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+         <element name="provider">
+         	<complexType>
+         		<attribute name="class" type="string" use="required" />
+	         </complexType>
+         </element>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/SecondaryStepAuthProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/SecondaryStepAuthProvider.java
@@ -1,0 +1,33 @@
+package org.jkiss.dbeaver.ext.mysql;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.Platform;
+import org.jkiss.dbeaver.Log;
+
+public interface SecondaryStepAuthProvider {
+    
+    static final Log log = Log.getLog(SecondaryStepAuthProvider.class);
+    
+    String obtainSecondaryPassword(String reason);
+    
+    public static SecondaryStepAuthProvider getSecondaryAuthProvider() {
+        IExtensionPoint ep = Platform.getExtensionRegistry().getExtensionPoint("org.jkiss.dbeaver.ext.mysql.auth.secondaryStepDialogProvider");
+        if (ep != null) {
+            IExtension[] exts =  ep.getExtensions();
+            if (exts.length > 0) {
+                IConfigurationElement[] elts = exts[0].getConfigurationElements();
+                if (elts.length > 0) {
+                    try {
+                        return (SecondaryStepAuthProvider)elts[0].createExecutableExtension("class");
+                    } catch (CoreException e) {
+                        log.error("Failed to load SecondaryStepDialogProvider", e);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
For each connection user will get such dialog 
![image](https://user-images.githubusercontent.com/28875055/156842993-663e7d3a-6017-44d9-8f4b-0f08c120044d.png)

Unfortunately, there is no callback for custom dialog plugin in connector/j library as it is in connector/c. Driver overrides custom dialog plugin class, so there are two options:
- make dirty hacks with class loading
- retry on specific error during connection

Class loading hacks are hardly combined with dynamic loading, so the second way is presented. Connector/J throws ordinary SQL Exception while trying to connect using two-factor authentication without secondary password being specified, so we are intercepting this exception and checking its message for a reason then displaying password prompt if needed.