### PR TITLE
#15763 Fix Bug:  MV changes are not saved.

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleMaterializedViewManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleMaterializedViewManager.java
@@ -59,7 +59,7 @@ public class OracleMaterializedViewManager extends SQLObjectEditor<OracleMateria
         if (CommonUtils.isEmpty(command.getObject().getName())) {
             throw new DBException("View name cannot be empty"); //$NON-NLS-1$
         }
-        if (CommonUtils.isEmpty(command.getObject().getObjectDefinitionText(monitor, options))) {
+        if (CommonUtils.isEmpty(((OracleMaterializedView) command.getObject()).getMViewText())) {
             throw new DBException("View definition cannot be empty"); //$NON-NLS-1$
         }
     }


### PR DESCRIPTION
Any changes in Oracle MV can not be saved when switch to DDL Compact Format. But it works well when switch to Full DDL Format.


**CREATE MATERIALIZED VIEW MVTEST AS SELECT 1 FROM dual;**


![image](https://user-images.githubusercontent.com/9913942/157390935-9d791162-14cd-45e8-a0f0-77e90aeccc02.png)
![image](https://user-images.githubusercontent.com/9913942/157391149-04d93f42-b608-4680-8f61-985758b4d5e3.png)
