### PR TITLE
#15763 Fix bug Oralce  MV changes are not saved

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleMaterializedViewManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleMaterializedViewManager.java
@@ -59,7 +59,7 @@ public class OracleMaterializedViewManager extends SQLObjectEditor<OracleMateria
         if (CommonUtils.isEmpty(command.getObject().getName())) {
             throw new DBException("View name cannot be empty"); //$NON-NLS-1$
         }
-        if (CommonUtils.isEmpty(command.getObject().getObjectDefinitionText(monitor, options))) {
+        if (CommonUtils.isEmpty(((OracleMaterializedView) command.getObject()).getMViewText())) {
             throw new DBException("View definition cannot be empty"); //$NON-NLS-1$
         }
     }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleMaterializedViewManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleMaterializedViewManager.java
@@ -59,7 +59,7 @@ public class OracleMaterializedViewManager extends SQLObjectEditor<OracleMateria
         if (CommonUtils.isEmpty(command.getObject().getName())) {
             throw new DBException("View name cannot be empty"); //$NON-NLS-1$
         }
-        if (CommonUtils.isEmpty(((OracleMaterializedView) command.getObject()).getMViewText())) {
+        if (CommonUtils.isEmpty(command.getObject().getMViewText())) {
             throw new DBException("View definition cannot be empty"); //$NON-NLS-1$
         }
     }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleMaterializedViewManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleMaterializedViewManager.java
@@ -59,9 +59,6 @@ public class OracleMaterializedViewManager extends SQLObjectEditor<OracleMateria
         if (CommonUtils.isEmpty(command.getObject().getName())) {
             throw new DBException("View name cannot be empty"); //$NON-NLS-1$
         }
-        if (CommonUtils.isEmpty(command.getObject().getMViewText())) {
-            throw new DBException("View definition cannot be empty"); //$NON-NLS-1$
-        }
     }
 
     @Nullable


### PR DESCRIPTION
Any changes in Oracle MV can not be saved when switch to DDL Compact Format. But it works well when switch to Full DDL Format.