### PR TITLE
#14589 add line numeration to rows in PlainTextPresentation

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetPreferences.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetPreferences.java
@@ -85,6 +85,7 @@ public final class ResultSetPreferences {
     public static final String RESULT_TEXT_DELIMITER_TOP = "resultset.text.delimiter.top"; //$NON-NLS-1$
     public static final String RESULT_TEXT_DELIMITER_BOTTOM = "resultset.text.delimiter.bottom"; //$NON-NLS-1$
     public static final String RESULT_TEXT_EXTRA_SPACES = "resultset.text.extra.spaces"; //$NON-NLS-1$
+    public static final String RESULT_TEXT_LINE_NUMBER = "resultset.text.line.number";
 
     // Confirmations
     public static final String CONFIRM_ORDER_RESULTSET = "order_resultset"; //$NON-NLS-1$
@@ -94,4 +95,5 @@ public final class ResultSetPreferences {
     public static final String CONFIRM_RS_PANEL_RESET = "reset_panels_content"; //$NON-NLS-1$
     public static final String CONFIRM_KEEP_STATEMENT_OPEN = "keep_statement_open"; //$NON-NLS-1$
     public static final String KEEP_STATEMENT_OPEN = "keep.statement.open"; //$NON-NLS-1$
+
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/plaintext/PlainTextPresentation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/plaintext/PlainTextPresentation.java
@@ -169,7 +169,7 @@ public class PlainTextPresentation extends AbstractPresentation implements IAdap
 
     private void onCursorChange(int offset) {
         ResultSetModel model = controller.getModel();
-        DBPPreferenceStore prefs = getController().getPreferenceStore();
+        DBPPreferenceStore prefs = controller.getPreferenceStore();
         int lineNum = text.getLineAtOffset(offset);
         int lineOffset = text.getOffsetAtLine(lineNum);
         int horizontalOffset = offset - lineOffset;
@@ -273,7 +273,7 @@ public class PlainTextPresentation extends AbstractPresentation implements IAdap
         if (colWidths == null) {
             // Calculate column widths
             colWidths = new int[attrs.size()];
-            if (attrs.size() != 0 && lineNumbers) {
+            if (!attrs.isEmpty() && lineNumbers) {
                 startOffset = getStringWidth(String.valueOf(allRows.size() + 1)) + extraSpacesNum + 1;
             } else {
                 startOffset = 0;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsMessages.java
@@ -83,6 +83,7 @@ public class DataEditorsMessages extends NLS {
     public static String pref_page_database_resultsets_label_text_delimiter_bottom;
     public static String pref_page_database_resultsets_label_text_extra_spaces;
     public static String pref_page_database_resultsets_label_text_show_line_numbers;
+    public static String pref_page_database_resultsets_label_text_show_line_numbers_tip;
 
 	public static String virtual_structure_editor_abstract_job_load_entity;
 	public static String virtual_structure_editor_info_label_entity_structure;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsMessages.java
@@ -82,7 +82,8 @@ public class DataEditorsMessages extends NLS {
     public static String pref_page_database_resultsets_label_text_delimiter_top;
     public static String pref_page_database_resultsets_label_text_delimiter_bottom;
     public static String pref_page_database_resultsets_label_text_extra_spaces;
-    
+    public static String pref_page_database_resultsets_label_text_show_line_numbers;
+
 	public static String virtual_structure_editor_abstract_job_load_entity;
 	public static String virtual_structure_editor_info_label_entity_structure;
 	public static String virtual_structure_editor_dictionary_page_text;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsPreferencesInitializer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsPreferencesInitializer.java
@@ -97,6 +97,7 @@ public class DataEditorsPreferencesInitializer extends AbstractPreferenceInitial
         PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_TEXT_DELIMITER_TOP, false);
         PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_TEXT_DELIMITER_BOTTOM, false);
         PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_TEXT_EXTRA_SPACES, false);
+        PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_TEXT_LINE_NUMBER, false);
 
         // Override default editor page
         //PrefUtils.setDefaultPreferenceValue(store, NavigatorPreferences.NAVIGATOR_DEFAULT_EDITOR_PAGE, DatabaseDataEditor.class.getName());

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsResources.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsResources.properties
@@ -59,6 +59,7 @@ pref_page_database_resultsets_label_text_delimiter_trailing = Trailing delimiter
 pref_page_database_resultsets_label_text_delimiter_top = Top delimiter
 pref_page_database_resultsets_label_text_delimiter_bottom = Bottom delimiter
 pref_page_database_resultsets_label_text_extra_spaces = Extra spaces
+pref_page_database_resultsets_label_text_show_line_numbers = Show line numbers
 
 virtual_structure_editor_abstract_job_load_entity = Load logical entity references
 virtual_structure_editor_info_label_entity_structure = Entity logical structure exists only on the client-side, not in a real database.\nYou can define virtual unique/foreign keys even if physical database doesn't have or doesn't support them.

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsResources.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsResources.properties
@@ -60,6 +60,7 @@ pref_page_database_resultsets_label_text_delimiter_top = Top delimiter
 pref_page_database_resultsets_label_text_delimiter_bottom = Bottom delimiter
 pref_page_database_resultsets_label_text_extra_spaces = Extra spaces
 pref_page_database_resultsets_label_text_show_line_numbers = Show line numbers
+pref_page_database_resultsets_label_text_show_line_numbers_tip = Row table position will be shown in the additional column
 
 virtual_structure_editor_abstract_job_load_entity = Load logical entity references
 virtual_structure_editor_info_label_entity_structure = Entity logical structure exists only on the client-side, not in a real database.\nYou can define virtual unique/foreign keys even if physical database doesn't have or doesn't support them.

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationPlainText.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationPlainText.java
@@ -48,6 +48,7 @@ public class PrefPageResultSetPresentationPlainText extends TargetPrefPage
     private Button textDelimiterTop;
     private Button textDelimiterBottom;
     private Button textExtraSpaces;
+    private Button textLineNumber;
 
     public PrefPageResultSetPresentationPlainText()
     {
@@ -67,7 +68,8 @@ public class PrefPageResultSetPresentationPlainText extends TargetPrefPage
             store.contains(ResultSetPreferences.RESULT_TEXT_DELIMITER_TRAILING) ||
             store.contains(ResultSetPreferences.RESULT_TEXT_DELIMITER_TOP) ||
             store.contains(ResultSetPreferences.RESULT_TEXT_DELIMITER_BOTTOM) ||
-            store.contains(ResultSetPreferences.RESULT_TEXT_EXTRA_SPACES);
+            store.contains(ResultSetPreferences.RESULT_TEXT_EXTRA_SPACES) ||
+            store.contains(ResultSetPreferences.RESULT_TEXT_LINE_NUMBER);
     }
 
     @Override
@@ -90,6 +92,7 @@ public class PrefPageResultSetPresentationPlainText extends TargetPrefPage
             showNulls = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_show_nulls, null, false, 2);
             textDelimiterLeading = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_delimiter_leading, null, false, 2);
             textDelimiterTrailing = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_delimiter_trailing, null, false, 2);
+            textLineNumber = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_show_line_numbers, null, false, 2);
             textDelimiterTop = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_delimiter_top, null, false, 2);
             textDelimiterBottom = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_delimiter_bottom, null, false, 2);
             textExtraSpaces = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_extra_spaces, null, false, 2);
@@ -109,6 +112,7 @@ public class PrefPageResultSetPresentationPlainText extends TargetPrefPage
             textDelimiterLeading.setSelection(store.getBoolean(ResultSetPreferences.RESULT_TEXT_DELIMITER_LEADING));
             textDelimiterTrailing.setSelection(store.getBoolean(ResultSetPreferences.RESULT_TEXT_DELIMITER_TRAILING));
             textDelimiterTop.setSelection(store.getBoolean(ResultSetPreferences.RESULT_TEXT_DELIMITER_TOP));
+            textLineNumber.setSelection(store.getBoolean(ResultSetPreferences.RESULT_TEXT_LINE_NUMBER));
             textDelimiterBottom.setSelection(store.getBoolean(ResultSetPreferences.RESULT_TEXT_DELIMITER_BOTTOM));
             textExtraSpaces.setSelection(store.getBoolean(ResultSetPreferences.RESULT_TEXT_EXTRA_SPACES));
         } catch (Exception e) {
@@ -127,6 +131,7 @@ public class PrefPageResultSetPresentationPlainText extends TargetPrefPage
             store.setValue(ResultSetPreferences.RESULT_TEXT_DELIMITER_LEADING, textDelimiterLeading.getSelection());
             store.setValue(ResultSetPreferences.RESULT_TEXT_DELIMITER_TRAILING, textDelimiterTrailing.getSelection());
             store.setValue(ResultSetPreferences.RESULT_TEXT_DELIMITER_TOP, textDelimiterTop.getSelection());
+            store.setValue(ResultSetPreferences.RESULT_TEXT_LINE_NUMBER, textLineNumber.getSelection());
             store.setValue(ResultSetPreferences.RESULT_TEXT_DELIMITER_BOTTOM, textDelimiterBottom.getSelection());
             store.setValue(ResultSetPreferences.RESULT_TEXT_EXTRA_SPACES, textExtraSpaces.getSelection());
         } catch (Exception e) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationPlainText.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationPlainText.java
@@ -90,9 +90,9 @@ public class PrefPageResultSetPresentationPlainText extends TargetPrefPage
             textMaxColumnSize = UIUtils.createLabelSpinner(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_maximum_column_length, 0, 10, Integer.MAX_VALUE);
             textValueFormat = new ValueFormatSelector(uiGroup);
             showNulls = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_show_nulls, null, false, 2);
+            textLineNumber = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_show_line_numbers, DataEditorsMessages.pref_page_database_resultsets_label_text_show_line_numbers_tip, false, 2);
             textDelimiterLeading = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_delimiter_leading, null, false, 2);
             textDelimiterTrailing = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_delimiter_trailing, null, false, 2);
-            textLineNumber = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_show_line_numbers, null, false, 2);
             textDelimiterTop = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_delimiter_top, null, false, 2);
             textDelimiterBottom = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_delimiter_bottom, null, false, 2);
             textExtraSpaces = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_text_extra_spaces, null, false, 2);


### PR DESCRIPTION
Allows adding line numbers for plainTextPresentation rows. This is done by the new checkbox `Editors -> Data Editor -> Appearance ->Plain text -> Show line numbers` 

![image](https://user-images.githubusercontent.com/20579256/159035965-3773f87e-6618-4b45-86d4-86a89273b00f.png)

The result of that settings:
![image](https://user-images.githubusercontent.com/20579256/159036535-9514aafd-20d6-4a8f-9bfe-c3020023f722.png)

![image](https://user-images.githubusercontent.com/20579256/159036033-de9d7a2c-e6eb-4366-9d91-1276703b6d22.png)
