### PR TITLE
#13756 Add more blocks to autoedit

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/AbstractSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/AbstractSQLDialect.java
@@ -58,6 +58,15 @@ public abstract class AbstractSQLDialect implements SQLDialect {
     public static final String[] DML_KEYWORDS = new String[0];
     public static final Pair<String, String> IN_CLAUSE_PARENTHESES = new Pair<>("(", ")");
 
+    protected static final SQLBlockCompletions DEFAULT_SQL_BLOCK_COMPLETIONS = new SQLBlockCompletionsCollection() {{
+        registerCompletionPair("BEGIN", "END");
+        registerCompletionPair("CASE", "END");
+        registerCompletionPair("LOOP", "END", "LOOP");
+        registerCompletionInfo("IF", new String[] { " THEN", SQLBlockCompletions.NEW_LINE_COMPLETION_PART,
+            SQLBlockCompletions.ONE_INDENT_COMPLETION_PART, SQLBlockCompletions.NEW_LINE_COMPLETION_PART, "END IF", SQLBlockCompletions.NEW_LINE_COMPLETION_PART
+        }, "END", "IF");   
+    }};
+
     // Keywords
     private TreeMap<String, DBPKeywordType> allKeywords = new TreeMap<>();
 
@@ -861,6 +870,11 @@ public abstract class AbstractSQLDialect implements SQLDialect {
     @Override
     public boolean hasCaseSensitiveFiltration() {
         return false;
+    }
+    
+    @Override
+    public SQLBlockCompletions getBlockCompletions() {
+        return DEFAULT_SQL_BLOCK_COMPLETIONS;
     }
 }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletionInfo.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletionInfo.java
@@ -1,0 +1,56 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2022 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql;
+
+public class SQLBlockCompletionInfo {
+    private final SQLBlockCompletionsCollection owner;
+
+    public final int headTokenId;
+    public final String[] completionParts;
+    public final int tailTokenId;
+    public final Integer tailEndTokenId;
+    public final Integer headCancelTokenId;
+
+    /**
+     * @param owner - SQLBlockCompletionsCollection where SQLBlockCompletionInfo is registered
+     * @param headTokenId - id of the beginning token of the block.
+     * @param completionParts - array of strings which should be inserted on autoedit
+     * Completion part can be a String, SQLBlockCompletions.ONE_INDENT_COMPLETION_PART - indentation, SQLBlockCompletions.NEW_LINE_COMPLETION_PART - new line.
+     * @param tailTokenId - id of the first token of the block end
+     * @param tailEndTokenId - id of the last token of the block end
+     * @param prevCancelTokenId - token that shouldn't precede the block begin token
+     */
+    public SQLBlockCompletionInfo(SQLBlockCompletionsCollection owner, int headTokenId, String[] completionParts, int tailTokenId, Integer tailEndTokenId, Integer prevCancelTokenId) {
+        this.owner = owner;
+        this.headTokenId = headTokenId;
+        this.completionParts = completionParts;
+        this.tailTokenId = tailTokenId;
+        this.tailEndTokenId = tailEndTokenId;
+        this.headCancelTokenId = prevCancelTokenId;
+    }
+
+    private String getTokenString(Integer tokenId) {
+        return tokenId == null ? "<UNBOUND>" : owner.getTokenString((int)tokenId);
+    }
+
+    @Override
+    public String toString() {
+        return (headCancelTokenId == null ? "" : ("[! " + getTokenString(headCancelTokenId) + "]")) +
+                getTokenString(headTokenId) + " ... " + getTokenString(tailTokenId) + " " + getTokenString(tailEndTokenId);
+    }
+}
+

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletionInfo.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletionInfo.java
@@ -16,14 +16,18 @@
  */
 package org.jkiss.dbeaver.model.sql;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.utils.CommonUtils;
+
 public class SQLBlockCompletionInfo {
     private final SQLBlockCompletionsCollection owner;
 
-    public final int headTokenId;
-    public final String[] completionParts;
-    public final int tailTokenId;
-    public final Integer tailEndTokenId;
-    public final Integer headCancelTokenId;
+    private final int headTokenId;
+    private final String[] completionParts;
+    private final int tailTokenId;
+    private final Integer tailEndTokenId;
+    private final Integer headCancelTokenId;
 
     /**
      * @param owner - SQLBlockCompletionsCollection where SQLBlockCompletionInfo is registered
@@ -34,7 +38,8 @@ public class SQLBlockCompletionInfo {
      * @param tailEndTokenId - id of the last token of the block end
      * @param prevCancelTokenId - token that shouldn't precede the block begin token
      */
-    public SQLBlockCompletionInfo(SQLBlockCompletionsCollection owner, int headTokenId, String[] completionParts, int tailTokenId, Integer tailEndTokenId, Integer prevCancelTokenId) {
+    public SQLBlockCompletionInfo(@NotNull SQLBlockCompletionsCollection owner, int headTokenId, @Nullable String[] completionParts,
+                                  int tailTokenId, @Nullable Integer tailEndTokenId, @Nullable Integer prevCancelTokenId) {
         this.owner = owner;
         this.headTokenId = headTokenId;
         this.completionParts = completionParts;
@@ -43,14 +48,39 @@ public class SQLBlockCompletionInfo {
         this.headCancelTokenId = prevCancelTokenId;
     }
 
+    public int getHeadTokenId() {
+        return headTokenId;
+    }
+
+    @Nullable
+    public String[] getCompletionParts() {
+        return completionParts;
+    }
+
+    public int getTailTokenId() {
+        return tailTokenId;
+    }
+
+    @Nullable
+    public Integer getTailEndTokenId() {
+        return tailEndTokenId;
+    }
+
+    @Nullable
+    public Integer getHeadCancelTokenId() {
+        return headCancelTokenId;
+    }
+
+    @NotNull
     private String getTokenString(Integer tokenId) {
-        return tokenId == null ? "<UNBOUND>" : owner.getTokenString((int)tokenId);
+        return tokenId == null ? "<UNBOUND>" : CommonUtils.notNull(owner.findTokenString((int)tokenId), "<UNKNOWN TOKEN ID #" + tokenId + ">");
     }
 
     @Override
+    @NotNull
     public String toString() {
         return (headCancelTokenId == null ? "" : ("[! " + getTokenString(headCancelTokenId) + "]")) +
-                getTokenString(headTokenId) + " ... " + getTokenString(tailTokenId) + " " + getTokenString(tailEndTokenId);
+            getTokenString(headTokenId) + " ... " + getTokenString(tailTokenId) + " " + getTokenString(tailEndTokenId);
     }
 }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletions.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletions.java
@@ -16,12 +16,15 @@
  */
 package org.jkiss.dbeaver.model.sql;
 
-public interface SQLBlockCompletions {
-    public static final String ONE_INDENT_COMPLETION_PART = "\t";
-    public static final String NEW_LINE_COMPLETION_PART = null;
-    public static final int KNOWN_TOKEN_ID_BASE = 100;
+import org.jkiss.code.Nullable;
 
-    String getTokenString(int id);
+public interface SQLBlockCompletions {
+    String ONE_INDENT_COMPLETION_PART = "\t";
+    String NEW_LINE_COMPLETION_PART = null;
+    int KNOWN_TOKEN_ID_BASE = 100;
+
+    @Nullable
     Integer findTokenId(String str);
+    @Nullable
     SQLBlockCompletionInfo findCompletionByHead(int headTokenId);
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletions.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletions.java
@@ -14,21 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.jkiss.dbeaver.model.sql;
 
-package org.jkiss.dbeaver.ui.editors.sql.indent;
+public interface SQLBlockCompletions {
+    public static final String ONE_INDENT_COMPLETION_PART = "\t";
+    public static final String NEW_LINE_COMPLETION_PART = null;
+    public static final int KNOWN_TOKEN_ID_BASE = 100;
 
-public interface SQLIndentSymbols {
-    
-    /**
-     * remember to keep all these ids lower than <code>SQLBlockCompletions.KNOWN_TOKEN_ID_BASE</code>
-     */
-    
-    
-    int TokenEOF   = -1;
-    int TokenOTHER = 0;
-
-    int TokenIDENT = 20;
-    int TokenKeyword = 30;
-    int TokenKeywordStart = 31;
+    String getTokenString(int id);
+    Integer findTokenId(String str);
+    SQLBlockCompletionInfo findCompletionByHead(int headTokenId);
 }
-

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletionsCollection.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLBlockCompletionsCollection.java
@@ -1,0 +1,134 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2022 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * A set of information about blocks for autoedit strategy.
+ */
+public class SQLBlockCompletionsCollection implements SQLBlockCompletions {
+    
+    private static final Predicate<String> RECOGNIZABLE_TOKEN_PATTERN = Pattern.compile("^\\w+$").asMatchPredicate();
+    
+    private final Map<String, Integer> tokenIdByString = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    private final List<String> tokenStringById = new ArrayList<>();   
+    
+    private final Map<Integer, SQLBlockCompletionInfo> blockCompletionByHeadToken = new HashMap<>();
+    private final Map<Integer, Map<Integer, Set<SQLBlockCompletionInfo>>> blockCompletionByTailToken = new HashMap<>();
+    
+    /**
+     * Get SQLBlockCompletionInfo by block beginning token id.
+     */
+    public SQLBlockCompletionInfo findCompletionByHead(int headTokenId) {
+        return blockCompletionByHeadToken.get(headTokenId);
+    }
+    
+    public String getTokenString(int id) {
+        String tokenString = tokenStringById.get(id - KNOWN_TOKEN_ID_BASE);
+        if (tokenString == null) {
+            throw new IllegalArgumentException("Unknown token id " + id);
+        } else {
+            return tokenString;   
+        }        
+    }
+    
+    public Integer findTokenId(String str) {
+        return tokenIdByString.get(str);
+    }
+    
+    /**
+     * Get token id for token string.
+     * If token has't been registered yet, id will be generated.
+     */
+    private int obtainTokenId(String str) {
+        if (!RECOGNIZABLE_TOKEN_PATTERN.test(str)) {
+            throw new IllegalArgumentException("Illegal block completion part '" + str + "' while expecting keyword-like token.");
+        }
+        
+        Integer id = tokenIdByString.get(str);
+        if (id == null) {
+            id = tokenStringById.size() + KNOWN_TOKEN_ID_BASE;
+            tokenStringById.add(str);
+            tokenIdByString.put(str, id);
+        }
+        return id;
+    }
+
+    /**
+     * Register block for autoedit containing token at the begin and token at the end (e.g. BEGIN .. END).
+     * @param headToken is a beginning token of the block
+     * @param tailToken is an ending token of the block
+     */
+    public void registerCompletionPair(String headToken, String tailToken) {
+        this.registerBlockCompletionInfo(headToken, new String[] { null, ONE_INDENT_COMPLETION_PART, null, tailToken, null }, tailToken, null, null);
+    }
+
+    /**
+     * Register block for autoedit containing token at the begin and two tokens at the end (e.g. LOOP .. END LOOP).
+     * @param headToken is a beginning token of the block.
+     * @param tailToken is a  beginning token of the block end.
+     * @param tailEndToken - last token of the block.
+     */
+    public void registerCompletionPair(String headToken, String tailToken, String tailEndToken) {
+        this.registerCompletionInfo(headToken, new String[] { null, tailToken + " " + tailEndToken, null }, tailToken, tailEndToken);
+    }
+    
+    /**
+     * Register block for autoedit containing token at the begin, middle token and one or two tokens at the end (e.g. IF .. THEN .. END IF).
+     * @param headToken is a beginning token of the block.
+     * @param completionParts is an array of strings which should be inserted on autoedit.
+     * Completion part can be a String,
+     * SQLBlockCompletions.ONE_INDENT_COMPLETION_PART - indentation,
+     * SQLBlockCompletions.NEW_LINE_COMPLETION_PART - new line.
+     * @param tailToken - first token of the block end.
+     * @param tailEndToken - last token of the block end.
+     */
+    public void registerCompletionInfo(String headToken, String[] completionParts, String tailToken, String tailEndToken) {
+        this.registerBlockCompletionInfo(headToken, completionParts, tailToken, tailEndToken, tailEndToken.equalsIgnoreCase(headToken) ? tailToken : null);
+    }
+    
+    
+    private void registerBlockCompletionInfo(String headToken, String[] completionParts, String tailToken, String tailEndToken, String prevCancelToken) {
+        if (headToken == null || completionParts == null || tailToken == null) {
+            throw new IllegalArgumentException("Illegal block completion info. headToken, completionParts and tailToken are mandatory.");
+        }
+        
+        SQLBlockCompletionInfo info = new SQLBlockCompletionInfo(
+                this,
+                obtainTokenId(headToken), 
+                completionParts, 
+                obtainTokenId(tailToken),
+                tailEndToken == null ? null : obtainTokenId(tailEndToken),
+                // token that shouldn't precede  the block begin token (example: END for block LOOP .. END LOOP)
+                prevCancelToken == null ? null : obtainTokenId(prevCancelToken) 
+        );
+        this.blockCompletionByHeadToken.put(info.headTokenId, info);    
+        this.blockCompletionByTailToken.computeIfAbsent(info.tailTokenId, n -> new HashMap<>())
+           .computeIfAbsent(info.tailEndTokenId, n -> new HashSet<>())
+           .add(info);
+    }
+}
+

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
@@ -451,4 +451,9 @@ public interface SQLDialect {
     default SQLTokenPredicateSet getSkipTokenPredicates() {
         return EmptyTokenPredicateSet.INSTANCE;
     }
+    
+    /**
+     * @return a set of SQLBlockCompletions with information about blocks for autoedit
+     */
+    SQLBlockCompletions getBlockCompletions();
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLPreferenceConstants.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLPreferenceConstants.java
@@ -92,7 +92,7 @@ public class SQLPreferenceConstants
     public static final String SQLEDITOR_CLOSE_DOUBLE_QUOTES           = "SQLEditor.closeDoubleQuotes";
     public static final String SQLEDITOR_CLOSE_BRACKETS                = "SQLEditor.closeBrackets";
     public static final String SQLEDITOR_CLOSE_COMMENTS                = "SQLEditor.closeComments";
-    public static final String SQLEDITOR_CLOSE_BEGIN_END               = "SQLEditor.closeBeginEndStatement";
+    public static final String SQLEDITOR_CLOSE_BLOCKS                  = "SQLEditor.closeBlocks";
 
     // Matching brackets
     public final static String MATCHING_BRACKETS                        = "SQLEditor.matchingBrackets";

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLAutoIndentStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLAutoIndentStrategy.java
@@ -322,9 +322,11 @@ public class SQLAutoIndentStrategy extends DefaultIndentLineAutoEditStrategy {
         int nextToken = scanner.nextToken(command.offset, SQLHeuristicScanner.UNBOUND);
 
         SQLBlockCompletionInfo completion = isBlocksCompletionEnabled() ? syntaxManager.getDialect().getBlockCompletions().findCompletionByHead(previousToken) : null;
-        int prevPreviousToken = completion == null || completion.headCancelTokenId == null ?
+        int prevPreviousToken = completion == null || completion.getHeadCancelTokenId() == null ?
             SQLHeuristicScanner.NOT_FOUND : scanner.previousToken(previousTokenPos, SQLHeuristicScanner.UNBOUND);
-        boolean autoCompletionSupported = completion != null && (completion.headCancelTokenId == null || ((int)completion.headCancelTokenId) != prevPreviousToken);
+        boolean autoCompletionSupported = completion != null && (
+            completion.getHeadCancelTokenId() == null || ((int)completion.getHeadCancelTokenId()) != prevPreviousToken
+        );
 
         String indent;
         String beginIndentaion = "";
@@ -394,7 +396,7 @@ public class SQLAutoIndentStrategy extends DefaultIndentLineAutoEditStrategy {
 
             if (autoCompletionSupported && getBlockBalance(document, command.offset, completion) > 0 && getTokenCount(start, command.offset, scanner, previousToken) > 0) {
                 buf.setLength(0);
-                for (String part: completion.completionParts) {
+                for (String part: completion.getCompletionParts()) {
                     if (part == SQLBlockCompletions.NEW_LINE_COMPLETION_PART) {
                         buf.append(getLineDelimiter(document));
                         buf.append(beginIndentaion);

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLHeuristicScanner.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLHeuristicScanner.java
@@ -16,9 +16,6 @@
  */
 package org.jkiss.dbeaver.ui.editors.sql.indent;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITypedRegion;
@@ -410,17 +407,16 @@ public class SQLHeuristicScanner implements SQLIndentSymbols {
      * Note that <code>start</code> must not point to the closing peer, but to the first token being searched.
      * </p>
      *
-     * @param start       the start position
-     * @param openingPeer the opening peer token (e.g. 'begin')
-     * @param closingPeer the closing peer token (e.g. 'end')
+     * @param start the start position
+     * @param blockInfo information about completion block
      * @return the matching peer character position, or <code>NOT_FOUND</code>
      */
     public int findOpeningPeer(int start, SQLBlockCompletionInfo blockInfo) {
         assert (start < document.getLength());
-        int openingPeer = blockInfo.headTokenId;
-        int closingPeer = blockInfo.tailTokenId;
-        int closingPeerEnd = blockInfo.tailEndTokenId != null ? blockInfo.tailEndTokenId : UNBOUND;
-        int headCancelToken = blockInfo.headCancelTokenId != null ? blockInfo.headCancelTokenId : UNBOUND;
+        int openingPeer = blockInfo.getHeadTokenId();
+        int closingPeer = blockInfo.getTailTokenId();
+        int closingPeerEnd = blockInfo.getTailEndTokenId() != null ? blockInfo.getTailEndTokenId() : UNBOUND;
+        int headCancelToken = blockInfo.getHeadCancelTokenId() != null ? blockInfo.getHeadCancelTokenId() : UNBOUND;
         
         int depth = 1;
         start += 1;
@@ -464,10 +460,10 @@ public class SQLHeuristicScanner implements SQLIndentSymbols {
      */
     public int findClosingPeer(int start, SQLBlockCompletionInfo blockInfo) {
         assert (start <= document.getLength());
-        int openingPeer = blockInfo.headTokenId;
-        int closingPeer = blockInfo.tailTokenId;
-        int closingPeerEnd = blockInfo.tailEndTokenId != null ? blockInfo.tailEndTokenId : UNBOUND;
-        int headCancelToken = blockInfo.headCancelTokenId != null ? blockInfo.headCancelTokenId : UNBOUND;
+        int openingPeer = blockInfo.getHeadTokenId();
+        int closingPeer = blockInfo.getTailTokenId();
+        int closingPeerEnd = blockInfo.getTailEndTokenId() != null ? blockInfo.getTailEndTokenId() : UNBOUND;
+        int headCancelToken = blockInfo.getHeadCancelTokenId() != null ? blockInfo.getHeadCancelTokenId() : UNBOUND;
 
         int depth = 1;
         start += 1;

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLHeuristicScanner.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLHeuristicScanner.java
@@ -263,12 +263,40 @@ public class SQLHeuristicScanner implements SQLIndentSymbols {
         assert (s != null);
 
         switch (s.length()) {
+            case 2:
+                if (SQLIndentSymbols.tif.equals(s)) {
+                    return Tokenif;
+                }
+                if (SQLIndentSymbols.tIF.equalsIgnoreCase(s)) {
+                    return TokenIF;
+                }
+                break;
             case 3:
                 if (SQLIndentSymbols.end.equals(s)) {
                     return Tokenend;
                 }
                 if (SQLIndentSymbols.END.equalsIgnoreCase(s)) {
                     return TokenEND;
+                }
+                break;
+            case 4:
+                if (SQLIndentSymbols.tcase.equals(s)) {
+                    return Tokencase;
+                }
+                if (SQLIndentSymbols.tCASE.equalsIgnoreCase(s)) {
+                    return TokenCASE;
+                }
+                if (SQLIndentSymbols.loop.equals(s)) {
+                    return Tokenloop;
+                }
+                if (SQLIndentSymbols.LOOP.equalsIgnoreCase(s)) {
+                    return TokenLOOP;
+                }
+                if (SQLIndentSymbols.tthen.equals(s)) {
+                    return Tokenthen;
+                }
+                if (SQLIndentSymbols.tTHEN.equalsIgnoreCase(s)) {
+                    return TokenTHEN;
                 }
                 break;
             case 5:
@@ -499,7 +527,17 @@ public class SQLHeuristicScanner implements SQLIndentSymbols {
             (firstToken == TokenBEGIN && secondToken == Tokenbegin) ||
             (firstToken == Tokenbegin && secondToken == TokenBEGIN) ||
             (firstToken == TokenEND && secondToken == Tokenend) ||
-            (firstToken == Tokenend && secondToken == TokenEND);
+            (firstToken == Tokenend && secondToken == TokenEND) ||
+            (firstToken == Tokencase && secondToken == TokenCASE) ||
+            (firstToken == TokenCASE && secondToken == Tokencase) ||
+            (firstToken == Tokenloop && secondToken == TokenLOOP) ||
+            (firstToken == TokenLOOP && secondToken == Tokenloop) ||
+            (firstToken == TokenIF && secondToken == Tokenif) ||
+            (firstToken == Tokenif && secondToken == TokenIF) ||
+            (firstToken == TokenTHEN && secondToken == Tokenthen) ||
+            (firstToken == Tokenthen && secondToken == TokenTHEN) ||
+            (firstToken == TokenENDIF && secondToken == Tokenendif) ||
+            (firstToken == Tokenendif && secondToken == TokenENDIF);
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLIndentSymbols.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLIndentSymbols.java
@@ -17,55 +17,33 @@
 
 package org.jkiss.dbeaver.ui.editors.sql.indent;
 
-public interface SQLIndentSymbols
-{
+public interface SQLIndentSymbols {
+    
     int TokenEOF   = -1;
     int TokenOTHER = 0;
 
-    int Tokenbegin = 1000;
     int TokenBEGIN = 1001;
-    int Tokenend = 1002;
-    int TokenEND = 1003;
+    int TokenEND = 1002;
 
-    int TokenCASE = 1004;
-    int Tokencase = 1005;
+    int TokenCASE = 1003;
 
-    int TokenLOOP = 1006;
-    int Tokenloop = 1007;
-    int TokenENDLOOP = 1008;
-    int Tokenendloop = 1009;
+    int TokenLOOP = 1004;
 
     int TokenIF = 1010;
-    int Tokenif = 1011;
-    int TokenTHEN = 1012;
-    int Tokenthen = 1013;
-    int TokenENDIF = 1014;
-    int Tokenendif = 1015;
+    int TokenTHEN = 1011;
 
     int TokenIDENT = 2000;
     int TokenKeyword = 3000;
     int TokenKeywordStart = 3001;
 
-    String BEGIN = "BEGIN";
-    String begin = "begin";
-    String end = "end";
-    String END = "END";
-//    String end2 = "end ";
-//    String END2 = "END ";
+    String StrBEGIN = "BEGIN";
+    String StrEND = "END";
 
-    String tCASE = "CASE";
-    String tcase = "case";
+    String StrCASE = "CASE";
 
-    String LOOP = "LOOP";
-    String loop = "loop";
-    String ENDLOOP = "END LOOP";
-    String endloop = "end loop";
+    String StrLOOP = "LOOP";
 
-    String tIF = "IF";
-    String tif = "if";
-    String tTHEN = "THEN";
-    String tthen = "then";
-    String tENDIF = "END IF";
-    String tendif = "end if";
+    String StrIF = "IF";
+    String StrTHEN = "THEN";
 }
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLIndentSymbols.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLIndentSymbols.java
@@ -21,10 +21,27 @@ public interface SQLIndentSymbols
 {
     int TokenEOF   = -1;
     int TokenOTHER = 0;
+
     int Tokenbegin = 1000;
     int TokenBEGIN = 1001;
     int Tokenend = 1002;
     int TokenEND = 1003;
+
+    int TokenCASE = 1004;
+    int Tokencase = 1005;
+
+    int TokenLOOP = 1006;
+    int Tokenloop = 1007;
+    int TokenENDLOOP = 1008;
+    int Tokenendloop = 1009;
+
+    int TokenIF = 1010;
+    int Tokenif = 1011;
+    int TokenTHEN = 1012;
+    int Tokenthen = 1013;
+    int TokenENDIF = 1014;
+    int Tokenendif = 1015;
+
     int TokenIDENT = 2000;
     int TokenKeyword = 3000;
     int TokenKeywordStart = 3001;
@@ -36,5 +53,19 @@ public interface SQLIndentSymbols
 //    String end2 = "end ";
 //    String END2 = "END ";
 
+    String tCASE = "CASE";
+    String tcase = "case";
+
+    String LOOP = "LOOP";
+    String loop = "loop";
+    String ENDLOOP = "END LOOP";
+    String endloop = "end loop";
+
+    String tIF = "IF";
+    String tif = "if";
+    String tTHEN = "THEN";
+    String tthen = "then";
+    String tENDIF = "END IF";
+    String tendif = "end if";
 }
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLIndenter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/indent/SQLIndenter.java
@@ -197,7 +197,7 @@ public class SQLIndenter {
      *
      * @return one indentation
      */
-    private StringBuilder createIndent() {
+    public static StringBuilder createIndent() {
         IPreferenceStore preferenceStore = EditorsPlugin.getDefault().getPreferenceStore();
         boolean useSpaces = preferenceStore.getBoolean(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SPACES_FOR_TABS);
         StringBuilder oneIndent = new StringBuilder();

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorPreferencesInitializer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorPreferencesInitializer.java
@@ -18,8 +18,6 @@ package org.jkiss.dbeaver.ui.editors.sql.internal;
 
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
-import org.jkiss.dbeaver.model.DBPDataSource;
-import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
 import org.jkiss.dbeaver.model.sql.SQLScriptCommitType;
 import org.jkiss.dbeaver.model.sql.SQLScriptErrorHandling;
@@ -97,7 +95,7 @@ public class SQLEditorPreferencesInitializer extends AbstractPreferenceInitializ
             PrefUtils.setDefaultPreferenceValue(store, SQLPreferenceConstants.SQLEDITOR_CLOSE_DOUBLE_QUOTES, true);
             PrefUtils.setDefaultPreferenceValue(store, SQLPreferenceConstants.SQLEDITOR_CLOSE_BRACKETS, true);
             PrefUtils.setDefaultPreferenceValue(store, SQLPreferenceConstants.SQLEDITOR_CLOSE_COMMENTS, true);
-            PrefUtils.setDefaultPreferenceValue(store, SQLPreferenceConstants.SQLEDITOR_CLOSE_BEGIN_END, true);
+            PrefUtils.setDefaultPreferenceValue(store, SQLPreferenceConstants.SQLEDITOR_CLOSE_BLOCKS, true);
 
             PrefUtils.setDefaultPreferenceValue(store, SQLPreferenceConstants.SQL_FORMAT_KEYWORD_CASE_AUTO, true);
             PrefUtils.setDefaultPreferenceValue(store, SQLPreferenceConstants.SQL_FORMAT_EXTRACT_FROM_SOURCE, true);


### PR DESCRIPTION
IF ... THEN ... END IF, CASE ... END, LOOP ... END LOOP automatically edited to close blocks. 

It's not editing automatically in situations when blocks hierarchy is broken or ambiguity is detected .

For example in this situation `begin` can't be supplemented with end because `end` is already exists after it:
```
if ... then
    begin

end if

```