### PR TITLE
Fix H2GIS geometry type to support the new H2 type signature

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.h2gis/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.h2gis/plugin.xml
@@ -72,7 +72,7 @@
 
             <datasource id="h2gis"/>
 
-            <type name="GEOMETRY"/>
+            <type name="*"/>
 
         </provider>
     </extension>

--- a/plugins/org.jkiss.dbeaver.ext.h2gis/src/org/jkiss/dbeaver/ext/h2gis/data/H2GISValueHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.h2gis/src/org/jkiss/dbeaver/ext/h2gis/data/H2GISValueHandlerProvider.java
@@ -32,7 +32,7 @@ public class H2GISValueHandlerProvider implements DBDValueHandlerProvider {
     @Override
     public DBDValueHandler getValueHandler(DBPDataSource dataSource, DBDFormatSettings preferences, DBSTypedObject typedObject)
     {
-        if (typedObject.getTypeName().equalsIgnoreCase("GEOMETRY")) {
+        if (typedObject.getTypeName().toUpperCase().startsWith("GEOMETRY")) {
             return H2GISGeometryValueHandler.INSTANCE;
         } else {
             return null;


### PR DESCRIPTION
#15376

This PR introduces a fix on the new geometry type signature returned by H2 since 2.0.X version.

e.g : GEOMETRY(POINT, 4326)

when a user creates the following table

```
CREATE TABLE mygeotable (ID INTEGER, GEOM GEOMETRY(POINT, 4326));
```