### PR TITLE
check text disposed status to avoid SWTException

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
@@ -3811,7 +3811,7 @@ public class ResultSetViewer extends Viewer
     }
 
     public void setSelectionStatistics(String stats) {
-        if (selectionStatLabel == null) {
+        if (selectionStatLabel == null || selectionStatLabel.isDisposed()) {
             return;
         }
         if (stats.equals(selectionStatLabel.getText())) {


### PR DESCRIPTION
```
!ENTRY org.eclipse.ui 4 4 2022-03-30 10:59:56.324
!MESSAGE An internal error has occurred.
!STACK 0
org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4918)
	at org.eclipse.swt.SWT.error(SWT.java:4833)
	at org.eclipse.swt.SWT.error(SWT.java:4804)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:447)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:366)
	at org.eclipse.swt.widgets.Text.getText(Text.java:1436)
	at org.jkiss.dbeaver.ui.controls.resultset.ResultSetViewer.setSelectionStatistics(ResultSetViewer.java:3818)
	at org.jkiss.dbeaver.ui.controls.resultset.ResultSetStatListener$SLUpdateJob.updateSelectionStatistics(ResultSetStatListener.java:89)
	at org.jkiss.dbeaver.ui.controls.resultset.ResultSetStatListener$SLUpdateJob.updateSelectionStatistics(ResultSetStatListener.java:71)
	at org.jkiss.dbeaver.ui.controls.resultset.ResultSetStatListener$SLUpdateJob.runInUIThread(ResultSetStatListener.java:65)
	at org.eclipse.ui.progress.UIJob.lambda$0(UIJob.java:95)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:185)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4035)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3635)
	at org.jkiss.dbeaver.core.DesktopUI.readAndDispatchEvents(DesktopUI.java:480)
	at org.jkiss.dbeaver.utils.RuntimeUtils.runTask(RuntimeUtils.java:242)
	at org.jkiss.dbeaver.model.impl.jdbc.JDBCExecutionContext.getTransactionIsolation(JDBCExecutionContext.java:279)
	at org.jkiss.dbeaver.ui.actions.datasource.DataSourceAutoCommitHandler.updateElement(DataSourceAutoCommitHandler.java:105)
	at org.eclipse.ui.internal.handlers.HandlerProxy.updateElement(HandlerProxy.java:434)
	at org.eclipse.ui.internal.handlers.E4HandlerProxy.updateElement(E4HandlerProxy.java:123)
	at org.eclipse.ui.internal.WorkbenchHandlerServiceHandler.updateElement(WorkbenchHandlerServiceHandler.java:45)
	at org.eclipse.ui.internal.commands.CommandService$1.run(CommandService.java:261)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.ui.internal.commands.CommandService.refreshElements(CommandService.java:265)
	at org.jkiss.dbeaver.ui.ActionUtils.lambda$0(ActionUtils.java:426)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:185)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4035)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3635)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1155)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:644)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:551)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:156)
	at org.jkiss.dbeaver.ui.app.standalone.DBeaverApplication.start(DBeaverApplication.java:268)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:596)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1467)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1440)
```

![2022-03-30 11_12_55-DBeaver Ultimate 22 0 1 - _postgres 13 3_Script-81](https://user-images.githubusercontent.com/45152336/160784371-7dad2ff1-f525-4322-b24c-3775a10c0953.png)

