### PR TITLE
#15450 Add shortcut to open sql source of db object

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.base/src/org/jkiss/dbeaver/ui/editors/ProgressEditorPart.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.base/src/org/jkiss/dbeaver/ui/editors/ProgressEditorPart.java
@@ -25,6 +25,7 @@ import org.eclipse.ui.part.EditorPart;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.load.AbstractLoadService;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
+import org.jkiss.dbeaver.ui.ActionUtils;
 import org.jkiss.dbeaver.ui.LoadingJob;
 import org.jkiss.dbeaver.ui.UIExecutionQueue;
 import org.jkiss.dbeaver.ui.UIUtils;
@@ -160,6 +161,7 @@ public class ProgressEditorPart extends EditorPart {
                 // Activate entity editor (we have changed inner editors and need to force contexts activation).
                 DBWorkbench.getPlatformUI().refreshPartState(ownerEditor);
             }
+            ActionUtils.evaluatePropertyState("org.jkiss.dbeaver.ui.editors.entity.hasSource");
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.navigator/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/OSGI-INF/l10n/bundle.properties
@@ -107,3 +107,6 @@ command.org.jkiss.dbeaver.ui.tools.select.schema.name = Select active schema
 command.org.jkiss.dbeaver.ui.tools.select.schema.description = Select active schema for current database
 command.org.jkiss.dbeaver.ui.tools.select.connection.name = Set active connection
 command.org.jkiss.dbeaver.ui.tools.select.connection.description = Select connection for current editor
+
+command.org.jkiss.dbeaver.ui.context.object.property.source.switch.name = Open Source tab
+command.org.jkiss.dbeaver.ui.context.object.property.source.switch.description = Open SQL definition of database object

--- a/plugins/org.jkiss.dbeaver.ui.navigator/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/plugin.xml
@@ -129,7 +129,7 @@
             class="org.jkiss.dbeaver.ui.editors.entity.EntityEditorPropertyTester"
             id="org.jkiss.dbeaver.ui.editors.entity.EntityEditorPropertyTester"
             namespace="org.jkiss.dbeaver.ui.editors.entity"
-            properties="dirty,canUndo,canRedo"
+            properties="dirty,canUndo,canRedo,hasSource"
             type="org.jkiss.dbeaver.ui.editors.entity.EntityEditor"/>
         <propertyTester
             class="org.jkiss.dbeaver.ui.editors.entity.FolderEditorPropertyTester"
@@ -279,6 +279,8 @@
 
         <command id="org.jkiss.dbeaver.navigator.create.column.index" name="%command.org.jkiss.dbeaver.navigator.create.column.index.name" description="%command.org.jkiss.dbeaver.navigator.create.column.index.description" categoryId="org.jkiss.dbeaver.core.database" />
         <command id="org.jkiss.dbeaver.navigator.create.column.constraint" name="%command.org.jkiss.dbeaver.navigator.create.column.constraint.name" description="%command.org.jkiss.dbeaver.navigator.create.column.constraint.description" categoryId="org.jkiss.dbeaver.core.database" />
+
+        <command id="org.jkiss.dbeaver.ui.object.property.source.activate" name="%command.org.jkiss.dbeaver.ui.context.object.property.source.switch.name" description="%command.org.jkiss.dbeaver.ui.context.object.property.source.switch.description" categoryId="org.jkiss.dbeaver.core.database"/>
     </extension>
 
     <extension point="org.eclipse.ui.commandImages">
@@ -316,6 +318,15 @@
     </extension>
 
     <extension point="org.eclipse.ui.handlers">
+    	<handler commandId="org.jkiss.dbeaver.ui.object.property.source.activate" class="org.jkiss.dbeaver.ui.editors.entity.handlers.ObjectPropertySwitchToSourceHandler">
+            <enabledWhen>
+                <with variable="activeEditor">
+                    <adapt type="org.jkiss.dbeaver.ui.editors.entity.EntityEditor">
+                        <test property="org.jkiss.dbeaver.ui.editors.entity.hasSource"/>
+                    </adapt>
+                </with>
+            </enabledWhen>
+    	</handler>
         <!-- Navigator handlers -->
 
         <handler commandId="org.jkiss.dbeaver.core.object.open" class="org.jkiss.dbeaver.ui.navigator.actions.NavigatorHandlerObjectOpen">
@@ -899,6 +910,7 @@
         <key commandId="org.jkiss.dbeaver.core.navigator.set.default" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+SHIFT+A"/>
         <key commandId="org.jkiss.dbeaver.core.object.goto" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+SHIFT+D"/>
         <key commandId="org.jkiss.dbeaver.core.object.open" contextId="org.jkiss.dbeaver.ui.context.navigator" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="F4"/>
+        <key commandId="org.jkiss.dbeaver.ui.object.property.source.activate" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+ALT+S" />
     </extension>
 
     <extension point="org.jkiss.dbeaver.navigator.nodeAction">

--- a/plugins/org.jkiss.dbeaver.ui.navigator/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/plugin.xml
@@ -910,7 +910,6 @@
         <key commandId="org.jkiss.dbeaver.core.navigator.set.default" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+SHIFT+A"/>
         <key commandId="org.jkiss.dbeaver.core.object.goto" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+SHIFT+D"/>
         <key commandId="org.jkiss.dbeaver.core.object.open" contextId="org.jkiss.dbeaver.ui.context.navigator" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="F4"/>
-        <key commandId="org.jkiss.dbeaver.ui.object.property.source.activate" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+ALT+S" />
     </extension>
 
     <extension point="org.jkiss.dbeaver.navigator.nodeAction">

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/EntityEditorPropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/EntityEditorPropertyTester.java
@@ -21,6 +21,7 @@ import org.eclipse.jface.text.IUndoManager;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.edit.DBECommandContext;
 import org.jkiss.dbeaver.ui.ActionUtils;
+import org.jkiss.dbeaver.ui.editors.entity.handlers.ObjectPropertySwitchToSourceHandler;
 
 /**
  * EntityEditorPropertyTester
@@ -33,6 +34,7 @@ public class EntityEditorPropertyTester extends PropertyTester
     public static final String PROP_DIRTY = "dirty";
     public static final String PROP_CAN_UNDO = "canUndo";
     public static final String PROP_CAN_REDO = "canRedo";
+    public static final String PROP_HAS_SOURCE = "hasSource";
 
     public EntityEditorPropertyTester() {
         super();
@@ -46,6 +48,8 @@ public class EntityEditorPropertyTester extends PropertyTester
         EntityEditor editor = (EntityEditor)receiver;
         if (PROP_DIRTY.equals(property)) {
             return editor.isDirty();
+        } else if (PROP_HAS_SOURCE.equals(property)) {
+            return ObjectPropertySwitchToSourceHandler.findSourceTextEditorId(editor) != null;
         }
 
         IUndoManager undoManager = editor.getAdapter(IUndoManager.class);

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/handlers/ObjectPropertySwitchToSourceHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/handlers/ObjectPropertySwitchToSourceHandler.java
@@ -1,0 +1,64 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2022 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.editors.entity.handlers;
+
+import java.util.List;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.ui.editors.entity.EntityEditor;
+import org.jkiss.dbeaver.ui.editors.entity.EntityEditorDescriptor;
+import org.jkiss.dbeaver.ui.editors.entity.EntityEditorsRegistry;
+import org.jkiss.dbeaver.ui.editors.entity.properties.ObjectPropertiesEditor;
+import org.jkiss.dbeaver.ui.editors.text.BaseTextEditor;
+
+public class ObjectPropertySwitchToSourceHandler extends AbstractHandler {
+
+    @Override
+    @Nullable
+    public Object execute(@NotNull ExecutionEvent event) throws ExecutionException {
+        IEditorPart editorPart = HandlerUtil.getActiveEditor(event);
+        if (editorPart instanceof EntityEditor) {
+            EntityEditor editor = (EntityEditor)editorPart;
+            String sourceEditorId = findSourceTextEditorId(editor);
+            if (sourceEditorId != null) {
+                editor.switchFolder(sourceEditorId);
+            }
+        }
+        return null;
+    }
+    
+    
+    @Nullable
+    public static String findSourceTextEditorId(@NotNull EntityEditor editor) {
+        ObjectPropertiesEditor part = (ObjectPropertiesEditor)editor.getPageEditor(EntityEditorDescriptor.DEFAULT_OBJECT_EDITOR_ID);
+        if (part != null) {
+            List<EntityEditorDescriptor> descrs = EntityEditorsRegistry.getInstance().getEntityEditors(editor.getDatabaseObject(), part, null);
+            for (EntityEditorDescriptor descr: descrs) {
+                if (BaseTextEditor.class.isAssignableFrom(descr.getEditorType().getObjectClass())) {
+                    return descr.getId();
+                }
+            }
+        } 
+        return null;
+    }
+}


### PR DESCRIPTION
A new command to open tab with source of database object was introduced. There is no default key binding. I used CTRL+ALT+S in this video.


https://user-images.githubusercontent.com/28875055/160796667-60153b2d-190b-4ed6-80d1-d7226cba16c7.mp4


