### PR TITLE
#16019 Fix nullpointer exception

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/wizard/DataTransferWizard.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/wizard/DataTransferWizard.java
@@ -16,7 +16,6 @@
  */
 package org.jkiss.dbeaver.tools.transfer.ui.wizard;
 
-import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.jface.dialogs.IDialogSettings;

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/sql/task/SQLScriptExecuteHandler.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/sql/task/SQLScriptExecuteHandler.java
@@ -59,8 +59,7 @@ public class SQLScriptExecuteHandler implements DBTTaskHandler {
         @NotNull Locale locale,
         @NotNull Log log,
         @NotNull PrintStream logStream,
-        @NotNull DBTTaskExecutionListener listener,
-        boolean showNotifications) throws DBException
+        @NotNull DBTTaskExecutionListener listener) throws DBException
     {
         SQLScriptExecuteSettings settings = new SQLScriptExecuteSettings();
         settings.loadConfiguration(runnableContext, task.getProperties());
@@ -90,7 +89,7 @@ public class SQLScriptExecuteHandler implements DBTTaskHandler {
         if (error != null) {
             log.error(error);
         }
-        listener.taskFinished(settings, null, error);
+        listener.taskFinished(task, null, error, settings);
 
         log.debug("SQL script execute completed");
     }

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/sql/task/SQLScriptExecuteHandler.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/sql/task/SQLScriptExecuteHandler.java
@@ -71,7 +71,7 @@ public class SQLScriptExecuteHandler implements DBTTaskHandler {
         log.debug("SQL Scripts Execute");
 
         // Start consumers
-        listener.taskStarted(settings);
+        listener.taskStarted(task);
         Throwable error = null;
         try {
             runnableContext.run(true, true, monitor -> {

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DataTransferJob.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DataTransferJob.java
@@ -87,12 +87,11 @@ public class DataTransferJob implements DBRRunnableWithProgress {
                     hasErrors = true;
                 }
             } catch (Exception e) {
-                listener.subTaskFinished(e);
                 throw new InvocationTargetException(e);
             }
         }
         monitor.done();
-        listener.subTaskFinished(null);
+//        listener.subTaskFinished(task, null);
         elapsedTime = System.currentTimeMillis() - startTime;
     }
 

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/task/DTTaskHandlerTransfer.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/task/DTTaskHandlerTransfer.java
@@ -73,10 +73,10 @@ public class DTTaskHandlerTransfer implements DBTTaskHandler {
         return DBTTaskRunStatus.makeStatisticsStatus(totalStatistics);
     }
 
-    public void executeWithSettings(@NotNull DBRRunnableContext runnableContext, DBTTask task, @NotNull Locale locale,
+    public void executeWithSettings(@NotNull DBRRunnableContext runnableContext, @Nullable DBTTask task, @NotNull Locale locale,
                                     @NotNull Log log, @NotNull DBTTaskExecutionListener listener,
                                     DataTransferSettings settings) throws DBException {
-        listener.taskStarted(settings);
+        listener.taskStarted(task);
         int indexOfLastPipeWithDisabledReferentialIntegrity = -1;
         try {
             indexOfLastPipeWithDisabledReferentialIntegrity = initializePipes(runnableContext, settings);

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/task/DTTaskHandlerTransfer.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/task/DTTaskHandlerTransfer.java
@@ -55,8 +55,7 @@ public class DTTaskHandlerTransfer implements DBTTaskHandler {
         @NotNull Locale locale,
         @NotNull Log log,
         @NotNull PrintStream logStream,
-        @NotNull DBTTaskExecutionListener listener,
-        boolean showNotifications) throws DBException
+        @NotNull DBTTaskExecutionListener listener) throws DBException
     {
         DataTransferSettings[] settings = new DataTransferSettings[1];
         try {
@@ -82,7 +81,7 @@ public class DTTaskHandlerTransfer implements DBTTaskHandler {
         try {
             indexOfLastPipeWithDisabledReferentialIntegrity = initializePipes(runnableContext, settings);
             Throwable error = runDataTransferJobs(runnableContext, task, locale, log, listener, settings);
-            listener.taskFinished(settings, null, error);
+            listener.taskFinished(task, null, error, settings);
         } catch (InvocationTargetException e) {
             DBWorkbench.getPlatformUI().showError(
                 DTMessages.data_transfer_task_handler_unexpected_error_title,
@@ -151,7 +150,6 @@ public class DTTaskHandlerTransfer implements DBTTaskHandler {
             } catch (InterruptedException e) {
                 break;
             }
-            listener.subTaskFinished(error);
         }
         return error;
     }

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/tasks/MySQLNativeToolHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/tasks/MySQLNativeToolHandler.java
@@ -42,9 +42,9 @@ public abstract class MySQLNativeToolHandler<SETTINGS extends AbstractNativeTool
     private File config;
 
     @Override
-    protected boolean doExecute(DBRProgressMonitor monitor, DBTTask task, SETTINGS settings, Log log, boolean showNotifications) throws DBException, InterruptedException {
+    protected boolean doExecute(DBRProgressMonitor monitor, DBTTask task, SETTINGS settings, Log log) throws DBException, InterruptedException {
         try {
-            return super.doExecute(monitor, task, settings, log, showNotifications);
+            return super.doExecute(monitor, task, settings, log);
         } finally {
             if (config != null && !config.delete()) {
                 log.debug("Failed to delete configuration file");

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/task/SQLToolExecuteHandler.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/task/SQLToolExecuteHandler.java
@@ -59,8 +59,7 @@ public abstract class SQLToolExecuteHandler<OBJECT_TYPE extends DBSObject, SETTI
         @NotNull Locale locale,
         @NotNull Log log,
         @NotNull PrintStream logStream,
-        @NotNull DBTTaskExecutionListener listener,
-        boolean showNotifications) throws DBException
+        @NotNull DBTTaskExecutionListener listener) throws DBException
     {
         SETTINGS settings = createToolSettings();
         settings.loadConfiguration(runnableContext, task.getProperties());
@@ -210,7 +209,7 @@ public abstract class SQLToolExecuteHandler<OBJECT_TYPE extends DBSObject, SETTI
         } finally {
             monitor.done();
         }
-        listener.taskFinished(settings, null, lastError);
+        listener.taskFinished(task, null, lastError, settings);
 
         outLog.println("Tool execution finished");
         outLog.flush();

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/task/SQLToolExecuteHandler.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/task/SQLToolExecuteHandler.java
@@ -91,7 +91,7 @@ public abstract class SQLToolExecuteHandler<OBJECT_TYPE extends DBSObject, SETTI
         List<OBJECT_TYPE> objectList = settings.getObjectList();
         Exception lastError = null;
 
-        listener.taskStarted(settings);
+        listener.taskStarted(task);
         try {
             monitor.beginTask("Execute tool '" + task.getType().getName() + "'", objectList.size());
             List<Throwable> warnings = settings.getWarnings();

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskExecutionListener.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskExecutionListener.java
@@ -16,7 +16,6 @@
  */
 package org.jkiss.dbeaver.model.task;
 
-import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 
 /**
@@ -24,10 +23,10 @@ import org.jkiss.code.Nullable;
  */
 public interface DBTTaskExecutionListener {
 
-    void taskStarted(@NotNull Object task);
+    void taskStarted(@Nullable DBTTask task);
 
-    void taskFinished(@NotNull DBTTask task, @Nullable Object result, @Nullable Throwable error, @Nullable Object settings);
+    void taskFinished(@Nullable DBTTask task, @Nullable Object result, @Nullable Throwable error, @Nullable Object settings);
 
-    void subTaskFinished(@NotNull DBTTask task, @Nullable Throwable error, @Nullable Object settings);
+    void subTaskFinished(@Nullable DBTTask task, @Nullable Throwable error, @Nullable Object settings);
 
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskExecutionListener.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskExecutionListener.java
@@ -26,8 +26,8 @@ public interface DBTTaskExecutionListener {
 
     void taskStarted(@NotNull Object task);
 
-    void taskFinished(@NotNull Object task, @Nullable Object result, @Nullable Throwable error);
+    void taskFinished(@NotNull DBTTask task, @Nullable Object result, @Nullable Throwable error, @Nullable Object settings);
 
-    void subTaskFinished(@Nullable Throwable error);
+    void subTaskFinished(@NotNull DBTTask task, @Nullable Throwable error, @Nullable Object settings);
 
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskHandler.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskHandler.java
@@ -36,8 +36,7 @@ public interface DBTTaskHandler {
         @NotNull Locale locale,
         @NotNull Log log,
         @NotNull PrintStream logStream,
-        @NotNull DBTTaskExecutionListener listener,
-        boolean showNotifications)
+        @NotNull DBTTaskExecutionListener listener)
         throws DBException;
 
 

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
@@ -18,7 +18,6 @@ package org.jkiss.dbeaver.registry.task;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
@@ -159,20 +158,20 @@ public class TaskRunJob extends AbstractJob implements DBRRunnableContext {
         }
 
         @Override
-        public void taskStarted(@NotNull Object task) {
+        public void taskStarted(@Nullable DBTTask task) {
             startTime = System.currentTimeMillis();
             parent.taskStarted(task);
         }
 
         @Override
-        public void taskFinished(@NotNull DBTTask task, @Nullable Object result, @Nullable Throwable error, @Nullable Object settings) {
+        public void taskFinished(@Nullable DBTTask task, @Nullable Object result, @Nullable Throwable error, @Nullable Object settings) {
             parent.taskFinished(task, result, error, settings);
             elapsedTime = System.currentTimeMillis() - startTime;
             taskError = error;
         }
 
         @Override
-        public void subTaskFinished(@NotNull DBTTask task, @Nullable Throwable error, @Nullable Object settings) {
+        public void subTaskFinished(@Nullable DBTTask task, @Nullable Throwable error, @Nullable Object settings) {
             parent.subTaskFinished(task, error, settings);
         }
     }

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
@@ -23,6 +23,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.runtime.*;
+import org.jkiss.dbeaver.model.task.DBTTask;
 import org.jkiss.dbeaver.model.task.DBTTaskExecutionListener;
 import org.jkiss.dbeaver.model.task.DBTTaskHandler;
 import org.jkiss.dbeaver.model.task.DBTTaskRunStatus;
@@ -123,7 +124,7 @@ public class TaskRunJob extends AbstractJob implements DBRRunnableContext {
     private DBTTaskRunStatus executeTask(DBRProgressMonitor monitor, PrintStream logWriter) throws DBException {
         activeMonitor = monitor;
         DBTTaskHandler taskHandler = task.getType().createHandler();
-        return taskHandler.executeTask(this, task, locale, taskLog, logWriter, executionListener, true);
+        return taskHandler.executeTask(this, task, locale, taskLog, logWriter, executionListener);
     }
 
     @Override
@@ -164,15 +165,15 @@ public class TaskRunJob extends AbstractJob implements DBRRunnableContext {
         }
 
         @Override
-        public void taskFinished(@NotNull Object task, @Nullable Object result, @Nullable Throwable error) {
-            parent.taskFinished(task, result, error);
+        public void taskFinished(@NotNull DBTTask task, @Nullable Object result, @Nullable Throwable error, @Nullable Object settings) {
+            parent.taskFinished(task, result, error, settings);
             elapsedTime = System.currentTimeMillis() - startTime;
             taskError = error;
         }
 
         @Override
-        public void subTaskFinished(@Nullable Throwable error) {
-            parent.subTaskFinished(error);
+        public void subTaskFinished(@NotNull DBTTask task, @Nullable Throwable error, @Nullable Object settings) {
+            parent.subTaskFinished(task, error, settings);
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.tasks.native/src/org/jkiss/dbeaver/tasks/nativetool/AbstractNativeToolHandler.java
+++ b/plugins/org.jkiss.dbeaver.tasks.native/src/org/jkiss/dbeaver/tasks/nativetool/AbstractNativeToolHandler.java
@@ -60,8 +60,7 @@ public abstract class AbstractNativeToolHandler<SETTINGS extends AbstractNativeT
         @NotNull Locale locale,
         @NotNull Log log,
         @NotNull PrintStream logStream,
-        @NotNull DBTTaskExecutionListener listener,
-        boolean showNotifications) throws DBException {
+        @NotNull DBTTaskExecutionListener listener) throws DBException {
         SETTINGS settings = createTaskSettings(runnableContext, task);
         settings.setLogWriter(logStream);
         if (!validateTaskParameters(task, settings, log)) {
@@ -76,11 +75,11 @@ public abstract class AbstractNativeToolHandler<SETTINGS extends AbstractNativeT
                 listener.taskStarted(task);
                 Throwable error = null;
                 try {
-                    doExecute(monitor, task, settings, log, showNotifications);
+                    doExecute(monitor, task, settings, log);
                 } catch (Exception e) {
                     error = e;
                 } finally {
-                    listener.taskFinished(settings, null, error);
+                    listener.taskFinished(task, null, error, settings);
                     Log.setLogWriter(null);
 
                     monitor.worked(1);
@@ -242,27 +241,7 @@ public abstract class AbstractNativeToolHandler<SETTINGS extends AbstractNativeT
         }
     }
 
-    protected void onSuccess(DBTTask task, SETTINGS settings, long workTime) {
-
-        StringBuilder message = new StringBuilder();
-        message.append("Task [").append(task.getName()).append("] is completed (").append(workTime).append("ms)");
-        List<String> objNames = new ArrayList<>();
-        for (BASE_OBJECT obj : settings.getDatabaseObjects()) {
-            objNames.add(obj.getName());
-        }
-        message.append("\nObject(s) processed: ").append(String.join(",", objNames));
-        DBWorkbench.getPlatformUI().showNotification(task.getName(), message.toString(), false);
-
-    }
-
-    protected void onError(DBTTask task, SETTINGS settings, long workTime) {
-//        DBWorkbench.getPlatformUI().showError(
-//            taskTitle,
-//            errorMessage == null ? "Internal error" : errorMessage,
-//            SWT.ICON_ERROR);
-    }
-
-    protected boolean doExecute(DBRProgressMonitor monitor, DBTTask task, SETTINGS settings, Log log, boolean showNotifications) throws DBException, InterruptedException {
+    protected boolean doExecute(DBRProgressMonitor monitor, DBTTask task, SETTINGS settings, Log log) throws DBException, InterruptedException {
         validateClientHome(monitor, settings);
 
         long startTime = System.currentTimeMillis();
@@ -298,14 +277,6 @@ public abstract class AbstractNativeToolHandler<SETTINGS extends AbstractNativeT
 
         long workTime = System.currentTimeMillis() - startTime;
         notifyToolFinish(task.getType().getName() + " - " + task.getName() + " has finished", workTime);
-        if (isSuccess) {
-            if (showNotifications) {
-                onSuccess(task, settings, workTime);
-            }
-        } else {
-            onError(task, settings, workTime);
-        }
-
         return isSuccess;
     }
 

--- a/plugins/org.jkiss.dbeaver.tasks.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jkiss.dbeaver.tasks.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jkiss.dbeaver.registry,
  org.jkiss.dbeaver.ui,
  org.jkiss.dbeaver.ui.navigator,
- org.jkiss.dbeaver.ui.editors.base
+ org.jkiss.dbeaver.ui.editors.base,
+ org.jkiss.dbeaver.tasks.native
 Export-Package: org.jkiss.dbeaver.tasks.ui,
  org.jkiss.dbeaver.tasks.ui.registry,
  org.jkiss.dbeaver.tasks.ui.wizard,

--- a/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskConfigurationWizard.java
+++ b/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskConfigurationWizard.java
@@ -98,6 +98,7 @@ public abstract class TaskConfigurationWizard<SETTINGS extends DBTTaskSettings> 
         return currentSelection;
     }
 
+    @Nullable
     public DBTTask getCurrentTask() {
         return currentTask;
     }

--- a/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskProcessorUI.java
+++ b/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskProcessorUI.java
@@ -74,14 +74,14 @@ public class TaskProcessorUI implements DBRRunnableContext, DBTTaskExecutionList
     }
 
     @Override
-    public void taskStarted(@NotNull Object task) {
+    public void taskStarted(@Nullable DBTTask task) {
         this.started = true;
         this.startTime = System.currentTimeMillis();
         this.timeSincePreviousTask = startTime;
     }
 
     @Override
-    public void taskFinished(@NotNull DBTTask task, @Nullable Object result, @Nullable Throwable error, @Nullable Object settings) {
+    public void taskFinished(@Nullable DBTTask task, @Nullable Object result, @Nullable Throwable error, @Nullable Object settings) {
         this.started = false;
 
         long elapsedTime = System.currentTimeMillis() - startTime;
@@ -90,7 +90,7 @@ public class TaskProcessorUI implements DBRRunnableContext, DBTTaskExecutionList
 
     }
 
-    private void sendNotification(@NotNull DBTTask task, @Nullable Throwable error, long elapsedTime, @Nullable Object settings) {
+    private void sendNotification(@Nullable DBTTask task, @Nullable Throwable error, long elapsedTime, @Nullable Object settings) {
         UIUtils.asyncExec(() -> {
             // Make a sound
             Display.getCurrent().beep();
@@ -98,7 +98,7 @@ public class TaskProcessorUI implements DBRRunnableContext, DBTTaskExecutionList
             boolean hasErrors = error != null;
             DBPPlatformUI platformUI = DBWorkbench.getPlatformUI();
             StringBuilder completeMessage = new StringBuilder();
-            completeMessage.append(task.getType().getName()).append(" ").append(TaskUIMessages.task_processor_ui_message_task_completed).append(" (").append(RuntimeUtils.formatExecutionTime(elapsedTime)).append(")");
+            completeMessage.append(task == null ? this.task.getType().getName() : task.getType().getName()).append(" ").append(TaskUIMessages.task_processor_ui_message_task_completed).append(" (").append(RuntimeUtils.formatExecutionTime(elapsedTime)).append(")");
             List<String> objects = new ArrayList<>();
             if (settings instanceof AbstractNativeToolSettings) {
                 for (DBSObject databaseObject : ((AbstractNativeToolSettings<?>) settings).getDatabaseObjects()) {
@@ -115,7 +115,7 @@ public class TaskProcessorUI implements DBRRunnableContext, DBTTaskExecutionList
                 // Show message box
                 DBeaverNotifications.showNotification(
                     "task",
-                    task.getName(),
+                    task == null ? this.task.getName() : task.getName(),
                     completeMessage.toString(),
                     DBPMessageType.INFORMATION,
                     null);
@@ -127,7 +127,7 @@ public class TaskProcessorUI implements DBRRunnableContext, DBTTaskExecutionList
 
 
     @Override
-    public void subTaskFinished(@NotNull DBTTask task, @Nullable Throwable error, @Nullable Object settings) {
+    public void subTaskFinished(@Nullable DBTTask task, @Nullable Throwable error, @Nullable Object settings) {
         long elapsedTime = System.currentTimeMillis() - timeSincePreviousTask;
         timeSincePreviousTask = System.currentTimeMillis();
         sendNotification(task, error, elapsedTime, settings);

--- a/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskWizardExecutor.java
+++ b/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskWizardExecutor.java
@@ -46,7 +46,7 @@ public class TaskWizardExecutor extends TaskProcessorUI {
     @Override
     protected void runTask() throws DBException {
         DBTTaskHandler handlerTransfer = getTask().getType().createHandler();
-        handlerTransfer.executeTask(this, getTask(), Locale.getDefault(), log, logWriter, this, true);
+        handlerTransfer.executeTask(this, getTask(), Locale.getDefault(), log, logWriter, this);
     }
 
 }


### PR DESCRIPTION
If the task passed to executeWithSettings is a fake one, like a data export that was done directly from the data editor, it will be null and cause nullpointer exception. For that situation we will assume what previously given task is the correct one 