### PR TITLE
ci: bump github actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 2
 

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: 'Set up JDK 11'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: 11
         distribution: 'adopt'


### PR DESCRIPTION
Bump GitHub Actions to their latest major versions. Main change is they're now using Node 16 instead of 12, which is EOL at end of month.

- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- Releases for `actions/setup-java` can be [found here](https://github.com/actions/setup-java/releases)
