### PR TITLE
#13290 add default modifier to varchar data type without modifiers

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.db2/src/org/jkiss/dbeaver/ext/db2/DB2Constants.java
+++ b/plugins/org.jkiss.dbeaver.ext.db2/src/org/jkiss/dbeaver/ext/db2/DB2Constants.java
@@ -52,6 +52,7 @@ public class DB2Constants {
     public static final Double             DB2v11_1                    = 11.1;
 
     public static final String             TYPE_NAME_DECFLOAT          = "DECFLOAT";
+    public static final String             TYPE_VARCHAR                = "VARCHAR";
     public static final int                EXT_TYPE_DECFLOAT           = -100001;                                                  // DB2Types.DECFLOAT
     public static final int                EXT_TYPE_CURSOR             = -100008;                                                  // DB2Types.CURSOR
 

--- a/plugins/org.jkiss.dbeaver.ext.db2/src/org/jkiss/dbeaver/ext/db2/model/DB2TableColumn.java
+++ b/plugins/org.jkiss.dbeaver.ext.db2/src/org/jkiss/dbeaver/ext/db2/model/DB2TableColumn.java
@@ -181,7 +181,7 @@ public class DB2TableColumn extends JDBCTableColumn<DB2TableBase>
 
         setMaxLength(50L);
         setOrdinalPosition(-1);
-        this.dataType = tableBase.getDataSource().getDataTypeCache().getCachedObject("VARCHAR");
+        this.dataType = tableBase.getDataSource().getDataTypeCache().getCachedObject(DB2Constants.TYPE_VARCHAR);
         if (dataType != null) {
             this.dataTypeSchema = dataType.getSchema();
             setTypeName(dataType.getFullyQualifiedName(DBPEvaluationContext.DML));


### PR DESCRIPTION
during data migration

![2022-04-08 12_28_03-DBeaver Ultimate 22 0 2 - varchar_columns](https://user-images.githubusercontent.com/45152336/162408437-a720b1cb-fc7b-413b-a23b-1bbf76dfd146.png)