### PR TITLE
Fix typo for importing connections from sqldeveloper

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
@@ -258,7 +258,7 @@ public class ConfigImportWizardPageSqlDeveloper extends ConfigImportWizardPage {
 
                     String dbName = CommonUtils.isEmpty(info.getSID()) ? info.getServiceName() : info.getSID();
 
-                    ImportConnectionInfo connectionInfo = new ImportConnectionInfo(oraDriver, null, conn.getName(), info.getUrl(), info.getHost(), info.getPort(), dbName, info.getHost(), null);
+                    ImportConnectionInfo connectionInfo = new ImportConnectionInfo(oraDriver, null, conn.getName(), info.getUrl(), info.getHost(), info.getPort(), dbName, info.getUser(), null);
                     if (!CommonUtils.isEmpty(info.getSID())) {
                         connectionInfo.setProviderProperty(OracleConstants.PROP_SID_SERVICE, OracleConnectionType.SID.name());
                     } else if (!CommonUtils.isEmpty(info.getServiceName())) {


### PR DESCRIPTION
Connection was imported using the Host as a user.
Correction made: use the correct getter.