### PR TITLE
#15126 Close extra result tabs for single query

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -2363,10 +2363,9 @@ public class SQLEditor extends SQLEditorBase implements
         }
 
         if (!export) {
-            // We only need to prompt user to close extra (unpinned) tabs if:
-            // 1. The user is not executing query in a new tab
-            // 2. The user is executing script that may open several result sets
-            if (!newTab && !isSingleQuery) {
+            // We only need to prompt user to close extra (unpinned) tabs if
+            // the user is not executing query in a new tab
+            if (!newTab) {
                 int tabsClosed = closeExtraResultTabs(null, true, false);
                 if (tabsClosed == IDialogConstants.CANCEL_ID) {
                     return false;


### PR DESCRIPTION
Previously opened tabs are prompted to close when executing script with Ctrl+Enter too (but not when executing with Ctrl+\). The same as it works for Alt+X (prompted) and Ctrl+Alt+Shift+X (not prompted) execution.