### PR TITLE
#14731 Set minimum digits count based on type's precision

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/NumberDataFormatter.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/NumberDataFormatter.java
@@ -92,10 +92,18 @@ public class NumberDataFormatter implements DBDDataFormatter {
                 numberFormat.setMinimumFractionDigits(fractionDigits);
             }
         }
-        if (type != null && (type.getTypeModifiers() & DBSTypedObject.TYPE_MOD_NUMBER_LEADING_ZEROES) > 0) {
-            // Override number format style set from properties in favor of type's own formatting rules
-            numberFormat.setMinimumIntegerDigits((int) type.getMaxLength());
-            numberFormat.setGroupingUsed(false);
+        if (type != null && CommonUtils.isBitSet(type.getTypeModifiers(), DBSTypedObject.TYPE_MOD_NUMBER_LEADING_ZEROES)) {
+            // Override number format style set from properties in favor of type's precision
+            if (type.getPrecision() != null && type.getPrecision() > 0) {
+                if (type.getScale() != null && type.getScale() > 0) {
+                    numberFormat.setMinimumIntegerDigits(type.getPrecision() - type.getScale());
+                    numberFormat.setMinimumFractionDigits(type.getScale());
+                } else {
+                    numberFormat.setMinimumIntegerDigits(type.getPrecision());
+                }
+
+                numberFormat.setGroupingUsed(false);
+            }
         }
         buffer = new StringBuffer();
         position = new FieldPosition(0);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35821147/164434366-6d79537b-81ca-4655-9186-027ec7f2ff5d.png)

DDL:
```sql
CREATE TABLE `issue_14731` (
  `id` int(11) NOT NULL,
  `value` decimal(5,2) unsigned zerofill NOT NULL,
  `value2` decimal(5,0) unsigned zerofill NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1;
```