### PR TITLE
#15068 Add confirmation before restore task execution

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/OSGI-INF/l10n/bundle.properties
@@ -285,4 +285,4 @@ meta.org.jkiss.dbeaver.ext.mysql.model.MySQLTableConstraint.checkClause.descript
 meta.org.jkiss.dbeaver.ext.mysql.tasks.MySQLToolTableTruncateSettings.force.name = Force
 meta.org.jkiss.dbeaver.ext.mysql.tasks.MySQLToolTableTruncateSettings.force.description = Truncate table with foreign key constraints
 
-mysqlDatabaseRestore.confirmationMessage = Are you going to restore database {0} from {1}?
+mysqlDatabaseRestore.confirmationMessage = You are about to restore database {0} from {1}.

--- a/plugins/org.jkiss.dbeaver.ext.mysql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/OSGI-INF/l10n/bundle.properties
@@ -284,3 +284,5 @@ meta.org.jkiss.dbeaver.ext.mysql.model.MySQLTableConstraint.checkClause.descript
 
 meta.org.jkiss.dbeaver.ext.mysql.tasks.MySQLToolTableTruncateSettings.force.name = Force
 meta.org.jkiss.dbeaver.ext.mysql.tasks.MySQLToolTableTruncateSettings.force.description = Truncate table with foreign key constraints
+
+mysqlDatabaseRestore.confirmationMessage = Are you going to restore database {0} from {1}?

--- a/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
@@ -406,7 +406,7 @@
             <objectType name="org.jkiss.dbeaver.ext.mysql.model.MySQLCatalog"/>
             <objectType name="org.jkiss.dbeaver.ext.mysql.model.MySQLTableBase"/>
         </task>
-        <task id="mysqlDatabaseRestore" name="MySQL restore" description="MySQL database import task" icon="platform:/plugin/org.jkiss.dbeaver.ui/icons/file/import.png" type="mysql" handler="org.jkiss.dbeaver.ext.mysql.tasks.MySQLScriptExecuteHandler">
+        <task id="mysqlDatabaseRestore" name="MySQL restore" description="MySQL database import task" icon="platform:/plugin/org.jkiss.dbeaver.ui/icons/file/import.png" type="mysql" handler="org.jkiss.dbeaver.ext.mysql.tasks.MySQLScriptExecuteHandler" confirmationMessage="%mysqlDatabaseRestore.confirmationMessage">
             <datasource id="mysql"/>
             <objectType name="org.jkiss.dbeaver.ext.mysql.model.MySQLCatalog"/>
         </task>

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/OSGI-INF/l10n/bundle.properties
@@ -774,4 +774,4 @@ meta.org.jkiss.dbeaver.ext.postgresql.tasks.PostgreToolBaseVacuumSettings.skipLo
 meta.org.jkiss.dbeaver.ext.postgresql.tasks.PostgreToolBaseVacuumSettings.skipLocked.description = Specifies that VACUUM should not wait for any conflicting locks to be released when beginning work on a relation:\n if a relation cannot be locked immediately without waiting, the relation is skipped.\n Note that even with this option, VACUUM may still block when opening the relation's indexes.\n Additionally, VACUUM ANALYZE may still block when acquiring sample rows from partitions, table inheritance children, and some types of foreign tables.\n Also, while VACUUM ordinarily processes all partitions of specified partitioned tables,\n this option will cause VACUUM to skip all partitions if there is a conflicting lock on the partitioned table.\nWorks since PostgreSQL 12.
 meta.org.jkiss.dbeaver.ext.postgresql.model.PostgreDataType.description.name = Description
 
-pgDatabaseRestore.confirmationMessage = Are you going to restore database {0} from {1}?
+pgDatabaseRestore.confirmationMessage = You are about to restore database {0} from {1}.

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/OSGI-INF/l10n/bundle.properties
@@ -773,3 +773,5 @@ meta.org.jkiss.dbeaver.ext.postgresql.tasks.PostgreToolBaseVacuumSettings.trunca
 meta.org.jkiss.dbeaver.ext.postgresql.tasks.PostgreToolBaseVacuumSettings.skipLocked.name = Skip locked
 meta.org.jkiss.dbeaver.ext.postgresql.tasks.PostgreToolBaseVacuumSettings.skipLocked.description = Specifies that VACUUM should not wait for any conflicting locks to be released when beginning work on a relation:\n if a relation cannot be locked immediately without waiting, the relation is skipped.\n Note that even with this option, VACUUM may still block when opening the relation's indexes.\n Additionally, VACUUM ANALYZE may still block when acquiring sample rows from partitions, table inheritance children, and some types of foreign tables.\n Also, while VACUUM ordinarily processes all partitions of specified partitioned tables,\n this option will cause VACUUM to skip all partitions if there is a conflicting lock on the partitioned table.\nWorks since PostgreSQL 12.
 meta.org.jkiss.dbeaver.ext.postgresql.model.PostgreDataType.description.name = Description
+
+pgDatabaseRestore.confirmationMessage = Are you going to restore database {0} from {1}?

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/plugin.xml
@@ -650,7 +650,7 @@
             <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema"/>
             <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreTableBase"/>
         </task>
-        <task id="pgDatabaseRestore" name="PostgreSQL restore" description="PostgreSQL database restore task" icon="platform:/plugin/org.jkiss.dbeaver.ui/icons/file/import.png" type="postgresql" handler="org.jkiss.dbeaver.ext.postgresql.tasks.PostgreDatabaseRestoreHandler">
+        <task id="pgDatabaseRestore" name="PostgreSQL restore" description="PostgreSQL database restore task" icon="platform:/plugin/org.jkiss.dbeaver.ui/icons/file/import.png" type="postgresql" handler="org.jkiss.dbeaver.ext.postgresql.tasks.PostgreDatabaseRestoreHandler" confirmationMessage="%pgDatabaseRestore.confirmationMessage">
             <datasource id="postgresql"/>
             <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase"/>
             <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema"/>

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBUtils.java
@@ -521,6 +521,11 @@ public final class DBUtils {
         return pathStr.toString();
     }
 
+    public static String getObjectNameFromId(String objectId) {
+        String[] parts = objectId.split("/");
+        return parts[parts.length - 1];
+    }
+
     /**
      * Find object by unique ID.
      * Note: this function searches only inside DBSObjectContainer objects.

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelMessages.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelMessages.java
@@ -228,6 +228,7 @@ public class ModelMessages extends NLS {
 	
 	public static String tasks_restore_confirmation_title;
 	public static String tasks_restore_confirmation_cancelled_message;
+    public static String tasks_restore_confirmation_message;
 
 	static {
 		// initialize resource bundle

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelMessages.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelMessages.java
@@ -225,6 +225,9 @@ public class ModelMessages extends NLS {
 	public static String controls_querylog_shell_text;
 	public static String controls_querylog_success;
 	public static String controls_querylog_transaction;
+	
+	public static String tasks_restore_confirmation_title;
+	public static String tasks_restore_confirmation_cancelled_message;
 
 	static {
 		// initialize resource bundle

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelResources.properties
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelResources.properties
@@ -193,3 +193,6 @@ controls_querylog_shell_text = View
 controls_querylog_success = Success
 controls_querylog_transaction = Transaction
 
+tasks_restore_confirmation_title = Confirmation required to launch {0}
+tasks_restore_confirmation_cancelled_message = Task execution was cancelled by user via confirmation dialog.
+

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelResources.properties
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelResources.properties
@@ -195,4 +195,5 @@ controls_querylog_transaction = Transaction
 
 tasks_restore_confirmation_title = Confirmation required to launch {0}
 tasks_restore_confirmation_cancelled_message = Task execution was cancelled by user via confirmation dialog.
+tasks_restore_confirmation_message = It may corrupt your database. Are you sure?
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskType.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTTaskType.java
@@ -59,4 +59,7 @@ public interface DBTTaskType {
     boolean isDriverApplicable(DBPDriver driver);
 
     boolean isObjectApplicable(Object object);
+
+    @Nullable
+    String confirmationMessageIfNeeded();
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTaskUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTaskUtils.java
@@ -171,6 +171,8 @@ public class DBTaskUtils {
         StringBuilder messageBuilder = new StringBuilder();
         if (!collectConfirmationMessages(messageBuilder, task, extraConfirmationsCollector)) {
             return true;
+        } else {
+            messageBuilder.append("\n").append(ModelMessages.tasks_restore_confirmation_message);
         }
         if (DBWorkbench.getPlatformUI().confirmAction(NLS.bind(ModelMessages.tasks_restore_confirmation_title, task.getName()), messageBuilder.toString())) {
             return true;

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/RegistryConstants.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/RegistryConstants.java
@@ -157,6 +157,7 @@ public class RegistryConstants {
     public static final String ATTR_CONTRIBUTOR = "contributor"; //$NON-NLS-1$
     public static final String ATTR_INPUT_FACTORY = "inputFactory"; //$NON-NLS-1$
 
+    public static final String ATTR_CONFIRMATION_MESSAGE = "confirmationMessage"; //$NON-NLS-1$
     public static final String ATTR_HANDLER_CLASS = "handlerClass"; //$NON-NLS-1$
     public static final String ATTR_UI_CLASS = "uiClass"; //$NON-NLS-1$
     public static final String ATTR_SECURED = "secured"; //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
@@ -26,6 +26,7 @@ import org.jkiss.dbeaver.model.task.DBTTask;
 import org.jkiss.dbeaver.model.task.DBTTaskExecutionListener;
 import org.jkiss.dbeaver.model.task.DBTTaskHandler;
 import org.jkiss.dbeaver.model.task.DBTTaskRunStatus;
+import org.jkiss.dbeaver.model.task.DBTaskUtils;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.StandardConstants;
@@ -120,8 +121,9 @@ public class TaskRunJob extends AbstractJob implements DBRRunnableContext {
         return Status.OK_STATUS;
     }
 
-    private DBTTaskRunStatus executeTask(DBRProgressMonitor monitor, PrintStream logWriter) throws DBException {
+    private DBTTaskRunStatus executeTask(DBRProgressMonitor monitor, PrintStream logWriter) throws DBException, InterruptedException {
         activeMonitor = monitor;
+        DBTaskUtils.confirmTaskOrThrow(task, taskLog, logWriter);
         DBTTaskHandler taskHandler = task.getType().createHandler();
         return taskHandler.executeTask(this, task, locale, taskLog, logWriter, executionListener);
     }

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskTypeDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskTypeDescriptor.java
@@ -18,6 +18,7 @@ package org.jkiss.dbeaver.registry.task;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.DBPImage;
 import org.jkiss.dbeaver.model.DBPNamedObjectLocalized;
@@ -128,6 +129,12 @@ public class TaskTypeDescriptor extends DataSourceBindingDescriptor implements D
     @Override
     public boolean isObjectApplicable(Object object) {
         return object instanceof DBPObject && appliesTo((DBPObject) object);
+    }
+
+    @Nullable
+    @Override
+    public String confirmationMessageIfNeeded() {
+        return CommonUtils.nullIfEmpty(config.getAttribute(RegistryConstants.ATTR_CONFIRMATION_MESSAGE));
     }
 
     public synchronized boolean matchesEntityElements() {

--- a/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskWizardExecutor.java
+++ b/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskWizardExecutor.java
@@ -22,6 +22,7 @@ import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.runtime.DBRRunnableContext;
 import org.jkiss.dbeaver.model.task.DBTTask;
 import org.jkiss.dbeaver.model.task.DBTTaskHandler;
+import org.jkiss.dbeaver.model.task.DBTaskUtils;
 import org.jkiss.utils.CommonUtils;
 
 import java.io.PrintStream;
@@ -45,8 +46,10 @@ public class TaskWizardExecutor extends TaskProcessorUI {
 
     @Override
     protected void runTask() throws DBException {
-        DBTTaskHandler handlerTransfer = getTask().getType().createHandler();
-        handlerTransfer.executeTask(this, getTask(), Locale.getDefault(), log, logWriter, this);
+        if (DBTaskUtils.confirmTask(getTask(), log, logWriter)) {
+            DBTTaskHandler handlerTransfer = getTask().getType().createHandler();
+            handlerTransfer.executeTask(this, getTask(), Locale.getDefault(), log, logWriter, this);
+        }
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskWizardExecutor.java
+++ b/plugins/org.jkiss.dbeaver.tasks.ui/src/org/jkiss/dbeaver/tasks/ui/wizard/TaskWizardExecutor.java
@@ -22,6 +22,8 @@ import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.runtime.DBRRunnableContext;
 import org.jkiss.dbeaver.model.task.DBTTask;
 import org.jkiss.dbeaver.model.task.DBTTaskHandler;
+import org.jkiss.dbeaver.model.task.DBTaskUtils;
+import org.jkiss.dbeaver.registry.task.TaskRunJob;
 import org.jkiss.utils.CommonUtils;
 
 import java.io.PrintStream;
@@ -45,8 +47,10 @@ public class TaskWizardExecutor extends TaskProcessorUI {
 
     @Override
     protected void runTask() throws DBException {
-        DBTTaskHandler handlerTransfer = getTask().getType().createHandler();
-        handlerTransfer.executeTask(this, getTask(), Locale.getDefault(), log, logWriter, this);
+        if (DBTaskUtils.confirmTask(getTask(), log, logWriter)) {
+            DBTTaskHandler handlerTransfer = getTask().getType().createHandler();
+            handlerTransfer.executeTask(this, getTask(), Locale.getDefault(), log, logWriter, this);
+        }
     }
 
 }


### PR DESCRIPTION
Confirmation appears on restore task run

![image](https://user-images.githubusercontent.com/28875055/164411185-f2d9fb4e-96ca-4300-9e80-d25ed6c95876.png)

or in restore wizard

![image](https://user-images.githubusercontent.com/28875055/164411455-3c23f50d-3459-4084-a455-35575d335ed1.png)

If user is not confirmed action, then it's logging in wizard 

![image](https://user-images.githubusercontent.com/28875055/164220628-dbef95fb-e8dd-4bfa-8351-4f5dcc8cec40.png)

or writing in task execution result

![image](https://user-images.githubusercontent.com/28875055/164221033-df89d013-b724-49ef-9a72-41aeebcfdba5.png)

