### PR TITLE
dbeaver/dbeaver-ee#1169 introduce new replace update method

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
@@ -333,11 +333,12 @@
     <extension point="org.jkiss.dbeaver.sqlInsertMethod">
         <method id="mysqlInsertIgnore" class="org.jkiss.dbeaver.ext.mysql.model.MySQLInsertReplaceMethodIgnore" label="INSERT IGNORE" description="Insert ignore duplicate key value"/>
         <method id="mysqlReplaceIgnore" class="org.jkiss.dbeaver.ext.mysql.model.MySQLInsertReplaceMethod" label="REPLACE INTO" description="Insert replace duplicate key value"/>
+        <method id="mysqlReplaceIgnoreUpdate" class="org.jkiss.dbeaver.ext.mysql.model.MySQLInsertReplaceMethodUpdate" label="ON DUPLICATE KEY UPDATE" description="Insert update duplicate key value"/>
     </extension>
 
     <extension point="org.jkiss.dbeaver.sqlDialect">
         <dialect id="mysql" parent="basic" class="org.jkiss.dbeaver.ext.mysql.model.MySQLDialect" label="MySQL" description="MySQL dialect." icon="icons/mysql_icon.png">
-            <property name="insertMethods" value="mysqlInsertIgnore,mysqlReplaceIgnore"/>
+            <property name="insertMethods" value="mysqlInsertIgnore,mysqlReplaceIgnore,mysqlReplaceIgnoreUpdate"/>
             <keywords value=""/>
             <execKeywords value=""/>
             <ddlKeywords value=""/>

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLInsertReplaceMethodUpdate.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLInsertReplaceMethodUpdate.java
@@ -24,6 +24,8 @@ import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
 import org.jkiss.dbeaver.model.struct.rdb.DBSTable;
 
+import java.util.StringJoiner;
+
 /**
  *   If you specify an ON DUPLICATE KEY UPDATE clause and a row to be inserted would cause a duplicate value in a UNIQUE index or PRIMARY KEY, an UPDATE of the old row occurs.
  *   It can be better then MySQLInsertReplaceMethod class with REPLACE INTO, because REPLACE INTO first deletes a row, and then insert a new one.
@@ -48,18 +50,15 @@ public class MySQLInsertReplaceMethodUpdate implements DBDInsertReplaceMethod {
     }
 
     private void appendUpdateCase(@NotNull StringBuilder query, @NotNull DBSTable table, DBSAttributeBase[] attributes) {
-        boolean first = true;
+        final StringJoiner names = new StringJoiner(",");
         for (DBSAttributeBase attribute : attributes) {
             if (DBUtils.isPseudoAttribute(attribute)) {
                 continue;
             }
-            if (!first) {
-                query.append(",");
-            }
             String attrName = getAttributeName(table, attribute);
-            query.append(attrName).append("=VALUES(").append(attrName).append(")");
-            first = false;
+            names.add(attrName + "=VALUES(" + attrName + ")");
         }
+        query.append(names);
     }
 
     private String getAttributeName(@NotNull DBSTable table, @NotNull DBSAttributeBase attribute) {

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLInsertReplaceMethodUpdate.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLInsertReplaceMethodUpdate.java
@@ -1,0 +1,69 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2022 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.mysql.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.data.DBDInsertReplaceMethod;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
+import org.jkiss.dbeaver.model.struct.rdb.DBSTable;
+
+/**
+ *   If you specify an ON DUPLICATE KEY UPDATE clause and a row to be inserted would cause a duplicate value in a UNIQUE index or PRIMARY KEY, an UPDATE of the old row occurs.
+ *   It can be better then MySQLInsertReplaceMethod class with REPLACE INTO, because REPLACE INTO first deletes a row, and then insert a new one.
+ * Example:
+ *   INSERT INTO insert_duplicate_values(id, name, another_name) VALUES (5,'Ben','Solo')
+ *     ON DUPLICATE KEY UPDATE id=VALUES(id), name=VALUES(name), another_name=VALUES(another_name);
+ */
+
+public class MySQLInsertReplaceMethodUpdate implements DBDInsertReplaceMethod {
+    @NotNull
+    @Override
+    public String getOpeningClause(@NotNull DBSTable table, @NotNull DBRProgressMonitor monitor) {
+        return "INSERT INTO";
+    }
+
+    @Override
+    public String getTrailingClause(@NotNull DBSTable table, @NotNull DBRProgressMonitor monitor, DBSAttributeBase[] attributes) {
+        StringBuilder query = new StringBuilder();
+        query.append(" ON DUPLICATE KEY UPDATE ");
+        appendUpdateCase(query, table, attributes);
+        return query.toString();
+    }
+
+    private void appendUpdateCase(@NotNull StringBuilder query, @NotNull DBSTable table, DBSAttributeBase[] attributes) {
+        boolean first = true;
+        for (DBSAttributeBase attribute : attributes) {
+            if (DBUtils.isPseudoAttribute(attribute)) {
+                continue;
+            }
+            if (!first) {
+                query.append(",");
+            }
+            String attrName = getAttributeName(table, attribute);
+            query.append(attrName).append("=VALUES(").append(attrName).append(")");
+            first = false;
+        }
+    }
+
+    private String getAttributeName(@NotNull DBSTable table, @NotNull DBSAttributeBase attribute) {
+        // Do not quote pseudo attribute name
+        return DBUtils.isPseudoAttribute(attribute) ? attribute.getName() : DBUtils.getObjectFullName(table.getDataSource(), attribute, DBPEvaluationContext.DML);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDInsertReplaceMethod.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDInsertReplaceMethod.java
@@ -24,8 +24,8 @@ import org.jkiss.dbeaver.model.struct.rdb.DBSTable;
 public interface DBDInsertReplaceMethod {
 
     @NotNull
-    String getOpeningClause(DBSTable table, DBRProgressMonitor monitor);
+    String getOpeningClause(@NotNull DBSTable table, @NotNull DBRProgressMonitor monitor);
 
-    String getTrailingClause(DBSTable table, DBRProgressMonitor monitor, DBSAttributeBase[] attributes);
+    String getTrailingClause(@NotNull DBSTable table, @NotNull DBRProgressMonitor monitor, DBSAttributeBase[] attributes);
 
 }


### PR DESCRIPTION
for key duplicate case during the data migration for MySQL/MariaDB

Example
```sql
INSERT INTO insert_duplicate_values(id, name, another_name) VALUES (5,'Ben','Solo')
   ON DUPLICATE KEY UPDATE id=VALUES(id), name=VALUES(name), another_name=VALUES(another_name);
```

![2022-04-20 23_59_15-Data Transfer](https://user-images.githubusercontent.com/45152336/164324213-44ebdcc1-33e3-4ec0-b379-fbcf61324cb9.png)

