### PR TITLE
#6536 #10184 macOS Horizontal Scroll Issue

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/LightGrid.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/LightGrid.java
@@ -62,7 +62,7 @@ public abstract class LightGrid extends Canvas {
     /**
      * Horizontal scrolling increment, in pixels.
      */
-    private static final int HORZ_SCROLL_INCREMENT = 5;
+    private static final int HORZ_SCROLL_INCREMENT = 12;
 
     /**
      * The area to the left and right of the column boundary/resizer that is
@@ -3023,7 +3023,7 @@ public abstract class LightGrid extends Canvas {
     }
 
     private void onMouseHorizontalWheel(Event e) {
-        if (hScroll.getVisible()) {
+        if (hScroll.getVisible() & columnScrolling) {
             scrollHorizontally(e.count);
             e.doit = false;
         }


### PR DESCRIPTION
The method scrollHorizontally() is called on event SWT.MouseHorizontalWheel. ~~In my testing, it seems like this event is being raised on macOS, but not Windows.~~ The method overrides normal horizontal scrolling and forces either the leftmost or rightmost visible column to be fully visible - depending on whether the user is scrolling to the left or right. This causes scrolling to feel "jumpy". If the user has columnScrolling disabled (i.e. Smooth Scrolling enabled), this method probably shouldn't be called.

The value for HORZ_SCROLL_INCREMENT is only used if columnScrolling is disabled (Smooth Scrolling enabled) and ~~only~~ appears impacts the UI when responding to a horizontal mouse wheel or if the user clicks the arrows on the scrollbar. The reason for increasing this value is that previously horizontal scroll was moving a column at a time. With this change, the scroll wheel is moving pixel by pixel, and that made scrolling extremely slow. I tested a range of values on a 2019 MacBook Pro and a Microsoft Surface Laptop 4 (in order to test with a Windows Precision Touchpad enabled device), and a value of 12 gave the closest approximation to scrolling in applications like Excel. Behavior was unchanged when using a basic wired mouse.