### PR TITLE
#16204 Append exported data to existing .sql files 

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
@@ -427,7 +427,6 @@ public class DataExporterSQL extends StreamExporterAbstract implements IAppendab
     
     @Override
     public void importData(@NotNull IStreamDataExporterSite site) {
-        return;
     }
     
     @Override

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
@@ -424,7 +424,7 @@ public class DataExporterSQL extends StreamExporterAbstract implements IAppendab
     @Override
     public void importData(@NotNull IStreamDataExporterSite site) {
     	// This method is called before this.init().
-    	// No pre-initialization process.
+    	// No pre-initialization process is needed.
     }
     
     @Override

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
@@ -47,7 +47,7 @@ import java.util.stream.Stream;
 /**
  * SQL Exporter
  */
-public class DataExporterSQL extends StreamExporterAbstract implements IAppendableDataExporter{
+public class DataExporterSQL extends StreamExporterAbstract implements IAppendableDataExporter {
 
     private static final Log log = Log.getLog(DataExporterSQL.class);
 
@@ -374,18 +374,14 @@ public class DataExporterSQL extends StreamExporterAbstract implements IAppendab
     @Override
     public void exportFooter(DBRProgressMonitor monitor) {
         PrintWriter out = getWriter();
-        if (insertKeyword == InsertKeyword.INSERT_ALL) {
-            if (rowCount > 0) {
+        if (rowCount > 0) {
+        	if (insertKeyword == InsertKeyword.INSERT_ALL) {
                 out.write(rowDelimiter + identifierCase.transform(KEYWORD_SELECT_FROM_DUAL) + ";");
-            }
-        } else if (!oneLineEntry) {
-            if (rowCount > 0) {
+            } else if (!oneLineEntry) {
                 addOnConflictExpression(out);
                 out.write(";");
                 out.write(rowDelimiter);
-            }
-        } else {
-        	if (rowCount > 0) {
+            } else {
                 out.write(rowDelimiter);
             }
         }
@@ -428,7 +424,7 @@ public class DataExporterSQL extends StreamExporterAbstract implements IAppendab
     @Override
     public void importData(@NotNull IStreamDataExporterSite site) {
     	// This method is called before this.init().
-    	// No pre-initialization process is needed.
+    	// No pre-initialization process.
     }
     
     @Override

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
@@ -427,6 +427,8 @@ public class DataExporterSQL extends StreamExporterAbstract implements IAppendab
     
     @Override
     public void importData(@NotNull IStreamDataExporterSite site) {
+    	// This method is called before this.init().
+    	// No pre-initialization process is needed.
     }
     
     @Override


### PR DESCRIPTION
Implement a feature enhancement [#16204](https://github.com/dbeaver/dbeaver/issues/16204), make appending to existing files and exporting to a single file available for SQL file exporting to SQL files.
Fixed a bug [#16009](https://github.com/dbeaver/dbeaver/issues/16009), so that appending files are correctly starting new lines instead of appended to the last SQL statement of the previous files.
