### PR TITLE
#16335 Implement SQLScriptDataReceiver for result logging in script task

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tasks/ui/sql/script/SQLScriptTaskPageSettings.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tasks/ui/sql/script/SQLScriptTaskPageSettings.java
@@ -286,7 +286,6 @@ class SQLScriptTaskPageSettings extends ActiveWizardPage<SQLScriptTaskConfigurat
 
             ignoreErrorsCheck = UIUtils.createCheckbox(settingsGroup, DTMessages.sql_script_task_page_settings_option_ignore_errors, "", dtSettings.isIgnoreErrors(), 1);
             dumpQueryCheck = UIUtils.createCheckbox(settingsGroup, DTMessages.sql_script_task_page_settings_option_dump_results, "", dtSettings.isDumpQueryResultsToLog(), 1);
-            dumpQueryCheck.setEnabled(false);
             autoCommitCheck = UIUtils.createCheckbox(settingsGroup, DTMessages.sql_script_task_page_settings_option_auto_commit, "", dtSettings.isAutoCommit(), 1);
 
             getWizard().createVariablesEditButton(settingsGroup);


### PR DESCRIPTION
Currently a DB script task has a disabled option called "Dump query results to log file" (originally created for issue #3605). This commit implements SQLScriptDataReceiver in a very straightforward way to make that option working. Just scratching a personal itch, a DBeaver developer definitely should check that code.