### PR TITLE
#16441 Add save argument to cli -con parameter

### DIFF
--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceUtils.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceUtils.java
@@ -65,6 +65,7 @@ public class DataSourceUtils {
     private static final String PARAM_FOLDER = "folder";
     private static final String PARAM_AUTO_COMMIT = "autoCommit";
     private static final String PARAM_CREATE = "create";
+    private static final String PARAM_SAVE = "save";
 
     private static final String PREFIX_HANDLER = "handler.";
     private static final String PREFIX_PROP = "prop.";
@@ -89,7 +90,8 @@ public class DataSourceUtils {
             hideFolders = false,
             hideSchemas = false,
             mergeEntities = false,
-            savePassword = true;
+            savePassword = true,
+            isTemporary = true;
         Boolean autoCommit = null;
         Map<String, String> conProperties = new HashMap<>();
         Map<String, Map<String, String>> handlerProps = new HashMap<>();
@@ -177,6 +179,9 @@ public class DataSourceUtils {
                     if (parameterHandler != null) {
                         parameterHandler.setParameter(paramName, paramValue);
                     }
+                    break;
+                case PARAM_SAVE:
+                    isTemporary = !CommonUtils.toBoolean(paramValue);
                     break;
                 default:
                     boolean handled = false;
@@ -338,7 +343,7 @@ public class DataSourceUtils {
 
         DBPDataSourceContainer newDS = dsRegistry.createDataSource(driver, connConfig);
         newDS.setName(dsName);
-        ((DataSourceDescriptor)newDS).setTemporary(!createNewDataSource);
+        ((DataSourceDescriptor)newDS).setTemporary(isTemporary);
         if (savePassword) {
             newDS.setSavePassword(true);
         }


### PR DESCRIPTION
Example of usage:
`-con "name=DS|folder=Con|driver=mysql8|database=mysql8|connect=false|create=true|save=true"`

`save=true`   - makes temporary connection
`save=false`  - connection will be saved between DBeaver launches