### PR TITLE
EpochTimeAttributeTransformer.java: add 4 more modes

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.model/OSGI-INF/l10n/bundle.properties
@@ -167,8 +167,8 @@ MapTransformer.general.description = Evaluate structure/map as a set of separate
 
 ArrayTransformer.general.description = Evaluate complex array elements as a set of separate columns
 
-EpochTimeTransformer.general.description = Represents integer value as timestamp in Epoch (C, Unix, POSIX, Java, etc) time - the number of seconds that have elapsed since 1970/01/01 00:00:00 (UTC)
-EpochTimeTransformer.property.unit.description = Measure unit - seconds, milliseconds, etc
+EpochTimeTransformer.general.description = Represents numerical value as timestamp in Epoch (C, Unix, POSIX, Java, etc) time or one of its Windows-friendly variants - the number of seconds that have elapsed since 1970/01/01 00:00:00 (UTC), or a reference point specific to the chosen variant.
+EpochTimeTransformer.property.unit.description = Measure unit - seconds, milliseconds, etc. Note dotnet and its friends also change the reference point from the Unix Epoch
 EpochTimeTransformer.property.timezoneID.description = Timezone ID. By default local machine timezone is used.\n3 ways to specify zone:\n\t-Local zone offset (+3, -04:30)\n\t-Specific zone offset (GMT+2, UTC+01:00)\n\t-Region based (UTC, ECT, PST, etc)
 
 RadixTransformer.general.description = Represents numbers in a specified radix.

--- a/plugins/org.jkiss.dbeaver.model/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.model/plugin.xml
@@ -180,7 +180,7 @@
                 custom="true">
             <type kind="NUMERIC"/>
             <propertyGroup label="Properties">
-                <property id="unit" label="Unit" type="string" description="%EpochTimeTransformer.property.unit.description" defaultValue="milliseconds" required="true" validValues="seconds,milliseconds,nanoseconds"/>
+                <property id="unit" label="Unit" type="string" description="%EpochTimeTransformer.property.unit.description" defaultValue="milliseconds" required="true" validValues="seconds,milliseconds,nanoseconds,dotnet,w32filetime,oadate,sqliteJulian"/>
                 <property id="zoneId" label="Timezone ID" type="string" description="%EpochTimeTransformer.property.timezoneID.description"/>
             </propertyGroup>
         </transformer>

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/transformers/EpochTimeAttributeTransformer.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/transformers/EpochTimeAttributeTransformer.java
@@ -50,8 +50,9 @@ public class EpochTimeAttributeTransformer implements DBDAttributeTransformer {
     private enum EpochUnit {
         seconds {
             @Override
-            Instant toInstant(long rawValue) {
-                return Instant.ofEpochSecond(rawValue);
+            Instant toInstant(Number value) {
+                long longValue = value.longValue();
+                return Instant.ofEpochSecond(longValue);
             }
 
             @Override
@@ -60,15 +61,16 @@ public class EpochTimeAttributeTransformer implements DBDAttributeTransformer {
             }
 
             @Override
-            long toRawValue(Instant instant) {
+            Long toRawValue(Instant instant) {
                 return instant.getEpochSecond();
             }
         },
 
         milliseconds {
             @Override
-            Instant toInstant(long rawValue) {
-                return Instant.ofEpochMilli(rawValue);
+            Instant toInstant(Number value) {
+                long longValue = value.longValue();
+                return Instant.ofEpochMilli(longValue);
             }
 
             @Override
@@ -77,15 +79,16 @@ public class EpochTimeAttributeTransformer implements DBDAttributeTransformer {
             }
 
             @Override
-            long toRawValue(Instant instant) {
+            Long toRawValue(Instant instant) {
                 return instant.toEpochMilli();
             }
         },
 
         nanoseconds {
             @Override
-            Instant toInstant(long rawValue) {
-                return Instant.ofEpochSecond(rawValue / 1_000_000_000, rawValue % 1_000_000_000);
+            Instant toInstant(Number value) {
+                long longValue = value.longValue();
+                return Instant.ofEpochSecond(longValue / GIGA, longValue % GIGA);
             }
 
             @Override
@@ -94,20 +97,123 @@ public class EpochTimeAttributeTransformer implements DBDAttributeTransformer {
             }
 
             @Override
-            long toRawValue(Instant instant) {
-                return instant.getEpochSecond() * 1_000_000_000 + instant.getNano();
+            Long toRawValue(Instant instant) {
+                return instant.getEpochSecond() * GIGA + instant.getNano();
+            }
+        },
+
+        // https://docs.microsoft.com/en-us/dotnet/api/system.datetime.ticks?view=net-6.0#remarks
+        dotnet {
+            @Override
+            Instant toInstant(Number value) {
+                return ticksToInstant(value.longValue(), DOTNET_TICKS_OFFSET);
+            }
+
+            @Override
+            DateTimeFormatter getFormatter() {
+                return DOTNET_TICKS_FORMATTER;
+            }
+
+            @Override
+            Long toRawValue(Instant instant) {
+                return instantToTicks(instant, DOTNET_TICKS_OFFSET);
+            }
+        },
+
+        // https://docs.microsoft.com/en-us/dotnet/api/system.datetime.fromfiletimeutc?view=net-6.0#system-datetime-fromfiletimeutc(system-int64)
+        w32filetime {
+            @Override
+            Instant toInstant(Number value) {
+                return ticksToInstant(value.longValue(), W32_FILETIME_OFFSET);
+            }
+
+            @Override
+            DateTimeFormatter getFormatter() {
+                return DOTNET_TICKS_FORMATTER;
+            }
+
+            @Override
+            Long toRawValue(Instant instant) {
+                return instantToTicks(instant, W32_FILETIME_OFFSET);
+            }
+        },
+
+        // https://docs.microsoft.com/en-us/dotnet/api/system.datetime.fromoadate?view=net-6.0#system-datetime-fromoadate(system-double)
+        oadate {
+            @Override
+            Instant toInstant(Number value) {
+                return daysToInstant(value.doubleValue(), OADATE_OFFSET);
+            }
+
+            @Override
+            DateTimeFormatter getFormatter() {
+                return NANOS_FORMATTER;
+            }
+
+            @Override
+            Double toRawValue(Instant instant) {
+                return instantToDays(instant, OADATE_OFFSET);
+            }
+        },
+
+        // https://www.sqlite.org/lang_datefunc.html
+        sqliteJulian {
+            @Override
+            Instant toInstant(Number value) {
+                return daysToInstant(value.doubleValue(), SQLITE_JULIAN_OFFSET);
+            }
+
+            @Override
+            DateTimeFormatter getFormatter() {
+                return NANOS_FORMATTER;
+            }
+
+            @Override
+            Double toRawValue(Instant instant) {
+                return instantToDays(instant, SQLITE_JULIAN_OFFSET);
             }
         };
 
+        private static Instant ticksToInstant(long rawValue, long offset) {
+            long sinceUnixEpoch = rawValue - offset;
+            return Instant.ofEpochSecond(sinceUnixEpoch / TEN_MEGA, sinceUnixEpoch % TEN_MEGA * TICKS_TO_NANOS);
+        }
+
+        private static long instantToTicks(Instant instant, long offset) {
+            return instant.getEpochSecond() * TEN_MEGA + instant.getNano() / TICKS_TO_NANOS + offset;
+        }
+
+        private static Instant daysToInstant(double rawValue, double offset) {
+            double daysSinceUnixEpoch = rawValue - offset;
+            long wholeDaysSinceUnixEpoch = (long)daysSinceUnixEpoch;
+            double fractionalDay = daysSinceUnixEpoch - wholeDaysSinceUnixEpoch;
+            return Instant.ofEpochSecond(wholeDaysSinceUnixEpoch * SECONDS_IN_DAY, (long)(fractionalDay * SECONDS_IN_DAY * GIGA));
+        }
+
+        private static double instantToDays(Instant instant, double offset) {
+            double daysSinceUnixEpoch = (instant.getEpochSecond() + 1e-9 * instant.getNano()) / SECONDS_IN_DAY;
+            return daysSinceUnixEpoch + offset;
+        }
+
+        private static final long GIGA = 1_000_000_000;
+        private static final long TEN_MEGA = 10_000_000;
+        private static final int TICKS_TO_NANOS = 100;
+        private static final long DOTNET_TICKS_OFFSET = 621_355_968_000_000_000L;  // DateTime.UnixEpoch.Ticks
+        private static final long W32_FILETIME_OFFSET = 116_444_736_000_000_000L;  // DateTime.UnixEpoch.ToFileTimeUtc()
+        private static final double OADATE_OFFSET = 25569.0;  // DateTime.UnixEpoch.ToOADate()
+        private static final double SQLITE_JULIAN_OFFSET = 2440587.5;  // select julianday(0, "unixepoch")
+        private static int SECONDS_IN_DAY = 24 * 3600;
+
         private static final DateTimeFormatter SECONDS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH);
         private static final DateTimeFormatter MILLIS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS", Locale.ENGLISH);
+        private static final DateTimeFormatter DOTNET_TICKS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.nnnnnnn", Locale.ENGLISH);
         private static final DateTimeFormatter NANOS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.nnnnnnnnn",Locale.ENGLISH);
 
-        abstract Instant toInstant(long rawValue);
+        abstract Instant toInstant(Number value);
 
         abstract DateTimeFormatter getFormatter();
 
-        abstract long toRawValue(Instant instant);
+        abstract Number toRawValue(Instant instant);
     }
 
     @Override
@@ -152,8 +258,7 @@ public class EpochTimeAttributeTransformer implements DBDAttributeTransformer {
             if (!(value instanceof Number)) {
                 return DBValueFormatting.getDefaultValueDisplayString(value, format);
             }
-            long rawValue = ((Number) value).longValue();
-            Instant instant = unit.toInstant(rawValue);
+            Instant instant = unit.toInstant((Number)value);
             ZonedDateTime dateTime = ZonedDateTime.ofInstant(instant, getZoneId());
             return unit.getFormatter().format(dateTime);
         }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/transformers/EpochTimeAttributeTransformer.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/transformers/EpochTimeAttributeTransformer.java
@@ -58,6 +58,8 @@ public class EpochTimeAttributeTransformer implements DBDAttributeTransformer {
 
     private static final DateTimeFormatter SECONDS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH);
     private static final DateTimeFormatter MILLIS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS", Locale.ENGLISH);
+    // 10 us precision
+    private static final DateTimeFormatter SQLITE_JULIAN_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.nnnnn", Locale.ENGLISH);
     // 100 ns precision
     private static final DateTimeFormatter DOTNET_TICKS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.nnnnnnn", Locale.ENGLISH);
     private static final DateTimeFormatter NANOS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.nnnnnnnnn",Locale.ENGLISH);
@@ -180,7 +182,7 @@ public class EpochTimeAttributeTransformer implements DBDAttributeTransformer {
 
             @Override
             DateTimeFormatter getFormatter() {
-                return NANOS_FORMATTER;
+                return SQLITE_JULIAN_FORMATTER;
             }
 
             @Override


### PR DESCRIPTION
dotnet, w32filetime, oadate, sqliteJulian

Hi, I just wanted to share my local modification (which might still be buggy) to serve my own needs with you. I'm not sure if they should be packed into the existing `EpochTimeAttributeTransformer.java`, let me hear your thoughts.

By the way, are there any documents on per-user plugin development outside the whole app repo? I had a quick look at https://dbeaver.com/docs/wiki/Optional-extensions/ but its scope was somewhat different from the kind of functionality I'm adding here.

I'm new to this codebase (and haven't written any Java for the last couple of years...) How am I supposed to add unit tests to cover my changes?