### PR TITLE
Having Script tabs underneath Project tabs ?

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.core/plugin.xml
@@ -21,9 +21,6 @@
 <plugin>
     <!-- UI extensions -->
     <extension-point id="org.jkiss.dbeaver.workbenchHandler" name="%extension-point.org.jkiss.dbeaver.workbenchHandler.name" schema="schema/org.jkiss.dbeaver.workbenchHandler.exsd"/>
-    <extension point="org.jkiss.dbeaver.workbenchHandler">
-        <workbenchWindowInitializer class="org.jkiss.dbeaver.ui.eula.EULAInitializer" priority="0"/>
-    </extension>
 
     <extension point="org.eclipse.core.contenttype.contentTypes">
         <content-type

--- a/plugins/org.jkiss.dbeaver.ext.mssql.ui/src/org/jkiss/dbeaver/ext/mssql/ui/SQLServerConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql.ui/src/org/jkiss/dbeaver/ext/mssql/ui/SQLServerConnectionPage.java
@@ -132,7 +132,6 @@ public class SQLServerConnectionPage extends ConnectionPageWithAuth implements I
             secureGroup.setLayoutData(gd);
             secureGroup.setLayout(new GridLayout(1, false));
 
-            createPasswordControls(secureGroup);
             if (!isSqlServer) {
                 encryptPassword = UIUtils.createCheckbox(secureGroup, SQLServerUIMessages.dialog_setting_encrypt_password, SQLServerUIMessages.dialog_setting_encrypt_password_tip, false, 2);
             }

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/tasks/MySQLExportSettings.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/tasks/MySQLExportSettings.java
@@ -332,7 +332,7 @@ public class MySQLExportSettings extends AbstractImportExportSettings<DBSObject>
 
     @NotNull
     public File getOutputFile(@NotNull MySQLDatabaseExportInfo info) {
-        String outFileName = resolveVars(info, getOutputFolderPattern());
+        String outFileName = resolveVars(info, getOutputFilePattern());
         return new File(getOutputFolder(info), outFileName);
     }
 


### PR DESCRIPTION
Don't know if the request has already been formulated,
but would it be possible to have the scripts open under an above tab corresponding to the project you're working in...

for, instance, the black tab would be active, and then seeing only the scripts in that project
![image](https://user-images.githubusercontent.com/82998099/168594833-f97f7b00-74a3-48d6-95eb-74651b159144.png)

or eventually, scripts under tabs corresponding to the database connexion you're in.

thanks ;)