### PR TITLE
#9875 escape wild cards for the Snowflake metadata search properly

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
@@ -58,4 +58,12 @@ public class SnowflakeSQLDialect extends GenericSQLDialect implements TPRuleProv
         }
     }
 
+    @NotNull
+    @Override
+    public String getSearchStringEscape() {
+        // Without escaping of wildcards Snowflake reads all metadata directly from database and ignores specified objects names
+        // #9875
+        return "\\";
+    }
+
 }


### PR DESCRIPTION
![2022-05-26 15_34_19-Window](https://user-images.githubusercontent.com/45152336/170490554-3f9935c2-67e4-418b-bc4c-be7fa74d07fa.png)

vs

![2022-05-26 15_36_32-Window](https://user-images.githubusercontent.com/45152336/170490557-47779b51-5555-4291-8b33-80673d8d825b.png)
