### PR TITLE
#14360 add cell move after enter & refactor grid preferences

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetPreferences.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetPreferences.java
@@ -64,6 +64,7 @@ public final class ResultSetPreferences {
     public static final String RESULT_SET_RIGHT_JUSTIFY_DATETIME = "resultset.show.rightJustifyDateTime"; //$NON-NLS-1$
     public static final String RESULT_SET_AUTO_SWITCH_MODE = "resultset.behavior.autoSwitchMode"; //$NON-NLS-1$
     public static final String RESULT_SET_DOUBLE_CLICK = "resultset.behavior.doubleClick"; //$NON-NLS-1$
+    public static final String RESULT_SET_INLINE_ENTER = "resultset.behavior.inlineEnter";
     public static final String RESULT_SET_ROW_BATCH_SIZE = "resultset.show.row.batch.size"; //$NON-NLS-1$
     public static final String RESULT_SET_MAX_COLUMN_DEF_WIDTH = "resultset.max.column.def.width"; //$NON-NLS-1$
     

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
@@ -45,6 +45,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.menus.CommandContributionItem;
 import org.eclipse.ui.themes.ITheme;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
@@ -81,6 +82,7 @@ import org.jkiss.dbeaver.ui.data.IMultiController;
 import org.jkiss.dbeaver.ui.data.IValueController;
 import org.jkiss.dbeaver.ui.data.IValueEditor;
 import org.jkiss.dbeaver.ui.data.IValueEditorStandalone;
+import org.jkiss.dbeaver.ui.data.editors.BaseValueEditor;
 import org.jkiss.dbeaver.ui.data.managers.BaseValueManager;
 import org.jkiss.dbeaver.ui.editors.TextEditorUtils;
 import org.jkiss.dbeaver.ui.properties.PropertySourceDelegate;
@@ -1191,6 +1193,22 @@ public class SpreadsheetPresentation extends AbstractPresentation implements IRe
         if (inline) {
             if (activeInlineEditor != null) {
                 spreadsheet.showCellEditor(placeholder);
+                if (activeInlineEditor instanceof BaseValueEditor && CommonUtils.getBoolean(getPreferenceStore().getString(ResultSetPreferences.RESULT_SET_INLINE_ENTER))) {
+                    ((BaseValueEditor<?>) activeInlineEditor).addAdditionalTraverseActions((it) -> {
+                        //We don't want to create another listener due to baseValueTraverseListener
+                        //removing any information about traverse event and setting it to TRAVERSE_NONE
+                        if (it.getFirst() == SWT.TRAVERSE_RETURN) {
+                            final Event applyEvent = new Event();
+                            if ((it.getSecond() & SWT.SHIFT) == 0) {
+                                applyEvent.keyCode = SWT.ARROW_DOWN;
+                            } else {
+                                applyEvent.keyCode = SWT.ARROW_RIGHT;
+                            }
+                            getSpreadsheet().notifyListeners(SWT.KeyDown, applyEvent);
+                        }
+                    });
+                }
+
                 return activeInlineEditor.getControl();
             } else {
                 // No editor was created so just drop placeholder

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
@@ -1198,9 +1198,9 @@ public class SpreadsheetPresentation extends AbstractPresentation implements IRe
                     ((BaseValueEditor<?>) activeInlineEditor).addAdditionalTraverseActions((it) -> {
                         //We don't want to create another listener due to baseValueTraverseListener
                         //removing any information about traverse event and setting it to TRAVERSE_NONE
-                        if (it.getFirst() == SWT.TRAVERSE_RETURN) {
+                        if (it.detail == SWT.TRAVERSE_RETURN) {
                             final Event applyEvent = new Event();
-                            if ((it.getSecond() & SWT.SHIFT) == 0) {
+                            if ((it.stateMask & SWT.SHIFT) == 0) {
                                 applyEvent.keyCode = SWT.ARROW_DOWN;
                             } else {
                                 applyEvent.keyCode = SWT.ARROW_RIGHT;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
@@ -1193,7 +1193,8 @@ public class SpreadsheetPresentation extends AbstractPresentation implements IRe
         if (inline) {
             if (activeInlineEditor != null) {
                 spreadsheet.showCellEditor(placeholder);
-                if (activeInlineEditor instanceof BaseValueEditor && CommonUtils.getBoolean(getPreferenceStore().getString(ResultSetPreferences.RESULT_SET_INLINE_ENTER))) {
+                if (activeInlineEditor instanceof BaseValueEditor && CommonUtils.getBoolean(
+                        getPreferenceStore().getString(ResultSetPreferences.RESULT_SET_INLINE_ENTER))) {
                     ((BaseValueEditor<?>) activeInlineEditor).addAdditionalTraverseActions((it) -> {
                         //We don't want to create another listener due to baseValueTraverseListener
                         //removing any information about traverse event and setting it to TRAVERSE_NONE

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsMessages.java
@@ -41,6 +41,8 @@ public class DataEditorsMessages extends NLS {
     public static String pref_page_database_resultsets_label_auto_completion_tip;
     // ResultSetGrid
     public static String pref_page_database_resultsets_group_grid;
+    public static String pref_page_database_resultsets_group_behavior;
+    public static String pref_page_database_resultsets_group_appearance;
     public static String pref_page_database_resultsets_label_mark_odd_rows;
     public static String pref_page_database_resultsets_label_highlight_rows_with_selected_cells;
     public static String pref_page_database_resultsets_label_colorize_data_types;
@@ -63,6 +65,8 @@ public class DataEditorsMessages extends NLS {
     public static String pref_page_database_resultsets_label_toggle_boolean_on_click_tip;
     public static String pref_page_database_resultsets_label_show_boolean_config_link;
     public static String pref_page_database_resultsets_label_double_click_behavior;
+    public static String pref_page_database_resultsets_label_enter_for_inline_behavior;
+    public static String pref_page_database_resultsets_label_enter_for_inline_behavior_tip;
 
     public static String pref_page_result_selector_editor;
 	public static String pref_page_result_selector_inline_editor;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsPreferencesInitializer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsPreferencesInitializer.java
@@ -77,7 +77,7 @@ public class DataEditorsPreferencesInitializer extends AbstractPreferenceInitial
         PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_SET_SHOW_SEL_ROWS, true);
         PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_SET_SHOW_SEL_COLUMNS, false);
         PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_SET_SHOW_SEL_CELLS, false);
-
+        PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_SET_INLINE_ENTER, false);
         PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_SET_COLORIZE_DATA_TYPES, false);
         PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_SET_RIGHT_JUSTIFY_NUMBERS, true);
         PrefUtils.setDefaultPreferenceValue(store, ResultSetPreferences.RESULT_SET_RIGHT_JUSTIFY_DATETIME, true);

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsResources.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/internal/DataEditorsResources.properties
@@ -19,6 +19,8 @@ pref_page_database_resultsets_label_auto_completion = Enable auto-completion in 
 pref_page_database_resultsets_label_auto_completion_tip = Columns auto-complete enabled in the data filter text
 #ResultSetsGrid
 pref_page_database_resultsets_group_grid = Grid
+pref_page_database_resultsets_group_behavior = Behavior
+pref_page_database_resultsets_group_appearance = Appearance
 pref_page_database_resultsets_label_mark_odd_rows = Mark odd/even rows
 pref_page_database_resultsets_label_highlight_rows_with_selected_cells = Highlight rows with selected cells
 pref_page_database_resultsets_label_colorize_data_types = Colorize data types
@@ -39,6 +41,9 @@ pref_page_database_resultsets_label_toggle_boolean_on_click = Toggle boolean on 
 pref_page_database_resultsets_label_toggle_boolean_on_click_tip = Toggle boolean values on single click
 pref_page_database_resultsets_label_show_boolean_config_link = Configure booleans view
 pref_page_database_resultsets_label_double_click_behavior = Double-click behavior
+pref_page_database_resultsets_label_enter_for_inline_behavior = Select next cell after inline edit
+pref_page_database_resultsets_label_enter_for_inline_behavior_tip = After completing the inline edit, a cell on the next row will be selected, SHIFT+ENTER can be pressed to select the cell on the next column
+
 pref_page_result_selector_editor = Editor
 pref_page_result_selector_inline_editor = Inline Editor
 pref_page_result_selector_none = None

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationGrid.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationGrid.java
@@ -149,7 +149,7 @@ public class PrefPageResultSetPresentationGrid extends TargetPrefPage
             PreferenceLinkArea editorsLink = new PreferenceLinkArea(behaviorGroup, SWT.NONE,
                 "org.jkiss.dbeaver.preferences.editors",
                 "<a>" + DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_config_link
-                    + "  - ''{0}''</a>", (IWorkbenchPreferenceContainer) getContainer(), null);//$NON-NLS-1$
+                    + "  - ''{0}''</a>", (IWorkbenchPreferenceContainer) getContainer(), null); //$NON-NLS-1$
             GridData gd = new GridData(GridData.FILL_HORIZONTAL);
             gd.horizontalSpan = 2;
             editorsLink.getControl().setLayoutData(gd);

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationGrid.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationGrid.java
@@ -56,6 +56,7 @@ public class PrefPageResultSetPresentationGrid extends TargetPrefPage
     private Button showBooleanAsCheckbox;
     private Button showWhitespaceCharacters;
     private Button toggleBooleanOnClick;
+    private Button moveAfterInlineEnter;
     private Combo gridDoubleClickBehavior;
     private Text gridRowBatchSize;
     private Text maxDefColumnWidth;
@@ -97,20 +98,28 @@ public class PrefPageResultSetPresentationGrid extends TargetPrefPage
         Composite composite = UIUtils.createPlaceholder(parent, 2, 5);
 
         {
-            Group uiGroup = UIUtils.createControlGroup(composite, DataEditorsMessages.pref_page_database_resultsets_group_grid, 2, GridData.VERTICAL_ALIGN_BEGINNING, 0);
+            Group uiGroup = UIUtils.createControlGroup(composite, DataEditorsMessages.pref_page_database_resultsets_group_grid, 1, GridData.FILL_BOTH, 0);
 
-            gridShowOddRows = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_mark_odd_rows, null, false, 2);
-            gridHighlightRowsWithSelectedCells = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_highlight_rows_with_selected_cells, null, false, 2);
-            colorizeDataTypes = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_colorize_data_types, null, false, 2);
+            final Group appearanceGroup = UIUtils.createControlGroup(uiGroup, DataEditorsMessages.pref_page_database_resultsets_group_appearance, 2, GridData.FILL_HORIZONTAL, 0);
+            gridShowOddRows = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_mark_odd_rows, null, false, 2);
+            colorizeDataTypes = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_colorize_data_types, null, false, 2);
             //gridShowCellIcons = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_cell_icons, null, false, 2);
-            gridShowAttrIcons = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_icons, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_icons_tip, false, 2);
-            gridShowAttrFilters = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_filters, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_filters_tip, false, 2);
-            gridShowAttrOrder = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_ordering, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_ordering_tip, false, 2);
-            useSmoothScrolling = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_use_smooth_scrolling, DataEditorsMessages.pref_page_database_resultsets_label_use_smooth_scrolling_tip, false, 2);
-            showBooleanAsCheckbox = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_as_checkbox, DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_as_checkbox_tip, false, 2);
-            showWhitespaceCharacters = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_whitespace_characters, DataEditorsMessages.pref_page_database_resultsets_label_show_whitespace_characters_tip, false, 2);
-            toggleBooleanOnClick = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_toggle_boolean_on_click, DataEditorsMessages.pref_page_database_resultsets_label_toggle_boolean_on_click_tip, false, 2);
-            PreferenceLinkArea editorsLink = new PreferenceLinkArea(uiGroup, SWT.NONE,
+            gridShowAttrIcons = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_icons, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_icons_tip, false, 2);
+            gridShowAttrFilters = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_filters, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_filters_tip, false, 2);
+            gridShowAttrOrder = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_ordering, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_ordering_tip, false, 2);
+            showBooleanAsCheckbox = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_as_checkbox, DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_as_checkbox_tip, false, 2);
+            showWhitespaceCharacters = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_whitespace_characters, DataEditorsMessages.pref_page_database_resultsets_label_show_whitespace_characters_tip, false, 2);
+            maxDefColumnWidth = UIUtils.createLabelText(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_max_def_column_width, "", SWT.BORDER);
+            maxDefColumnWidth.setToolTipText(DataEditorsMessages.pref_page_database_resultsets_label_max_def_column_width_tip);
+            maxDefColumnWidth.addVerifyListener(UIUtils.getIntegerVerifyListener(Locale.getDefault()));
+
+            final Group behaviorGroup = UIUtils.createControlGroup(uiGroup, DataEditorsMessages.pref_page_database_resultsets_group_behavior, 2, GridData.FILL_HORIZONTAL, 0);
+            gridHighlightRowsWithSelectedCells = UIUtils.createCheckbox(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_highlight_rows_with_selected_cells, null, false, 2);
+            useSmoothScrolling = UIUtils.createCheckbox(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_use_smooth_scrolling, DataEditorsMessages.pref_page_database_resultsets_label_use_smooth_scrolling_tip, false, 2);
+            toggleBooleanOnClick = UIUtils.createCheckbox(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_toggle_boolean_on_click, DataEditorsMessages.pref_page_database_resultsets_label_toggle_boolean_on_click_tip, false, 2);
+            moveAfterInlineEnter = UIUtils.createCheckbox(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_enter_for_inline_behavior, DataEditorsMessages.pref_page_database_resultsets_label_enter_for_inline_behavior_tip, false, 2);
+
+            PreferenceLinkArea editorsLink = new PreferenceLinkArea(behaviorGroup, SWT.NONE,
                 "org.jkiss.dbeaver.preferences.editors",
                 "<a>" + DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_config_link + "  - ''{0}''</a>",
                 (IWorkbenchPreferenceContainer) getContainer(), null);//$NON-NLS-1$
@@ -118,17 +127,18 @@ public class PrefPageResultSetPresentationGrid extends TargetPrefPage
             gd.horizontalSpan = 2;
             editorsLink.getControl().setLayoutData(gd);
 
-            gridDoubleClickBehavior = UIUtils.createLabelCombo(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_double_click_behavior, SWT.READ_ONLY);
+            gridDoubleClickBehavior = UIUtils.createLabelCombo(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_double_click_behavior, SWT.READ_ONLY);
             gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_none, Spreadsheet.DoubleClickBehavior.NONE.ordinal());
             gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_editor, Spreadsheet.DoubleClickBehavior.EDITOR.ordinal());
             gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_inline_editor, Spreadsheet.DoubleClickBehavior.INLINE_EDITOR.ordinal());
             gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_copy_cell, Spreadsheet.DoubleClickBehavior.COPY_VALUE.ordinal());
             gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_paste_cell_value, Spreadsheet.DoubleClickBehavior.COPY_PASTE_VALUE.ordinal());
-            gridRowBatchSize = UIUtils.createLabelText(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_row_batch_size, "", SWT.BORDER);
+
+
+
+            gridRowBatchSize = UIUtils.createLabelText(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_row_batch_size, "", SWT.BORDER);
             gridRowBatchSize.setToolTipText(DataEditorsMessages.pref_page_database_resultsets_label_row_batch_size_tip);
-            maxDefColumnWidth = UIUtils.createLabelText(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_max_def_column_width, "", SWT.BORDER);
-            maxDefColumnWidth.setToolTipText(DataEditorsMessages.pref_page_database_resultsets_label_max_def_column_width_tip);
-            maxDefColumnWidth.addVerifyListener(UIUtils.getIntegerVerifyListener(Locale.getDefault()));
+
         }
 
         return composite;
@@ -149,6 +159,7 @@ public class PrefPageResultSetPresentationGrid extends TargetPrefPage
             showBooleanAsCheckbox.setSelection(store.getBoolean(ResultSetPreferences.RESULT_SET_SHOW_BOOLEAN_AS_CHECKBOX));
             showWhitespaceCharacters.setSelection(store.getBoolean(ResultSetPreferences.RESULT_SET_SHOW_WHITESPACE_CHARACTERS));
             toggleBooleanOnClick.setSelection(store.getBoolean(ResultSetPreferences.RESULT_SET_CLICK_TOGGLE_BOOLEAN));
+            moveAfterInlineEnter.setSelection(store.getBoolean(ResultSetPreferences.RESULT_SET_INLINE_ENTER));
             gridDoubleClickBehavior.select(
                 CommonUtils.valueOf(
                     Spreadsheet.DoubleClickBehavior.class,
@@ -167,6 +178,7 @@ public class PrefPageResultSetPresentationGrid extends TargetPrefPage
     {
         try {
             store.setValue(ResultSetPreferences.RESULT_SET_SHOW_ODD_ROWS, gridShowOddRows.getSelection());
+            store.setValue(ResultSetPreferences.RESULT_SET_INLINE_ENTER, moveAfterInlineEnter.getSelection());
             store.setValue(ResultSetPreferences.RESULT_SET_HIGHLIGHT_SELECTED_ROWS, gridHighlightRowsWithSelectedCells.getSelection());
             store.setValue(ResultSetPreferences.RESULT_SET_COLORIZE_DATA_TYPES, colorizeDataTypes.getSelection());
             //store.setValue(ResultSetPreferences.RESULT_SET_SHOW_CELL_ICONS, gridShowCellIcons.getSelection());
@@ -192,6 +204,7 @@ public class PrefPageResultSetPresentationGrid extends TargetPrefPage
     @Override
     protected void clearPreferences(DBPPreferenceStore store)
     {
+        store.setToDefault(ResultSetPreferences.RESULT_SET_INLINE_ENTER);
         store.setToDefault(ResultSetPreferences.RESULT_SET_SHOW_ODD_ROWS);
         store.setToDefault(ResultSetPreferences.RESULT_SET_HIGHLIGHT_SELECTED_ROWS);
         store.setToDefault(ResultSetPreferences.RESULT_SET_COLORIZE_DATA_TYPES);

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationGrid.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/data/preferences/PrefPageResultSetPresentationGrid.java
@@ -98,45 +98,78 @@ public class PrefPageResultSetPresentationGrid extends TargetPrefPage
         Composite composite = UIUtils.createPlaceholder(parent, 2, 5);
 
         {
-            Group uiGroup = UIUtils.createControlGroup(composite, DataEditorsMessages.pref_page_database_resultsets_group_grid, 1, GridData.FILL_BOTH, 0);
+            Group uiGroup = UIUtils.createControlGroup(composite,
+                DataEditorsMessages.pref_page_database_resultsets_group_grid, 2, GridData.FILL_BOTH, 0);
 
-            final Group appearanceGroup = UIUtils.createControlGroup(uiGroup, DataEditorsMessages.pref_page_database_resultsets_group_appearance, 2, GridData.FILL_HORIZONTAL, 0);
-            gridShowOddRows = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_mark_odd_rows, null, false, 2);
-            colorizeDataTypes = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_colorize_data_types, null, false, 2);
+            final Group appearanceGroup = UIUtils.createControlGroup(uiGroup,
+                DataEditorsMessages.pref_page_database_resultsets_group_appearance, 2,
+                GridData.FILL_HORIZONTAL | GridData.VERTICAL_ALIGN_BEGINNING, 0);
+            gridShowOddRows = UIUtils.createCheckbox(appearanceGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_mark_odd_rows, null, false, 2);
+            colorizeDataTypes = UIUtils.createCheckbox(appearanceGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_colorize_data_types, null, false, 2);
             //gridShowCellIcons = UIUtils.createCheckbox(uiGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_cell_icons, null, false, 2);
-            gridShowAttrIcons = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_icons, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_icons_tip, false, 2);
-            gridShowAttrFilters = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_filters, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_filters_tip, false, 2);
-            gridShowAttrOrder = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_ordering, DataEditorsMessages.pref_page_database_resultsets_label_show_attr_ordering_tip, false, 2);
-            showBooleanAsCheckbox = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_as_checkbox, DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_as_checkbox_tip, false, 2);
-            showWhitespaceCharacters = UIUtils.createCheckbox(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_show_whitespace_characters, DataEditorsMessages.pref_page_database_resultsets_label_show_whitespace_characters_tip, false, 2);
-            maxDefColumnWidth = UIUtils.createLabelText(appearanceGroup, DataEditorsMessages.pref_page_database_resultsets_label_max_def_column_width, "", SWT.BORDER);
-            maxDefColumnWidth.setToolTipText(DataEditorsMessages.pref_page_database_resultsets_label_max_def_column_width_tip);
+            gridShowAttrIcons = UIUtils.createCheckbox(appearanceGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_attr_icons,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_attr_icons_tip, false, 2);
+            gridShowAttrFilters = UIUtils.createCheckbox(appearanceGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_attr_filters,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_attr_filters_tip, false, 2);
+            gridShowAttrOrder = UIUtils.createCheckbox(appearanceGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_attr_ordering,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_attr_ordering_tip, false, 2);
+            showBooleanAsCheckbox = UIUtils.createCheckbox(appearanceGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_as_checkbox,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_as_checkbox_tip, false, 2);
+            showWhitespaceCharacters = UIUtils.createCheckbox(appearanceGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_whitespace_characters,
+                DataEditorsMessages.pref_page_database_resultsets_label_show_whitespace_characters_tip, false, 2);
+            maxDefColumnWidth = UIUtils.createLabelText(appearanceGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_max_def_column_width, "", SWT.BORDER);
+            maxDefColumnWidth.setToolTipText(
+                DataEditorsMessages.pref_page_database_resultsets_label_max_def_column_width_tip);
             maxDefColumnWidth.addVerifyListener(UIUtils.getIntegerVerifyListener(Locale.getDefault()));
 
-            final Group behaviorGroup = UIUtils.createControlGroup(uiGroup, DataEditorsMessages.pref_page_database_resultsets_group_behavior, 2, GridData.FILL_HORIZONTAL, 0);
-            gridHighlightRowsWithSelectedCells = UIUtils.createCheckbox(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_highlight_rows_with_selected_cells, null, false, 2);
-            useSmoothScrolling = UIUtils.createCheckbox(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_use_smooth_scrolling, DataEditorsMessages.pref_page_database_resultsets_label_use_smooth_scrolling_tip, false, 2);
-            toggleBooleanOnClick = UIUtils.createCheckbox(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_toggle_boolean_on_click, DataEditorsMessages.pref_page_database_resultsets_label_toggle_boolean_on_click_tip, false, 2);
-            moveAfterInlineEnter = UIUtils.createCheckbox(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_enter_for_inline_behavior, DataEditorsMessages.pref_page_database_resultsets_label_enter_for_inline_behavior_tip, false, 2);
+            final Group behaviorGroup = UIUtils.createControlGroup(uiGroup,
+                DataEditorsMessages.pref_page_database_resultsets_group_behavior, 2,
+                GridData.FILL_HORIZONTAL | GridData.VERTICAL_ALIGN_BEGINNING, 0);
+            gridHighlightRowsWithSelectedCells = UIUtils.createCheckbox(behaviorGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_highlight_rows_with_selected_cells, null, false,
+                2);
+            useSmoothScrolling = UIUtils.createCheckbox(behaviorGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_use_smooth_scrolling,
+                DataEditorsMessages.pref_page_database_resultsets_label_use_smooth_scrolling_tip, false, 2);
+            toggleBooleanOnClick = UIUtils.createCheckbox(behaviorGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_toggle_boolean_on_click,
+                DataEditorsMessages.pref_page_database_resultsets_label_toggle_boolean_on_click_tip, false, 2);
+            moveAfterInlineEnter = UIUtils.createCheckbox(behaviorGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_enter_for_inline_behavior,
+                DataEditorsMessages.pref_page_database_resultsets_label_enter_for_inline_behavior_tip, false, 2);
 
             PreferenceLinkArea editorsLink = new PreferenceLinkArea(behaviorGroup, SWT.NONE,
                 "org.jkiss.dbeaver.preferences.editors",
-                "<a>" + DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_config_link + "  - ''{0}''</a>",
-                (IWorkbenchPreferenceContainer) getContainer(), null);//$NON-NLS-1$
+                "<a>" + DataEditorsMessages.pref_page_database_resultsets_label_show_boolean_config_link
+                    + "  - ''{0}''</a>", (IWorkbenchPreferenceContainer) getContainer(), null);//$NON-NLS-1$
             GridData gd = new GridData(GridData.FILL_HORIZONTAL);
             gd.horizontalSpan = 2;
             editorsLink.getControl().setLayoutData(gd);
 
-            gridDoubleClickBehavior = UIUtils.createLabelCombo(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_double_click_behavior, SWT.READ_ONLY);
-            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_none, Spreadsheet.DoubleClickBehavior.NONE.ordinal());
-            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_editor, Spreadsheet.DoubleClickBehavior.EDITOR.ordinal());
-            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_inline_editor, Spreadsheet.DoubleClickBehavior.INLINE_EDITOR.ordinal());
-            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_copy_cell, Spreadsheet.DoubleClickBehavior.COPY_VALUE.ordinal());
-            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_paste_cell_value, Spreadsheet.DoubleClickBehavior.COPY_PASTE_VALUE.ordinal());
+            gridDoubleClickBehavior = UIUtils.createLabelCombo(behaviorGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_double_click_behavior, SWT.READ_ONLY);
+            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_none,
+                Spreadsheet.DoubleClickBehavior.NONE.ordinal());
+            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_editor,
+                Spreadsheet.DoubleClickBehavior.EDITOR.ordinal());
+            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_inline_editor,
+                Spreadsheet.DoubleClickBehavior.INLINE_EDITOR.ordinal());
+            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_copy_cell,
+                Spreadsheet.DoubleClickBehavior.COPY_VALUE.ordinal());
+            gridDoubleClickBehavior.add(DataEditorsMessages.pref_page_result_selector_paste_cell_value,
+                Spreadsheet.DoubleClickBehavior.COPY_PASTE_VALUE.ordinal());
 
 
-
-            gridRowBatchSize = UIUtils.createLabelText(behaviorGroup, DataEditorsMessages.pref_page_database_resultsets_label_row_batch_size, "", SWT.BORDER);
+            gridRowBatchSize = UIUtils.createLabelText(behaviorGroup,
+                DataEditorsMessages.pref_page_database_resultsets_label_row_batch_size, "", SWT.BORDER);
             gridRowBatchSize.setToolTipText(DataEditorsMessages.pref_page_database_resultsets_label_row_batch_size_tip);
 
         }


### PR DESCRIPTION
Now user can tick "Select next cell after inline edit", which automatically switches the cell to one on the next row or, in case of shift+enter, the next column.
Closes #14360
![image](https://user-images.githubusercontent.com/20579256/172171782-af475ab8-7276-4511-8b06-22fdf0b8a5bb.png)
