### PR TITLE
#15698 Improve support for structs

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreValueParser.java
@@ -49,9 +49,7 @@ public class PostgreValueParser {
 
     public static Object convertStringToValue(DBCSession session, DBSTypedObject arrayType, String string) throws DBCException {
         if (arrayType.getDataKind() == DBPDataKind.ARRAY) {
-            if (CommonUtils.isEmpty(string)) {
-                return new Object[0];
-            } else if (string.startsWith("{") && string.endsWith("}")) {
+            if (string != null && string.startsWith("{") && string.endsWith("}")) {
                 try {
                     return prepareToParseArray(session, arrayType, string);
                 } catch (Exception e) {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDialect.java
@@ -842,12 +842,12 @@ public class PostgreDialect extends JDBCSQLDialect implements TPRuleProvider, SQ
     @NotNull
     @Override
     public String escapeScriptValue(DBSTypedObject attribute, @NotNull Object value, @NotNull String strValue) {
-        if (PostgreUtils.isPGObject(value) ||
-            PostgreConstants.TYPE_BIT.equals(attribute.getTypeName()) ||
-            PostgreConstants.TYPE_INTERVAL.equals(attribute.getTypeName()) ||
-            attribute.getTypeID() == Types.OTHER ||
-            attribute.getTypeID() == Types.ARRAY ||
-            attribute.getTypeID() == Types.STRUCT)
+        if (PostgreUtils.isPGObject(value)
+            || PostgreConstants.TYPE_BIT.equals(attribute.getTypeName())
+            || PostgreConstants.TYPE_INTERVAL.equals(attribute.getTypeName())
+            || attribute.getTypeID() == Types.OTHER
+            || attribute.getTypeID() == Types.ARRAY
+            || attribute.getTypeID() == Types.STRUCT)
         {
             // TODO: we need to add value handlers for all PG data types.
             // For now we use workaround: represent objects as strings

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDialect.java
@@ -845,7 +845,9 @@ public class PostgreDialect extends JDBCSQLDialect implements TPRuleProvider, SQ
         if (PostgreUtils.isPGObject(value) ||
             PostgreConstants.TYPE_BIT.equals(attribute.getTypeName()) ||
             PostgreConstants.TYPE_INTERVAL.equals(attribute.getTypeName()) ||
-            attribute.getTypeID() == Types.OTHER)
+            attribute.getTypeID() == Types.OTHER ||
+            attribute.getTypeID() == Types.ARRAY ||
+            attribute.getTypeID() == Types.STRUCT)
         {
             // TODO: we need to add value handlers for all PG data types.
             // For now we use workaround: represent objects as strings

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreArrayValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreArrayValueHandler.java
@@ -103,7 +103,12 @@ public class PostgreArrayValueHandler extends JDBCArrayValueHandler {
                     return convertStringToCollection(session, type, itemType, (String) object);
                 }
             } else if (object instanceof Object[]) {
-                return new JDBCCollection(session.getProgressMonitor(), itemType, DBUtils.findValueHandler(session, itemType), (Object[]) object);
+                return new JDBCCollection(
+                    session.getProgressMonitor(),
+                    itemType,
+                    DBUtils.findValueHandler(session, itemType),
+                    (Object[]) object
+                );
             }
         }
         return super.getValueFromObject(session, type, object, copy, validateValue);
@@ -187,7 +192,12 @@ public class PostgreArrayValueHandler extends JDBCArrayValueHandler {
     }
 
     @NotNull
-    private static String getArrayMemberDisplayString(@NotNull DBSTypedObject type, @NotNull DBDValueHandler handler, @Nullable Object value, @NotNull DBDDisplayFormat format) {
+    private static String getArrayMemberDisplayString(
+        @NotNull DBSTypedObject type,
+        @NotNull DBDValueHandler handler,
+        @Nullable Object value,
+        @NotNull DBDDisplayFormat format
+    ) {
         if (DBUtils.isNullValue(value)) {
             return SQLConstants.NULL_VALUE;
         }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreStructValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreStructValueHandler.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.ext.postgresql.model.data;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.postgresql.PostgreUtils;
@@ -25,8 +26,10 @@ import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataType;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataTypeAttribute;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTypeType;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.data.DBDComposite;
 import org.jkiss.dbeaver.model.data.DBDDisplayFormat;
+import org.jkiss.dbeaver.model.data.DBDValueHandler;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.DBCSession;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
@@ -35,8 +38,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCStructImpl;
 import org.jkiss.dbeaver.model.impl.jdbc.data.JDBCComposite;
 import org.jkiss.dbeaver.model.impl.jdbc.data.JDBCCompositeStatic;
 import org.jkiss.dbeaver.model.impl.jdbc.data.handlers.JDBCStructValueHandler;
-import org.jkiss.dbeaver.model.sql.SQLUtils;
-import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 
 import java.sql.SQLException;
@@ -44,6 +46,7 @@ import java.sql.Struct;
 import java.sql.Types;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.StringJoiner;
 
 /**
  * PostgreArrayValueHandler
@@ -111,14 +114,61 @@ public class PostgreStructValueHandler extends JDBCStructValueHandler {
     @NotNull
     @Override
     public synchronized String getValueDisplayString(@NotNull DBSTypedObject column, Object value, @NotNull DBDDisplayFormat format) {
-        if (format == DBDDisplayFormat.NATIVE && value instanceof DBDComposite && column instanceof DBSObject) {
-            final DBDComposite struct = (DBDComposite) value;
-            if (!struct.isNull() && struct instanceof JDBCComposite) {
-                final Object[] values = ((JDBCComposite) struct).getValues();
-                return SQLUtils.quoteString((DBSObject) column, PostgreValueParser.generateObjectString(values));
+        if (!DBUtils.isNullValue(value) && value instanceof JDBCComposite) {
+            final JDBCComposite composite = (JDBCComposite) value;
+            final StringJoiner output = new StringJoiner(",", "(", ")");
+
+            for (DBSAttributeBase attribute : composite.getAttributes()) {
+                final DBDValueHandler handler = DBUtils.findValueHandler(composite.getDataType().getDataSource(), attribute);
+                final Object item = composite.getAttributeValue(attribute);
+                final String member = getStructMemberDisplayString(attribute, handler, item);
+
+                output.add(member);
+            }
+
+            return output.toString();
+        }
+
+        return super.getValueDisplayString(column, value, format);
+    }
+
+    @NotNull
+    private static String getStructMemberDisplayString(@NotNull DBSTypedObject type, @NotNull DBDValueHandler handler, @Nullable Object value) {
+        if (DBUtils.isNullValue(value)) {
+            return "";
+        }
+
+        final String string = handler.getValueDisplayString(type, value, DBDDisplayFormat.NATIVE);
+
+        if (isQuotingRequired(string)) {
+            return '"' + string.replace("\"", "\"\"") + '"';
+        }
+
+        return string;
+    }
+
+    /**
+     * @see <a href="https://www.postgresql.org/docs/current/rowtypes.html#ROWTYPES-IO-SYNTAX">8.16.6. Composite Type Input and Output Syntax</a>
+     */
+    private static boolean isQuotingRequired(@NotNull String value) {
+        if (value.isEmpty()) {
+            return true;
+        }
+
+        for (int index = 0; index < value.length(); index++) {
+            switch (value.charAt(index)) {
+                case '(':
+                case ')':
+                case '"':
+                case ',':
+                case '\\':
+                    return true;
+                default:
+                    break;
             }
         }
-        return super.getValueDisplayString(column, value, format);
+
+        return false;
     }
 
     private JDBCCompositeStatic convertStringToStruct(@NotNull DBCSession session, @NotNull PostgreDataType compType, @NotNull String value) throws DBException {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreStructValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreStructValueHandler.java
@@ -133,7 +133,11 @@ public class PostgreStructValueHandler extends JDBCStructValueHandler {
     }
 
     @NotNull
-    private static String getStructMemberDisplayString(@NotNull DBSTypedObject type, @NotNull DBDValueHandler handler, @Nullable Object value) {
+    private static String getStructMemberDisplayString(
+        @NotNull DBSTypedObject type,
+        @NotNull DBDValueHandler handler,
+        @Nullable Object value
+    ) {
         if (DBUtils.isNullValue(value)) {
             return "";
         }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCComposite.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/JDBCComposite.java
@@ -173,8 +173,7 @@ public abstract class JDBCComposite implements DBDComposite, DBDValueCloneable {
 
     @Nullable
     @Override
-    public Object getAttributeValue(@NotNull DBSAttributeBase attribute) throws DBCException
-    {
+    public Object getAttributeValue(@NotNull DBSAttributeBase attribute) {
         int position = attribute.getOrdinalPosition();
         if (position >= values.length) {
             log.debug("Attribute index is out of range (" + position + ">=" + values.length + ")");


### PR DESCRIPTION
Now structs are also compatible with the output of `psql`.

Several test cases:

```sql
create type pair as (a int[], b int[]);
select array[row(array[1,2,3], array[4,5,6])::pair, row(array[1,2,3], NULL)::pair]::pair[];
```

```sql
create type a as (a text);
select row(null)::a, row('')::a, row('"')::a, row('()')::a;
```

