### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/commit-msgs-validator.yml
+++ b/.github/workflows/commit-msgs-validator.yml
@@ -12,6 +12,11 @@ on:
       - ready_for_review
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   check-commit-message:
+    permissions:
+      contents: none
     uses: dbeaver/dbeaver/.github/workflows/reused-commit-msgs-validator.yml@devel

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - devel
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
