### PR TITLE
#15695 use default value in "table" pattern file name 

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DTConstants.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DTConstants.java
@@ -26,4 +26,5 @@ public class DTConstants {
 
     public static final String PRODUCT_FEATURE_SIMPLE_DATA_TRANSFER = "simpleDataTransfer";
 
+    public static final String DEFAULT_TABLE_NAME_EXPORT = "export";
 }

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DTUtils.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DTUtils.java
@@ -98,6 +98,28 @@ public class DTUtils {
         }
     }
 
+
+    /**
+     * Use this method for the export cases. E.g. if "table" used as a pattern
+     * and you do not want to see all statement for query with JOINs etc. instead of clear table name.
+     * Methods returns default value in this case.
+     *
+     * @param dataSource dataSource
+     * @param queryContainer not nullable query container
+     * @return table name founded in the query or default name
+     */
+    public static String getTableNameFromQueryContainer(DBPDataSource dataSource, @NotNull SQLQueryContainer queryContainer) {
+        if (dataSource == null) {
+            return DTConstants.DEFAULT_TABLE_NAME_EXPORT;
+        }
+        String nameFromQuery = DTUtils.getTableNameFromQuery(dataSource, queryContainer, true);
+        if (CommonUtils.isEmpty(nameFromQuery)) {
+            // Use default pattern name for this case, not the all statement
+            return DTConstants.DEFAULT_TABLE_NAME_EXPORT;
+        }
+        return nameFromQuery;
+    }
+
     public static String getTableNameFromQuery(DBPDataSource dataSource, SQLQueryContainer queryContainer, boolean shortName) {
         SQLScriptElement query = queryContainer.getQuery();
         if (query instanceof SQLQuery) {
@@ -135,26 +157,6 @@ public class DTUtils {
         }
         DBPIdentifierCase identifierCase = dialect.storesUnquotedCase();
         return identifierCase.transform(name);
-    }
-
-    @NotNull
-    public static List<DBSAttributeBase> getSourceAndTargetAttributes(@NotNull DBRProgressMonitor monitor, @NotNull DBSEntity target, @NotNull DBSDataContainer container, @NotNull Object controller) throws DBException {
-        // In some cases, we need a list of target columns with the list of source columns
-        final List<DBSAttributeBase> attributes = new ArrayList<>();
-        for (DBSEntityAttribute attr : CommonUtils.safeList(target.getAttributes(monitor))) {
-            if (DBUtils.isHiddenObject(attr)) {
-                continue;
-            }
-            attributes.add(attr);
-        }
-        List<DBSAttributeBase> sourceAttributes = getAttributes(monitor, container, controller);
-        for (DBSAttributeBase attribute : sourceAttributes) {
-            boolean match = attributes.stream().anyMatch(attr -> attr.getName().equalsIgnoreCase(attribute.getName())); // Usually we ignore attributes names case in Data Transfer process
-            if (!match) {
-                attributes.add(attribute);
-            }
-        }
-        return attributes;
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/StreamTransferConsumer.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/StreamTransferConsumer.java
@@ -38,6 +38,7 @@ import org.jkiss.dbeaver.model.struct.rdb.DBSSchema;
 import org.jkiss.dbeaver.model.task.DBTTask;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.runtime.serialize.DBPObjectSerializer;
+import org.jkiss.dbeaver.tools.transfer.DTConstants;
 import org.jkiss.dbeaver.tools.transfer.DTUtils;
 import org.jkiss.dbeaver.tools.transfer.IDataTransferConsumer;
 import org.jkiss.dbeaver.tools.transfer.IDataTransferEventProcessor;
@@ -595,10 +596,13 @@ public class StreamTransferConsumer implements IDataTransferConsumer<StreamConsu
                 }
                 case VARIABLE_TABLE: {
                     if (settings.isUseSingleFile()) {
-                        return "export";
+                        return DTConstants.DEFAULT_TABLE_NAME_EXPORT;
                     }
                     if (dataContainer == null) {
                         return null;
+                    }
+                    if (dataContainer instanceof SQLQueryContainer) {
+                        return DTUtils.getTableNameFromQueryContainer(dataContainer.getDataSource(), (SQLQueryContainer) dataContainer);
                     }
                     String tableName = DTUtils.getTableName(dataContainer.getDataSource(), dataContainer, true);
                     return stripObjectName(tableName);

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterSQL.java
@@ -26,6 +26,7 @@ import org.jkiss.dbeaver.model.exec.DBCSession;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.sql.SQLConstants;
 import org.jkiss.dbeaver.model.sql.SQLDialect;
+import org.jkiss.dbeaver.model.sql.SQLQueryContainer;
 import org.jkiss.dbeaver.model.sql.SQLUtils;
 import org.jkiss.dbeaver.model.sql.parser.SQLIdentifierDetector;
 import org.jkiss.dbeaver.model.struct.DBSDataManipulator;
@@ -42,7 +43,6 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Stream;
 
 /**
  * SQL Exporter
@@ -186,7 +186,11 @@ public class DataExporterSQL extends StreamExporterAbstract implements IAppendab
         }
         columns = getSite().getAttributes();
         DBPNamedObject source = getSite().getSource();
-        tableName = DTUtils.getTableName(session.getDataSource(), source, omitSchema);
+        if (source instanceof SQLQueryContainer) {
+            tableName = DTUtils.getTableNameFromQueryContainer(session.getDataSource(), (SQLQueryContainer) source);
+        } else {
+            tableName = DTUtils.getTableName(session.getDataSource(), source, omitSchema);
+        }
 
         rowCount = 0;
     }


### PR DESCRIPTION
for sql queries transfer and in SQL export

getSourceAndTargetAttributes method removed (doesn't need anymore)

![2022-06-16 13_31_11-export_202206161330 sql — H__asya_special_dbeaver_backup — Atom](https://user-images.githubusercontent.com/45152336/174058066-201378d5-a4be-4169-94a6-3370e772c2e6.png)

![2022-06-16 13_05_33-DBeaver Ultimate 22 1 0 - _DBeaver Sample Database (SQLite)_Script-165](https://user-images.githubusercontent.com/45152336/174058059-6b84ada2-c1ad-42a7-af3b-eeafeef7bd62.png)

