### PR TITLE
#14537 fix selected columns export to another database

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferConsumer.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferConsumer.java
@@ -307,7 +307,11 @@ public class DatabaseTransferConsumer implements IDataTransferConsumer<DatabaseC
                 if (column.sourceAttr instanceof DBDAttributeBindingCustom) {
                     attrValue = DBUtils.getAttributeValue(column.sourceAttr, sourceBindings, rowValues);
                 } else {
-                    attrValue = column.sourceValueHandler.fetchValueObject(session, resultSet, column.sourceAttr, i);
+                    attrValue = column.sourceValueHandler.fetchValueObject(
+                        session,
+                        resultSet,
+                        column.sourceAttr,
+                        column.sourceAttr.getOrdinalPosition());
                 }
             } else {
                 // No value handler - get raw value


### PR DESCRIPTION
Please test it attentively

- Tables with hidden columns
- Tables with changed order columns
- Document-Based data bases
- Export from SQL editor - different type of queries
- All with and without "selected columns only" setting