### PR TITLE
#15369 Fix sql script parameters handling

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -676,7 +676,7 @@ public class SQLScriptParser {
             if (tokenType == SQLTokenType.T_PARAMETER && tokenLength > 0) {
                 try {
                     String paramName = document.get(tokenOffset, tokenLength);
-                    if (!supportParamsInEmbeddedCode && ddlQuery || insideDollarQuote) {
+                    if (!supportParamsInEmbeddedCode && (ddlQuery || insideDollarQuote)) {
                         continue;
                     }
                     if (execQuery && paramName.equals(String.valueOf(syntaxManager.getAnonymousParameterMark()))) {


### PR DESCRIPTION
To be tested on statements like:
`select $$ $a $$;`
`CREATE TEMPORARY TABLE tmpTest SELECT :row_id AS id , :title AS title , NOW() AS created;`
with `Enable parameters in DDL and $$..$$ blocks` and `Show $$ quote` set to `Code block`

In other preferences combinations it should not show Bind parameters dialog.

For simple cases like `select $a` dialog should be shown when `Enable SQL parameters` enabled.

