### PR TITLE
#15777 Throw exception on invalid quote sequence for csv import

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/importer/DataImporterCSV.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/importer/DataImporterCSV.java
@@ -226,6 +226,9 @@ public class DataImporterCSV extends StreamImporterAbstract {
                         }
                         String[] line = csvReader.readNext();
                         if (line == null) {
+                            if (csvReader.getParser().isPending()) {
+                                throw new IOException("Un-terminated quote sequence was detected");
+                            }
                             break;
                         }
                         if (line.length == 0) {


### PR DESCRIPTION
Please, test for different cases.

Should throw with this data when `\` is an escape char in import preferences
```
1,"ABC ""Z"" MTK",4
2,"AR ""Z"" MTK\",5
3,"AB ""Z"" MTK",6
```
![image](https://user-images.githubusercontent.com/28875055/178451151-09815529-c950-4bde-8290-9b999f5d3a49.png)
