### PR TITLE
#14436 Improve support for view edit for Clickhouse

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/edit/ClickhouseViewManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/edit/ClickhouseViewManager.java
@@ -16,8 +16,8 @@
  */
 package org.jkiss.dbeaver.ext.clickhouse.edit;
 
-import java.util.*;
-
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.clickhouse.model.ClickhouseView;
 import org.jkiss.dbeaver.ext.generic.GenericConstants;
 import org.jkiss.dbeaver.ext.generic.edit.GenericViewManager;
@@ -33,6 +33,8 @@ import org.jkiss.dbeaver.model.impl.sql.edit.SQLObjectEditor;
 import org.jkiss.dbeaver.model.impl.sql.edit.struct.SQLTableManager;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 
+import java.util.*;
+
 /**
  * Clickhouse table manager
  */
@@ -43,24 +45,33 @@ public class ClickhouseViewManager extends GenericViewManager {
         return "TABLE";
     }
     
+    @NotNull
     @Override
     protected GenericTableBase createDatabaseObject(
-        DBRProgressMonitor monitor, DBECommandContext context, Object container, Object copyFrom, Map<String, Object> options
+        @NotNull DBRProgressMonitor monitor,
+        @Nullable DBECommandContext context,
+        @NotNull Object container,
+        @Nullable Object copyFrom, 
+        @Nullable Map<String, Object> options
     ) {
         GenericStructContainer structContainer = (GenericStructContainer) container;
         String tableName = getNewChildName(monitor, structContainer, SQLTableManager.BASE_VIEW_NAME);
         GenericTableBase viewImpl = structContainer.getDataSource().getMetaModel()
             .createTableImpl(structContainer, tableName, GenericConstants.TABLE_TYPE_VIEW, null);
         if (viewImpl instanceof GenericView) {
-            ((GenericView) viewImpl).setObjectDefinitionText("CREATE OR REPLACE VIEW " + viewImpl.getFullyQualifiedName(DBPEvaluationContext.DDL) + " AS SELECT 1 as A\n");
+            ((GenericView) viewImpl).setObjectDefinitionText(
+                "CREATE OR REPLACE VIEW " + viewImpl.getFullyQualifiedName(DBPEvaluationContext.DDL) + " AS SELECT 1 as A\n");
         }
         return viewImpl;
     }
 
     @Override
     protected void addObjectModifyActions(
-        DBRProgressMonitor monitor, DBCExecutionContext executionContext, List<DBEPersistAction> actionList, SQLObjectEditor<GenericTableBase,
-        GenericStructContainer>.ObjectChangeCommand command, Map<String, Object> options
+        @Nullable DBRProgressMonitor monitor,
+        @Nullable DBCExecutionContext executionContext,
+        @NotNull List<DBEPersistAction> actionList, 
+        @NotNull SQLObjectEditor<GenericTableBase, GenericStructContainer>.ObjectChangeCommand command,
+        @Nullable Map<String, Object> options
     ) {
         final ClickhouseView view = (ClickhouseView) command.getObject();
         String sql = view.getDDL();

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/edit/ClickhouseViewManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/edit/ClickhouseViewManager.java
@@ -16,17 +16,57 @@
  */
 package org.jkiss.dbeaver.ext.clickhouse.edit;
 
+import java.util.*;
+
+import org.jkiss.dbeaver.ext.clickhouse.model.ClickhouseView;
+import org.jkiss.dbeaver.ext.generic.GenericConstants;
 import org.jkiss.dbeaver.ext.generic.edit.GenericViewManager;
+import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
+import org.jkiss.dbeaver.ext.generic.model.GenericView;
+import org.jkiss.dbeaver.model.*;
+import org.jkiss.dbeaver.model.edit.DBECommandContext;
+import org.jkiss.dbeaver.model.edit.DBEPersistAction;
+import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
+import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
+import org.jkiss.dbeaver.model.impl.sql.edit.SQLObjectEditor;
+import org.jkiss.dbeaver.model.impl.sql.edit.struct.SQLTableManager;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 
 /**
  * Clickhouse table manager
  */
 public class ClickhouseViewManager extends GenericViewManager {
 
-
     @Override
     protected String getDropViewType(GenericTableBase object) {
         return "TABLE";
+    }
+    
+    @Override
+    protected GenericTableBase createDatabaseObject(
+        DBRProgressMonitor monitor, DBECommandContext context, Object container, Object copyFrom, Map<String, Object> options
+    ) {
+        GenericStructContainer structContainer = (GenericStructContainer) container;
+        String tableName = getNewChildName(monitor, structContainer, SQLTableManager.BASE_VIEW_NAME);
+        GenericTableBase viewImpl = structContainer.getDataSource().getMetaModel()
+            .createTableImpl(structContainer, tableName, GenericConstants.TABLE_TYPE_VIEW, null);
+        if (viewImpl instanceof GenericView) {
+            ((GenericView) viewImpl).setObjectDefinitionText("CREATE OR REPLACE VIEW " + viewImpl.getFullyQualifiedName(DBPEvaluationContext.DDL) + " AS SELECT 1 as A\n");
+        }
+        return viewImpl;
+    }
+
+    @Override
+    protected void addObjectModifyActions(
+        DBRProgressMonitor monitor, DBCExecutionContext executionContext, List<DBEPersistAction> actionList, SQLObjectEditor<GenericTableBase,
+        GenericStructContainer>.ObjectChangeCommand command, Map<String, Object> options
+    ) {
+        final ClickhouseView view = (ClickhouseView) command.getObject();
+        String sql = view.getDDL();
+        if (sql.contains("CREATE") && !sql.contains("CREATE OR REPLACE")) {
+            sql = sql.replaceFirst("CREATE", "CREATE OR REPLACE");
+        }
+        actionList.add(new SQLDatabasePersistAction("Create view", sql));
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSQLDialect.java
@@ -71,8 +71,13 @@ public class ClickhouseSQLDialect extends GenericSQLDialect {
         "formatRow"
     };
     private static final String[] CLICKHOUSE_NONKEYWORDS = {
-            "DEFAULT",
-            "SYSTEM"
+        "DEFAULT",
+        "SYSTEM"
+    };
+
+    private static final String[] CLICKHOUSE_KEYWORDS = {
+        "COMMENT",
+        "REPLACE"
     };
 
     public ClickhouseSQLDialect() {
@@ -90,6 +95,7 @@ public class ClickhouseSQLDialect extends GenericSQLDialect {
             removeSQLKeyword(word);
         }
         addFunctions(Arrays.asList(CLICKHOUSE_FUNCTIONS));
+        addSQLKeywords(Arrays.asList(CLICKHOUSE_KEYWORDS));
 
         setIdentifierQuoteString(new String[][]{
             { "`", "`" },

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseView.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseView.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.ext.clickhouse.model;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
@@ -33,11 +34,13 @@ public class ClickhouseView extends GenericView
         super(container, tableName, tableType, dbResult);
     }
 
+    @NotNull
     @Override
-    public String generateTableUpdateBegin(String tableName) {
+    public String generateTableUpdateBegin(@NotNull String tableName) {
         return "ALTER TABLE " + tableName + " UPDATE ";
     }
     
+    @NotNull
     @Override
     public String generateTableUpdateSet() {
         return "";

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseView.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseView.java
@@ -33,4 +33,14 @@ public class ClickhouseView extends GenericView
         super(container, tableName, tableType, dbResult);
     }
 
+    @Override
+    public String generateTableUpdateBegin(String tableName) {
+        return "ALTER TABLE " + tableName + " UPDATE ";
+    }
+    
+    @Override
+    public String generateTableUpdateSet() {
+        return "";
+    }
+
 }


### PR DESCRIPTION
- fix view ddl editing (create or replace instead of create is generated for persist action on update)
![image](https://user-images.githubusercontent.com/28875055/178503834-2ba8366f-8a24-44db-9ec0-26cc2d77e612.png)

- fix sql for update view table (the following exception should be thrown for now)
![image](https://user-images.githubusercontent.com/28875055/178503118-f92a041e-1364-4d66-8406-1a77f6fed89b.png)
