### PR TITLE
#15153 Add `singleConnection` driver property and use one connection for editor and meta

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageMetaData.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageMetaData.java
@@ -73,6 +73,9 @@ public class PrefPageMetaData extends TargetPrefPage
             Group metadataGroup = UIUtils.createControlGroup(composite, CoreMessages.pref_page_database_general_group_metadata, 1, GridData.HORIZONTAL_ALIGN_BEGINNING, 0);
 
             separateMetaConnectionCheck = UIUtils.createCheckbox(metadataGroup, CoreMessages.pref_page_database_general_separate_meta_connection, CoreMessages.pref_page_database_general_separate_meta_connection_tip, false, 1);
+            if (getDataSourceContainer()!= null && getDataSourceContainer().isForceUseSingleConnection()) {
+                separateMetaConnectionCheck.setEnabled(false);
+            }
             caseSensitiveNamesCheck = UIUtils.createCheckbox(metadataGroup, CoreMessages.pref_page_database_general_checkbox_case_sensitive_names, CoreMessages.pref_page_database_general_checkbox_case_sensitive_names_tip, false, 1);
             readExpensiveCheck = UIUtils.createCheckbox(metadataGroup, CoreMessages.pref_page_database_general_checkbox_show_row_count, CoreMessages.pref_page_database_general_checkbox_show_row_count_tip, false, 1);
             serverSideFiltersCheck = UIUtils.createCheckbox(metadataGroup, CoreMessages.pref_page_database_general_server_side_object_filters, CoreMessages.pref_page_database_general_server_side_object_filters_tip, false, 1);

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageMetaData.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageMetaData.java
@@ -73,7 +73,7 @@ public class PrefPageMetaData extends TargetPrefPage
             Group metadataGroup = UIUtils.createControlGroup(composite, CoreMessages.pref_page_database_general_group_metadata, 1, GridData.HORIZONTAL_ALIGN_BEGINNING, 0);
 
             separateMetaConnectionCheck = UIUtils.createCheckbox(metadataGroup, CoreMessages.pref_page_database_general_separate_meta_connection, CoreMessages.pref_page_database_general_separate_meta_connection_tip, false, 1);
-            if (getDataSourceContainer()!= null && getDataSourceContainer().isForceUseSingleConnection()) {
+            if (getDataSourceContainer() != null && getDataSourceContainer().isForceUseSingleConnection()) {
                 separateMetaConnectionCheck.setEnabled(false);
             }
             caseSensitiveNamesCheck = UIUtils.createCheckbox(metadataGroup, CoreMessages.pref_page_database_general_checkbox_case_sensitive_names, CoreMessages.pref_page_database_general_checkbox_case_sensitive_names_tip, false, 1);

--- a/plugins/org.jkiss.dbeaver.ext.bigquery/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.bigquery/plugin.xml
@@ -30,7 +30,8 @@
                         description="Google BigQuery driver"
                         webURL="https://cloud.google.com/bigquery/partners/simba-drivers/"
                         propertiesURL="https://cdn.simba.com/products/BigQuery/doc/JDBC_InstallGuide/"
-                        categories="bigdata">
+                        categories="bigdata"
+                        singleConnection="true">
                     <file type="jar" path="https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.2.21.1025.zip" bundle="!drivers.bigquery"/>/>
                     <file type="jar" path="drivers/bigquery" bundle="drivers.bigquery"/>/>
 

--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -690,7 +690,8 @@
                     webURL="http://phoenix.apache.org/"
                     description="Thin driver for Apache Phoenix HBase Database"
                     category="Hadoop"
-                    categories="hadoop">
+                    categories="hadoop"
+                    singleConnection="true">
                     <parameter name="omit-type-cache" value="true"/>
                     <file type="jar" path="maven:/org.apache.phoenix:phoenix-client:RELEASE[4.14.1-HBase-1.4]" ignore-dependencies="true"/>
                 </driver>
@@ -705,7 +706,8 @@
                     description="Pivotal GemfireXD"
                     webURL="http://blog.pivotal.io/tag/gemfire-xd"
                     category="Hadoop"
-                    categories="hadoop">
+                    categories="hadoop"
+                    singleConnection="true">
                     <file type="jar" path="maven:/io.snappydata:gemfirexd-client:RELEASE"/>
                 </driver>
                 <driver
@@ -719,7 +721,8 @@
                     description="Pivotal GemfireXD"
                     webURL="https://snappydatainc.github.io/snappydata/"
                     category="Hadoop"
-                    categories="hadoop">
+                    categories="hadoop"
+                    singleConnection="true">
                     <file type="jar" path="maven:/io.snappydata:snappydata-store-client:RELEASE"/>
                     <!--<file type="jar" path="https://github.com/SnappyDataInc/snappydata/releases/download/v0.8/snappydata-client-1.5.4.jar"/>-->
                 </driver>
@@ -735,7 +738,8 @@
                     description="Apache Hive JDBC"
                     webURL="https://cwiki.apache.org/confluence/display/Hive/Home"
                     category="Hadoop"
-                    categories="hadoop">
+                    categories="hadoop"
+                    singleConnection="true">
 
                     <file type="jar" path="https://github.com/timveil/hive-jdbc-uber-jar/releases/download/v1.9-2.6.5/hive-jdbc-uber-2.6.5.0-292.jar" bundle="!drivers.hive"/>
                     <file type="jar" path="drivers/hive" bundle="drivers.hive"/>
@@ -754,7 +758,8 @@
                     description="Spark Thrift Server connector"
                     webURL="https://jaceklaskowski.gitbooks.io/mastering-apache-spark/spark-sql-thrift-server.html"
                     category="Hadoop"
-                    categories="hadoop">
+                    categories="hadoop"
+                    singleConnection="true">
                     <file type="jar" path="maven:/org.spark-project.hive:hive-jdbc:RELEASE"/>
                     <file type="jar" path="maven:/org.apache.hadoop:hadoop-core:RELEASE"/>
 
@@ -772,7 +777,8 @@
                     description="Kyuubi Thrift Server connector"
                     webURL="https://kyuubi.apache.org/"
                     category="Hadoop"
-                    categories="hadoop">
+                    categories="hadoop"
+                    singleConnection="true">
                     <file type="jar" path="maven:/org.apache.kyuubi:kyuubi-hive-jdbc-shaded:RELEASE" bundle="!drivers.kyuubi"/>
                     <file type="jar" path="drivers/kyuubi" bundle="drivers.kyuubi"/>
 
@@ -789,7 +795,8 @@
                     description="Apache Drill JDBC"
                     webURL="http://drill.apache.org/docs/using-the-jdbc-driver/"
                     category="Hadoop"
-                    categories="hadoop">
+                    categories="hadoop"
+                    singleConnection="true">
                     <file type="jar" path="maven:/org.apache.drill.exec:drill-jdbc-all:RELEASE"/>
 
                     <parameter name="supports-truncate" value="false"/>

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/auth/SQLServerAuthModelMFA.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/auth/SQLServerAuthModelMFA.java
@@ -43,6 +43,7 @@ public class SQLServerAuthModelMFA extends SQLServerAuthModelAbstract {
     @Override
     public Object initAuthentication(@NotNull DBRProgressMonitor monitor, @NotNull DBPDataSource dataSource, AuthModelDatabaseNativeCredentials credentials, DBPConnectionConfiguration configuration, @NotNull Properties connProperties) throws DBException {
         connProperties.put(SQLServerConstants.PROP_CONNECTION_AUTHENTICATION, SQLServerConstants.AUTH_ACTIVE_DIRECTORY_INTERACTIVE);
+        dataSource.getContainer().setForceUseSingleConnection(true);
         return credentials;
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.spanner/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.spanner/plugin.xml
@@ -27,7 +27,8 @@
                         defaultPort=""
                         description="Google Cloud Spanner Open Source JDBC Driver"
                         webURL="https://cloud.google.com/spanner/docs/use-oss-jdbc"
-                        categories="sql,bigdata,cloud">
+                        categories="sql,bigdata,cloud"
+                        singleConnection="true">
                     <replace provider="google_spanner" driver="spanner_jdbc"/>
                     <parameter name="omit-catalog" value="true"/>
                     <parameter name="omit-schema" value="false"/>

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/connection/DBPDriver.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/connection/DBPDriver.java
@@ -108,6 +108,7 @@ public interface DBPDriver extends DBPNamedObject
     boolean supportsDriverProperties();
 
     boolean isEmbedded();
+    boolean isSingleConnection();
     boolean isAnonymousAccess();
     boolean isAllowsEmptyPassword();
     boolean isLicenseRequired();

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/connection/DBPDriver.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/connection/DBPDriver.java
@@ -108,7 +108,6 @@ public interface DBPDriver extends DBPNamedObject
     boolean supportsDriverProperties();
 
     boolean isEmbedded();
-    boolean isSingleConnection();
     boolean isAnonymousAccess();
     boolean isAllowsEmptyPassword();
     boolean isLicenseRequired();
@@ -116,6 +115,8 @@ public interface DBPDriver extends DBPNamedObject
     boolean isSampleURLApplicable();
     boolean isCustomEndpointInformation();
 
+    boolean isSingleConnection();
+    
     // Can be created
     boolean isInstantiable();
     // Driver shipped along with JDK/DBeaver, doesn't need any additional libraries. Basically it is ODBC driver.

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
@@ -89,8 +89,6 @@ public class DataSourceDescriptor
     public static final String CATEGORY_DRIVER = "Driver";
     public static final String CATEGORY_DRIVER_FILES = "Driver Files";
 
-    private static final String EDITOR_SEPARATE_CONNECTION = "database.editor.separate.connection";
-
     @NotNull
     private final DBPDataSourceRegistry registry;
     @NotNull
@@ -1492,8 +1490,6 @@ public class DataSourceDescriptor
 
     @Override
     public boolean isForceUseSingleConnection() {
-        getPreferenceStore().setDefault(ModelPreferences.META_SEPARATE_CONNECTION, false);
-        getPreferenceStore().setDefault(EDITOR_SEPARATE_CONNECTION, false);
         return this.forceUseSingleConnection;
     }
 

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceDescriptor.java
@@ -89,6 +89,8 @@ public class DataSourceDescriptor
     public static final String CATEGORY_DRIVER = "Driver";
     public static final String CATEGORY_DRIVER_FILES = "Driver Files";
 
+    private static final String EDITOR_SEPARATE_CONNECTION = "database.editor.separate.connection";
+
     @NotNull
     private final DBPDataSourceRegistry registry;
     @NotNull
@@ -940,6 +942,9 @@ public class DataSourceDescriptor
     }
 
     public void openDataSource(DBRProgressMonitor monitor, boolean initialize) throws DBException {
+        if (this.getDriver().isSingleConnection()) {
+            this.setForceUseSingleConnection(true);
+        }
         this.dataSource = getDriver().getDataSourceProvider().openDataSource(monitor, this);
         this.connectTime = new Date();
         monitor.worked(1);
@@ -1487,6 +1492,8 @@ public class DataSourceDescriptor
 
     @Override
     public boolean isForceUseSingleConnection() {
+        getPreferenceStore().setDefault(ModelPreferences.META_SEPARATE_CONNECTION, false);
+        getPreferenceStore().setDefault(EDITOR_SEPARATE_CONNECTION, false);
         return this.forceUseSingleConnection;
     }
 

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/RegistryConstants.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/RegistryConstants.java
@@ -89,6 +89,7 @@ public class RegistryConstants {
     public static final String ATTR_ANONYMOUS = "anonymous"; //$NON-NLS-1$
     public static final String ATTR_LICENSE_REQUIRED = "licenseRequired"; //$NON-NLS-1$
     public static final String ATTR_EMBEDDED = "embedded"; //$NON-NLS-1$
+    public static final String ATTR_SINGLE_CONNECTION = "singleConnection"; //$NON-NLS-1$
     public static final String ATTR_CUSTOM_DRIVER_LOADER = "customDriverLoader"; //$NON-NLS-1$
     public static final String ATTR_USE_URL_TEMPLATE = "useURL"; //$NON-NLS-1$
     public static final String ATTR_CUSTOM_ENDPOINT = "customEndpoint"; //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverDescriptor.java
@@ -155,6 +155,7 @@ public class DriverDescriptor extends AbstractDescriptor implements DBPDriver {
     private DBPImage iconError;
     private DBPImage iconBig;
     private boolean embedded, origEmbedded;
+    private boolean singleConnection;
     private boolean clientRequired;
     private boolean supportsDriverProperties;
     private boolean anonymousAccess, origAnonymousAccess;
@@ -262,6 +263,7 @@ public class DriverDescriptor extends AbstractDescriptor implements DBPDriver {
             this.webURL = copyFrom.webURL;
             this.propertiesWebURL = copyFrom.webURL;
             this.embedded = copyFrom.embedded;
+            this.singleConnection = copyFrom.singleConnection;
             this.clientRequired = copyFrom.clientRequired;
             this.supportsDriverProperties = copyFrom.supportsDriverProperties;
             this.anonymousAccess = copyFrom.anonymousAccess;
@@ -323,6 +325,7 @@ public class DriverDescriptor extends AbstractDescriptor implements DBPDriver {
         this.supportsDriverProperties = CommonUtils.getBoolean(config.getAttribute(RegistryConstants.ATTR_SUPPORTS_DRIVER_PROPERTIES), true);
         this.origInstantiable = this.instantiable = CommonUtils.getBoolean(config.getAttribute(RegistryConstants.ATTR_INSTANTIABLE), true);
         this.origEmbedded = this.embedded = CommonUtils.getBoolean(config.getAttribute(RegistryConstants.ATTR_EMBEDDED));
+        this.singleConnection = CommonUtils.getBoolean(config.getAttribute(RegistryConstants.ATTR_SINGLE_CONNECTION));
         this.origAnonymousAccess = this.anonymousAccess = CommonUtils.getBoolean(config.getAttribute(RegistryConstants.ATTR_ANONYMOUS));
         this.origAllowsEmptyPassword = this.allowsEmptyPassword = CommonUtils.getBoolean("allowsEmptyPassword");
         this.licenseRequired = CommonUtils.getBoolean(config.getAttribute(RegistryConstants.ATTR_LICENSE_REQUIRED));
@@ -768,6 +771,15 @@ public class DriverDescriptor extends AbstractDescriptor implements DBPDriver {
 
     public void setEmbedded(boolean embedded) {
         this.embedded = embedded;
+    }
+
+    @Override
+    public boolean isSingleConnection() {
+        return singleConnection;
+    }
+
+    public void setSingleConnection(boolean singleConnection) {
+        this.singleConnection = embedded;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/preferences/PrefPageSQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/preferences/PrefPageSQLEditor.java
@@ -96,7 +96,9 @@ public class PrefPageSQLEditor extends TargetPrefPage
             Group connectionsGroup = UIUtils.createControlGroup(composite, SQLEditorMessages.pref_page_sql_editor_group_connections, 1, GridData.VERTICAL_ALIGN_BEGINNING | GridData.FILL_HORIZONTAL, 0);
             ((GridData)connectionsGroup.getLayoutData()).horizontalSpan = 2;
             editorSeparateConnectionCheck = UIUtils.createCheckbox(connectionsGroup, SQLEditorMessages.pref_page_sql_editor_label_separate_connection_each_editor, false);
-
+            if (getDataSourceContainer()!= null && getDataSourceContainer().isForceUseSingleConnection()) {
+                editorSeparateConnectionCheck.setEnabled(false);
+            }
             connectOnActivationCheck = UIUtils.createCheckbox(connectionsGroup, SQLEditorMessages.pref_page_sql_editor_label_connect_on_editor_activation, false);
             connectOnExecuteCheck = UIUtils.createCheckbox(connectionsGroup, SQLEditorMessages.pref_page_sql_editor_label_connect_on_query_execute, false);
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/preferences/PrefPageSQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/preferences/PrefPageSQLEditor.java
@@ -96,7 +96,7 @@ public class PrefPageSQLEditor extends TargetPrefPage
             Group connectionsGroup = UIUtils.createControlGroup(composite, SQLEditorMessages.pref_page_sql_editor_group_connections, 1, GridData.VERTICAL_ALIGN_BEGINNING | GridData.FILL_HORIZONTAL, 0);
             ((GridData)connectionsGroup.getLayoutData()).horizontalSpan = 2;
             editorSeparateConnectionCheck = UIUtils.createCheckbox(connectionsGroup, SQLEditorMessages.pref_page_sql_editor_label_separate_connection_each_editor, false);
-            if (getDataSourceContainer()!= null && getDataSourceContainer().isForceUseSingleConnection()) {
+            if (getDataSourceContainer() != null && getDataSourceContainer().isForceUseSingleConnection()) {
                 editorSeparateConnectionCheck.setEnabled(false);
             }
             connectOnActivationCheck = UIUtils.createCheckbox(connectionsGroup, SQLEditorMessages.pref_page_sql_editor_label_connect_on_editor_activation, false);


### PR DESCRIPTION
Added for:
- SQLServer Azure AD MFA
- BigQuery
- BigTable
- Spanner
- Apache Hadoop, Apache Drill, Apache Kyuubi, Apache Spark, Apache Hive, SnappyData, Gemfire XD, Apache Phoenix
- Redshift

https://github.com/dbeaver/dbeaver-ee/pull/1776