### PR TITLE
#17070 fix Oracle null/not null column modifier

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleTableColumnManager.java
@@ -85,7 +85,7 @@ public class OracleTableColumnManager extends SQLTableColumnManager<OracleTableC
 
     protected ColumnModifier[] getSupportedModifiers(OracleTableColumn column, Map<String, Object> options)
     {
-        return new ColumnModifier[] {OracleDataTypeModifier, DefaultModifier, NullNotNullModifierConditional};
+        return new ColumnModifier[] {OracleDataTypeModifier, DefaultModifier, NullNotNullModifier};
     }
 
     @Override

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/OracleAlterTableColumnTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/OracleAlterTableColumnTest.java
@@ -96,7 +96,7 @@ public class OracleAlterTableColumnTest {
         List<DBEPersistAction> actions = DBExecUtils.getActionsListFromCommandContext(monitor, commandContext, executionContext, Collections.emptyMap(), null);
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
-        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE ADD COLUMN4 INTEGER;" + lineBreak;
+        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE ADD COLUMN4 INTEGER NULL;" + lineBreak;
 
         Assert.assertEquals(script, expectedDDL);
     }
@@ -145,7 +145,8 @@ public class OracleAlterTableColumnTest {
 
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
-        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN1 VARCHAR(100) DEFAULT 'Test value';" + lineBreak;
+        String expectedDDL =
+            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN1 VARCHAR(100) DEFAULT 'Test value' NULL;" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -161,7 +162,8 @@ public class OracleAlterTableColumnTest {
 
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
-        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(38,0) DEFAULT 42;" + lineBreak;
+        String expectedDDL =
+            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(38,0) DEFAULT 42 NULL;" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -178,7 +180,8 @@ public class OracleAlterTableColumnTest {
 
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
-        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN1 VARCHAR(50) DEFAULT 'Test value';" + lineBreak;
+        String expectedDDL =
+            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN1 VARCHAR(50) DEFAULT 'Test value' NULL;" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -194,7 +197,7 @@ public class OracleAlterTableColumnTest {
 
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
-        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN3 CHAR(33);" + lineBreak;
+        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN3 CHAR(33) NULL;" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -210,7 +213,7 @@ public class OracleAlterTableColumnTest {
 
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
-        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(22,0);" + lineBreak;
+        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(22,0) NULL;" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -227,7 +230,8 @@ public class OracleAlterTableColumnTest {
 
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
-        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(38,17) DEFAULT 42;" + lineBreak;
+        String expectedDDL =
+            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(38,17) DEFAULT 42 NULL;" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/OracleBaseTableTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/OracleBaseTableTest.java
@@ -27,6 +27,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCRemoteInstance;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.sql.SQLUtils;
 import org.jkiss.dbeaver.model.struct.DBSEntityConstraintType;
+import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.runtime.properties.PropertySourceEditable;
 import org.jkiss.utils.StandardConstants;
@@ -97,9 +98,45 @@ public class OracleBaseTableTest {
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
         String expectedDDL = "CREATE TABLE TEST_SCHEMA.\"NewTable\" (" + lineBreak +
-                "\tCOLUMN1 INTEGER," + lineBreak +
-                "\tCOLUMN2 INTEGER" + lineBreak +
+                "\tCOLUMN1 INTEGER NULL," + lineBreak +
+                "\tCOLUMN2 INTEGER NULL" + lineBreak +
                 ");" + lineBreak;
+
+        Assert.assertEquals(script, expectedDDL);
+    }
+
+    @Test
+    public void generateCreateTableWithTwoColumnsOneNullableStatement() throws Exception {
+        TestCommandContext commandContext = new TestCommandContext(executionContext, false);
+
+        OracleTable newObject = objectMaker.createNewObject(
+            monitor,
+            commandContext,
+            testSchema,
+            null,
+            Collections.emptyMap());
+        DBEObjectMaker objectManager = OracleTestUtils.getManagerForClass(OracleTableColumn.class);
+        objectManager.createNewObject(monitor, commandContext, newObject, null, Collections.emptyMap());
+        final DBSObject newColumn =
+            objectManager.createNewObject(monitor, commandContext, newObject, null, Collections.emptyMap());
+        if (newColumn instanceof OracleTableColumn) {
+            ((OracleTableColumn) newColumn).setRequired(true);
+        }
+        List<DBEPersistAction> actions = DBExecUtils.getActionsListFromCommandContext(
+            monitor,
+            commandContext,
+            executionContext,
+            Collections.emptyMap(),
+            null);
+        String script = SQLUtils.generateScript(
+            testDataSource,
+            actions.toArray(new DBEPersistAction[0]),
+            false);
+
+        String expectedDDL = "CREATE TABLE TEST_SCHEMA.\"NewTable\" (" + lineBreak +
+            "\tCOLUMN1 INTEGER NULL," + lineBreak +
+            "\tCOLUMN2 INTEGER NOT NULL" + lineBreak +
+            ");" + lineBreak;
 
         Assert.assertEquals(script, expectedDDL);
     }
@@ -123,8 +160,8 @@ public class OracleBaseTableTest {
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
         String expectedDDL = "CREATE TABLE TEST_SCHEMA.\"NewTable\" (" + lineBreak +
-                "\tCOLUMN1 INTEGER," + lineBreak +
-                "\tCOLUMN2 INTEGER," + lineBreak +
+                "\tCOLUMN1 INTEGER NULL," + lineBreak +
+                "\tCOLUMN2 INTEGER NULL," + lineBreak +
                 "\tCONSTRAINT NEWTABLE_PK PRIMARY KEY (COLUMN1)" + lineBreak +
                 ");" + lineBreak;
 
@@ -146,8 +183,8 @@ public class OracleBaseTableTest {
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
         String expectedDDL = "CREATE TABLE TEST_SCHEMA.\"NewTable\" (" + lineBreak +
-                "\tCOLUMN1 INTEGER," + lineBreak +
-                "\tCOLUMN2 INTEGER" + lineBreak +
+                "\tCOLUMN1 INTEGER NULL," + lineBreak +
+                "\tCOLUMN2 INTEGER NULL" + lineBreak +
                 ");" + lineBreak +
                 "COMMENT ON COLUMN TEST_SCHEMA.\"NewTable\".COLUMN1 IS 'Test comment 1';" + lineBreak +
                 "COMMENT ON COLUMN TEST_SCHEMA.\"NewTable\".COLUMN2 IS 'Test comment 2';" + lineBreak;


### PR DESCRIPTION
![2022-07-13 15_05_26-NEWTABLE_2 - Persist Changes](https://user-images.githubusercontent.com/45152336/178750911-7ea09ad8-8b2f-4aed-b77a-63edda307fc0.png)

The creation of new tables and editing of existing ones should be tested.
