### PR TITLE
#14945 Composite types filtering and sorting

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataBoundTypeAttribute.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataBoundTypeAttribute.java
@@ -1,0 +1,88 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2022 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.*;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSAttributeEnumerable;
+import org.jkiss.dbeaver.model.struct.DBSContextBoundAttribute;
+import org.jkiss.dbeaver.model.struct.DBSEntityAttribute;
+
+import java.util.LinkedList;
+
+/**
+ * Provides information about context for data type attribute
+ */
+public class PostgreDataBoundTypeAttribute extends PostgreAttribute<PostgreTableBase>
+    implements DBSEntityAttribute, DBSAttributeEnumerable, DBSContextBoundAttribute {
+
+    private final DBSEntityAttribute context;
+    private final PostgreDataTypeAttribute member;
+    
+    public PostgreDataBoundTypeAttribute(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull PostgreTableBase container,
+        @NotNull DBSEntityAttribute context,
+        @NotNull PostgreDataTypeAttribute attr
+    ) throws DBException {
+        super(monitor, container, attr);
+        this.context = context;
+        this.member = attr;
+    }
+
+    @NotNull
+    @Override
+    public String formatMemberReference(
+        boolean isIncludeContainerName,
+        @Nullable String containerAliasOrNull,
+        @NotNull DBPAttributeReferencePurpose purpose
+    ) {
+        LinkedList<String> parts = new LinkedList<>();
+        parts.addLast(DBUtils.getQuotedIdentifier(member));
+        DBSEntityAttribute context = this.context;
+        while (context instanceof PostgreDataBoundTypeAttribute) {
+            PostgreDataBoundTypeAttribute boundAttr = (PostgreDataBoundTypeAttribute) context;
+            parts.addFirst(DBUtils.getQuotedIdentifier(boundAttr.member));
+            context = boundAttr.context;
+        } 
+        parts.addFirst(DBUtils.getQuotedIdentifier(context));
+        if (isIncludeContainerName) {
+            if (containerAliasOrNull == null) {
+                if (context.getParentObject() != this.getTable()) {
+                    parts.addFirst(DBUtils.getQuotedIdentifier(context.getParentObject()));
+                }
+                parts.addFirst(DBUtils.getObjectFullName(this.getTable(), DBPEvaluationContext.DML));
+            } else {
+                parts.addFirst(containerAliasOrNull);
+            }
+        }
+        if (purpose.equals(DBPAttributeReferencePurpose.DATA_SELECTION)) {
+            return "(".repeat(parts.size() - 1) + String.join(").", parts);
+        } else {
+            return String.join(".", parts);
+        }
+    }
+
+    @NotNull
+    @Override
+    public PostgreSchema getSchema() {
+        return member.getSchema();
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataType.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataType.java
@@ -48,8 +48,9 @@ import java.util.*;
 /**
  * PostgreTypeType
  */
-public class PostgreDataType extends JDBCDataType<PostgreSchema> implements PostgreClass, PostgreScriptObject, DBPQualifiedObject, DBPImageProvider
-{
+public class PostgreDataType extends JDBCDataType<PostgreSchema> 
+    implements PostgreClass, PostgreScriptObject, DBPQualifiedObject, DBPImageProvider, DBSBindableDataType {
+
     private static final Log log = Log.getLog(PostgreDataType.class);
 
     //private static final String CAT_MAIN = "Main";
@@ -530,6 +531,25 @@ public class PostgreDataType extends JDBCDataType<PostgreSchema> implements Post
     @Override
     public DBSEntityType getEntityType() {
         return DBSEntityType.TYPE;
+    }
+
+    @Nullable
+    @Override
+    public List<? extends DBSContextBoundAttribute> bindAttributesToContext(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull DBSEntity dataContainer,
+        @NotNull DBSEntityAttribute memberContext
+    ) throws DBException {
+        List<PostgreDataTypeAttribute> attrs = this.getAttributes(monitor);
+        if (attrs == null) {
+            return null;
+        }
+    
+        List<PostgreDataBoundTypeAttribute> boundAttrs = new ArrayList<>(attrs.size());
+        for (PostgreDataTypeAttribute attr : attrs) {
+            boundAttrs.add(new PostgreDataBoundTypeAttribute(monitor, (PostgreTableBase) dataContainer, memberContext, attr));
+        }
+        return boundAttrs;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPAttributeReferencePurpose.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPAttributeReferencePurpose.java
@@ -1,0 +1,23 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2022 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model;
+
+public enum DBPAttributeReferencePurpose {
+    UPDATE_TARGET,
+    DATA_SELECTION,
+    UNSPECIFIED
+}

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBUtils.java
@@ -72,13 +72,43 @@ public final class DBUtils {
     @NotNull
     public static String getQuotedIdentifier(@NotNull DBPNamedObject object)
     {
-        return object instanceof DBSObject ? getQuotedIdentifier(((DBSObject) object).getDataSource(), object.getName()) : object.getName();
+        if (object instanceof DBSContextBoundAttribute) {
+            return ((DBSContextBoundAttribute) object).formatMemberReference(false, null, DBPAttributeReferencePurpose.UNSPECIFIED);
+        } else {
+            return object instanceof DBSObject 
+                ? getQuotedIdentifier(((DBSObject) object).getDataSource(), object.getName()) 
+                : object.getName();
+        }
+    }
+    /**
+     * Get object name in quotes if they are needed.
+
+     * @param object to get identifier of
+     * @return object identifier
+     */
+    @NotNull
+    public static String getQuotedIdentifier(@NotNull DBSObject object) {
+        if (object instanceof DBSContextBoundAttribute) {
+            return ((DBSContextBoundAttribute) object).formatMemberReference(false, null, DBPAttributeReferencePurpose.UNSPECIFIED);
+        } else {
+            return getQuotedIdentifier(object.getDataSource(), object.getName());
+        }
     }
 
+    /**
+     * Get object name in quotes if they are needed.
+
+     * @param object to get identifier of
+     * @param purpose of identifier usage
+     * @return object identifier
+     */
     @NotNull
-    public static String getQuotedIdentifier(@NotNull DBSObject object)
-    {
-        return getQuotedIdentifier(object.getDataSource(), object.getName());
+    public static String getQuotedIdentifier(@NotNull DBSObject object, @NotNull DBPAttributeReferencePurpose purpose) {
+        if (object instanceof DBSContextBoundAttribute) {
+            return ((DBSContextBoundAttribute) object).formatMemberReference(false, null, purpose);
+        } else {
+            return getQuotedIdentifier(object.getDataSource(), object.getName());
+        }
     }
 
     public static boolean isQuotedIdentifier(@NotNull DBPDataSource dataSource, @NotNull String str) {
@@ -1610,16 +1640,47 @@ public final class DBUtils {
         if (object instanceof DBPQualifiedObject) {
             return ((DBPQualifiedObject) object).getFullyQualifiedName(context);
         } else if (object instanceof DBSObject && ((DBSObject) object).getDataSource() != null) {
-            return getObjectFullName(((DBSObject) object).getDataSource(), object, context);
+            return getObjectFullName(((DBSObject) object).getDataSource(), object, context, DBPAttributeReferencePurpose.UNSPECIFIED);
         } else {
             return object.getName();
         }
     }
+    
+    /**
+     * Get the full name of the object.
 
+     * @param dataSource container
+     * @param object object to get name of
+     * @param context evaluation context
+     * @return full name of the object
+     */
     @NotNull
-    public static String getObjectFullName(@NotNull DBPDataSource dataSource, @NotNull DBPNamedObject object, DBPEvaluationContext context)
+    public static String getObjectFullName(
+        @NotNull DBPDataSource dataSource,
+        @NotNull DBPNamedObject object, 
+        @NotNull DBPEvaluationContext context) {
+        return getObjectFullName(dataSource, object, context, DBPAttributeReferencePurpose.UNSPECIFIED);
+    }
+
+    /**
+     * Get the full name of the object.
+
+     * @param dataSource container
+     * @param object object to get name of
+     * @param context evaluation context
+     * @param purpose to use object name to
+     * @return full name of the object
+     */
+    @NotNull
+    public static String getObjectFullName(
+        @NotNull DBPDataSource dataSource,
+        @NotNull DBPNamedObject object, 
+        @NotNull DBPEvaluationContext context,
+        @NotNull DBPAttributeReferencePurpose purpose)
     {
-        if (object instanceof DBPQualifiedObject) {
+        if (object instanceof DBDAttributeBinding) {
+            return ((DBDAttributeBinding) object).getFullyQualifiedName(context, purpose);
+        } else if (object instanceof DBPQualifiedObject) {
             return ((DBPQualifiedObject) object).getFullyQualifiedName(context);
         } else {
             return getQuotedIdentifier(dataSource, object.getName());

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDAttributeBinding.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDAttributeBinding.java
@@ -221,6 +221,22 @@ public abstract class DBDAttributeBinding implements DBSObject, DBSAttributeBase
     @NotNull
     @Override
     public String getFullyQualifiedName(DBPEvaluationContext context) {
+        return getFullyQualifiedName(context, DBPAttributeReferencePurpose.UNSPECIFIED);
+    }
+
+    /**
+     * Entity full qualified name.
+     * Should include all parent objects' names and thus uniquely identify this entity within database.
+
+     * @param context evaluation context
+     * @param purpose of name usage
+     * @return full qualified name, never returns null.
+     */
+    @NotNull
+    public String getFullyQualifiedName(DBPEvaluationContext context, @NotNull DBPAttributeReferencePurpose purpose) {
+        if (this.getEntityAttribute() instanceof DBSContextBoundAttribute) {
+            return DBUtils.getQuotedIdentifier(this.getEntityAttribute(), purpose);
+        }
         final DBPDataSource dataSource = getDataSource();
         if (getParentObject() == null) {
             return DBUtils.getQuotedIdentifier(dataSource, getName());

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDDataFilter.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDDataFilter.java
@@ -290,7 +290,7 @@ public class DBDDataFilter {
     public boolean hasNameDuplicates(String name) {
         int count = 0;
         for (DBDAttributeConstraint c : constraints) {
-            if (name.equalsIgnoreCase(c.getAttributeName())) {
+            if (name.equalsIgnoreCase(c.getFullAttributeName())) {
                 count++;
             }
         }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/transformers/ArrayAttributeTransformer.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/transformers/ArrayAttributeTransformer.java
@@ -49,7 +49,7 @@ public class ArrayAttributeTransformer implements DBDAttributeTransformer {
         if (collectionType != null) {
             DBSDataType componentType = collectionType.getComponentType(session.getProgressMonitor());
             if (componentType instanceof DBSEntity) {
-                ComplexTypeAttributeTransformer.createNestedTypeBindings(session, attribute, rows, (DBSEntity) componentType);
+                ComplexTypeAttributeTransformer.createNestedTypeBindings(session, attribute, rows, componentType);
                 return;
             }
         }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCTableColumn.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCTableColumn.java
@@ -181,7 +181,7 @@ public abstract class JDBCTableColumn<TABLE_TYPE extends DBSEntity> extends JDBC
         boolean formatValues,
         boolean caseInsensitiveSearch) throws DBException
     {
-        final String identifier = DBUtils.getQuotedIdentifier(this);
+        final String identifier = DBUtils.getQuotedIdentifier(this, DBPAttributeReferencePurpose.DATA_SELECTION);
         DBDValueHandler valueHandler = DBUtils.findValueHandler(session, this);
         StringBuilder query = new StringBuilder();
         query.append("SELECT ");
@@ -244,7 +244,7 @@ public abstract class JDBCTableColumn<TABLE_TYPE extends DBSEntity> extends JDBC
     @Override
     public Long getDistinctValuesCount(@NotNull DBCSession session) throws DBException {
         final String query
-            = "SELECT COUNT(DISTINCT " + DBUtils.getQuotedIdentifier(this) + ")\n"
+            = "SELECT COUNT(DISTINCT " + DBUtils.getQuotedIdentifier(this, DBPAttributeReferencePurpose.DATA_SELECTION) + ")\n"
             + "FROM " + DBUtils.getObjectFullName(getTable(), DBPEvaluationContext.DML);
 
         try (DBCStatement stmt = session.prepareStatement(DBCStatementType.QUERY, query, false, false, false)) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/DBSBindableDataType.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/DBSBindableDataType.java
@@ -1,0 +1,47 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2022 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jkiss.dbeaver.model.struct;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+
+import java.util.List;
+
+/**
+ * Data type descriptor capable of binding its attributes to the data container context.
+ */
+public interface DBSBindableDataType extends DBSDataType {
+
+    /**
+     * Binds data type attributes the given data container context 
+     * and returns a context-bound attributes containing corresponding information
+
+     * @param monitor a progress monitor
+     * @param dataContainer actual data container, where the instances of a data type are situated (it usually is a table)
+     * @param memberContext concrete attribute of the container record's hierarchy containing the instance of a data type 
+     *     (it usually is a field of a table, or of an other nested data type in the table, whose field is of this type)
+     * @return a context-bound attributes containing information about the given data container context
+     * @throws DBException on any DB error
+     */
+    @NotNull
+    List<? extends DBSContextBoundAttribute> bindAttributesToContext(
+        @NotNull DBRProgressMonitor monitor, @NotNull DBSEntity dataContainer, @NotNull DBSEntityAttribute memberContext
+    ) throws DBException;
+}
+

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/DBSContextBoundAttribute.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/DBSContextBoundAttribute.java
@@ -1,0 +1,42 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2022 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.struct;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.model.DBPAttributeReferencePurpose;
+
+/**
+ * Context-specific entity attribute
+ */
+public interface DBSContextBoundAttribute extends DBSEntityAttribute {
+    /**
+     * Makes a string addressing the attribute with respect to the context
+
+     * @param isIncludeContainerName true to include container name, otherwise false
+     * @param containerAliasOrNull data container name to use during formatting
+       ({@code null} to substitute the explicit data container name, or explicit non-empty string)
+     * @param purpose to specify in which part of query this reference will be used
+     * @return attribute reference as a string (for example, {@code "(compositecolumn).datatypefield"})
+     */
+    @NotNull
+    String formatMemberReference(
+            boolean isIncludeContainerName,
+            @Nullable String containerAliasOrNull,
+            @NotNull DBPAttributeReferencePurpose purpose
+    );
+}

--- a/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDialectFunctionsTest.java
+++ b/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDialectFunctionsTest.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.postgresql.model;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.PostgreTestUtils;
+import org.jkiss.dbeaver.model.DBPAttributeReferencePurpose;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.data.DBDAttributeBinding;
@@ -104,7 +105,8 @@ public class PostgreDialectFunctionsTest {
         Mockito.when(mockAttributeBinding.getDataType()).thenReturn(column.getDataType());
         Mockito.when(mockAttributeBinding.getDataSource()).thenReturn(testDataSource);
         Mockito.when(mockAttributeBinding.getName()).thenReturn(column.getName());
-        Mockito.when(mockAttributeBinding.getFullyQualifiedName(DBPEvaluationContext.DML)).thenReturn(column.getName());
+        Mockito.when(mockAttributeBinding.getFullyQualifiedName(DBPEvaluationContext.DML, DBPAttributeReferencePurpose.UNSPECIFIED))
+            .thenReturn(column.getName());
 
         String typeCastClause = postgreDialect.getCastedAttributeName(mockAttributeBinding, mockAttributeBinding.getName());
         String expectedTypeCast = "column1::text"; // We use this method only for column names in condition. JSON column name must be casted to text as in getTypeCastClause will be casted column data
@@ -140,7 +142,8 @@ public class PostgreDialectFunctionsTest {
         Mockito.when(mockAttributeBinding.getDataType()).thenReturn(column.getDataType());
         Mockito.when(mockAttributeBinding.getDataSource()).thenReturn(testDataSource);
         Mockito.when(mockAttributeBinding.getName()).thenReturn(column.getName());
-        Mockito.when(mockAttributeBinding.getFullyQualifiedName(DBPEvaluationContext.DML)).thenReturn(column.getName());
+        Mockito.when(mockAttributeBinding.getFullyQualifiedName(DBPEvaluationContext.DML, DBPAttributeReferencePurpose.UNSPECIFIED))
+            .thenReturn(column.getName());
 
         String typeCastClause = postgreDialect.getCastedAttributeName(mockAttributeBinding, mockAttributeBinding.getName());
         String expectedTypeCast = "column1::text"; // We use this method only for column names in condition. JSON column name must be casted to text as in getTypeCastClause will be casted column data


### PR DESCRIPTION
- [x] Use parenthesis only for PostgreSQL
- [x] Add parenthesis for server-side sorting
- [x] Add parenthesis for filtering
- [x] Fix query for getting distinct column values (needs model changes) fixes #14998

About the last todo point.
Let's say that we have such table
![image](https://user-images.githubusercontent.com/28875055/184116990-37d5efc3-8179-4d30-9863-467dedd9a5bb.png)

The problem is that we have wrong query for composite types:
```
SELECT DISTINCT "name"
FROM public.zzz
ORDER BY 1
```
instead of
```
SELECT DISTINCT (composite)."name"
FROM aaa
ORDER BY 1
```
It happens because we have type definition (`public.zzz`) in PostgreDataTypeAttribute instead of the table (`aaa`) where this type is used. And no information about parent (`composite`) of the composite column (`name`) is provided. That's why we have a bunch of bugs (not only with filtering and sorting) connected with composite types. I'm sure that this model changes is the way to start fixing those bugs too.

_I'm not sure how to merge it to existing model (I guess there is no way to do it) without creating new interfaces. Ready for suggestions._
_P.S. I found a bunch of bugs connected with composite types and nested arrays, so, I'm sure that provided model changes is useful_

To be tested:
- composite type filtering
- composite type sorting