### PR TITLE
#17065 Escape `catalog` when calling `getProcedureColumns`

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericProcedure.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericProcedure.java
@@ -121,18 +121,18 @@ public class GenericProcedure extends AbstractProcedure<GenericDataSource, Gener
             final JDBCResultSet dbResult;
             if (DBSProcedureType.PROCEDURE == procedureType) {
                 dbResult = session.getMetaData().getProcedureColumns(
-                    getCatalog() == null ?
+                    JDBCUtils.quoteSearchStringIfNeeded(session, getCatalog() == null ?
                         this.getPackage() == null || !this.getPackage().isNameFromCatalog() ?
                             null :
                             this.getPackage().getName() :
-                        getCatalog().getName(),
+                        getCatalog().getName()),
                     getSchema() == null ? null : JDBCUtils.escapeWildCards(session, getSchema().getName()),
                     JDBCUtils.escapeWildCards(session, getName()),
                     getDataSource().getAllObjectsPattern()
                 );
             } else {
                 dbResult = session.getMetaData().getFunctionColumns(
-                    getCatalog() == null ? null : getCatalog().getName(),
+                    JDBCUtils.quoteSearchStringIfNeeded(session, getCatalog() == null ? null : getCatalog().getName()),
                     getSchema() == null ? null : JDBCUtils.escapeWildCards(session, getSchema().getName()),
                     JDBCUtils.escapeWildCards(session, getName()),
                     getDataSource().getAllObjectsPattern()

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
@@ -71,6 +71,11 @@ public class SnowflakeSQLDialect extends GenericSQLDialect implements TPRuleProv
         return "\\";
     }
 
+    @Override
+    public boolean isQuoteSearchString() {
+        return true;
+    }
+
     @NotNull
     @Override
     public MultiValueInsertMode getDefaultMultiValueInsertMode() {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCSQLDialect.java
@@ -257,6 +257,15 @@ public class JDBCSQLDialect extends BasicSQLDialect implements SQLDataTypeConver
         return searchStringEscape;
     }
 
+    /**
+     * Determines whether the search string should be quoted.
+     * <p>
+     * Generally, it should be done by the driver itself, but some don't do that.
+     */
+    public boolean isQuoteSearchString() {
+        return false;
+    }
+
     @Override
     public int getCatalogUsage() {
         return catalogUsage;

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCUtils.java
@@ -850,6 +850,17 @@ public class JDBCUtils {
         }
     }
 
+    @Nullable
+    public static String quoteSearchStringIfNeeded(@NotNull JDBCSession session, @Nullable String string) {
+        final JDBCSQLDialect dialect = (JDBCSQLDialect) session.getDataSource().getSQLDialect();
+
+        if (!dialect.isQuoteSearchString() || CommonUtils.isEmpty(string)) {
+            return string;
+        }
+
+        return dialect.getQuotedIdentifier(string, true, false);
+    }
+
     public static boolean queryHasOutputParameters(SQLDialect sqlDialect, String sqlQuery) {
         return sqlQuery.contains("?");
     }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCUtils.java
@@ -850,6 +850,9 @@ public class JDBCUtils {
         }
     }
 
+    /**
+     * Quotes search string, if needed, depending on {@link JDBCSQLDialect#isQuoteSearchString()}.
+     */
     @Nullable
     public static String quoteSearchStringIfNeeded(@NotNull JDBCSession session, @Nullable String string) {
         final JDBCSQLDialect dialect = (JDBCSQLDialect) session.getDataSource().getSQLDialect();
@@ -858,7 +861,7 @@ public class JDBCUtils {
             return string;
         }
 
-        return dialect.getQuotedIdentifier(string, true, false);
+        return dialect.getQuotedString(string);
     }
 
     public static boolean queryHasOutputParameters(SQLDialect sqlDialect, String sqlQuery) {


### PR DESCRIPTION
I don't like this solution. Any suggestions are welcome.