### PR TITLE
dbeaver/dbeaver-ee#877 add simple filter statement

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPDataSourceInfo.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPDataSourceInfo.java
@@ -156,6 +156,13 @@ public interface DBPDataSourceInfo
 
     boolean supportsBatchUpdates();
 
+    /**
+     * Some databases doesn't provide in statement for select where queries
+     * in that case we need to create different query
+     * @return is datasource supports select where in statements
+     */
+    boolean supportsWhereInStatements();
+
     boolean supportsResultSetLimit();
 
     boolean supportsResultSetScroll();

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPDataSourceInfo.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPDataSourceInfo.java
@@ -156,13 +156,6 @@ public interface DBPDataSourceInfo
 
     boolean supportsBatchUpdates();
 
-    /**
-     * Some databases doesn't provide in statement for select where queries
-     * in that case we need to create different query
-     * @return is datasource supports select where in statements
-     */
-    boolean supportsWhereInStatements();
-
     boolean supportsResultSetLimit();
 
     boolean supportsResultSetScroll();

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractDataSourceInfo.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractDataSourceInfo.java
@@ -130,9 +130,4 @@ public abstract class AbstractDataSourceInfo implements DBPDataSourceInfo
     {
         return false;
     }
-
-    @Override
-    public boolean supportsWhereInStatements() {
-        return true;
-    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractDataSourceInfo.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractDataSourceInfo.java
@@ -131,4 +131,8 @@ public abstract class AbstractDataSourceInfo implements DBPDataSourceInfo
         return false;
     }
 
+    @Override
+    public boolean supportsWhereInStatements() {
+        return true;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
@@ -652,7 +652,33 @@ public final class SQLUtils {
             if (constraint.isReverseOperator()) {
                 conString.append("NOT ");
             }
-            if (operator.getArgumentCount() > 0) {
+            if (operator.equals(DBCLogicalOperator.EQUALS)) {
+                if (value instanceof Object[]) {
+                    Object[] array = ((Object[]) value);
+                    for (int i = 0; i < array.length; i++) {
+                        if (i > 0) {
+                            conString.append(" OR");
+                            conString.append(' ').append(DBUtils.getQuotedIdentifier(dataSource,
+                                constraint.getAttributeLabel())).append(' ');
+                        }
+                        conString.append(operator.getExpression());
+                        String strValue;
+                        if (constraint.getAttribute() == null) {
+                            // We have only attribute name
+                            if (array[i] instanceof CharSequence) {
+                                strValue = dataSource.getSQLDialect().getQuotedString(array[i].toString());
+                            } else {
+                                strValue = CommonUtils.toString(array[i]);
+                            }
+                        } else if (inlineCriteria) {
+                            strValue = convertValueToSQL(dataSource, constraint.getAttribute(), array[i]);
+                        } else {
+                            strValue = dataSource.getSQLDialect().getTypeCastClause(constraint.getAttribute(), "?", true);
+                        }
+                        conString.append(' ').append(strValue);
+                    }
+                }
+            } else if (operator.getArgumentCount() > 0) {
                 conString.append(operator.getExpression());
                 for (int i = 0; i < operator.getArgumentCount(); i++) {
                     if (i > 0) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
@@ -2555,7 +2555,11 @@ public class ResultSetViewer extends Viewer
             DBDAttributeConstraint constraint = filter.getConstraint(curAttribute);
             if (constraint != null) {
                 if (!ArrayUtils.isEmpty((Object[]) value)) {
-                    constraint.setOperator(DBCLogicalOperator.IN);
+                    if (getDataSource() != null && !getDataSource().getInfo().supportsWhereInStatements()) {
+                        constraint.setOperator(DBCLogicalOperator.EQUALS);
+                    } else {
+                        constraint.setOperator(DBCLogicalOperator.IN);
+                    }
                     constraint.setValue(value);
                 } else {
                     constraint.setOperator(null);
@@ -3431,7 +3435,7 @@ public class ResultSetViewer extends Viewer
             for (int k = 0; k < rows.size(); k++) {
                 keyValues[k] = model.getCellValue(new ResultSetCellLocation(attrBinding, rows.get(k)));
             }
-            constraint.setOperator(DBCLogicalOperator.IN);
+            constraint.setOperator(DBCLogicalOperator.EQUALS);
             constraint.setValue(keyValues);
         }
     }

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
@@ -2553,9 +2553,11 @@ public class ResultSetViewer extends Viewer
 
             DBDDataFilter filter = new DBDDataFilter(model.getDataFilter());
             DBDAttributeConstraint constraint = filter.getConstraint(curAttribute);
+            DBCLogicalOperator[] supportedOperators =
+                curAttribute.getValueHandler().getSupportedOperators(curAttribute);
             if (constraint != null) {
                 if (!ArrayUtils.isEmpty((Object[]) value)) {
-                    if (getDataSource() != null && !getDataSource().getInfo().supportsWhereInStatements()) {
+                    if (getDataSource() != null && !ArrayUtils.contains(supportedOperators, DBCLogicalOperator.IN)) {
                         constraint.setOperator(DBCLogicalOperator.EQUALS);
                     } else {
                         constraint.setOperator(DBCLogicalOperator.IN);
@@ -3435,7 +3437,13 @@ public class ResultSetViewer extends Viewer
             for (int k = 0; k < rows.size(); k++) {
                 keyValues[k] = model.getCellValue(new ResultSetCellLocation(attrBinding, rows.get(k)));
             }
-            constraint.setOperator(DBCLogicalOperator.EQUALS);
+            DBCLogicalOperator[] supportedOperators =
+                attrBinding.getValueHandler().getSupportedOperators(attrBinding);
+            if (ArrayUtils.contains(supportedOperators, DBCLogicalOperator.IN)) {
+                constraint.setOperator(DBCLogicalOperator.IN);
+            } else {
+                constraint.setOperator(DBCLogicalOperator.EQUALS);
+            }
             constraint.setValue(keyValues);
         }
     }


### PR DESCRIPTION
Linked pr: https://github.com/dbeaver/dbeaver-ee/pull/1887
Now for Influx, the different query will be generated. It looks something like this because it was made due to Influx not supporting WHERE IN
`select * from where item = value1 or item = value2`
Limitations: You can't filter time columns, this is the Influx limitation for where statement