### PR TITLE
#17399 Rename Console View to SQL Terminal

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.console/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.data.console/OSGI-INF/l10n/bundle.properties
@@ -16,8 +16,8 @@
 # limitations under the License.
 
 Bundle-Vendor = JKISS
-Bundle-Name = DBeaver SQL Script Output Console
+Bundle-Name = DBeaver SQL Terminal
 
-console_view_item_text = Console View
-command.org.jkiss.dbeaver.ui.editors.sql.show.consoleView.name = Console Output View
-command.org.jkiss.dbeaver.ui.editors.sql.show.consoleView.description = SQL Script Output Console
+console_view_item_text = SQL Terminal
+command.org.jkiss.dbeaver.ui.editors.sql.show.consoleView.name = SQL Terminal
+command.org.jkiss.dbeaver.ui.editors.sql.show.consoleView.description = SQL Terminal

--- a/plugins/org.jkiss.dbeaver.data.console/src/org/jkiss/dbeaver/data/console/ConsoleMessages.properties
+++ b/plugins/org.jkiss.dbeaver.data.console/src/org/jkiss/dbeaver/data/console/ConsoleMessages.properties
@@ -1,4 +1,4 @@
-console_view_item_text = Console View
-pref_page_console_view_label_show_output_console_view = Use SQL Console View Output by default
-pref_page_console_view_label_show_output_console_view_tip = Use SQL Console View Output by default
-console_view_action_tooltip = Toggle Console View
+console_view_item_text = SQL Terminal
+pref_page_console_view_label_show_output_console_view = Use SQL Terminal by default
+pref_page_console_view_label_show_output_console_view_tip = Use SQL Terminal by default
+console_view_action_tooltip = SQL Terminal


### PR DESCRIPTION
Should be renamed everywhere: in context menu, on a toolbar, in preferences