### PR TITLE
#16626 Fix remote host identifier changed dialog for jsch

### DIFF
--- a/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages.java
@@ -54,6 +54,7 @@ public class SSHUIMessages extends NLS {
 	public static String model_ssh_configurator_variables_hint_label;
 	public static String model_ssh_configurator_ssh_documentation_link;
 
+    public static String jsch_remote_host_identifier_changed_warning_title;
 
 	static {
 		// initialize resource bundle

--- a/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages.properties
+++ b/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages.properties
@@ -64,4 +64,4 @@ model_ssh_configurator_variables_hint_label = You can use variables in SSH param
 model_ssh_configurator_ssh_documentation_link = <a>SSH Documentation</a>
 
 jsch_remote_host_identifier_changed_warning_title = SSH Message
-}
+

--- a/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages.properties
+++ b/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages.properties
@@ -62,3 +62,6 @@ model_ssh_configurator_group_jump_server_checkbox_label = Use jump server
 model_ssh_configurator_variables_hint_label = You can use variables in SSH parameters.
 
 model_ssh_configurator_ssh_documentation_link = <a>SSH Documentation</a>
+
+jsch_remote_host_identifier_changed_warning_title = SSH Message
+}

--- a/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/jsch/JSCHUIPromptProvider.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/jsch/JSCHUIPromptProvider.java
@@ -23,6 +23,8 @@ import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.net.ssh.JSCHUserInfoPromptProvider;
 import org.jkiss.dbeaver.model.net.ssh.config.SSHAuthConfiguration;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
+import org.jkiss.dbeaver.ui.net.ssh.SSHUIMessages;
 import org.jkiss.utils.CommonUtils;
 
 public class JSCHUIPromptProvider implements JSCHUserInfoPromptProvider {
@@ -78,6 +80,11 @@ public class JSCHUIPromptProvider implements JSCHUserInfoPromptProvider {
 
         private boolean shouldUsePassword() {
             return configuration.getType().usesPassword() && (configuration.isSavePassword() || CommonUtils.isNotEmpty(configuration.getPassword()));
+        }
+
+        @Override
+        public boolean promptYesNo(String question) {
+            return DBWorkbench.getPlatformUI().confirmAction(SSHUIMessages.jsch_remote_host_identifier_changed_warning_title, question);
         }
     }
 }


### PR DESCRIPTION
_**How to check:**_

0. Run DBeaver
1. Choose the database and switch to JSCH in Advanced SSH settings
2. Open some script for the chosen database and enable setting to connect to the database on script opening
3. Turn on Tip of the day
4. Shutdown DBeaver
3. Change a couple of symbols of the key for the host of the chosen database in .ssh/known_hosts file
5. Run DBeaver
6. Wait for the Tip of the day and ssh message about changed host identifier. SSH Message will grab focus.
7. After clicking on the tip of the day modal window the SSH Message window should not be hidden.