### PR TITLE
dbeaver/dbeaver-ee#1933 Speed up generic container refresh

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericCatalog.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericCatalog.java
@@ -158,10 +158,9 @@ public class GenericCatalog extends GenericObjectContainer implements DBSCatalog
 
     @Override
     public DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException {
-        super.refreshObject(monitor);
         this.schemas = null;
         this.isInitialized = false;
-        return this;
+        return super.refreshObject(monitor);
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericObjectContainer.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericObjectContainer.java
@@ -411,8 +411,9 @@ public abstract class GenericObjectContainer implements GenericStructContainer, 
     }
 
     @Override
-    public synchronized DBSObject refreshObject(@NotNull DBRProgressMonitor monitor)
-        throws DBException {
+    public synchronized DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException {
+        final boolean needsStructureCaching = !getTableCache().isEmpty();
+
         this.tableCache.clearCache();
         this.indexCache.clearCache();
         this.constraintKeysCache.clearCache();
@@ -425,6 +426,11 @@ public abstract class GenericObjectContainer implements GenericStructContainer, 
         this.procedures = null;
         this.sequences = null;
         this.synonyms = null;
+
+        if (needsStructureCaching) {
+            cacheStructure(monitor, STRUCT_ALL);
+        }
+
         return this;
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericPackage.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericPackage.java
@@ -140,7 +140,7 @@ public class GenericPackage extends GenericObjectContainer implements DBPQualifi
     public DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException
     {
         procedures.clear();
-        return this;
+        return super.refreshObject(monitor);
     }
 
     public boolean isNameFromCatalog()


### PR DESCRIPTION
This is achieved by caching its structure afterward.

Please ensure schema refresh works nicely in generic databases, such as Vertica.