### PR TITLE
#15319 default client changed for 8th for MySQL; 5 and 8 clients are …

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
@@ -268,6 +268,14 @@
 
             <nativeClients>
                 <client id="mysql_client" label="MySQL Binaries">
+                    <dist os="win32" targetPath="clients/mysql_8/win" remotePath="repo:/drivers/mysql/client_8/win" resourcePath="clients/mysql_8/win">
+                        <file type="exec" name="mysql.exe"/>
+                        <file type="exec" name="mysqldump.exe"/>
+                        <file type="lib" name="libssl-1_1-x64.dll"/>
+                        <file type="lib" name="libcrypto-1_1-x64.dll"/>
+                    </dist>
+                </client>
+                <client id="mysql5_client" label="MySQL 5 Binaries">
                     <dist os="win32" targetPath="clients/mysql/win" remotePath="repo:/drivers/mysql/client/win" resourcePath="clients/mysql/win">
                         <file type="exec" name="mysql.exe"/>
                         <file type="exec" name="mysqldump.exe"/>


### PR DESCRIPTION
…available now for downloading from remotePath

Please check:
- that both native clients (5 and 8(default) are working)
- that they are reading from internet in CE
- that they are not reading from internet in EE

![2022-09-26 11_08_50-Connection _localhost_ configuration](https://user-images.githubusercontent.com/45152336/192225932-6df7f7b8-37e2-4662-9592-0be08e0d8189.png)
