### PR TITLE
#14221 Query some user cols only w/ SELECT ANY DICTIONARY

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/ExasolDataSource.java
@@ -177,8 +177,8 @@ public class ExasolDataSource extends JDBCDataSource implements IAdaptable {
 				+ "	USER_NAME,\n"
 				+ "	CREATED,\n"
 				+ (this.exasolCurrentUserPrivileges.getUserHasDictionaryAccess() ? "	DISTINGUISHED_NAME,\n" : "")
-				+ "	KERBEROS_PRINCIPAL,\n"
-				+ "	PASSWORD,\n"
+				+ (this.exasolCurrentUserPrivileges.getUserHasDictionaryAccess() ? "	KERBEROS_PRINCIPAL,\n" : "")
+				+ (this.exasolCurrentUserPrivileges.getUserHasDictionaryAccess() ? "	PASSWORD,\n" : "")
 				+ priorityColUser
 				+ "	PASSWORD_STATE,\n"
 				+ "	PASSWORD_STATE_CHANGED,\n"


### PR DESCRIPTION
Query KERBEROS_PRINCIPAL and PASSWORD user cols only when current user has SELECT ANY DICTIONARY system privilege.

Fixes 14221.