### PR TITLE
dbeaver/dbeaver-ee#2057 Add logging for task start/finish

### DIFF
--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskRunJob.java
@@ -22,11 +22,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.runtime.*;
-import org.jkiss.dbeaver.model.task.DBTTask;
-import org.jkiss.dbeaver.model.task.DBTTaskExecutionListener;
-import org.jkiss.dbeaver.model.task.DBTTaskHandler;
-import org.jkiss.dbeaver.model.task.DBTTaskRunStatus;
-import org.jkiss.dbeaver.model.task.DBTaskUtils;
+import org.jkiss.dbeaver.model.task.*;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.StandardConstants;
@@ -88,6 +84,7 @@ public class TaskRunJob extends AbstractJob implements DBRRunnableContext {
         task.addNewRun(taskRun);
 
         try (PrintStream logStream = new PrintStream(Files.newOutputStream(logFile), true, StandardCharsets.UTF_8.name())) {
+            log.debug(String.format("Task '%s' (%s) started", task.getName(), task.getId()));
             taskLog = Log.getLog(TaskRunJob.class);
             Log.setLogWriter(logStream);
             monitor.beginTask("Run task '" + task.getName() + " (" + task.getType().getName() + ")", 1);
@@ -101,6 +98,7 @@ public class TaskRunJob extends AbstractJob implements DBRRunnableContext {
                 monitor.done();
                 taskLog.flush();
                 Log.setLogWriter(null);
+                log.debug(String.format("Task '%s' (%s) finished in %s ms", task.getName(), task.getId(), elapsedTime));
 
                 taskRun.setRunDuration(elapsedTime);
                 if (taskError != null) {


### PR DESCRIPTION
This PR adds logging for tasks execution, so we can see when they were started and finished:
```
2022-10-17 12:24:38.864 - Task 'Export XLSX' (ff36ebc0-ab7c-4f6d-92bc-54d0529fd3f8) started
2022-10-17 12:24:38.991 - Task 'Export XLSX' (ff36ebc0-ab7c-4f6d-92bc-54d0529fd3f8) finished in 127 ms
```