### PR TITLE
dbeaver/dbeaver#16972 fix sqlite recreate ddl

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/edit/GenericTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/edit/GenericTableColumnManager.java
@@ -121,13 +121,11 @@ public class GenericTableColumnManager extends SQLTableColumnManager<GenericTabl
         GenericMetaModel metaModel = column.getDataSource().getMetaModel();
         if (!metaModel.supportsNotNullColumnModifiers(column)) {
             return new ColumnModifier[]{
-                DataTypeModifier,
-                DefaultModifier
+                DataTypeModifier, DefaultModifier
             };
         } else {
             return new ColumnModifier[]{
-                DataTypeModifier,
-                DefaultModifier,
+                DataTypeModifier, DefaultModifier,
                 metaModel.isColumnNotNullByDefault() ? NullNotNullModifier : NotNullModifier
             };
         }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleTableColumnManager.java
@@ -34,8 +34,6 @@ import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
 import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
 import org.jkiss.dbeaver.model.impl.sql.edit.struct.SQLTableColumnManager;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
-import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
-import org.jkiss.dbeaver.model.sql.SQLUtils;
 import org.jkiss.dbeaver.model.struct.DBSDataType;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.cache.DBSObjectCache;

--- a/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/edit/SQLiteTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/edit/SQLiteTableColumnManager.java
@@ -47,6 +47,17 @@ public class SQLiteTableColumnManager extends GenericTableColumnManager implemen
     }
 
     @Override
+    protected ColumnModifier[] getSupportedModifiers(
+        GenericTableColumn column, Map<String, Object> options
+    ) {
+        return new ColumnModifier[]{
+            DataTypeModifier, sqliteDefaultModifier
+        };
+    }
+
+    protected SQLiteDefaultModifier sqliteDefaultModifier = new SQLiteDefaultModifier();
+
+    @Override
     public boolean canDeleteObject(GenericTableColumn object) {
         return true;
     }
@@ -93,6 +104,15 @@ public class SQLiteTableColumnManager extends GenericTableColumnManager implemen
     @Override
     public void renameObject(@NotNull DBECommandContext commandContext, @NotNull GenericTableColumn object, @NotNull Map<String, Object> options, @NotNull String newName) throws DBException {
         processObjectRename(commandContext, object, options, newName);
+    }
+
+    private class SQLiteDefaultModifier extends BaseDefaultModifier {
+        @Override
+        protected void appendDefaultValue(@NotNull StringBuilder sql, @NotNull String defaultValue, boolean useQuotes) {
+            sql.append("(");
+            super.appendDefaultValue(sql, defaultValue, useQuotes);
+            sql.append(")");
+        }
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/edit/SQLiteTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/edit/SQLiteTableManager.java
@@ -19,7 +19,10 @@ package org.jkiss.dbeaver.ext.sqlite.edit;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.generic.edit.GenericTableManager;
-import org.jkiss.dbeaver.ext.generic.model.*;
+import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
+import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
+import org.jkiss.dbeaver.ext.generic.model.GenericTableIndex;
+import org.jkiss.dbeaver.ext.generic.model.GenericUniqueKey;
 import org.jkiss.dbeaver.ext.sqlite.model.SQLiteTableColumn;
 import org.jkiss.dbeaver.ext.sqlite.model.SQLiteTableForeignKey;
 import org.jkiss.dbeaver.model.DBUtils;
@@ -42,9 +45,9 @@ public class SQLiteTableManager extends GenericTableManager implements DBEObject
 
     private static final Class<? extends DBSObject>[] CHILD_TYPES = CommonUtils.array(
         SQLiteTableColumn.class,
-        SQLiteTableForeignKey.class,
+        GenericUniqueKey.class,
         GenericTableIndex.class,
-        GenericUniqueKey.class
+        SQLiteTableForeignKey.class
     );
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLTableColumnManager.java
@@ -90,29 +90,7 @@ public abstract class SQLTableColumnManager<OBJECT_TYPE extends DBSEntityAttribu
         NullNotNullModifier.appendModifier(monitor, column, sql, command);
     };
 
-    protected final ColumnModifier<OBJECT_TYPE> DefaultModifier = (monitor, column, sql, command) -> {
-        String defaultValue = CommonUtils.toString(column.getDefaultValue());
-        if (!CommonUtils.isEmpty(defaultValue)) {
-            DBPDataKind dataKind = column.getDataKind();
-            boolean useQuotes = false;//dataKind == DBPDataKind.STRING;
-            if (!defaultValue.startsWith(QUOTE) && !defaultValue.endsWith(QUOTE)) {
-                if (useQuotes && defaultValue.trim().startsWith(QUOTE)) {
-                    useQuotes = false;
-                }
-                if (dataKind == DBPDataKind.DATETIME) {
-                    final char firstChar = defaultValue.trim().charAt(0);
-                    if (!Character.isLetter(firstChar) && firstChar != '(' && firstChar != '[') {
-                        useQuotes = true;
-                    }
-                }
-            }
-
-            sql.append(" DEFAULT "); //$NON-NLS-1$
-            if (useQuotes) sql.append(QUOTE);
-            sql.append(defaultValue);
-            if (useQuotes) sql.append(QUOTE);
-        }
-    };
+    protected ColumnModifier<OBJECT_TYPE> DefaultModifier = new BaseDefaultModifier();
 
     protected ColumnModifier[] getSupportedModifiers(OBJECT_TYPE column, Map<String, Object> options)
     {
@@ -307,5 +285,47 @@ public abstract class SQLTableColumnManager<OBJECT_TYPE extends DBSEntityAttribu
             "COMMENT ON COLUMN " + DBUtils.getObjectFullName(table, DBPEvaluationContext.DDL) + "." + DBUtils.getQuotedIdentifier(column) +
                 " IS " + SQLUtils.quoteString(column.getDataSource(), CommonUtils.notEmpty(column.getDescription()))));
     }
-}
 
+    protected class BaseDefaultModifier implements ColumnModifier<OBJECT_TYPE> {
+        @Override
+        public void appendModifier(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull OBJECT_TYPE column,
+            @NotNull StringBuilder sql,
+            @NotNull DBECommandAbstract<OBJECT_TYPE> command
+        ) {
+            String defaultValue = CommonUtils.toString(column.getDefaultValue());
+            if (!CommonUtils.isEmpty(defaultValue)) {
+                DBPDataKind dataKind = column.getDataKind();
+                boolean useQuotes = isUsesQuotes(defaultValue, dataKind);
+                sql.append(" DEFAULT "); //$NON-NLS-1$
+                appendDefaultValue(sql, defaultValue, useQuotes);
+            }
+        }
+
+        protected boolean isUsesQuotes(@NotNull String defaultValue, @NotNull DBPDataKind dataKind) {
+            boolean useQuotes = false;
+            if (!defaultValue.startsWith(QUOTE) && !defaultValue.endsWith(QUOTE)) {
+                if (dataKind == DBPDataKind.DATETIME) {
+                    final char firstChar = defaultValue.trim().charAt(0);
+                    if (!Character.isLetter(firstChar) && firstChar != '(' && firstChar != '[') {
+                        useQuotes = true;
+                    }
+                }
+            }
+            return useQuotes;
+        }
+
+        protected void appendDefaultValue(@NotNull StringBuilder sql, @NotNull String defaultValue, boolean useQuotes) {
+            if (useQuotes) {
+                sql.append(QUOTE);
+            }
+            sql.append(defaultValue);
+            if (useQuotes) {
+                sql.append(QUOTE);
+            }
+        }
+
+    }
+
+}

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLTableManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLTableManager.java
@@ -185,6 +185,12 @@ public abstract class SQLTableManager<OBJECT_TYPE extends DBSEntity, CONTAINER_T
 
         final DBERegistry editorsRegistry = DBWorkbench.getPlatform().getEditorsRegistry();
         SQLObjectEditor<DBSEntityAttribute, OBJECT_TYPE> tcm = getObjectEditor(editorsRegistry, DBSEntityAttribute.class);
+        /*
+         * FIXME: We have a pretty major problem with inheritance and managers
+         * FIXME: we search for constraint manager by class which is also a parent
+         * FIXME: for indexes and foreign keys this may lead to incorrect manager provided for key
+         * Temporary workaround - provide primary key before indexes and foreign keys in getChildTypes
+         */
         SQLObjectEditor<DBSEntityConstraint, OBJECT_TYPE> pkm = getObjectEditor(editorsRegistry, DBSEntityConstraint.class);
         SQLObjectEditor<DBSTableForeignKey, OBJECT_TYPE> fkm = getObjectEditor(editorsRegistry, DBSTableForeignKey.class);
         SQLObjectEditor<DBSTableIndex, OBJECT_TYPE> im = getObjectEditor(editorsRegistry, DBSTableIndex.class);


### PR DESCRIPTION
Closes #16972 
Fixes issue with incorrect DDL. In the process was found that we have a pretty annoying dependency on the class position in the `CHILD_TYPES` enum, it may require large refactoring in the future.