### PR TITLE
dbeaver/dbeaver-ee#2074 Prefer column name case from the metadata

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
@@ -756,7 +756,7 @@ public class DBExecUtils {
                             SQLSelectItem selectItem = sqlQuery.getSelectItem(attrMeta.getOrdinalPosition());
                             if (selectItem.isPlainColumn()) {
                                 String realColumnName = selectItem.getName();
-                                if (!CommonUtils.equalObjects(realColumnName, columnName)) {
+                                if (!realColumnName.equalsIgnoreCase(columnName)) {
                                     if (DBUtils.isQuotedIdentifier(dataSource, realColumnName)) {
                                         columnName = DBUtils.getUnQuotedIdentifier(dataSource, realColumnName);
                                     } else {


### PR DESCRIPTION
It was happening when the `rowid` was spelled in lowercase in the query.