### PR TITLE
#16597 add proper null monitor handling in getSchemas of GenericCatalog

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericCatalog.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericCatalog.java
@@ -24,6 +24,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.meta.Association;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.rdb.DBSCatalog;
 import org.jkiss.utils.CommonUtils;
@@ -149,7 +150,8 @@ public class GenericCatalog extends GenericObjectContainer implements DBSCatalog
     public Class<? extends DBSObject> getPrimaryChildType(@Nullable DBRProgressMonitor monitor)
         throws DBException
     {
-        if (!CommonUtils.isEmpty(schemas) || (monitor != null && !CommonUtils.isEmpty(getSchemas(monitor)))) {
+        if (!CommonUtils.isEmpty(schemas) || !CommonUtils.isEmpty(getSchemas(monitor == null ?
+                                                                             new VoidProgressMonitor() : monitor))) {
             return GenericSchema.class;
         } else {
             return GenericTable.class;


### PR DESCRIPTION
Closes #16597 
NULL monitor led to generic catalogs being counted as containing DBSTable instead of DBSSchema. 