### PR TITLE
Add setting for SQL editor variable pattern

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRuleManager.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRuleManager.java
@@ -144,7 +144,7 @@ public class SQLRuleManager {
         {
             if (!minimalRules && syntaxManager.isVariablesEnabled()) {
                 // Variable rule
-                rules.add(new ScriptVariableRule(parameterToken));
+                rules.add(new ScriptVariableRule(parameterToken, syntaxManager.getVariablePattern()));
             }
         }
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -714,10 +714,19 @@ public class SQLScriptParser {
                         parameters = new ArrayList<>();
                     }
 
+                    String varName = paramName;
+                    for (String prefix : syntaxManager.getNamedParameterPrefixes()) {
+                        if (varName.startsWith(prefix)) {
+                            varName = varName.substring(prefix.length());
+                            break;
+                        }
+                    }
+
                     SQLQueryParameter parameter = new SQLQueryParameter(
                         syntaxManager,
                         parameters.size(),
                         paramName,
+                        varName,
                         tokenOffset - queryOffset,
                         tokenLength);
 
@@ -735,7 +744,7 @@ public class SQLScriptParser {
                 // Use regex
                 String query = document.get(queryOffset, queryLength);
 
-                Matcher matcher = SQLQueryParameter.getVariablePattern().matcher(query);
+                Matcher matcher = syntaxManager.getVariablePattern().matcher(query);
                 int position = 0;
                 while (matcher.find(position)) {
                     {
@@ -754,7 +763,7 @@ public class SQLScriptParser {
                         }
 
                         if (param == null) {
-                            param = new SQLQueryParameter(syntaxManager, orderPos, matcher.group(0), start, matcher.end() - matcher.start());
+                            param = new SQLQueryParameter(syntaxManager, orderPos, matcher.group(0), matcher.group(1), start, matcher.end() - matcher.start());
                             if (parameters == null) {
                                 parameters = new ArrayList<>();
                             }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/rules/ScriptVariableRule.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/rules/ScriptVariableRule.java
@@ -16,11 +16,13 @@
  */
 package org.jkiss.dbeaver.model.sql.parser.rules;
 
-import org.jkiss.dbeaver.model.sql.SQLQueryParameter;
 import org.jkiss.dbeaver.model.text.parser.TPCharacterScanner;
 import org.jkiss.dbeaver.model.text.parser.TPRule;
 import org.jkiss.dbeaver.model.text.parser.TPToken;
 import org.jkiss.dbeaver.model.text.parser.TPTokenAbstract;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
 * SQL variable rule.
@@ -29,51 +31,71 @@ import org.jkiss.dbeaver.model.text.parser.TPTokenAbstract;
 public class ScriptVariableRule implements TPRule {
 
     private final TPToken parameterToken;
+    private final Pattern variablePattern;
 
-    public ScriptVariableRule(TPToken parameterToken) {
+    public ScriptVariableRule(TPToken parameterToken, Pattern variablePattern) {
         this.parameterToken = parameterToken;
+        this.variablePattern = variablePattern;
     }
 
     @Override
     public TPToken evaluate(TPCharacterScanner scanner)
     {
-        int c = scanner.read();
-        if (c == '$') {
-            int prefixLength = 0;
-            c = scanner.read();
-            if (SQLQueryParameter.supportsJasperSyntax()) {
-                if (c == 'P') {
-                    c = scanner.read();
-                    prefixLength++;
-                    if (c == '!') {
-                        c = scanner.read();
-                        prefixLength++;
-                    }
-                }
-            }
-            if (c == '{') {
-                int varLength = 0;
-                for (;;) {
-                    c = scanner.read();
-                    if (c == '}' || Character.isWhitespace(c) || c == TPCharacterScanner.EOF) {
-                        break;
-                    }
-                    varLength++;
-                }
-                if (varLength > 0 && c == '}') {
-                    return parameterToken;
-                }
+        CharacterScannerToSequenceWrapper stream = new CharacterScannerToSequenceWrapper(scanner);
+        Matcher matcher = variablePattern.matcher(stream);
+        if(matcher.lookingAt()) {
+            for(int i = stream.getScannedCharacters(); i > matcher.end(); i --) {
                 scanner.unread();
-
-                for (int i = varLength - 1 + prefixLength; i >= 0; i--) {
-                    scanner.unread();
-                }
             }
-            scanner.unread();
+            return parameterToken;
+        } else {
+            for (int i = stream.getScannedCharacters(); i > 0; i--) {
+                scanner.unread();
+            }
+            return TPTokenAbstract.UNDEFINED;
         }
-        scanner.unread();
-
-        return TPTokenAbstract.UNDEFINED;
     }
 
+    private static class CharacterScannerToSequenceWrapper implements CharSequence {
+        final private TPCharacterScanner scanner;
+        final private StringBuilder buffer = new StringBuilder();
+        private int scannedCharacters = 0;
+
+        private CharacterScannerToSequenceWrapper(TPCharacterScanner scanner) {
+            this.scanner = scanner;
+        }
+
+        @Override
+        public int length() {
+            return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public char charAt(int index) {
+            if(buffer.length() > index) {
+                return buffer.charAt(index);
+            }
+
+            int c = 0;
+            while(buffer.length() <= index) {
+                c = scanner.read();
+                scannedCharacters++;
+                if(c == -1) {
+                    return '\0';
+                } else {
+                    buffer.appendCodePoint(c);
+                }
+            }
+            return (char)c;
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            throw new UnsupportedOperationException("subSequence");
+        }
+
+        public int getScannedCharacters() {
+            return scannedCharacters;
+        }
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/ModelPreferences.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/ModelPreferences.java
@@ -144,6 +144,7 @@ public final class ModelPreferences
     public static final String SQL_NAMED_PARAMETERS_PREFIX = "sql.parameter.prefix"; //$NON-NLS-1$
     public static final String SQL_CONTROL_COMMAND_PREFIX = "sql.command.prefix"; //$NON-NLS-1$
     public static final String SQL_VARIABLES_ENABLED = "sql.variables.enabled"; //$NON-NLS-1$
+    public static final String SQL_VARIABLE_PATTERN = "sql.variables.pattern"; //$NON-NLS-1$
     public static final String SQL_FILTER_FORCE_SUBSELECT = "sql.query.filter.force.subselect"; //$NON-NLS-1$
 
     public final static String SQL_FORMAT_KEYWORD_CASE = "sql.format.keywordCase";
@@ -287,6 +288,7 @@ public final class ModelPreferences
         PrefUtils.setDefaultPreferenceValue(store, SQL_NAMED_PARAMETERS_PREFIX, String.valueOf(SQLConstants.DEFAULT_PARAMETER_PREFIX));
         PrefUtils.setDefaultPreferenceValue(store, SQL_CONTROL_COMMAND_PREFIX, String.valueOf(SQLConstants.DEFAULT_CONTROL_COMMAND_PREFIX));
         PrefUtils.setDefaultPreferenceValue(store, SQL_VARIABLES_ENABLED, true);
+        PrefUtils.setDefaultPreferenceValue(store, SQL_VARIABLE_PATTERN, SQLConstants.DEFAULT_VARIABLE_PATTERN);
         PrefUtils.setDefaultPreferenceValue(store, SQL_FILTER_FORCE_SUBSELECT, false);
 
         PrefUtils.setDefaultPreferenceValue(store, SQL_FORMAT_KEYWORD_CASE, "");

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLConstants.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLConstants.java
@@ -662,6 +662,7 @@ public class SQLConstants {
 
     public static final char DEFAULT_PARAMETER_MARK = '?';
     public static final char DEFAULT_PARAMETER_PREFIX = ':';
+    public static final String DEFAULT_VARIABLE_PATTERN = "\\$P?!?\\{([a-z0-9_]+)\\}";
     public static final String DEFAULT_IDENTIFIER_QUOTE = "\"";
     public static final String DEFAULT_LIKE_ESCAPE = "\\";
     public static final String KEYWORD_PATTERN_CHARS = "\\*\\";

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQueryParameter.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQueryParameter.java
@@ -16,35 +16,26 @@
  */
 package org.jkiss.dbeaver.model.sql;
 
-import org.jkiss.code.NotNull;
-
-import java.util.regex.Pattern;
-
 /**
  * SQL statement parameter info
  */
 public class SQLQueryParameter {
-
-
-    private static final Pattern VARIABLE_PATTERN_SIMPLE = Pattern.compile("\\$\\{[a-z0-9_]+\\}", Pattern.CASE_INSENSITIVE);
-    private static final Pattern VARIABLE_PATTERN_FULL = Pattern.compile("\\$P?!?\\{[a-z0-9_]+\\}", Pattern.CASE_INSENSITIVE);
-
-
     private final SQLSyntaxManager syntaxManager;
     private int ordinalPosition;
     private String name;
+    private String varName;
     private String value;
     private boolean variableSet;
     private final int tokenOffset;
     private final int tokenLength;
     private SQLQueryParameter previous;
 
-    public SQLQueryParameter(SQLSyntaxManager syntaxManager, int ordinalPosition, String name)
+    public SQLQueryParameter(SQLSyntaxManager syntaxManager, int ordinalPosition, String name, String varName)
     {
-        this(syntaxManager, ordinalPosition, name, 0, 0);
+        this(syntaxManager, ordinalPosition, name, varName, 0, 0);
     }
 
-    public SQLQueryParameter(SQLSyntaxManager syntaxManager, int ordinalPosition, String name, int tokenOffset, int tokenLength)
+    public SQLQueryParameter(SQLSyntaxManager syntaxManager, int ordinalPosition, String name, String varName, int tokenOffset, int tokenLength)
     {
         this.syntaxManager = syntaxManager;
         if (tokenOffset < 0) {
@@ -55,6 +46,7 @@ public class SQLQueryParameter {
         }
         this.ordinalPosition = ordinalPosition;
         this.name = name.trim();
+        this.varName = varName;
         this.tokenOffset = tokenOffset;
         this.tokenLength = tokenLength;
     }
@@ -107,50 +99,10 @@ public class SQLQueryParameter {
         this.variableSet = variableSet;
     }
 
-    public String getVarName() {
-        String varName = stripVariablePattern(name);
-        if (!varName.equals(name)) {
-            return varName;
-        }
-        for (String prefix : syntaxManager.getNamedParameterPrefixes()) {
-            if (name.startsWith(prefix)) {
-                return name.substring(prefix.length());
-            }
-        }
-        return name;
-    }
+    public String getVarName() { return varName; }
 
     @Override
     public String toString() {
         return getVarName() + "=" + value;
     }
-
-    public static Pattern getVariablePattern() {
-        if (supportsJasperSyntax()) {
-            return VARIABLE_PATTERN_FULL;
-        } else {
-            return VARIABLE_PATTERN_SIMPLE;
-        }
-    }
-
-    public static boolean supportsJasperSyntax() {
-        return true;
-    }
-
-    @NotNull
-    public static String stripVariablePattern(String pattern) {
-        if (supportsJasperSyntax()) {
-            if (pattern.startsWith("$P{") && pattern.endsWith("}")) {
-                return pattern.substring(3, pattern.length() - 1);
-            } else if (pattern.startsWith("$P!{") && pattern.endsWith("}")) {
-                return pattern.substring(4, pattern.length() - 1);
-            }
-        }
-        if (pattern.startsWith("${") && pattern.endsWith("}")) {
-            return pattern.substring(2, pattern.length() - 1);
-        }
-
-        return pattern;
-    }
-
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLSyntaxManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLSyntaxManager.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.regex.Pattern;
 
 /**
  * SQLSyntaxManager.
@@ -52,6 +53,7 @@ public class SQLSyntaxManager {
     private String[] namedParameterPrefixes;
     private String controlCommandPrefix;
     private boolean variablesEnabled;
+    private Pattern variablePattern;
     @NotNull
     private String catalogSeparator = String.valueOf(SQLConstants.STRUCT_SEPARATOR);
     @NotNull
@@ -132,6 +134,10 @@ public class SQLSyntaxManager {
         return variablesEnabled;
     }
 
+    public Pattern getVariablePattern() {
+        return variablePattern;
+    }
+
     public void init(@NotNull SQLDialect dialect, @NotNull DBPPreferenceStore preferenceStore)
     {
         this.statementDelimiters = new String[0];
@@ -163,6 +169,7 @@ public class SQLSyntaxManager {
         this.parametersEnabled = preferenceStore.getBoolean(ModelPreferences.SQL_PARAMETERS_ENABLED);
         this.anonymousParametersEnabled = preferenceStore.getBoolean(ModelPreferences.SQL_ANONYMOUS_PARAMETERS_ENABLED);
         this.variablesEnabled = preferenceStore.getBoolean(ModelPreferences.SQL_VARIABLES_ENABLED);
+        this.variablePattern = Pattern.compile(preferenceStore.getString(ModelPreferences.SQL_VARIABLE_PATTERN), Pattern.CASE_INSENSITIVE);
         String markString = preferenceStore.getString(ModelPreferences.SQL_ANONYMOUS_PARAMETERS_MARK);
         if (CommonUtils.isEmpty(markString)) {
             this.anonymousParameterMark = SQLConstants.DEFAULT_PARAMETER_MARK;

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -128,8 +128,8 @@ import org.jkiss.utils.CommonUtils;
 import java.io.*;
 import java.net.URI;
 import java.text.SimpleDateFormat;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -3111,6 +3111,7 @@ public class SQLEditor extends SQLEditorBase implements
             case ModelPreferences.SQL_ANONYMOUS_PARAMETERS_MARK:
             case ModelPreferences.SQL_ANONYMOUS_PARAMETERS_ENABLED:
             case ModelPreferences.SQL_VARIABLES_ENABLED:
+            case ModelPreferences.SQL_VARIABLE_PATTERN:
             case ModelPreferences.SQL_NAMED_PARAMETERS_PREFIX:
             case ModelPreferences.SQL_CONTROL_COMMAND_PREFIX:
                 reloadSyntaxRules();

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.java
@@ -171,6 +171,7 @@ public class SQLEditorMessages extends NLS {
     public static String pref_page_sql_editor_enable_parameters_in_ddl_tip;
     public static String pref_page_sql_editor_enable_variables;
     public static String pref_page_sql_editor_enable_variables_tip;
+    public static String pref_page_sql_editor_variable_pattern;
     // SQProposalsSearch
     public static String pref_page_sql_format_group_search;
     public static String pref_page_sql_completion_label_match_contains;

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.properties
@@ -154,7 +154,8 @@ pref_page_sql_editor_label_sql_timeout_tip = Query execute timeout (in seconds).
 pref_page_sql_editor_enable_parameters_in_ddl = Enable parameters in DDL and $$..$$ blocks
 pref_page_sql_editor_enable_parameters_in_ddl_tip = Usually DDL (like CREATE PROCEDURE) does not use input query parameters but may contain complex logic and scripting.\nIn some databases $$..$$ is a special block that may contain a string, including $.\nThis may conflict with the parameters prefix.\nIt is suggested to disable parameter parsing for such queries.
 pref_page_sql_editor_enable_variables = Enable variables
-pref_page_sql_editor_enable_variables_tip = Enable variables in SQL scripts.\nVariable is a special mark ${VAR_NAME} which will be replaced with user input before query execution.
+pref_page_sql_editor_enable_variables_tip = Enable variables in SQL scripts.\nVariable is a special mark ${VAR_NAME} (by default) which will be replaced with user input before query execution.\nYou may change the exact mark used with an option below.
+pref_page_sql_editor_variable_pattern = Variable regex pattern
 
 # SQL Scripts: New script template
 pref_page_sql_editor_new_script_template_group=New SQL script template

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/preferences/PrefPageSQLExecute.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/preferences/PrefPageSQLExecute.java
@@ -73,6 +73,7 @@ public class PrefPageSQLExecute extends TargetPrefPage
     private Text controlCommandPrefixText;
     private Button enableParametersInEmbeddedCode;
     private Button enableVariables;
+    private Text variablePattern;
 
     public PrefPageSQLExecute()
     {
@@ -104,6 +105,7 @@ public class PrefPageSQLExecute extends TargetPrefPage
             store.contains(ModelPreferences.SQL_NAMED_PARAMETERS_PREFIX) ||
             store.contains(ModelPreferences.SQL_CONTROL_COMMAND_PREFIX) ||
             store.contains(ModelPreferences.SQL_VARIABLES_ENABLED) ||
+            store.contains(ModelPreferences.SQL_VARIABLE_PATTERN) ||
 
             store.contains(SQLPreferenceConstants.RESET_CURSOR_ON_EXECUTE) ||
             store.contains(SQLPreferenceConstants.MAXIMIZE_EDITOR_ON_SCRIPT_EXECUTE) ||
@@ -223,6 +225,7 @@ public class PrefPageSQLExecute extends TargetPrefPage
             controlCommandPrefixText.setTextLimit(1);
             enableParametersInEmbeddedCode = UIUtils.createCheckbox(paramsGroup, SQLEditorMessages.pref_page_sql_editor_enable_parameters_in_ddl, SQLEditorMessages.pref_page_sql_editor_enable_parameters_in_ddl_tip, false, 2);
             enableVariables = UIUtils.createCheckbox(paramsGroup, SQLEditorMessages.pref_page_sql_editor_enable_variables, SQLEditorMessages.pref_page_sql_editor_enable_variables_tip, false, 2);
+            variablePattern = UIUtils.createLabelText(paramsGroup, SQLEditorMessages.pref_page_sql_editor_variable_pattern, "");
 
             GridData gd = new GridData(GridData.FILL_HORIZONTAL);
             gd.horizontalSpan = 2;
@@ -286,6 +289,7 @@ public class PrefPageSQLExecute extends TargetPrefPage
             controlCommandPrefixText.setText(store.getString(ModelPreferences.SQL_CONTROL_COMMAND_PREFIX));
             enableParametersInEmbeddedCode.setSelection(store.getBoolean(ModelPreferences.SQL_PARAMETERS_IN_EMBEDDED_CODE_ENABLED));
             enableVariables.setSelection(store.getBoolean(ModelPreferences.SQL_VARIABLES_ENABLED));
+            variablePattern.setText(store.getString(ModelPreferences.SQL_VARIABLE_PATTERN));
         } catch (Exception e) {
             log.warn(e);
         }
@@ -320,6 +324,7 @@ public class PrefPageSQLExecute extends TargetPrefPage
             store.setValue(ModelPreferences.SQL_CONTROL_COMMAND_PREFIX, controlCommandPrefixText.getText());
             store.setValue(ModelPreferences.SQL_PARAMETERS_IN_EMBEDDED_CODE_ENABLED, enableParametersInEmbeddedCode.getSelection());
             store.setValue(ModelPreferences.SQL_VARIABLES_ENABLED, enableVariables.getSelection());
+            store.setValue(ModelPreferences.SQL_VARIABLE_PATTERN, variablePattern.getText());
         } catch (Exception e) {
             log.warn(e);
         }
@@ -351,6 +356,7 @@ public class PrefPageSQLExecute extends TargetPrefPage
         store.setToDefault(ModelPreferences.SQL_ANONYMOUS_PARAMETERS_MARK);
         store.setToDefault(ModelPreferences.SQL_CONTROL_COMMAND_PREFIX);
         store.setToDefault(ModelPreferences.SQL_VARIABLES_ENABLED);
+        store.setToDefault(ModelPreferences.SQL_VARIABLE_PATTERN);
 
         store.setToDefault(ModelPreferences.SQL_NAMED_PARAMETERS_PREFIX);
         store.setToDefault(SQLPreferenceConstants.BEEP_ON_QUERY_END);


### PR DESCRIPTION
Adds a setting to specify the exact regex used for variables.

todo:
- Less hacky implementation of `ScriptVariableRule`?
- Tip text?
- A list of predefined formats?
- Tests?

Please share your feedback.

Fixes #15978, 