### PR TITLE
#15352 Add hint for database field on the connection page for PostgreSQL

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/PostgreMessages.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/PostgreMessages.java
@@ -159,6 +159,7 @@ public class PostgreMessages extends NLS {
     public static String dialog_create_role_label_role_name;
     public static String dialog_create_role_label_user_password;
     public static String dialog_create_role_label_user_role;
+    public static String dialog_database_name_hint;
 
     /* Permissions */
     public static String edit_command_grant_privilege_action_grant_privilege;

--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/PostgresResources.properties
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/PostgresResources.properties
@@ -137,7 +137,7 @@ dialog_setting_connection_password = Password
 dialog_setting_connection_port = Port
 dialog_setting_connection_settings = Settings
 dialog_setting_connection_user = User
-dialog_database_name_hint = equals to username if not specified
+dialog_database_name_hint = Username is used if not specified
 
 # PostgreCreateRoleDialog
 dialog_create_role_title = Create role

--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/PostgresResources.properties
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/PostgresResources.properties
@@ -137,6 +137,7 @@ dialog_setting_connection_password = Password
 dialog_setting_connection_port = Port
 dialog_setting_connection_settings = Settings
 dialog_setting_connection_user = User
+dialog_database_name_hint = equals to username if not specified
 
 # PostgreCreateRoleDialog
 dialog_create_role_title = Create role

--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/PostgreConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/PostgreConnectionPage.java
@@ -163,6 +163,7 @@ public class PostgreConnectionPage extends ConnectionPageWithAuth implements IDi
         gd.horizontalSpan = 3;
         dbText.setLayoutData(gd);
         dbText.addModifyListener(textListener);
+        dbText.setMessage(PostgreMessages.dialog_database_name_hint);
         addControlToGroup(GROUP_CONNECTION, dbText);
 
         createAuthPanel(mainGroup, 1);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28875055/197870050-a5fb0c56-2a37-4258-a7bc-a6dfd4b3e2f1.png)


By default we set database and user name to postgres, so user will see this hint only if they intentionally deletes the text from this field.