### PR TITLE
#18164 the "Information" tab and the "Driver class" combo can not be …

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/driver/DriverEditDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/driver/DriverEditDialog.java
@@ -537,6 +537,7 @@ public class DriverEditDialog extends HelpEnabledDialog {
                             if (obj instanceof DriverLibraryAbstract) {
                                 driver.resetDriverInstance();
                                 libraries.remove(obj);
+                                changeLibContent();
                             }
                         }
                     }
@@ -738,6 +739,8 @@ public class DriverEditDialog extends HelpEnabledDialog {
         if (updateVersionButton != null) {
             updateVersionButton.setEnabled(hasDownloads);
         }
+        detailsButton.setEnabled(hasFiles);
+        classListCombo.setEnabled(hasFiles);
     }
 
     private void changeLibSelection() {


### PR DESCRIPTION
…enabled if no drivers in the table

![2022-11-10 20_05_45-Window](https://user-images.githubusercontent.com/45152336/201160436-53289686-c54e-401c-bfdf-d93485b7d5be.png)
