### PR TITLE
dbeaver/pro#1272 use "int"/"integer" synonyms for the better data typ…

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/DBStructUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/DBStructUtils.java
@@ -48,6 +48,13 @@ public final class DBStructUtils {
 
     private static final Log log = Log.getLog(DBStructUtils.class);
 
+    private static final String INT_DATA_TYPE = "int";
+    private static final String INTEGER_DATA_TYPE = "integer";
+    private static final String FLOAT_DATA_TYPE = "float";
+    private static final String REAL_DATA_TYPE = "real";
+    private static final String DOUBLE_DATA_TYPE = "double";
+    private static final String TEXT_DATA_TYPE = "text";
+
     @Nullable
     public static DBSEntityReferrer getEnumerableConstraint(@NotNull DBRProgressMonitor monitor, @NotNull DBDAttributeBinding attribute) throws DBException {
         DBSEntityAttribute entityAttribute = attribute.getEntityAttribute();
@@ -317,7 +324,7 @@ public final class DBStructUtils {
                 // It seems this data type has modifiers. Try to find without modifiers
                 dataType = dataTypeProvider.getLocalDataType(SQLUtils.stripColumnTypeModifiers(typeName));
             }
-            if (dataType == null && typeNameLower.equals("double")) {
+            if (dataType == null && typeNameLower.equals(DOUBLE_DATA_TYPE)) {
                 dataType = dataTypeProvider.getLocalDataType("DOUBLE PRECISION");
                 if (dataType != null) {
                     typeName = dataType.getTypeName();
@@ -351,28 +358,36 @@ public final class DBStructUtils {
                             }
                         }
                         if (targetType == null) {
-                            if (typeNameLower.contains("float") ||
-                                typeNameLower.contains("real") ||
+                            if (typeNameLower.contains(FLOAT_DATA_TYPE) ||
+                                typeNameLower.contains(REAL_DATA_TYPE) ||
                                 (srcTypedObject.getScale() != null && srcTypedObject.getScale() > 0 && srcTypedObject.getScale() <= 6))
                             {
                                 for (String psn : possibleTypes.keySet()) {
-                                    if (psn.contains("float") || psn.contains("real")) {
+                                    if (psn.contains(FLOAT_DATA_TYPE) || psn.contains(REAL_DATA_TYPE)) {
                                         targetType = possibleTypes.get(psn);
                                         break;
                                     }
                                 }
-                            } else if (typeNameLower.contains("double") ||
+                            } else if (typeNameLower.contains(DOUBLE_DATA_TYPE) ||
                                 (srcTypedObject.getScale() != null && srcTypedObject.getScale() > 0 && srcTypedObject.getScale() <= 15))
                             {
                                 for (String psn : possibleTypes.keySet()) {
-                                    if (psn.contains("double")) {
+                                    if (psn.contains(DOUBLE_DATA_TYPE)) {
                                         targetType = possibleTypes.get(psn);
                                         break;
                                     }
                                 }
-                            } else if (typeNameLower.contains("int")) {
+                            } else if ((INT_DATA_TYPE.equals(typeNameLower) && possibleTypes.get(INTEGER_DATA_TYPE) != null)
+                                || (INTEGER_DATA_TYPE.equals(typeNameLower) && possibleTypes.get(INT_DATA_TYPE) != null))
+                            {
+                                // Let's use the closest int/integer synonym
+                                targetType = INT_DATA_TYPE.equals(typeNameLower)
+                                    ? possibleTypes.get(INTEGER_DATA_TYPE) : possibleTypes.get(INT_DATA_TYPE);
+
+                            } else if (typeNameLower.contains(INT_DATA_TYPE)) {
+                                // Ok, probably we do not have int/integer types, let's find something similar
                                 for (String psn : possibleTypes.keySet()) {
-                                    if (psn.contains("int")) {
+                                    if (psn.contains(INT_DATA_TYPE)) {
                                         targetType = possibleTypes.get(psn);
                                         break;
                                     }
@@ -380,12 +395,12 @@ public final class DBStructUtils {
                             }
                         }
                     } else if (targetType == null && dataKind == DBPDataKind.STRING) {
-                        if (typeNameLower.contains("text")) {
-                            if (possibleTypes.containsKey("text")) {
-                                targetType = possibleTypes.get("text");
+                        if (typeNameLower.contains(TEXT_DATA_TYPE)) {
+                            if (possibleTypes.containsKey(TEXT_DATA_TYPE)) {
+                                targetType = possibleTypes.get(TEXT_DATA_TYPE);
                             } else {
                                 for (Map.Entry<String, DBSDataType> type : possibleTypes.entrySet()) {
-                                    if (type.getKey().contains("text")) {
+                                    if (type.getKey().contains(TEXT_DATA_TYPE)) {
                                         targetType = type.getValue();
                                         break;
                                     }


### PR DESCRIPTION
…es mapping


![2022-11-22 20_13_57-143 453 106 - AnyDesk](https://user-images.githubusercontent.com/45152336/203380778-abd7d681-bd9f-4d3f-bb14-0cd57032a9c0.png)

Qriteries:

- [ ] The XLSX file can be imported in the new table with the "INT"/"INTEGER" data type for the new numeric column
- [ ] Tables with INT columns can be imported into other databases. INT data type will be not converted or converted to INTEGER.
- [ ] Tables with INTEGER columns can be imported into other databases. The INTEGER data type will be not converted or converted to INT.
