### PR TITLE
#18015 return Iris Cache driver downloading path

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -481,6 +481,7 @@
                     supportedConfigurationTypes="MANUAL,URL"
                     categories="sql,object">
                     <file type="license" path="https://www.apache.org/licenses/LICENSE-2.0.txt" bundle="!drivers.cache"/>
+                    <file type="jar" path="repo:/drivers/cache/CacheDB.jar" bundle="!drivers.cache"/>
                     <file type="jar" path="drivers/cache" bundle="drivers.cache"/>
                     <file type="license" path="drivers/cache/LICENSE.txt" bundle="drivers.cache"/>
                 </driver>


### PR DESCRIPTION
![2022-11-24 13_42_39-DBeaver 22 2 5 - _master 3_ Script-80](https://user-images.githubusercontent.com/45152336/203764461-81192dda-878e-4439-8e8b-7d22ea33c5e4.png)

Qriteries:

- [x] The driver is on the library list
- [x]  You can try to connect to Iris, and your error will contain info from the driver. Like:
```java
 java.sql.SQLException: [Cache JDBC] Communication link failure: Connection refused: connect
	at com.intersys.jdbc.CacheConnection.connect(CacheConnection.java:1063)
```
- [ ] The driver is on the library list in EE

