### PR TITLE
#18172 fix table DDL generation for Clickhouse

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSQLDialect.java
@@ -136,6 +136,12 @@ public class ClickhouseSQLDialect extends GenericSQLDialect {
                 return true;
             }
         }
+        for (int i = 0; i < str.length(); i++) {
+            int c = str.charAt(i);
+            if (Character.isLetter(c) && !(c >= 'a' && c <= 'z') && !(c >= 'A' && c <= 'Z')) {
+                return true;
+            }
+        }
         return super.mustBeQuoted(str, forceCaseSensitive);
     }
 


### PR DESCRIPTION
Using quotes (escaping) for non-English table name #18172 

Old command for table DDL generation:
```
show create table `default`.тест
```

New command for table DDL generation:
```
show create table `default`.`тест`
```
