### PR TITLE
#18101 Do not set windows trust store if it has been already set

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreMessages.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreMessages.java
@@ -624,6 +624,7 @@ public class CoreMessages extends NLS {
     public static String pref_page_connections_group_security;
     public static String pref_page_connections_use_win_cert_label;
     public static String pref_page_connections_use_win_cert_tip;
+    public static String pref_page_connections_use_win_cert_disabled_tip;
 
     public static String pref_page_transactions_notify_name_group_label;
     public static String pref_page_transactions_notifications_show_check_label;

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreResources.properties
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreResources.properties
@@ -599,6 +599,7 @@ monitor_panel_transaction_monitor_tip = Transactions monitor
 pref_page_connections_group_security = Security
 pref_page_connections_use_win_cert_label = Use Windows trust store
 pref_page_connections_use_win_cert_tip = Changes will be applied after DBeaver restart. Sets javax.net.ssl.trustStoreType to WINDOWS-ROOT
+pref_page_connections_use_win_cert_disabled_tip = javax.net.ssl.trustStoreType or javax.net.ssl.trustStore has been already set
 
 pref_page_transactions_notify_name_group_label = Notifications
 pref_page_transactions_notifications_show_check_label = Show transaction end notification

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConnectionsGeneral.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConnectionsGeneral.java
@@ -125,21 +125,23 @@ public class PrefPageConnectionsGeneral extends AbstractPrefPage implements IWor
             );
             
 
-            if (System.getProperty(GeneralUtils.PROP_TRUST_STORE) != null || System.getProperty(GeneralUtils.PROP_TRUST_STORE_TYPE) != null) {
+            if (System.getProperty(GeneralUtils.PROP_TRUST_STORE) != null
+                || System.getProperty(GeneralUtils.PROP_TRUST_STORE_TYPE) != null
+            ) {
                 Composite winTrustStoreComposite = UIUtils.createComposite(settings, 1);
                 useWinTrustStoreCheck = UIUtils.createCheckbox(
-                        winTrustStoreComposite,
-                        CoreMessages.pref_page_connections_use_win_cert_label,
-                        ModelPreferences.getPreferences().getBoolean(ModelPreferences.PROP_USE_WIN_TRUST_STORE_TYPE)
-                    );
+                    winTrustStoreComposite,
+                    CoreMessages.pref_page_connections_use_win_cert_label,
+                    ModelPreferences.getPreferences().getBoolean(ModelPreferences.PROP_USE_WIN_TRUST_STORE_TYPE)
+                );
                 winTrustStoreComposite.setToolTipText(CoreMessages.pref_page_connections_use_win_cert_disabled_tip);
                 useWinTrustStoreCheck.setEnabled(false);
             } else {
                 useWinTrustStoreCheck = UIUtils.createCheckbox(
-                        settings,
-                        CoreMessages.pref_page_connections_use_win_cert_label,
-                        ModelPreferences.getPreferences().getBoolean(ModelPreferences.PROP_USE_WIN_TRUST_STORE_TYPE)
-                    );
+                    settings,
+                    CoreMessages.pref_page_connections_use_win_cert_label,
+                    ModelPreferences.getPreferences().getBoolean(ModelPreferences.PROP_USE_WIN_TRUST_STORE_TYPE)
+                );
                 useWinTrustStoreCheck.setToolTipText(CoreMessages.pref_page_connections_use_win_cert_tip);
             }
         }

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConnectionsGeneral.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConnectionsGeneral.java
@@ -123,12 +123,25 @@ public class PrefPageConnectionsGeneral extends AbstractPrefPage implements IWor
                 GridData.FILL_HORIZONTAL,
                 300
             );
-            useWinTrustStoreCheck = UIUtils.createCheckbox(
-                settings,
-                CoreMessages.pref_page_connections_use_win_cert_label,
-                ModelPreferences.getPreferences().getBoolean(ModelPreferences.PROP_USE_WIN_TRUST_STORE_TYPE)
-            );
-            useWinTrustStoreCheck.setToolTipText(CoreMessages.pref_page_connections_use_win_cert_tip);
+            
+
+            if (System.getProperty(GeneralUtils.PROP_TRUST_STORE) != null || System.getProperty(GeneralUtils.PROP_TRUST_STORE_TYPE) != null) {
+                Composite winTrustStoreComposite = UIUtils.createComposite(settings, 1);
+                useWinTrustStoreCheck = UIUtils.createCheckbox(
+                        winTrustStoreComposite,
+                        CoreMessages.pref_page_connections_use_win_cert_label,
+                        ModelPreferences.getPreferences().getBoolean(ModelPreferences.PROP_USE_WIN_TRUST_STORE_TYPE)
+                    );
+                winTrustStoreComposite.setToolTipText(CoreMessages.pref_page_connections_use_win_cert_disabled_tip);
+                useWinTrustStoreCheck.setEnabled(false);
+            } else {
+                useWinTrustStoreCheck = UIUtils.createCheckbox(
+                        settings,
+                        CoreMessages.pref_page_connections_use_win_cert_label,
+                        ModelPreferences.getPreferences().getBoolean(ModelPreferences.PROP_USE_WIN_TRUST_STORE_TYPE)
+                    );
+                useWinTrustStoreCheck.setToolTipText(CoreMessages.pref_page_connections_use_win_cert_tip);
+            }
         }
         
         {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
@@ -77,7 +77,10 @@ public class GeneralUtils {
         '8', '9', 'a', 'b',
         'c', 'd', 'e', 'f'
     };
-
+    
+    public static final String PROP_TRUST_STORE = "javax.net.ssl.trustStore"; //$NON-NLS-1$
+    public static final String PROP_TRUST_STORE_TYPE = "javax.net.ssl.trustStoreType"; //$NON-NLS-1$
+    
     static {
         // Compose byte to hex map
         for (int i = 0; i < 256; ++i) {

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/DBeaverApplication.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/DBeaverApplication.java
@@ -98,7 +98,6 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
     private static final String PROP_EXIT_DATA = IApplicationContext.EXIT_DATA_PROPERTY; //$NON-NLS-1$
     private static final String PROP_EXIT_CODE = "eclipse.exitcode"; //$NON-NLS-1$
 
-    private static final String PROP_TRUST_STORE_TYPE = "javax.net.ssl.trustStoreType"; //$NON-NLS-1$
     private static final String VALUE_TRUST_STRORE_TYPE_WINDOWS = "WINDOWS-ROOT"; //$NON-NLS-1$
 
     public static final String DEFAULT_WORKSPACE_FOLDER = "workspace6";
@@ -278,8 +277,12 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
         }
         TimezoneRegistry.overrideTimezone();
 
-        if (RuntimeUtils.isWindows() && ModelPreferences.getPreferences().getBoolean(ModelPreferences.PROP_USE_WIN_TRUST_STORE_TYPE)) {
-            System.setProperty(PROP_TRUST_STORE_TYPE, VALUE_TRUST_STRORE_TYPE_WINDOWS);
+        if (RuntimeUtils.isWindows()
+            && System.getProperty(GeneralUtils.PROP_TRUST_STORE) == null
+            && System.getProperty(GeneralUtils.PROP_TRUST_STORE_TYPE) == null
+            && ModelPreferences.getPreferences().getBoolean(ModelPreferences.PROP_USE_WIN_TRUST_STORE_TYPE)
+        ) {
+            System.setProperty(GeneralUtils.PROP_TRUST_STORE_TYPE, VALUE_TRUST_STRORE_TYPE_WINDOWS);
         }
 
         // Prefs default


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28875055/204019902-67ae7fe8-8d0d-438c-929e-864052c53bd4.png)

javax.net.ssl.trustStoreType = WINDOWS-ROOT should not be set if javax.net.ssl.trustStoreType or javax.net.ssl.trustStore props are already set by user via vmargs or in dbeaver.ini.