### PR TITLE
#17763 add special condition before displaying the statistics tab

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -4230,7 +4230,11 @@ public class SQLEditor extends SQLEditorBase implements
                             // in that case we need to update tab selection and
                             // select new statistics tab
                             // see #16605
-                            setResultTabSelection(results.resultsTab);
+                            // But we need to avoid the result tab with the select statement
+                            // because the statistics window can not be in focus in this case
+                            if (query.getType() != SQLQueryType.SELECT) {
+                                setResultTabSelection(results.resultsTab);
+                            }
                             continue;
                         }
                         if (resultsIndex < result.getExecuteResults().size()) {


### PR DESCRIPTION
![2022-11-30 22_54_49-DBeaver Ultimate 22 3 0 - _postgres_ Script-86](https://user-images.githubusercontent.com/45152336/204895741-c8db835c-7b62-4286-a87b-6933df84f70c.png)

![2022-11-30 23_02_20-DBeaver Ultimate 22 3 0 - _postgres_ Script-86](https://user-images.githubusercontent.com/45152336/204896896-07e3bda2-0916-4468-9752-77774478be98.png)

Also, please check 

- [ ] some different types of queries, 
- [ ] as a script, 
- [ ] as opening in the new tab, 
- [ ] with variable, 
- [ ] selects, 
- [ ] updates, 
- [ ] creates.
- [ ]  And check the #16605 ticket, if it still works well.
- [ ] And this case: https://github.com/dbeaver/dbeaver/issues/17763#issuecomment-1261512513
