### PR TITLE
#17908 Require JNA bundles

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.firebird/META-INF/MANIFEST.MF
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/META-INF/MANIFEST.MF
@@ -5,6 +5,8 @@ Bundle-SymbolicName: org.jkiss.dbeaver.ext.firebird;singleton:=true
 Bundle-Version: 1.0.196.qualifier
 Bundle-Release-Date: 20221205
 Require-Bundle: org.eclipse.core.runtime,
+ com.sun.jna,
+ com.sun.jna.platform,
  org.jkiss.dbeaver.model,
  org.jkiss.dbeaver.ext.generic
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
During connection, you might get another error saying it can't find the native library `fbclient.dll` / `fbclient.so`.

To solve this error, you will have to [download](https://firebirdsql.org/en/firebird-3-0-10/) the Firebird ZIP kit, unpack it somewhere and point to it in the driver files.