### PR TITLE
Fix french translation

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/internal/DTUIMessages_fr.properties
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/internal/DTUIMessages_fr.properties
@@ -4,4 +4,4 @@ data_transfer_wizard_final_description = V\u00E9rifier les r\u00E9sultats
 data_transfer_wizard_final_group_tables = Tables
 data_transfer_wizard_final_name = Confirmer
 data_transfer_wizard_final_title = Confirmer
-data_transfer_wizard_name = Transf\u00E9r de donn\u00E9es
+data_transfer_wizard_name = Transfert de donn\u00E9es


### PR DESCRIPTION
Fix the window title when exporting data.

In french, the verb is `Transférer` and the noun is `Transfert`.

![image](https://user-images.githubusercontent.com/3403829/205254175-b584f3b4-ac23-46d5-b932-4eae79daa79e.png)
