### PR TITLE
#18514 add more casting operations for dependency downloading statement

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependency.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependency.java
@@ -231,14 +231,14 @@ public class PostgreDependency implements PostgreObject, DBPOverloadedObject, DB
             String condObjId = dependents ? "refobjid" : "objid";
             try (JDBCPreparedStatement dbStat = session.prepareStatement(
                 "SELECT DISTINCT dep.deptype, dep.classid, dep." + queryObjId + ", cl.relkind, attr.attname,pg_get_expr(ad.adbin, ad.adrelid) adefval,\n" +
-                    "    CASE WHEN cl.relkind IS NOT NULL THEN cl.relkind || COALESCE(dep.objsubid::text, '')\n" +
+                    "    CASE WHEN cl.relkind IS NOT NULL THEN cl.relkind::text || COALESCE(dep.objsubid::text, '')::text\n" +
                     "        WHEN tg.oid IS NOT NULL THEN 'T'::text\n" +
                     "        WHEN ty.oid IS NOT NULL THEN 'y'::text\n" +
                     "        WHEN ns.oid IS NOT NULL THEN 'n'::text\n" +
                     "        WHEN pr.oid IS NOT NULL THEN 'p'::text\n" +
                     "        WHEN la.oid IS NOT NULL THEN 'l'::text\n" +
                     "        WHEN rw.oid IS NOT NULL THEN 'R'::text\n" +
-                    "        WHEN co.oid IS NOT NULL THEN 'C'::text || contype\n" +
+                    "        WHEN co.oid IS NOT NULL THEN 'C'::text || contype::text\n" +
                     "        WHEN ad.oid IS NOT NULL THEN 'A'::text\n" +
                     "        ELSE ''\n" +
                     "    END AS type,\n" +


### PR DESCRIPTION
![2022-12-19 14_08_29-Window](https://user-images.githubusercontent.com/45152336/208414102-eb5ab85b-761c-4595-84e5-a03642b72465.png)

Please check:

- [x] Any dependency. That dependency reading query is still working fine and shows the correct result.
- [x] Check PostgreSQL 15 Dependency tab opening
- [x] Check PostgreSQL 10/11/12/13 or 14 Dependency tab opening
- [x] Check PostgreSQL 9 Dependency tab opening
- [x] Check Greenplum Dependency tab opening
- [x] Check Redshift Dependency tab opening
- [x] Check Cockroach Dependency tab opening
- [x] Check EDB Dependency tab opening