### PR TITLE
#18532 turn on database tasks tooltips

### DIFF
--- a/plugins/org.jkiss.dbeaver.tasks.ui.view/src/org/jkiss/dbeaver/tasks/ui/view/DatabaseTasksTree.java
+++ b/plugins/org.jkiss.dbeaver.tasks.ui.view/src/org/jkiss/dbeaver/tasks/ui/view/DatabaseTasksTree.java
@@ -45,6 +45,7 @@ import org.jkiss.dbeaver.registry.task.TaskRegistry;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.tasks.ui.internal.TaskUIViewMessages;
 import org.jkiss.dbeaver.ui.DBeaverIcons;
+import org.jkiss.dbeaver.ui.DefaultViewerToolTipSupport;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.controls.ViewerColumnController;
 import org.jkiss.dbeaver.ui.dialogs.DialogUtils;
@@ -246,6 +247,7 @@ public class DatabaseTasksTree {
             }
         });
         taskColumnController.createColumns(true);
+        new DefaultViewerToolTipSupport(taskViewer);
 
         taskViewer.setContentProvider(new TreeListContentProvider());
     }


### PR DESCRIPTION
![2022-12-19 14_40_31-Window](https://user-images.githubusercontent.com/45152336/208418133-2b6be52e-bcd0-4cb9-a63b-e2e94a767565.png)

[getToolTip method is already in the code]

Please check:

- [x] A task description shows as a tooltip if a task has a description.
- [x] A task name shows as a tooltip if a task has a description.
- [x] The display of tooltips does not interfere with viewing tasks. There is a delay in a pop-up tooltip. It is advisable to check on Mac or Linux.