### PR TITLE
Remove Incubating from Kyuubi reference

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -832,7 +832,7 @@
                 </driver>
                 <driver
                     id="kyuubi_hive"
-                    label="Apache Kyuubi (Incubating)"
+                    label="Apache Kyuubi"
                     icon="icons/kyuubi_hive_icon.png"
                     iconBig="icons/kyuubi_hive_icon_big.png"
                     class="org.apache.kyuubi.jdbc.KyuubiHiveDriver"


### PR DESCRIPTION
This PR is proposes to remove incubating from Kyuubi reference, since the ASF board has approved a resolution to graduate Kyuubi into a full Top Level Project. 

https://github.com/apache/kyuubi/issues/4020
