### PR TITLE
#16121 Fix templates context initialization and filtering on insert

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorUtils.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorUtils.java
@@ -46,6 +46,8 @@ import org.jkiss.dbeaver.ui.editors.sql.handlers.SQLEditorVariablesResolver;
 import org.jkiss.dbeaver.ui.editors.sql.handlers.SQLNavigatorContext;
 import org.jkiss.dbeaver.ui.editors.sql.internal.SQLEditorActivator;
 import org.jkiss.dbeaver.ui.editors.sql.scripts.ScriptsHandlerImpl;
+import org.jkiss.dbeaver.ui.editors.sql.templates.SQLContextTypeBase;
+import org.jkiss.dbeaver.ui.editors.sql.templates.SQLContextTypeDriver;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.dbeaver.utils.ResourceUtils;
 import org.jkiss.utils.CommonUtils;
@@ -543,5 +545,29 @@ public class SQLEditorUtils {
             oldServicesEnabled && markWordForSelectionEnabled,
             newServicesEnabled && markWordForSelectionEnabled
         );
+    }
+    
+    /**
+     * Returns type id of the driver of data source container, associated with SQLEditor
+     * Returns null if editor is not instance fo SQLEditor or data source container is null
+     */
+    @Nullable
+    public static String getEditorContextTypeId(@NotNull SQLEditorBase editor) {
+        String contextTypeId = null;
+        if (editor instanceof SQLEditor) {
+            DBPDataSourceContainer dsContainer = ((SQLEditor) editor).getDataSourceContainer();
+            if (dsContainer != null) {
+                contextTypeId = SQLContextTypeDriver.getTypeId(dsContainer.getDriver());
+            }
+        }
+        return contextTypeId;
+    }
+    
+    /**
+     * Checks whether template's context is suitable for the editor context
+     */
+    public static boolean isTemplateContextFitsEditorContext(@NotNull String templateContextTypeId, @Nullable String editorContextId) {
+        return editorContextId != null && templateContextTypeId.equalsIgnoreCase(editorContextId) 
+            || templateContextTypeId.equalsIgnoreCase(SQLContextTypeBase.ID_SQL);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorUtils.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorUtils.java
@@ -548,8 +548,8 @@ public class SQLEditorUtils {
     }
     
     /**
-     * Returns type id of the driver of data source container, associated with SQLEditor
-     * Returns null if editor is not instance fo SQLEditor or data source container is null
+     * Returns type id of the driver of data source container, associated with SQLEditor, 
+     * or {@code null} if editor is not instance of SQLEditor or data source container is null
      */
     @Nullable
     public static String getEditorContextTypeId(@NotNull SQLEditorBase editor) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLCompletionProcessor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLCompletionProcessor.java
@@ -41,6 +41,7 @@ import org.jkiss.dbeaver.model.sql.registry.SQLCommandHandlerDescriptor;
 import org.jkiss.dbeaver.model.sql.registry.SQLCommandsRegistry;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
+import org.jkiss.dbeaver.ui.editors.sql.SQLEditorUtils;
 import org.jkiss.dbeaver.ui.editors.sql.SQLPreferenceConstants;
 import org.jkiss.dbeaver.ui.editors.sql.templates.SQLContext;
 import org.jkiss.dbeaver.ui.editors.sql.templates.SQLTemplateCompletionProposal;
@@ -183,10 +184,13 @@ public class SQLCompletionProcessor implements IContentAssistProcessor
     @NotNull
     private ICompletionProposal[] makeTemplateProposals(ITextViewer viewer, SQLCompletionRequest request) {
         String wordPart = request.getWordPart().toLowerCase();
+        String contextId = SQLEditorUtils.getEditorContextTypeId(editor);
         final List<SQLTemplateCompletionProposal> templateProposals = new ArrayList<>();
         // Templates
         for (Template template : editor.getTemplatesPage().getTemplateStore().getTemplates()) {
-            if (template.getName().toLowerCase().startsWith(wordPart)) {
+            if (template.getName().toLowerCase().startsWith(wordPart)
+                && SQLEditorUtils.isTemplateContextFitsEditorContext(template.getContextTypeId(), contextId)
+            ) { 
                 SQLContext templateContext = new SQLContext(
                     SQLTemplatesRegistry.getInstance().getTemplateContextRegistry().getContextType(template.getContextTypeId()),
                     viewer.getDocument(),

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/templates/SQLTemplatesPage.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/templates/SQLTemplatesPage.java
@@ -36,11 +36,13 @@ import org.eclipse.ui.part.IPageSite;
 import org.eclipse.ui.texteditor.templates.AbstractTemplatesPage;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.DBPDataSource;
+import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.connection.DBPDriver;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.ui.DBeaverIcons;
 import org.jkiss.dbeaver.ui.ProxyPageSite;
 import org.jkiss.dbeaver.ui.UIIcon;
+import org.jkiss.dbeaver.ui.editors.sql.SQLEditor;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorSourceViewer;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorSourceViewerConfiguration;
@@ -294,13 +296,23 @@ public class SQLTemplatesPage extends AbstractTemplatesPage {
      * @return an array of valid context id
      */
     @Override
-    protected String[] getContextTypeIds(IDocument document, int offset)
-    {
-        DBPDataSource dataSource = sqlEditor.getDataSource();
-        if (dataSource == null) {
+    protected String[] getContextTypeIds(IDocument document, int offset) {
+        DBPDriver driver = null;
+        if (sqlEditor instanceof SQLEditor) {
+            DBPDataSourceContainer dsContainer = ((SQLEditor) sqlEditor).getDataSourceContainer();
+            if (dsContainer != null) {
+                driver = dsContainer.getDriver();
+            }
+        }
+        if (driver == null) {
+            DBPDataSource dataSource = sqlEditor.getDataSource();
+            if (dataSource != null) {
+                driver = dataSource.getContainer().getDriver();
+            }
+        }
+        if (driver == null) {
             return new String[]{SQLContextTypeBase.ID_SQL};
         } else {
-            DBPDriver driver = dataSource.getContainer().getDriver();
             return new String[]{
                 SQLContextTypeBase.ID_SQL,
                 SQLContextTypeProvider.getTypeId(driver.getProviderId()),

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/util/SQLSymbolInserter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/util/SQLSymbolInserter.java
@@ -32,8 +32,11 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.sql.parser.SQLParserPartitions;
+import org.jkiss.dbeaver.ui.editors.sql.SQLEditor;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
+import org.jkiss.dbeaver.ui.editors.sql.templates.SQLContextTypeDriver;
 import org.jkiss.dbeaver.ui.editors.sql.templates.SQLTemplatesPage;
 
 import java.util.ArrayList;
@@ -266,7 +269,14 @@ public class SQLSymbolInserter implements VerifyKeyListener, ILinkedModeListener
                     if (curOffset != offset) {
                         String templateName = document.get(curOffset, offset - curOffset);
                         SQLTemplatesPage templatesPage = editor.getTemplatesPage();
-                        Template template = templatesPage.getTemplateStore().findTemplate(templateName);
+                        String contextId = null;
+                        if (editor instanceof SQLEditor) {
+                           DBPDataSourceContainer dsContainer = ((SQLEditor) editor).getDataSourceContainer();
+                           if (dsContainer != null) {
+                               contextId = SQLContextTypeDriver.getTypeId(dsContainer.getDriver());
+                           }
+                        }
+                        Template template = templatesPage.getTemplateStore().findTemplate(templateName, contextId);
                         if (template != null && template.isAutoInsertable()) {
                             sourceViewer.setSelectedRange(curOffset, offset - curOffset);
                             templatesPage.insertTemplate(template, document);

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/util/SQLSymbolInserter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/util/SQLSymbolInserter.java
@@ -32,11 +32,9 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.jkiss.dbeaver.Log;
-import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.sql.parser.SQLParserPartitions;
-import org.jkiss.dbeaver.ui.editors.sql.SQLEditor;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
-import org.jkiss.dbeaver.ui.editors.sql.templates.SQLContextTypeDriver;
+import org.jkiss.dbeaver.ui.editors.sql.SQLEditorUtils;
 import org.jkiss.dbeaver.ui.editors.sql.templates.SQLTemplatesPage;
 
 import java.util.ArrayList;
@@ -131,8 +129,7 @@ public class SQLSymbolInserter implements VerifyKeyListener, ILinkedModeListener
     }
 
     @Override
-    public void verifyKey(VerifyEvent event)
-    {
+    public void verifyKey(VerifyEvent event) {
 
         if (!event.doit) {
             return;
@@ -252,8 +249,7 @@ public class SQLSymbolInserter implements VerifyKeyListener, ILinkedModeListener
                     log.debug(e);
                 }
                 break;
-            case SWT.TAB:
-            {
+            case SWT.TAB: {
                 try {
                     int curOffset = offset;
 //                    if (curOffset == document.getLength()) {
@@ -269,15 +265,11 @@ public class SQLSymbolInserter implements VerifyKeyListener, ILinkedModeListener
                     if (curOffset != offset) {
                         String templateName = document.get(curOffset, offset - curOffset);
                         SQLTemplatesPage templatesPage = editor.getTemplatesPage();
-                        String contextId = null;
-                        if (editor instanceof SQLEditor) {
-                           DBPDataSourceContainer dsContainer = ((SQLEditor) editor).getDataSourceContainer();
-                           if (dsContainer != null) {
-                               contextId = SQLContextTypeDriver.getTypeId(dsContainer.getDriver());
-                           }
-                        }
-                        Template template = templatesPage.getTemplateStore().findTemplate(templateName, contextId);
-                        if (template != null && template.isAutoInsertable()) {
+                        String contextId = SQLEditorUtils.getEditorContextTypeId(editor);
+                        Template template = templatesPage.getTemplateStore().findTemplate(templateName);
+                        if (template != null && template.isAutoInsertable()
+                            && SQLEditorUtils.isTemplateContextFitsEditorContext(template.getContextTypeId(), contextId)
+                        ) {
                             sourceViewer.setSelectedRange(curOffset, offset - curOffset);
                             templatesPage.insertTemplate(template, document);
                             event.doit = false;


### PR DESCRIPTION
- Templates should be correctly saved and restored, while changing its context.
- Only templates with the corresponding context should be proposed and auto inserted. For example, if you opened editor for SQLite connection, you should be able to use for auto insertion templates with SQLite and SQL context, but templates with other contexts, for example, PostgreSQL, should not be available. The same is for templates proposal (Ctrl + Alt + Space).