### PR TITLE
CB-3013 alter Snowflake session parameter on start 

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
@@ -19,7 +19,6 @@ package org.jkiss.dbeaver.ext.snowflake.model;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
-import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.generic.model.GenericCatalog;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.GenericSchema;
@@ -36,8 +35,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SnowflakeDataSource extends GenericDataSource {
-
-    private static final Log log = Log.getLog(SnowflakeDataSource.class);
 
     public SnowflakeDataSource(DBRProgressMonitor monitor, DBPDataSourceContainer container, SnowflakeMetaModel metaModel)
         throws DBException

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
@@ -25,17 +25,13 @@ import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.GenericSchema;
 import org.jkiss.dbeaver.ext.snowflake.SnowflakeConstants;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
-import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
 import org.jkiss.dbeaver.model.connection.DBPDriver;
-import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
-import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCExecutionContext;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCRemoteInstance;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.utils.CommonUtils;
 
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -81,22 +77,6 @@ public class SnowflakeDataSource extends GenericDataSource {
     @Override
     protected JDBCExecutionContext createExecutionContext(JDBCRemoteInstance instance, String type) {
         return new SnowflakeExecutionContext(instance, type);
-    }
-
-    @Override
-    public void initialize(@NotNull DBRProgressMonitor monitor) throws DBException {
-        try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Alter Snowflake Session")) {
-            // JDBC Driver throws java.lang.NoClassDefFoundError for class RootAllocator in Arrow Library, while trying to run a select query.
-            // So this is official workaround for systems with Java 17 and if Arrow library installation is not possible
-            // or if the Operating System is not supported by Arrow.
-            try (JDBCStatement dbStat = session.createStatement()) {
-                dbStat.execute("ALTER SESSION SET JDBC_QUERY_RESULT_FORMAT='JSON'");
-            } catch (SQLException e) {
-                // Only logging because
-                log.error("Can't change current session format parameter", e);
-            }
-        }
-        super.initialize(monitor);
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
@@ -19,22 +19,29 @@ package org.jkiss.dbeaver.ext.snowflake.model;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.generic.model.GenericCatalog;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.GenericSchema;
 import org.jkiss.dbeaver.ext.snowflake.SnowflakeConstants;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
 import org.jkiss.dbeaver.model.connection.DBPDriver;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCExecutionContext;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCRemoteInstance;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.utils.CommonUtils;
 
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
 public class SnowflakeDataSource extends GenericDataSource {
+
+    private static final Log log = Log.getLog(SnowflakeDataSource.class);
 
     public SnowflakeDataSource(DBRProgressMonitor monitor, DBPDataSourceContainer container, SnowflakeMetaModel metaModel)
         throws DBException
@@ -74,6 +81,22 @@ public class SnowflakeDataSource extends GenericDataSource {
     @Override
     protected JDBCExecutionContext createExecutionContext(JDBCRemoteInstance instance, String type) {
         return new SnowflakeExecutionContext(instance, type);
+    }
+
+    @Override
+    public void initialize(@NotNull DBRProgressMonitor monitor) throws DBException {
+        try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Alter Snowflake Session")) {
+            // JDBC Driver throws java.lang.NoClassDefFoundError for class RootAllocator in Arrow Library, while trying to run a select query.
+            // So this is official workaround for systems with Java 17 and if Arrow library installation is not possible
+            // or if the Operating System is not supported by Arrow.
+            try (JDBCStatement dbStat = session.createStatement()) {
+                dbStat.execute("ALTER SESSION SET JDBC_QUERY_RESULT_FORMAT='JSON'");
+            } catch (SQLException e) {
+                // Only logging because
+                log.error("Can't change current session format parameter", e);
+            }
+        }
+        super.initialize(monitor);
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
@@ -208,7 +208,7 @@ class SnowflakeExecutionContext extends GenericExecutionContext {
 
     @NotNull
     @Override
-    public List<String> getExtraInitQueries() {
+    protected List<String> getExtraInitQueries() {
         // JDBC Driver throws java.lang.NoClassDefFoundError for class RootAllocator in Arrow Library, while trying to run a select query.
         // So this is official workaround for systems with Java 17 and if Arrow library installation is not possible
         // or if the Operating System is not supported by Arrow.

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
@@ -39,7 +39,6 @@ import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.utils.CommonUtils;
 
 import java.sql.SQLException;
-import java.util.Collections;
 import java.util.List;
 
 class SnowflakeExecutionContext extends GenericExecutionContext {
@@ -213,6 +212,6 @@ class SnowflakeExecutionContext extends GenericExecutionContext {
         // JDBC Driver throws java.lang.NoClassDefFoundError for class RootAllocator in Arrow Library, while trying to run a select query.
         // So this is official workaround for systems with Java 17 and if Arrow library installation is not possible
         // or if the Operating System is not supported by Arrow.
-        return Collections.singletonList("ALTER SESSION SET JDBC_QUERY_RESULT_FORMAT='JSON'");
+        return List.of("ALTER SESSION SET JDBC_QUERY_RESULT_FORMAT='JSON'");
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
@@ -210,16 +210,8 @@ class SnowflakeExecutionContext extends GenericExecutionContext {
         // So this is official workaround for systems with Java 17 (and maybe earlier) and if Arrow library installation is not possible
         // or if the Operating System is not supported by Arrow.
         String query = "ALTER SESSION SET JDBC_QUERY_RESULT_FORMAT='JSON'";
-        try {
-            try (DBCStatement dbStat = session.prepareStatement(
-                DBCStatementType.SCRIPT,
-                query,
-                false,
-                false,
-                false))
-            {
-                dbStat.executeStatement();
-            }
+        try (DBCStatement dbStat = session.prepareStatement(DBCStatementType.SCRIPT, query, false, false, false)) {
+            dbStat.executeStatement();
         } catch (Exception e) {
             log.warn("Error executing initial query.");
         }

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
@@ -39,6 +39,8 @@ import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.utils.CommonUtils;
 
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
 
 class SnowflakeExecutionContext extends GenericExecutionContext {
     private static final Log log = Log.getLog(SnowflakeExecutionContext.class);
@@ -203,5 +205,14 @@ class SnowflakeExecutionContext extends GenericExecutionContext {
             log.error("Unable to set active schema due to unexpected SQLException. schemaName=" + schemaName);
             throw new DBCException(e, this);
         }
+    }
+
+    @NotNull
+    @Override
+    public List<String> getExtraInitQueries() {
+        // JDBC Driver throws java.lang.NoClassDefFoundError for class RootAllocator in Arrow Library, while trying to run a select query.
+        // So this is official workaround for systems with Java 17 and if Arrow library installation is not possible
+        // or if the Operating System is not supported by Arrow.
+        return Collections.singletonList("ALTER SESSION SET JDBC_QUERY_RESULT_FORMAT='JSON'");
     }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractExecutionContext.java
@@ -125,11 +125,9 @@ public abstract class AbstractExecutionContext<DATASOURCE extends DBPDataSource>
             }
             return true;
         } else {
-            boolean executed;
             try (DBCSession session = openSession(monitor, DBCExecutionPurpose.UTIL, "Run extra init queries")) {
-                executed = executeExtraInitQueries(session);
+                return executeExtraInitQueries(session);
             }
-            return executed;
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractExecutionContext.java
@@ -27,6 +27,7 @@ import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.utils.CommonUtils;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,6 +102,7 @@ public abstract class AbstractExecutionContext<DATASOURCE extends DBPDataSource>
         // Execute bootstrap queries
         DBPConnectionBootstrap bootstrap = getBootstrapSettings();
         List<String> initQueries = bootstrap.getInitQueries();
+        initQueries.addAll(getExtraInitQueries());
         if (!CommonUtils.isEmpty(initQueries)) {
             monitor.subTask("Run bootstrap queries");
             try (DBCSession session = openSession(monitor, DBCExecutionPurpose.UTIL, "Run bootstrap queries")) {
@@ -119,11 +121,20 @@ public abstract class AbstractExecutionContext<DATASOURCE extends DBPDataSource>
                             throw new DBCException(message, e, this);
                         }
                     }
+                    monitor.worked(1);
                 }
             }
             return true;
         }
         return false;
+    }
+
+    /**
+     * Returns a list of queries that should be performed before initializing the session.
+     */
+    @NotNull
+    public List<String> getExtraInitQueries() {
+        return new ArrayList<>();
     }
 
     protected void closeContext()


### PR DESCRIPTION
to avoid SELECT statement reading issues

![2022-12-27 10_50_30-Window](https://user-images.githubusercontent.com/45152336/209653726-f982a1cb-52a8-4c59-ab3b-105c48110cc1.png)

Knowable issue for now: `SELECT CURRENT_DATABASE(), CURRENT_SCHEMA()` is working before `ALTER SESSION`, and because of that, we do not see the default catalog at the start (if it is not in the bootstrap settings).
