### PR TITLE
#18479 hide as utility sqlite_autoindex_% tables 

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTableBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTableBase.java
@@ -58,6 +58,7 @@ public abstract class GenericTableBase extends JDBCTable<GenericDataSource, Gene
 
     private String tableType;
     private boolean isSystem;
+    private boolean isUtility;
     private String description;
     private Long rowCount;
     private List<? extends GenericTrigger> triggers;
@@ -81,6 +82,7 @@ public abstract class GenericTableBase extends JDBCTable<GenericDataSource, Gene
 
         final GenericMetaModel metaModel = container.getDataSource().getMetaModel();
         this.isSystem = metaModel.isSystemTable(this);
+        this.isUtility = metaModel.isUtilityTable(this);
 
         boolean mergeEntities = container.getDataSource().isMergeEntities();
         if (mergeEntities && dbResult != null) {
@@ -133,6 +135,10 @@ public abstract class GenericTableBase extends JDBCTable<GenericDataSource, Gene
 
     public void setSystem(boolean system) {
         isSystem = system;
+    }
+
+    public boolean isUtility() {
+        return isUtility;
     }
 
     @Property(viewable = true, order = 2)

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/GenericMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/GenericMetaModel.java
@@ -33,6 +33,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCDataSourceInfo;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCBasicDataTypeCache;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCDataType;
+import org.jkiss.dbeaver.model.navigator.DBNBrowseSettings;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.sql.SQLConstants;
 import org.jkiss.dbeaver.model.sql.SQLUtils;
@@ -607,7 +608,8 @@ public class GenericMetaModel {
         String tableType = GenericUtils.safeGetStringTrimmed(tableObject, dbResult, JDBCConstants.TABLE_TYPE);
 
         String tableSchema = GenericUtils.safeGetStringTrimmed(tableObject, dbResult, JDBCConstants.TABLE_SCHEM);
-        if (!CommonUtils.isEmpty(tableSchema) && owner.getDataSource().isOmitSchema()) {
+        GenericDataSource dataSource = owner.getDataSource();
+        if (!CommonUtils.isEmpty(tableSchema) && dataSource.isOmitSchema()) {
             // Ignore tables with schema [Google Spanner]
             log.debug("Ignore table " + tableSchema + "." + tableName + " (schemas are omitted)");
             return null;
@@ -635,8 +637,13 @@ public class GenericMetaModel {
             return null;
         }
 
+        DBNBrowseSettings navigatorSettings = dataSource.getContainer().getNavigatorSettings();
         boolean isSystemTable = table.isSystem();
-        if (isSystemTable && !owner.getDataSource().getContainer().getNavigatorSettings().isShowSystemObjects()) {
+        if (isSystemTable && !navigatorSettings.isShowSystemObjects()) {
+            return null;
+        }
+        boolean isUtilityTable = table.isUtility();
+        if (isUtilityTable && !navigatorSettings.isShowUtilityObjects()) {
             return null;
         }
         return table;
@@ -684,6 +691,10 @@ public class GenericMetaModel {
     public boolean isSystemTable(GenericTableBase table) {
         final String tableType = table.getTableType().toUpperCase(Locale.ENGLISH);
         return tableType.contains("SYSTEM");
+    }
+
+    public boolean isUtilityTable(@NotNull GenericTableBase table) {
+        return false;
     }
 
     public boolean isView(String tableType) {

--- a/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/model/SQLiteMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/model/SQLiteMetaModel.java
@@ -173,6 +173,13 @@ public class SQLiteMetaModel extends GenericMetaModel implements DBCQueryTransfo
     }
 
     @Override
+    public boolean isUtilityTable(@NotNull GenericTableBase table) {
+        // Autoindex tables - are some kind of index tables? No information about them. But they broke our ERD diagrams.
+        // Let's hide these "tables" deeper.
+        return table.getName().startsWith("sqlite_autoindex_");
+    }
+
+    @Override
     public boolean supportsSequences(@NotNull GenericDataSource dataSource) {
         return true;
     }


### PR DESCRIPTION
to avoid ERD downloading issues

![2022-12-27 15_50_54-DBeaver 22 3 1 - _DBeaver Sample Database (SQLite)_ Script-16](https://user-images.githubusercontent.com/45152336/209669370-70bed16c-3cd6-4c91-a5d1-edf964a69f79.png)

Qriteries:

- [x] the ERD diagram is displayed correctly when the "Show system objects" setting is unchecked
- [x] the ERD diagram is displayed correctly when the "Show system objects" setting is checked
- [x] the ERD diagram is displayed correctly when the "Show utility objects" setting is unchecked
- [x] "sqlite_index_%" tables are visible in the tables list when the "Show utility objects" setting is checked
- [x] "sqlite_index_%" tables are not visible in the tables list when the "Show utility objects" setting is unchecked
