### PR TITLE
dbeaver/pro#1321 do not extra json type for MariaDB driver

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLDataSource.java
@@ -256,8 +256,22 @@ public class MySQLDataSource extends JDBCDataSource implements DBPObjectStatisti
         super.initialize(monitor);
 
         dataTypeCache.getAllObjects(monitor, this);
-        if (isServerVersionAtLeast(5, 7) && dataTypeCache.getCachedObject(MySQLConstants.TYPE_JSON) == null) {
-            dataTypeCache.cacheObject(new JDBCDataType<>(this, java.sql.Types.OTHER, MySQLConstants.TYPE_JSON, MySQLConstants.TYPE_JSON, false, true, 0, 0, 0));
+        if ((!isMariaDB() && isServerVersionAtLeast(5, 7))
+            && dataTypeCache.getCachedObject(MySQLConstants.TYPE_JSON) == null)
+        {
+            // For MariaDB JSON is an alias for LONGTEXT introduced for compatibility reasons with MySQL's JSON data type.
+            // Even if you through the SQL Editor create a JSON column, it will turn into longtext
+            dataTypeCache.cacheObject(
+                new JDBCDataType<>(
+                    this,
+                    java.sql.Types.OTHER,
+                    MySQLConstants.TYPE_JSON,
+                    MySQLConstants.TYPE_JSON,
+                    false,
+                    true,
+                    0,
+                    0,
+                    0));
         }
         if (isMariaDB() && isServerVersionAtLeast(10, 7) && dataTypeCache.getCachedObject(MySQLConstants.TYPE_UUID) == null) {
             // Not supported by MariaDB driver for now (3.0.8). Waiting for the driver support


### PR DESCRIPTION
So. Big step. 
I think that we do not need JSON data type for MariaDB
https://mariadb.com/kb/en/json-data-type/
Because it is not JSON -it Is a longtext. 
Even information_schema.COLUMNS thinks so.

![2022-12-28 16_33_52-DBeaver Ultimate 22 3 1 - _Maria 10 3 7_ Script-32](https://user-images.githubusercontent.com/45152336/209843186-2cd539ae-fd68-4bae-b0bc-60494606d432.png)

![2022-12-28 19_25_00-DBeaver Ultimate 22 3 1 - _MariaDB 10 6 1 1_ Script-92](https://user-images.githubusercontent.com/45152336/209843194-5b82f09d-96e9-43bd-a6f5-f81fef3f4b0d.png)

![2022-12-28 19_30_34-DBeaver Ultimate 22 3 1 - _MariaDB 10 6 1 1_ Script-87](https://user-images.githubusercontent.com/45152336/209843198-3373ab36-b7ce-4169-82c6-a522fdd5f52a.png)

Qriteries:
