### PR TITLE
dbeaver/pro#1318 Fix incorrect data type for non-simple select items with aliases as table columns

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
@@ -778,7 +778,10 @@ public class DBExecUtils {
                     if (bindingMeta.getPseudoAttribute() != null) {
                         tableColumn = bindingMeta.getPseudoAttribute().createFakeAttribute(attrEntity, attrMeta);
                     } else if (columnName != null) {
-                        tableColumn = attrEntity.getAttribute(monitor, columnName);
+                        SQLSelectItem selectItem = sqlQuery.getSelectItem(columnName);
+                        if (selectItem != null && selectItem.isPlainColumn()) {
+                            tableColumn = attrEntity.getAttribute(monitor, columnName);
+                        }
                     }
 
                     if (tableColumn != null) {


### PR DESCRIPTION
Please, test different cases of queries with and without aliases, including:
- column and alias are the same
- column and alias are not the same, but alias is the same with another column name
- method call with or without some alias
- check select queries for different databases (mysql, oracle, postgresql, sqlite) and no-sql database (mongo or dynamodb)