### PR TITLE
#17198 change case sensitivity condition for generic schema cache

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
@@ -527,7 +527,7 @@ public class GenericDataSource extends JDBCDataSource implements DBPTermProvider
                     List<GenericSchema> tmpSchemas = metaModel.loadSchemas(session, this, null);
                     if (tmpSchemas != null) {
                         this.schemas = new SimpleObjectCache<>();
-                        this.schemas.setCaseSensitive(getSQLDialect().storesUnquotedCase() == DBPIdentifierCase.MIXED);
+                        this.schemas.setCaseSensitive(getSQLDialect().storesUnquotedCase() != DBPIdentifierCase.MIXED);
                         this.schemas.setCache(tmpSchemas);
                     }
                 } catch (Throwable e) {


### PR DESCRIPTION
The main problem is here:
https://github.com/dbeaver/dbeaver/blob/devel/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/cache/AbstractObjectCache.java#L310

If we have caseSensitive flag as false (like we have for the schema cache), we do not have "test" and "TEST" schemas in the objectMap, only one "TEST" as a key.

So IMHO it was a mistake condition.

Postgres has a Mixed case and has false as caseSensitive
Oracle has upper case and true as caseSensitive
And this: https://github.com/dbeaver/dbeaver/blob/devel/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/cache/AbstractObjectCache.java#L264

Please check:
- That schemas list still can have "TEST" and "test"
- "TEST" can be chosen as default from SQL Editor
- "test" can be chosen as default from SQL Editor
- "TEST" can be chosen as default from the navigator tree
- "test" can be chosen as default from the navigator tree
