### PR TITLE
#8647 use case insensitive schemas search for MIXED case databases

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericCatalog.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericCatalog.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.generic.model;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.DBPIdentifierCase;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.meta.Association;
@@ -89,7 +90,10 @@ public class GenericCatalog extends GenericObjectContainer implements DBSCatalog
     public GenericSchema getSchema(DBRProgressMonitor monitor, String name)
         throws DBException
     {
-        return DBUtils.findObject(getSchemas(monitor), name);
+        return DBUtils.findObject(
+            getSchemas(monitor),
+            name,
+            getDataSource().getSQLDialect().storesUnquotedCase() == DBPIdentifierCase.MIXED);
     }
 
     @NotNull


### PR DESCRIPTION
![2023-01-05 15_54_53-](https://user-images.githubusercontent.com/45152336/210900252-236dad0f-26fb-4a54-a60c-d08b323e58ab.png)

```java
@Nullable
    public static <T extends DBPNamedObject> T findObject(@Nullable Collection<T> theList, String objectName, boolean caseInsensitive) {
        if (theList != null && !theList.isEmpty()) {
            for (T object : theList) {
                if (caseInsensitive ? object.getName().equalsIgnoreCase(objectName) : object.getName().equals(objectName)) {
                    return object;
                }
            }
        }
        return null;
    }
```

to not use caseInsensitive as false always for schema searching
IMHO, Mixed case databases usually do not have the ability to create objects with the same name (like PG or Sybase). If you have schema "test," you can not create "TEST". 