### PR TITLE
#17350 add triggers creation statements to view DDL for PostgreSQL

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreViewBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreViewBase.java
@@ -27,6 +27,7 @@ import org.jkiss.dbeaver.model.edit.DBEPersistAction;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.DBObjectNameCaseTransformer;
 import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
+import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistActionComment;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
@@ -125,6 +126,15 @@ public abstract class PostgreViewBase extends PostgreTableReal implements DBSVie
                 }
             }
 
+        }
+        if (isPersisted()) {
+            Collection<PostgreTrigger> triggers = getTriggers(monitor);
+            if (!CommonUtils.isEmpty(triggers)) {
+                actions.add(new SQLDatabasePersistActionComment(getDataSource(), "View Triggers"));
+                for (PostgreTrigger trigger : triggers) {
+                    actions.add(new SQLDatabasePersistAction("Create trigger", trigger.getObjectDefinitionText(monitor, options)));
+                }
+            }
         }
         if (isPersisted() && CommonUtils.getOption(options, DBPScriptObject.OPTION_INCLUDE_PERMISSIONS)) {
             PostgreUtils.getObjectGrantPermissionActions(monitor, this, actions, options);


### PR DESCRIPTION
![2023-01-09 14_08_25-DBeaver 22 3 2 - customer_projects_view](https://user-images.githubusercontent.com/45152336/211295476-519d6745-a55b-4021-aa00-54b2e066cded.png)

Statements to check: https://www.dbi-services.com/blog/can-i-do-it-with-postgresql-18-instead-of-triggers-on-views/

- [x] View with trigger has the correct DDL
- [x] View with triggers has the correct DDL
- [x] View without trigger has the correct DDL
- [x] Check some other random PG-like databases (EDB, Greenplum, etc.)