### PR TITLE
#18427 Hide status bar for the statistics tab

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
@@ -739,7 +739,8 @@ public class ResultSetViewer extends Viewer
             if (resultSet instanceof StatResultSet) {
                 // Statistics - let's use special presentation for it
                 if (filtersPanel != null) {
-                    filtersPanel.setVisible(false);
+                    UIUtils.setControlVisible(filtersPanel, false);
+                    UIUtils.setControlVisible(statusBar, false);
                 }
                 availablePresentations = Collections.emptyList();
                 setActivePresentation(new StatisticsPresentation());
@@ -748,7 +749,8 @@ public class ResultSetViewer extends Viewer
             } else {
                 // Regular results
                 if (filtersPanel != null) {
-                    filtersPanel.setVisible(true);
+                    UIUtils.setControlVisible(filtersPanel, true);
+                    UIUtils.setControlVisible(statusBar, true);
                 }
                 IResultSetContext context = new ResultSetContextImpl(this, resultSet);
                 final List<ResultSetPresentationDescriptor> newPresentations;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/view/StatisticsPresentation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/view/StatisticsPresentation.java
@@ -55,7 +55,6 @@ public class StatisticsPresentation extends AbstractPresentation {
     @Override
     public void createPresentation(@NotNull IResultSetController controller, @NotNull Composite parent) {
         super.createPresentation(controller, parent);
-        UIUtils.createHorizontalLine(parent);
         table = new Table(parent, SWT.MULTI | SWT.FULL_SELECTION);
         table.setLinesVisible(!UIStyles.isDarkTheme());
         table.setHeaderVisible(true);


### PR DESCRIPTION
Acceptance criteria:
- [x] Status bar and filters are hidden for statistics and available in all other presentations

![image](https://user-images.githubusercontent.com/35821147/211356240-a8d04f9a-e45e-43ca-a1ac-aeeb78a8a7a9.png)

This might be a somewhat controversial change, but I believe it looks better now.

The status bar is quite redundant as the statistics table already includes all required information, such as completion time.