### PR TITLE
#18706 Support quoted variables in set, fix case sensitivity

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.model.sql.commands;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.sql.SQLControlCommand;
@@ -51,15 +52,15 @@ public class SQLCommandSet implements SQLControlCommandHandler {
         return true;
     }
     
-    private String tryParseVariableName(SQLScriptContext ctx, String text, int start) {
+    private String tryParseVariableName(@NotNull SQLScriptContext ctx, @NotNull String text, int start) {
         while (start < text.length() && Character.isWhitespace(text.charAt(start))) {
             start++;
         }
         SQLDialect sqlDialect = ctx.getExecutionContext().getDataSource().getSQLDialect();
         int end = ScriptParameterRule.tryConsumeParameterName(sqlDialect, text, start);
-        if (end > 0) {
+        if (end != -1) {
             String rawParamName = text.substring(start, end);
-            if (end > 0 && sqlDialect.isQuotedIdentifier(rawParamName)) {
+            if (sqlDialect.isQuotedIdentifier(rawParamName)) {
                 return sqlDialect.getUnquotedIdentifier(rawParamName);
             } else {
                 return rawParamName.toUpperCase(Locale.ENGLISH);

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
@@ -20,9 +20,13 @@ import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.sql.SQLControlCommand;
 import org.jkiss.dbeaver.model.sql.SQLControlCommandHandler;
+import org.jkiss.dbeaver.model.sql.SQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLScriptContext;
+import org.jkiss.dbeaver.model.sql.parser.rules.ScriptParameterRule;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.utils.CommonUtils;
+
+import java.util.Locale;
 
 /**
  * Control command handler
@@ -32,18 +36,36 @@ public class SQLCommandSet implements SQLControlCommandHandler {
     @Override
     public boolean handleCommand(SQLControlCommand command, SQLScriptContext scriptContext) throws DBException {
         String parameter = command.getParameter();
-        int divPos = parameter.indexOf('=');
+        String varName = tryParseVariableName(scriptContext, parameter, 0);
+        if (varName == null) {
+            throw new DBCException("Missing variable name. Expected syntax:\n@set varName = value or expression");
+        }
+        int divPos = parameter.indexOf('=', varName.length());
         if (divPos == -1) {
             throw new DBCException("Bad set syntax. Expected syntax:\n@set varName = value or expression");
         }
-        String varName = parameter.substring(0, divPos).trim();
         String varValue = parameter.substring(divPos + 1).trim();
         varValue = GeneralUtils.replaceVariables(varValue, name -> CommonUtils.toString(scriptContext.getVariable(name)));
-        scriptContext.setVariable(varName, varValue);
+        scriptContext.setVariable(varName.trim(), varValue);
 
         return true;
     }
-
-    ;
-
+    
+    private String tryParseVariableName(SQLScriptContext ctx, String text, int start) {
+        while (start < text.length() && Character.isWhitespace(text.charAt(start))) {
+            start++;
+        }
+        SQLDialect sqlDialect = ctx.getExecutionContext().getDataSource().getSQLDialect();
+        int end = ScriptParameterRule.tryConsumeParameterName(sqlDialect, text, start);
+        if (end > 0) {
+            String rawParamName = text.substring(start, end);
+            if (end > 0 && sqlDialect.isQuotedIdentifier(rawParamName)) {
+                return sqlDialect.getUnquotedIdentifier(rawParamName);
+            } else {
+                return rawParamName.toUpperCase(Locale.ENGLISH);
+            }
+        } else {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
@set command should allow quotation depends on the dialect. IF variable is qouted then it's name is case sensitive. If variable is unquoted then it is case-insensitive.

The following script provides minimal set of cases to check.
```
@set aBc = 1
@set "aBc" = 2

select :aBc from Album a; -- 1
select :"ABC" from Album a; -- 1
select :ABC from Album a; -- 1
select :abc from Album a; -- 1
select :"aBc" from Album a; -- 2
select :"abc" from Album a; -- asks for binding
```
