### PR TITLE
#18716 create connection URL by template for non default databases

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
@@ -486,7 +486,12 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
                     // Patch URL with new database name
                     if (CommonUtils.isEmpty(conConfig.getUrl()) || !CommonUtils.isEmpty(conConfig.getHostName())) {
                         conConfig.setDatabaseName(instance.getName());
-                        conConfig.setUrl(getContainer().getDriver().getConnectionURL(conConfig));
+                        final DBPDriver driver = getContainer().getDriver();
+                        String newURL = JDBCURL.generateUrlByTemplate(driver, conConfig);
+                        if (CommonUtils.isEmpty(newURL)) {
+                            newURL = driver.getDataSourceProvider().getConnectionURL(driver, conConfig);
+                        }
+                        conConfig.setUrl(newURL);
                     }
 
                     pgConnection = super.openConnection(monitor, context, purpose);


### PR DESCRIPTION
![2023-01-10 19_58_46-DBeaver 22 3 2 - _database_a_ Script-95](https://user-images.githubusercontent.com/45152336/211622034-03eee5f1-3696-4310-84cb-4a03b852318e.png)

Basically, I just copied logic from `getConnectionURL(conConfig)` method, yes. I do not see any important reason to create a new method in the driver class.

And probably we do not need

```java
if (CommonUtils.isEmpty(newURL)) {
                            newURL = driver.getDataSourceProvider().getConnectionURL(driver, conConfig);
}
```

but I'm not sure.

Important condition is higher:

!CommonUtils.equalObjects(instance.getName(), conConfig.getDatabaseName())

So, please check the following:

- [x] case from the ticket
- [x] and any other cases which come to your mind about opening a connection for PG when the new connection will have different from the connection settings database name
