### PR TITLE
#18706 Support quotes in unset command, manual variables addition via UI, fix ${var} handling

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
@@ -47,7 +47,7 @@ public class SQLCommandSet implements SQLControlCommandHandler {
         if (divPos == -1) {
             throw new DBCException("Bad set syntax. Expected syntax:\n@set varName = value or expression");
         }
-        String shouldBeEmpty= parameter.substring(varNameEnd, divPos).trim();
+        String shouldBeEmpty = parameter.substring(varNameEnd, divPos).trim();
         if (shouldBeEmpty.length() > 0) {
             throw new DBCException(
                 "Unexpected characters " + shouldBeEmpty + " after the variable name " + varName + ". " +
@@ -61,6 +61,9 @@ public class SQLCommandSet implements SQLControlCommandHandler {
         return true;
     }
 
+    /*
+     * Unquotes variable name if it was quoted, otherwise converts case to upper
+     */
     @NotNull
     public static String prepareVarName(@NotNull SQLDialect sqlDialect, @NotNull String rawName) {
         if (sqlDialect.isQuotedIdentifier(rawName)) {

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/eval/ScriptVariablesResolver.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/eval/ScriptVariablesResolver.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.model.sql.eval;
 
 import org.jkiss.dbeaver.model.sql.SQLScriptContext;
+import org.jkiss.dbeaver.model.sql.commands.SQLCommandSet;
 import org.jkiss.dbeaver.runtime.IVariableResolver;
 import org.jkiss.utils.CommonUtils;
 
@@ -33,6 +34,10 @@ public class ScriptVariablesResolver implements IVariableResolver {
 
     @Override
     public String get(String name) {
-        return CommonUtils.toString(scriptContext.getVariable(name));
+        String varName = SQLCommandSet.prepareVarName(
+            scriptContext.getExecutionContext().getDataSource().getSQLDialect(),
+            name
+        );
+        return CommonUtils.toString(scriptContext.getVariable(varName));
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -718,18 +718,27 @@ public class SQLScriptParser {
                             parameters = new ArrayList<>();
                         }
 
-                        String preparedParamName;
+                        String preparedParamName = null;
                         String paramMark = paramName.substring(0, 1);
-                        if (ArrayUtils.contains(syntaxManager.getNamedParameterPrefixes(), paramMark)) {
-                            String rawParamName = paramName.substring(1);
-                            if (sqlDialect.isQuotedIdentifier(rawParamName)) {
-                                preparedParamName = sqlDialect.getUnquotedIdentifier(rawParamName);
-                            } else {
-                                preparedParamName = rawParamName.toUpperCase(Locale.ENGLISH);
+                        if (paramMark.equals("$")) {
+                            String variableName = SQLQueryParameter.stripVariablePattern(paramName);
+                            if (!variableName.equals(paramName)) {
+                                preparedParamName = variableName.toUpperCase(Locale.ENGLISH);
                             }
-                        } else {
-                            preparedParamName = paramName;
+                        } 
+                        if (preparedParamName == null) {
+                            if (ArrayUtils.contains(syntaxManager.getNamedParameterPrefixes(), paramMark)) {
+                                String rawParamName = paramName.substring(1);
+                                if (sqlDialect.isQuotedIdentifier(rawParamName)) {
+                                    preparedParamName = sqlDialect.getUnquotedIdentifier(rawParamName);
+                                } else {
+                                    preparedParamName = rawParamName.toUpperCase(Locale.ENGLISH);
+                                }
+                            } else {
+                                preparedParamName = paramName;
+                            }
                         }
+                        
                         SQLQueryParameter parameter = new SQLQueryParameter(
                             syntaxManager,
                             parameters.size(),

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/rules/ScriptParameterRule.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/rules/ScriptParameterRule.java
@@ -119,12 +119,16 @@ public class ScriptParameterRule implements TPRule {
         return TPTokenAbstract.UNDEFINED;
     }
     
+    /**
+     * Parse variable name from buffer
+     * Return the position of the last variable name character or -1 if the name is not valid
+     */
     public static int tryConsumeParameterName(@NotNull SQLDialect sqlDialect, @NotNull CharSequence buffer, int position) {
         int endPos = tryConsumeParameterNameImpl(sqlDialect, buffer, position);
         return endPos > position ? endPos : -1;
     }
     
-    private static int tryConsumeParameterNameImpl(@NotNull SQLDialect sqlDialect, CharSequence buffer, int position) {
+    private static int tryConsumeParameterNameImpl(@NotNull SQLDialect sqlDialect, @NotNull CharSequence buffer, int position) {
         String[][] quoteStrings = sqlDialect.getIdentifierQuoteStrings();
  
         // keep in sync with the above

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/rules/ScriptParameterRule.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/rules/ScriptParameterRule.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.model.sql.parser.rules;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.sql.SQLConstants;
 import org.jkiss.dbeaver.model.sql.SQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLSyntaxManager;
@@ -118,30 +119,34 @@ public class ScriptParameterRule implements TPRule {
         return TPTokenAbstract.UNDEFINED;
     }
     
-    public static int tryConsumeParameterName(SQLDialect sqlDialect, CharSequence buffer, int position) {
-        // keep in sync with the above
-        if (position >= buffer.length()) {
-            return -1;
-        }
+    public static int tryConsumeParameterName(@NotNull SQLDialect sqlDialect, @NotNull CharSequence buffer, int position) {
+        int endPos = tryConsumeParameterNameImpl(sqlDialect, buffer, position);
+        return endPos > position ? endPos : -1;
+    }
+    
+    private static int tryConsumeParameterNameImpl(@NotNull SQLDialect sqlDialect, CharSequence buffer, int position) {
         String[][] quoteStrings = sqlDialect.getIdentifierQuoteStrings();
-        char c = buffer.charAt(position);
+ 
+        // keep in sync with the above
+        int c = position < buffer.length() ? buffer.charAt(position) : TPCharacterScanner.EOF;
         position++;
-        if (isIdentifierQuote(c, true, false, quoteStrings)) {
-            while (position < buffer.length()) {
-                c = buffer.charAt(position);
+        if (isIdentifierQuote((char) c, true, false, quoteStrings)) {
+            do {
+                c = position < buffer.length() ? buffer.charAt(position) : TPCharacterScanner.EOF;
                 position++;
-                if (isIdentifierQuote(c, false, true, quoteStrings)) {
-                    return position;
+                if (isIdentifierQuote((char) c, false, true, quoteStrings)) {
+                    c = position < buffer.length() ? buffer.charAt(position) : TPCharacterScanner.EOF;
+                    position++;
+                    break;
                 }
-            }
-            return -1;
+            } while (c != TPCharacterScanner.EOF);
         } else {
-            while (position < buffer.length() && Character.isJavaIdentifierPart(c)) {
-                c = buffer.charAt(position);
+            while (c != TPCharacterScanner.EOF && Character.isJavaIdentifierPart(c)) {
+                c = position < buffer.length() ? buffer.charAt(position) : TPCharacterScanner.EOF;
                 position++;
             }
-            return position;
         }
+        return position - 1;
     }
     
     private static boolean isIdentifierQuote(char c, boolean testStart, boolean testEnd, String[][] quoteStrings) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQueryParameter.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQueryParameter.java
@@ -108,15 +108,6 @@ public class SQLQueryParameter {
     }
 
     public String getVarName() {
-        String varName = stripVariablePattern(name);
-        if (!varName.equals(name)) {
-            return varName;
-        }
-        for (String prefix : syntaxManager.getNamedParameterPrefixes()) {
-            if (name.startsWith(prefix)) {
-                return name.substring(prefix.length());
-            }
-        }
         return name;
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.java
@@ -98,6 +98,8 @@ public class SQLEditorMessages extends NLS {
     public static String action_result_tabs_delete_variables;
     public static String action_assign_variables_error_duplicated_title;
     public static String action_assign_variables_error_duplicated_info;
+    public static String action_assign_variables_error_invalid_title;
+    public static String action_assign_variables_error_invalid_info;
 
     public static String action_popup_sqleditor_layout_horizontal;
     public static String action_popup_sqleditor_layout_vertical;

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.properties
@@ -243,6 +243,9 @@ action_result_tabs_delete_variables = Are you sure you want to delete selected v
 action_result_tabs_delete_variables_question = Delete
 action_assign_variables_error_duplicated_title = Duplicate variable
 action_assign_variables_error_duplicated_info = Variable ''{0}'' is already declared
+action_assign_variables_error_invalid_title = Invalid variable name
+action_assign_variables_error_invalid_info = Failed to parse variable name according to SQL dialect: {0}
+
 
 script_selector_project_scripts = Show scripts for all connections
 script_selector_create_script = &New script

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/variables/AssignVariableAction.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/variables/AssignVariableAction.java
@@ -22,11 +22,15 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.PartInitException;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
+import org.jkiss.dbeaver.model.sql.SQLDialect;
+import org.jkiss.dbeaver.model.sql.commands.SQLCommandSet;
+import org.jkiss.dbeaver.model.sql.parser.rules.ScriptParameterRule;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.dialogs.EnterNameDialog;
 import org.jkiss.dbeaver.ui.editors.StringEditorInput;
@@ -72,6 +76,13 @@ public class AssignVariableAction extends Action {
             isQuery ? SQLEditorMessages.action_result_tabs_assign_variable_sql : SQLEditorMessages.action_result_tabs_assign_variable,
             "")
         {
+            private String varName = null;
+
+            @Nullable
+            @Override
+            public String getResult() {
+                return varName;
+            }
 
             @Override
             protected IDialogSettings getDialogBoundsSettings() {
@@ -110,18 +121,41 @@ public class AssignVariableAction extends Action {
 
             @Override
             protected void okPressed() {
-                if (checkDuplicates) {
-                    String varName = propNameText.getText();
-                    if (editor.getGlobalScriptContext().hasVariable(varName)) {
-                        UIUtils.showMessageBox(getShell(),
-                                SQLEditorMessages.action_assign_variables_error_duplicated_title,
-                                NLS.bind(SQLEditorMessages.action_assign_variables_error_duplicated_info, varName),
-                                SWT.ICON_ERROR);
-                        return;
-                    }
-                }
+                SQLDialect sqlDialect = editor.getSQLDialect();
+                String rawVarName = propNameText.getText().trim();
+                if (ScriptParameterRule.tryConsumeParameterName(sqlDialect, rawVarName, 0) != rawVarName.length()) {
+                    UIUtils.showMessageBox(getShell(),
+                        SQLEditorMessages.action_assign_variables_error_invalid_title,
+                        NLS.bind(SQLEditorMessages.action_assign_variables_error_invalid_info, rawVarName),
+                        SWT.ICON_ERROR);
+                    varName = null;
+                    return;
+                } 
+                String preparedVarName = SQLCommandSet.prepareVarName(sqlDialect, rawVarName);
+
+                if (checkDuplicates && editor.getGlobalScriptContext().hasVariable(preparedVarName)) {
+                    UIUtils.showMessageBox(getShell(),
+                            SQLEditorMessages.action_assign_variables_error_duplicated_title,
+                            NLS.bind(SQLEditorMessages.action_assign_variables_error_duplicated_info, preparedVarName),
+                            SWT.ICON_ERROR);
+                    varName = null;
+                    return;
+                } 
+
+                varName = preparedVarName;
                 varValue = valueEditor.getEditorControl().getText();
                 super.okPressed();
+            }
+            
+            @Override
+            protected void updateButtonsState() {
+                super.updateButtonsState();
+                Button button = getButton(IDialogConstants.OK_ID);
+                if (button != null && propNameText != null && button.getEnabled()) {
+                    String rawVarName = propNameText.getText().trim();
+                    int consumedNameLength = ScriptParameterRule.tryConsumeParameterName(editor.getSQLDialect(), rawVarName, 0);
+                    button.setEnabled(consumedNameLength == rawVarName.length());
+                }
             }
         };
         if (dialog.open() == IDialogConstants.OK_ID) {

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/dialogs/EnterNameDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/dialogs/EnterNameDialog.java
@@ -121,7 +121,7 @@ public class EnterNameDialog extends Dialog {
         return dialog.chooseName();
     }
 
-    private void updateButtonsState() {
+    protected void updateButtonsState() {
         Button button = getButton(IDialogConstants.OK_ID);
         if (button != null && propNameText != null) {
             button.setEnabled(!CommonUtils.isEmptyTrimmed(propNameText.getText()));

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserGenericsTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserGenericsTest.java
@@ -144,12 +144,29 @@ public class SQLScriptParserGenericsTest {
     }
     
     @Test
+    public void parseVariables() throws DBException {
+        List<String> inputParamNames = List.of("aBc", "PrE#%&@T", "a@c=");
+        StringJoiner joiner = new StringJoiner(", ", "select ", " from dual");
+        inputParamNames.stream().forEach(p -> joiner.add("${" + p + "}"));
+        String query = joiner.toString();
+        SQLParserContext context = createParserContext(setDialect("snowflake"), query);
+        List<SQLQueryParameter> params = SQLScriptParser.parseParametersAndVariables(context, 0, query.length());
+        List<String> actualParamNames = new ArrayList<String>();
+        for (SQLQueryParameter sqlQueryParameter : params) {
+            actualParamNames.add(sqlQueryParameter.getName());
+        }
+        Assert.assertEquals(List.of("ABC", "PRE#%&@T", "A@C="), actualParamNames);
+    }
+    
+    @Test
     public void parseParameterFromSetCommand() throws DBException {
+        List<String> varNames = List.of("aBc", "\"aBc\"", "\"a@c=\"");
         ArrayList<String> expectedCommandsText = new ArrayList<>();
-        expectedCommandsText.add("@set aBc = 1");
-        expectedCommandsText.add("@set \"aBc\" = 2");
-        String script = expectedCommandsText.get(0) + "\n" + expectedCommandsText.get(1);
-
+        String script = "";
+        for (int i = 0; i < varNames.size(); i++) {
+            expectedCommandsText.add("@set " + varNames.get(i) + " = 1");
+            script += expectedCommandsText.get(i) + "\n";
+        }
         SQLParserContext context = createParserContext(setDialect("snowflake"), script);
         List<SQLScriptElement> elements = SQLScriptParser.parseScript(context.getDataSource(), script);
         List<SQLControlCommand> commands = new ArrayList<>();
@@ -162,14 +179,13 @@ public class SQLScriptParserGenericsTest {
             }
         }
         Assert.assertEquals(expectedCommandsText, actualCommandsText);
-        // unquoted
-        String text = commands.get(0).getParameter();
-        int end = ScriptParameterRule.tryConsumeParameterName(context.getDialect(), text, 0);
-        Assert.assertEquals("aBc", text.substring(0, end).trim());
-        // quoted
-        text = commands.get(1).getParameter();
-        end = ScriptParameterRule.tryConsumeParameterName(context.getDialect(),text, 0);
-        Assert.assertEquals("\"aBc\"", text.substring(0, end).trim());
+        String text;
+        int end;
+        for (int i = 0; i < varNames.size(); i++) {
+            text = commands.get(i).getParameter();
+            end = ScriptParameterRule.tryConsumeParameterName(context.getDialect(), text, 0);
+            Assert.assertEquals(varNames.get(i), text.substring(0, end).trim());
+        }
     }
     
     


### PR DESCRIPTION
- case sensitive variable name works only in `@set`, `@unset` and after `:`
You can do
```
@set "xXx" = 1 //interpreted as xXx
@set xxx = 2 // interpreted as XXX
select :"xXx", :xxx, :xXx, :XxX from dual; // interpreted as select 1, 2, 2, 2 from dual;
@unset "xXx"
@unset xxx
```
- "+" in Variables panel accepts quoted variable names and interpret them as case sensitive
- OK button in Add variable dialog is disabled while variable name is invalid - unquoted variable name can't contain symbols like @, quoted variable name can contain such symbols. Also `"te@st"n` is invalid variable name as it contains character after second quote.

- `${var}` variables should work correct and variable name interpreted as in upper case (case insensitive). Quoted variable names are not supported here.
```
@set xxx = 2 // interpreted as XXX
select ${xxx} from dual;
```