### PR TITLE
#18798 escape wild cards during primary and imported keys loading

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/GenericMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/GenericMetaModel.java
@@ -732,8 +732,9 @@ public class GenericMetaModel {
             throws SQLException, DBException {
         return session.getMetaData().getPrimaryKeys(
             owner.getCatalog() == null ? null : owner.getCatalog().getName(),
-            owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ? null : owner.getSchema().getName(),
-            forParent == null ? owner.getDataSource().getAllObjectsPattern() : forParent.getName())
+            owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ?
+                null : JDBCUtils.escapeWildCards(session, owner.getSchema().getName()),
+            forParent == null ? owner.getDataSource().getAllObjectsPattern() : JDBCUtils.escapeWildCards(session, forParent.getName()))
             .getSourceStatement();
     }
 
@@ -749,10 +750,11 @@ public class GenericMetaModel {
     public JDBCStatement prepareForeignKeysLoadStatement(@NotNull JDBCSession session, @NotNull GenericStructContainer owner, @Nullable GenericTableBase forParent) throws SQLException {
         return session.getMetaData().getImportedKeys(
                 owner.getCatalog() == null ? null : owner.getCatalog().getName(),
-                owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ? null : owner.getSchema().getName(),
+                owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ?
+                    null : JDBCUtils.escapeWildCards(session, owner.getSchema().getName()),
                 forParent == null ?
                         owner.getDataSource().getAllObjectsPattern() :
-                        forParent.getName())
+                    JDBCUtils.escapeWildCards(session, forParent.getName()))
                 .getSourceStatement();
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/GenericMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/GenericMetaModel.java
@@ -732,9 +732,8 @@ public class GenericMetaModel {
             throws SQLException, DBException {
         return session.getMetaData().getPrimaryKeys(
             owner.getCatalog() == null ? null : owner.getCatalog().getName(),
-            owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ?
-                null : JDBCUtils.escapeWildCards(session, owner.getSchema().getName()),
-            forParent == null ? owner.getDataSource().getAllObjectsPattern() : JDBCUtils.escapeWildCards(session, forParent.getName()))
+            owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ? null : owner.getSchema().getName(),
+            forParent == null ? owner.getDataSource().getAllObjectsPattern() : forParent.getName())
             .getSourceStatement();
     }
 
@@ -749,13 +748,12 @@ public class GenericMetaModel {
 
     public JDBCStatement prepareForeignKeysLoadStatement(@NotNull JDBCSession session, @NotNull GenericStructContainer owner, @Nullable GenericTableBase forParent) throws SQLException {
         return session.getMetaData().getImportedKeys(
-                owner.getCatalog() == null ? null : owner.getCatalog().getName(),
-                owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ?
-                    null : JDBCUtils.escapeWildCards(session, owner.getSchema().getName()),
-                forParent == null ?
-                        owner.getDataSource().getAllObjectsPattern() :
-                    JDBCUtils.escapeWildCards(session, forParent.getName()))
-                .getSourceStatement();
+            owner.getCatalog() == null ? null : owner.getCatalog().getName(),
+            owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ? null : owner.getSchema().getName(),
+            forParent == null ?
+                owner.getDataSource().getAllObjectsPattern() :
+                forParent.getName())
+            .getSourceStatement();
     }
 
     public boolean isFKConstraintWordDuplicated() {

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeMetaModel.java
@@ -20,10 +20,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
-import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
-import org.jkiss.dbeaver.ext.generic.model.GenericProcedure;
-import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
-import org.jkiss.dbeaver.ext.generic.model.GenericView;
+import org.jkiss.dbeaver.ext.generic.model.*;
 import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaModel;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
@@ -34,9 +31,12 @@ import org.jkiss.dbeaver.model.exec.DBCQueryTransformer;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.sql.QueryTransformerLimit;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
+import org.jkiss.utils.CommonUtils;
 
 import java.sql.SQLException;
 import java.util.Map;
@@ -136,5 +136,66 @@ public class SnowflakeMetaModel extends GenericMetaModel implements DBCQueryTran
             return new QueryTransformerLimit(false, false);
         }
         return null;
+    }
+
+    @Override
+    public JDBCStatement prepareUniqueConstraintsLoadStatement(
+        @NotNull JDBCSession session,
+        @NotNull GenericStructContainer owner,
+        @Nullable GenericTableBase forParent
+    ) throws SQLException {
+        boolean recognizeWildCards = isRecognizeWildCards(session, owner);
+        GenericSchema schema = owner.getSchema();
+        String schemaName = getSchemaNameForPattern(session, recognizeWildCards, schema);
+        String tableName = getTableNameForPattern(session, owner, forParent, recognizeWildCards);
+        return session.getMetaData()
+            .getPrimaryKeys(owner.getCatalog() == null ? null : owner.getCatalog().getName(), schemaName, tableName)
+            .getSourceStatement();
+    }
+
+    @Override
+    public JDBCStatement prepareForeignKeysLoadStatement(
+        @NotNull JDBCSession session,
+        @NotNull GenericStructContainer owner,
+        @Nullable GenericTableBase forParent
+    ) throws SQLException {
+        boolean recognizeWildCards = isRecognizeWildCards(session, owner);
+        GenericSchema schema = owner.getSchema();
+        String schemaName = getSchemaNameForPattern(session, recognizeWildCards, schema);
+        String tableName = getTableNameForPattern(session, owner, forParent, recognizeWildCards);
+        return session.getMetaData()
+            .getImportedKeys(owner.getCatalog() == null ? null : owner.getCatalog().getName(), schemaName, tableName)
+            .getSourceStatement();
+    }
+
+    private boolean isRecognizeWildCards(@NotNull JDBCSession session, @NotNull GenericStructContainer owner) throws SQLException {
+        // Snowflake driver do not recognize wild cards patterns before version 3.13.19 - and 19 here is the number of patch, not minor
+        if (owner.getDataSource().isDriverVersionAtLeast(3, 13)) {
+            String driverVersion = session.getMetaData().getDriverVersion();
+            if (CommonUtils.isNotEmpty(driverVersion) && driverVersion.contains(".")) {
+                String[] strings = driverVersion.split("\\.");
+                if (strings.length == 3) {
+                    return CommonUtils.toLong(strings[2]) >= 19;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    private String getSchemaNameForPattern(@NotNull JDBCSession session, boolean recognizeWildCards, @Nullable GenericSchema schema) {
+        return schema == null || DBUtils.isVirtualObject(schema) ?
+            null : recognizeWildCards ? JDBCUtils.escapeWildCards(session, schema.getName()) : schema.getName();
+    }
+
+    @NotNull
+    private String getTableNameForPattern(
+        @NotNull JDBCSession session,
+        @NotNull GenericStructContainer owner,
+        @Nullable GenericTableBase forParent,
+        boolean recognizeWildCards)
+    {
+        return forParent == null ? owner.getDataSource().getAllObjectsPattern()
+            : recognizeWildCards ? JDBCUtils.escapeWildCards(session, forParent.getName()) : forParent.getName();
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeMetaModel.java
@@ -144,7 +144,7 @@ public class SnowflakeMetaModel extends GenericMetaModel implements DBCQueryTran
         @NotNull GenericStructContainer owner,
         @Nullable GenericTableBase forParent
     ) throws SQLException {
-        boolean recognizeWildCards = isRecognizeWildCards(session, owner);
+        boolean recognizeWildCards = supportsWildcards(session, owner);
         GenericSchema schema = owner.getSchema();
         String schemaName = getSchemaNameForPattern(session, recognizeWildCards, schema);
         String tableName = getTableNameForPattern(session, owner, forParent, recognizeWildCards);
@@ -159,7 +159,7 @@ public class SnowflakeMetaModel extends GenericMetaModel implements DBCQueryTran
         @NotNull GenericStructContainer owner,
         @Nullable GenericTableBase forParent
     ) throws SQLException {
-        boolean recognizeWildCards = isRecognizeWildCards(session, owner);
+        boolean recognizeWildCards = supportsWildcards(session, owner);
         GenericSchema schema = owner.getSchema();
         String schemaName = getSchemaNameForPattern(session, recognizeWildCards, schema);
         String tableName = getTableNameForPattern(session, owner, forParent, recognizeWildCards);
@@ -168,7 +168,7 @@ public class SnowflakeMetaModel extends GenericMetaModel implements DBCQueryTran
             .getSourceStatement();
     }
 
-    private boolean isRecognizeWildCards(@NotNull JDBCSession session, @NotNull GenericStructContainer owner) throws SQLException {
+    private boolean supportsWildcards(@NotNull JDBCSession session, @NotNull GenericStructContainer owner) throws SQLException {
         // Snowflake driver do not recognize wild cards patterns before version 3.13.19 - and 19 here is the number of patch, not minor
         if (owner.getDataSource().isDriverVersionAtLeast(3, 13)) {
             String driverVersion = session.getMetaData().getDriverVersion();


### PR DESCRIPTION
![2023-01-18 19_30_19-DBeaver 22 3 3 - _TEST_DB_ Script-36](https://user-images.githubusercontent.com/45152336/213239082-7e1772be-8f65-4afe-a5b6-306aa53094a2.png)

Please check

- [x] primary keys loading (CE) for Snowflake for a table with "_" with driver >= 3.13.19
- [x] primary keys loading (CE) for Snowflake for a schema with "_" with driver >= 3.13.19
- [x] foreign keys loading for Snowflake for a table with "_"  with driver >= 3.13.19
- [x] foreign keys loading for Snowflake for a schema with "_" with driver >= 3.13.19
- [x] primary keys loading (CE) for Snowflake for a table with "_" with driver < 3.13.19
- [x] primary keys loading (CE) for Snowflake for a schema with "_" with driver < 3.13.19
- [x] foreign keys loading for Snowflake for a table with "_"  with driver < 3.13.19
- [x] foreign keys loading for Snowflake for a schema with "_" with driver < 3.13.19
