### PR TITLE
dbeaver/dbeaver#16683 Add support for LocalDateTime and Instant values & code refactoring

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
@@ -139,8 +139,8 @@ dialog_value_view_dialog_error_updating_title = Error updating column
 dialog_value_view_job_selector_name = Select 
 dialog_value_view_label_dictionary = Dictionary  (<a>{0}</a>): 
 
-dialog_value_view_error_parsing_date_title = Error parsing date
-dialog_value_view_error_parsing_date_message = Calendar is not able to parse this value {0}
+dialog_value_view_error_parsing_date_title = Error retrieving date
+dialog_value_view_error_parsing_date_message = Error retrieving date/time information from the value 
 
 dialog_filter_value_edit_title = Filter by ''{0}''
 dialog_filter_value_edit_label_choose_values = Choose value(s) to filter by

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/DateTimeInlineEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/DateTimeInlineEditor.java
@@ -44,8 +44,6 @@ import org.jkiss.dbeaver.ui.controls.CustomTimeEditor;
 import org.jkiss.dbeaver.ui.controls.resultset.internal.ResultSetMessages;
 import org.jkiss.dbeaver.ui.data.IValueController;
 
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.Date;
 
 /**
@@ -94,7 +92,7 @@ public class DateTimeInlineEditor extends BaseValueEditor<Control> {
     /**
      * Action which selects datetime mode
      */
-    private static class DateEditorMode extends Action {
+    private class DateEditorMode extends Action {
         private final DateTimeInlineEditor parent;
         CustomTimeEditor editor;
 
@@ -115,26 +113,26 @@ public class DateTimeInlineEditor extends BaseValueEditor<Control> {
             if (parent.isDirty()) {
                 try {
                     Object value = parent.extractEditorValue();
-                    if (value instanceof Date || value == null) {
-                        editor.setValue((Date) value);
-                    }
+                    editor.setValue(value);
                 } catch (DBException e) {
                     DBWorkbench.getPlatformUI().showError(ResultSetMessages.dialog_value_view_dialog_error_updating_title, ResultSetMessages.dialog_value_view_dialog_error_updating_message, e);
                     return;
                 }
             }
             try {
-                Object value = parent.extractEditorValue();
-                if (!(value instanceof Date) && value != null) {
-                    DBWorkbench.getPlatformUI().showWarningMessageBox(ResultSetMessages.dialog_value_view_error_parsing_date_title, NLS.bind(ResultSetMessages.dialog_value_view_error_parsing_date_message, value));
-                    ModelPreferences.getPreferences().setValue(ModelPreferences.RESULT_SET_USE_DATETIME_EDITOR, false);
-                    this.setChecked(false);
-                    parent.textMode.setChecked(true);
-                    return;
+                if (!parent.isDirty()) {
+                    editor.adaptToDate(valueController.getValue());
                 }
                 editor.setToDateComposite();
-            } catch (DBException e) {
-                DBWorkbench.getPlatformUI().showError(ResultSetMessages.dialog_value_view_dialog_error_updating_title, ResultSetMessages.dialog_value_view_dialog_error_updating_message, e);
+            } catch (DBCException exception) {
+                DBWorkbench.getPlatformUI()
+                    .showWarningMessageBox(
+                        ResultSetMessages.dialog_value_view_error_parsing_date_title,
+                        ResultSetMessages.dialog_value_view_error_parsing_date_message
+                    );
+                ModelPreferences.getPreferences().setValue(ModelPreferences.RESULT_SET_USE_DATETIME_EDITOR, false);
+                this.setChecked(false);
+                parent.textMode.setChecked(true);
                 return;
             }
             ModelPreferences.getPreferences().setValue(ModelPreferences.RESULT_SET_USE_DATETIME_EDITOR, true);
@@ -192,7 +190,7 @@ public class DateTimeInlineEditor extends BaseValueEditor<Control> {
     }
 
     @Override
-    public Object extractEditorValue() throws DBException {
+    public Object extractEditorValue() throws DBCException {
         try (DBCSession session = valueController.getExecutionContext().openSession(new VoidProgressMonitor(), DBCExecutionPurpose.UTIL, "Make datetime value from editor")) {
             if (!isCalendarMode()) {
                 final String strValue = timeEditor.getValueAsString();
@@ -216,17 +214,15 @@ public class DateTimeInlineEditor extends BaseValueEditor<Control> {
     @Override
     public void primeEditorValue(@Nullable Object value) {
         timeEditor.setTextValue(valueController.getValueHandler().getValueDisplayString(valueController.getValueType(), value, DBDDisplayFormat.EDIT));
-        if (value == null) {
-            timeEditor.setValue(null);
-        } else if (value instanceof Time) {
-            timeEditor.setValue((Time) value);
-        } else if (value instanceof Timestamp) {
-            timeEditor.setValue((Timestamp) value);
-        } else if (value instanceof Date) {
-            timeEditor.setValue((Date) value);
-        } else {
-            if (isCalendarMode()){
-                DBWorkbench.getPlatformUI().showWarningMessageBox(ResultSetMessages.dialog_value_view_error_parsing_date_title, ResultSetMessages.dialog_value_view_error_parsing_date_message);
+        try {
+            timeEditor.setValue(value);
+        } catch (DBCException exception) {
+            if (isCalendarMode()) {
+                DBWorkbench.getPlatformUI()
+                    .showWarningMessageBox(
+                        ResultSetMessages.dialog_value_view_error_parsing_date_title,
+                        NLS.bind(ResultSetMessages.dialog_value_view_error_parsing_date_message, exception.getMessage())
+                    );
                 textMode.run();
             }
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/DateTimeStandaloneEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/DateTimeStandaloneEditor.java
@@ -28,16 +28,17 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ModelPreferences;
 import org.jkiss.dbeaver.model.data.DBDDisplayFormat;
+import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.DBCExecutionPurpose;
 import org.jkiss.dbeaver.model.exec.DBCSession;
 import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.controls.CustomTimeEditor;
+import org.jkiss.dbeaver.ui.controls.resultset.internal.ResultSetMessages;
 import org.jkiss.dbeaver.ui.data.IValueController;
 import org.jkiss.dbeaver.ui.data.dialogs.ValueViewDialog;
 
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.Date;
 
 /**
@@ -112,12 +113,14 @@ public class DateTimeStandaloneEditor extends ValueViewDialog {
     @Override
     public void primeEditorValue(@Nullable Object value) {
         timeEditor.setTextValue(valueController.getValueHandler().getValueDisplayString(valueController.getValueType(), value, DBDDisplayFormat.EDIT));
-        if (value instanceof Time) {
-            timeEditor.setValue((Time) value);
-        } else if (value instanceof Timestamp) {
-            timeEditor.setValue((Timestamp) value);
-        } else if (value instanceof Date) {
-            timeEditor.setValue((Date) value);
+        try {
+            timeEditor.setValue(value);
+        } catch (DBCException e) {
+            DBWorkbench.getPlatformUI()
+                .showWarningMessageBox(
+                    ResultSetMessages.dialog_value_view_error_parsing_date_title,
+                    ResultSetMessages.dialog_value_view_error_parsing_date_message
+                );
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/CustomTimeEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/CustomTimeEditor.java
@@ -24,7 +24,9 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.DBIcon;
+import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.impl.jdbc.exec.JDBCColumnMetaData;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTableColumn;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
@@ -35,6 +37,8 @@ import org.jkiss.utils.CommonUtils;
 import java.sql.JDBCType;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -42,7 +46,6 @@ import java.util.Date;
  * CustomTimeEditor
  */
 public class CustomTimeEditor {
-    private final static String FORMAT_PATTERN = "pattern";
     private final int style;
     private final boolean isPanel;
     private DateTime dateEditor;
@@ -55,7 +58,7 @@ public class CustomTimeEditor {
     private String dateAsText = "";
     private final boolean isInline;
 
-    private InputMode inputMode = InputMode.None;
+    private InputMode inputMode = InputMode.NONE;
     private final Calendar calendar = Calendar.getInstance();
     private Text textEditor;
     private Listener modifyListener;
@@ -66,10 +69,10 @@ public class CustomTimeEditor {
     private JDBCType jdbcType;
 
     private enum InputMode {
-        None,
-        Date,
-        Time,
-        DateTime
+        NONE,
+        DATE,
+        TIME,
+        DATETIME
     }
 
     public void createDateFormat(@NotNull DBSTypedObject valueType) {
@@ -89,15 +92,15 @@ public class CustomTimeEditor {
         if (jdbcType != null) {
             switch (jdbcType) {
                 case DATE:
-                    inputMode = InputMode.Date;
+                    inputMode = InputMode.DATE;
                     disposeEditor(timeEditor, timeLabel);
                     break;
                 case TIME:
-                    inputMode = InputMode.Time;
+                    inputMode = InputMode.TIME;
                     disposeEditor(dateEditor, dateLabel);
                     break;
                 default:
-                    inputMode = InputMode.DateTime;
+                    inputMode = InputMode.DATETIME;
                     break;
             }
         }
@@ -271,19 +274,26 @@ public class CustomTimeEditor {
         }
     }
 
-    public void setValue(@Nullable Date value) {
+    /**
+     * Sets value to the calendar
+     *
+     * @param value value to which calendar should be set
+     * @throws DBCException if it can't be adapted to Date type
+     */
+    public void setValue(@Nullable Object value) throws DBCException {
         updateWarningLabel(value);
-        if (value != null) {
-            calendar.setTime(value);
+        Date adaptedValue = adaptToDate(value);
+        if (adaptedValue != null) {
+            calendar.setTime(adaptedValue);
         } else {
             switch (inputMode) {
-                case Time:
+                case TIME:
                     calendar.setTime(new Time(System.currentTimeMillis()));
                     break;
-                case Date:
+                case DATE:
                     calendar.setTime(new Date(System.currentTimeMillis()));
                     break;
-                case DateTime:
+                case DATETIME:
                     calendar.setTime(new Timestamp(System.currentTimeMillis()));
                     break;
                 default:
@@ -322,13 +332,13 @@ public class CustomTimeEditor {
     public Date getValueAsDate() {
 
         switch (inputMode) {
-            case Time:
+            case TIME:
                 calendar.set(0, Calendar.JANUARY, 0, timeEditor.getHours(), timeEditor.getMinutes(), timeEditor.getSeconds());
                 break;
-            case Date:
+            case DATE:
                 calendar.set(dateEditor.getYear(), dateEditor.getMonth(), dateEditor.getDay());
                 break;
-            case DateTime:
+            case DATETIME:
                 calendar.set(dateEditor.getYear(), dateEditor.getMonth(), dateEditor.getDay(), timeEditor.getHours(),
                         timeEditor.getMinutes(), timeEditor.getSeconds());
                 break;
@@ -369,4 +379,25 @@ public class CustomTimeEditor {
         }
     }
 
+    /**
+     * Adapts values to date
+     *
+     * @param value value which should be adapted
+     * @return adapted value
+     * @throws DBCException when it can't be adapted, should be shown as text in presentation
+     */
+    @Nullable
+    public Date adaptToDate(@Nullable Object value) throws DBCException {
+        if (value == null) {
+            return null;
+        } else if (value instanceof Date) {
+            return (Date) value;
+        } else if (value instanceof Instant) {
+            return Date.from((Instant) value);
+        } else if (value instanceof LocalDateTime) {
+            return Date.from(Instant.from((LocalDateTime) value));
+        } else {
+            throw new DBCException(value.toString());
+        }
+    }
 }


### PR DESCRIPTION
Adds an ability to parse LocalDateTime and Instant values. 
## Acceptance: 
Can parse DateTime, time, date, instant, and LocalDateTime 
(Contact me if any questions regarding testing)
LocalDateTime could be found in Clickhouse
Instant could be found in Influx2 

Linked pr: https://github.com/dbeaver/dbeaver-ee/pull/2230
Closes #16683 