### PR TITLE
#18752 Navigator refresh on dirty editor

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerRefresh.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerRefresh.java
@@ -131,8 +131,9 @@ public class NavigatorHandlerRefresh extends AbstractHandler {
                             if (((IRefreshablePart) editorPart).refreshPart(this, true) == IRefreshablePart.RefreshResult.CANCELED) {
                                 return true;
                             }
-                            // we still want to refresh source object, see #18752
-                            // iter.remove(); 
+                            if (nextNode == editorNode) {
+                                iter.remove();
+                            }
                         }
                     }
                 }

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerRefresh.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerRefresh.java
@@ -131,7 +131,8 @@ public class NavigatorHandlerRefresh extends AbstractHandler {
                             if (((IRefreshablePart) editorPart).refreshPart(this, true) == IRefreshablePart.RefreshResult.CANCELED) {
                                 return true;
                             }
-                            iter.remove();
+                            // we still want to refresh source object, see #18752
+                            // iter.remove(); 
                         }
                     }
                 }


### PR DESCRIPTION
We should not remove source from refresh list if entity editor was dirty and changes was reverted.

Check
- on dirty entity editor (2 cases: confirm and revert changes)
- on opened entity editor without changes
- no opened entity editors
