### PR TITLE
#18707 Quote identifiers starts with numbers

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLDialect.java
@@ -33,6 +33,7 @@ import org.jkiss.utils.ArrayUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -125,6 +126,8 @@ public class MySQLDialect extends JDBCSQLDialect {
         "ST_POINTFROMTEXT",
         "ST_POLYFROMTEXT"
     };
+    
+    private static final Pattern QUOTED_IDENTIFIER_PATTERN = Pattern.compile("[0-9]+");
 
     private static String[] EXEC_KEYWORDS =  { "CALL" };
     private int lowerCaseTableNames;
@@ -196,7 +199,8 @@ public class MySQLDialect extends JDBCSQLDialect {
 
     @Override
     public boolean mustBeQuoted(String str, boolean forceCaseSensitive) {
-        if (Pattern.matches("[0-9]+", str)) { // we should quote numeric names
+        Matcher matcher = QUOTED_IDENTIFIER_PATTERN.matcher(str);
+        if (matcher.lookingAt()) { // we should quote numeric names and names starts with number
             return true;
         }
         return super.mustBeQuoted(str, forceCaseSensitive);

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLDialect.java
@@ -127,7 +127,7 @@ public class MySQLDialect extends JDBCSQLDialect {
         "ST_POLYFROMTEXT"
     };
     
-    private static final Pattern QUOTED_IDENTIFIER_PATTERN = Pattern.compile("[0-9]+");
+    private static final Pattern ONE_OR_MORE_DIGITS_PATTERN = Pattern.compile("[0-9]+");
 
     private static String[] EXEC_KEYWORDS =  { "CALL" };
     private int lowerCaseTableNames;
@@ -199,7 +199,7 @@ public class MySQLDialect extends JDBCSQLDialect {
 
     @Override
     public boolean mustBeQuoted(String str, boolean forceCaseSensitive) {
-        Matcher matcher = QUOTED_IDENTIFIER_PATTERN.matcher(str);
+        Matcher matcher = ONE_OR_MORE_DIGITS_PATTERN.matcher(str);
         if (matcher.lookingAt()) { // we should quote numeric names and names starts with number
             return true;
         }


### PR DESCRIPTION
Check that DBeaver can correctly work (switch default database, for example) with
- identifiers like `1234`
- identifiers like `table1234`
- identifiers like `_fs%sfn`
- identifiers like `66e60ce`