### PR TITLE
dbeaver/pro#1363 do not read trigger cache if triggers are not suppor…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableReal.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableReal.java
@@ -60,7 +60,7 @@ public abstract class PostgreTableReal extends PostgreTableBase implements DBPOb
     protected transient volatile Long rowCount;
     protected transient volatile Long diskSpace;
     protected transient volatile long tableRelSize;
-    private final TriggerCache triggerCache = new TriggerCache();
+    private final TriggerCache triggerCache = getDataSource().getServerType().supportsTriggers() ? new TriggerCache() : null;
     private final RuleCache ruleCache = getDataSource().getServerType().supportsRules() ? new RuleCache() : null;
 
     public boolean isRefreshSchemaStatisticsOnTableRefresh () {
@@ -91,6 +91,7 @@ public abstract class PostgreTableReal extends PostgreTableBase implements DBPOb
         }
     }
 
+    @Nullable
     public TriggerCache getTriggerCache() {
         return triggerCache;
     }
@@ -232,13 +233,14 @@ public abstract class PostgreTableReal extends PostgreTableBase implements DBPOb
     public List<PostgreTrigger> getTriggers(@NotNull DBRProgressMonitor monitor)
         throws DBException
     {
-        return triggerCache.getAllObjects(monitor, this);
+        return triggerCache != null ? triggerCache.getAllObjects(monitor, this) : List.of();
     }
 
+    @Nullable
     public PostgreTrigger getTrigger(DBRProgressMonitor monitor, String name)
         throws DBException
     {
-        return triggerCache.getObject(monitor, this, name);
+        return triggerCache != null ? triggerCache.getObject(monitor, this, name) : null;
     }
 
     @Association

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTrigger.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTrigger.java
@@ -296,7 +296,11 @@ public class PostgreTrigger extends PostgreTriggerBase implements DBSEntityEleme
     @Nullable
     @Override
     public DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException {
-        return getParentObject().getTriggerCache().refreshObject(monitor, getParentObject(), this);
+        PostgreTableReal.TriggerCache triggerCache = getParentObject().getTriggerCache();
+        if (triggerCache != null) {
+            return triggerCache.refreshObject(monitor, getParentObject(), this);
+        }
+        return null;
     }
 
     @NotNull


### PR DESCRIPTION
…ted by server type

Before
![2023-01-23 19_54_54-DBeaver Ultimate 22 3 2 - pg_group](https://user-images.githubusercontent.com/45152336/214102011-bf73977d-50e6-4495-ab44-78e681cd6747.png)

After
![2023-01-23 19_56_52-DBeaver Ultimate 22 3 3 - pg_group](https://user-images.githubusercontent.com/45152336/214102018-e9cdccb7-7894-4353-bbc3-766e49c0813b.png)

you can check: pg_catalog.pg_group, pg_catalog.pg_database or pg_catalog.pg_shadow
