### PR TITLE
dbeaver/pro#1371 move typcategory column support to the server type flag

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
@@ -712,7 +712,9 @@ public class PostgreDatabase extends JDBCRemoteInstance
     // So make a separate request to the database for checking.
     boolean supportsSysTypCategoryColumn(JDBCSession session) {
         if (supportTypColumn == null) {
-            if (!dataSource.isServerVersionAtLeast(10, 0)) {
+            if (!getDataSource().getServerType().supportsSysTypCategoryColumn()){
+                supportTypColumn = false;
+            } else if (!dataSource.isServerVersionAtLeast(10, 0)) {
                 try {
                     JDBCUtils.queryString(
                         session,

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
@@ -712,7 +712,7 @@ public class PostgreDatabase extends JDBCRemoteInstance
     // So make a separate request to the database for checking.
     boolean supportsSysTypCategoryColumn(JDBCSession session) {
         if (supportTypColumn == null) {
-            if (!getDataSource().getServerType().supportsSysTypCategoryColumn()){
+            if (!getDataSource().getServerType().supportsSysTypCategoryColumn()) {
                 supportTypColumn = false;
             } else if (!dataSource.isServerVersionAtLeast(10, 0)) {
                 try {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
@@ -173,6 +173,7 @@ public interface PostgreServerExtension {
     /** True if supports external types - types from another databases (like Athena). These types in this case will be turned into fake types */
     boolean supportsExternalTypes();
 
+    /** True if pg_type contains typcategory column for the correct data types reading */
     boolean supportsSysTypCategoryColumn();
 
     boolean supportsBackslashStringEscape();

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
@@ -173,6 +173,8 @@ public interface PostgreServerExtension {
     /** True if supports external types - types from another databases (like Athena). These types in this case will be turned into fake types */
     boolean supportsExternalTypes();
 
+    boolean supportsSysTypCategoryColumn();
+
     boolean supportsBackslashStringEscape();
 
     /** The ability to disable triggers need for the data transfer */

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
@@ -502,6 +502,11 @@ public abstract class PostgreServerExtensionBase implements PostgreServerExtensi
     }
 
     @Override
+    public boolean supportsSysTypCategoryColumn() {
+        return true;
+    }
+
+    @Override
     public boolean supportsBackslashStringEscape() {
         return false;
     }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
@@ -298,6 +298,11 @@ public class PostgreServerRedshift extends PostgreServerExtensionBase implements
     }
 
     @Override
+    public boolean supportsSysTypCategoryColumn() {
+        return false;
+    }
+
+    @Override
     public boolean supportsEntityMetadataInResults() {
         return true;
     }


### PR DESCRIPTION
Please check:

- [ ] - PostgreSQL > 10
- [ ] - PostgreSQL < 10
- [ ] - Redshift in CE
- [ ]  Redshift in CE Production
- [ ] - Redshift in EE
- [ ] Redshift in EE Production
- [ ] - Greenplum
- [ ] - Cockroach