### PR TITLE
dbeaver/pro#1350 Improve accessibility for entity properties

### DIFF
--- a/bundles/org.jkiss.utils/src/org/jkiss/utils/ArrayUtils.java
+++ b/bundles/org.jkiss.utils/src/org/jkiss/utils/ArrayUtils.java
@@ -174,6 +174,9 @@ public class ArrayUtils {
         }
     }
 
+    /**
+     * Returns index of the first found element satisfying a given predicate in the provided array 
+     */
     public static <T> int indexOf(T[] array, @NotNull Predicate<T> condition) {
         for (int i = 0; i < array.length; i++) {
             if (condition.test(array[i])) {

--- a/bundles/org.jkiss.utils/src/org/jkiss/utils/ArrayUtils.java
+++ b/bundles/org.jkiss.utils/src/org/jkiss/utils/ArrayUtils.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Common utils
@@ -171,6 +172,15 @@ public class ArrayUtils {
         } else {
             return Arrays.asList(array);
         }
+    }
+
+    public static <T> int indexOf(T[] array, @NotNull Predicate<T> condition) {
+        for (int i = 0; i < array.length; i++) {
+            if (condition.test(array[i])) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     public static <T> int indexOf(T[] array, T element) {

--- a/bundles/org.jkiss.utils/src/org/jkiss/utils/ArrayUtils.java
+++ b/bundles/org.jkiss.utils/src/org/jkiss/utils/ArrayUtils.java
@@ -177,7 +177,7 @@ public class ArrayUtils {
     /**
      * Returns index of the first found element satisfying a given predicate in the provided array 
      */
-    public static <T> int indexOf(T[] array, @NotNull Predicate<T> condition) {
+    public static <T> int indexOf(@NotNull T[] array, @NotNull Predicate<T> condition) {
         for (int i = 0; i < array.length; i++) {
             if (condition.test(array[i])) {
                 return i;

--- a/plugins/org.jkiss.dbeaver.ui.navigator/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/OSGI-INF/l10n/bundle.properties
@@ -111,6 +111,14 @@ command.org.jkiss.dbeaver.ui.tools.select.connection.description = Select connec
 command.org.jkiss.dbeaver.ui.context.object.property.source.switch.name = Open Source tab
 command.org.jkiss.dbeaver.ui.context.object.property.source.switch.description = Open SQL definition of database object
 
+category.org.jkiss.dbeaver.entity.propsTab.name = Entity Properties
+category.org.jkiss.dbeaver.entity.propsTab.description = Entity properties tab
+
+command.org.jkiss.dbeaver.entity.propsTab.nextPage.name = Next Entity Properties tab
+command.org.jkiss.dbeaver.entity.propsTab.nextPage.description = Switch to the next entity properties tab page
+command.org.jkiss.dbeaver.entity.propsTab.prevPage.name = Previous Entity Properties tab
+command.org.jkiss.dbeaver.entity.propsTab.prevPage.description = Switch to the previous entity properties tab page
+
 confirm.object.editor.group.name = Object Editor
 confirm.entity_revert.message = Are you sure you want to revert all changes in "{0}"?
 confirm.entity_revert.title = Revert changes

--- a/plugins/org.jkiss.dbeaver.ui.navigator/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/plugin.xml
@@ -992,4 +992,33 @@
     </extension>
 
 
+
+    <extension point="org.eclipse.ui.commands">
+        <category id="org.jkiss.dbeaver.entity.propsTab" name="%category.org.jkiss.dbeaver.entity.propsTab.name" description="%category.org.jkiss.dbeaver.entity.propsTab.description"/>
+        <command id="org.jkiss.dbeaver.entity.propsTab.nextPage" name="%command.org.jkiss.dbeaver.entity.propsTab.nextPage.name" description="%command.org.jkiss.dbeaver.entity.propsTab.nextPage.description" categoryId="org.jkiss.dbeaver.entity.propsTab" />
+        <command id="org.jkiss.dbeaver.entity.propsTab.prevPage" name="%command.org.jkiss.dbeaver.entity.propsTab.prevPage.name" description="%command.org.jkiss.dbeaver.entity.propsTab.prevPage.description" categoryId="org.jkiss.dbeaver.entity.propsTab" />
+    </extension>
+
+    <extension point="org.eclipse.ui.bindings">
+        <key commandId="org.jkiss.dbeaver.entity.propsTab.nextPage" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+SHIFT+ARROW_DOWN"/>
+        <key commandId="org.jkiss.dbeaver.entity.propsTab.prevPage" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+SHIFT+ARROW_UP"/>
+    </extension>
+
+    <extension point="org.eclipse.ui.handlers">
+        <handler commandId="org.jkiss.dbeaver.entity.propsTab.nextPage" class="org.jkiss.dbeaver.ui.editors.entity.properties.ObjectPropertiesTabFolderSwitchCommandHandler">
+            <enabledWhen>
+                <with variable="activeEditor">
+                    <adapt type="org.jkiss.dbeaver.ui.editors.entity.EntityEditor" />
+                </with>
+            </enabledWhen>
+        </handler>
+        <handler commandId="org.jkiss.dbeaver.entity.propsTab.prevPage" class="org.jkiss.dbeaver.ui.editors.entity.properties.ObjectPropertiesTabFolderSwitchCommandHandler">
+            <enabledWhen>
+                <with variable="activeEditor">
+                    <adapt type="org.jkiss.dbeaver.ui.editors.entity.EntityEditor" />
+                </with>
+            </enabledWhen>
+        </handler>
+    </extension>
+
 </plugin>

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/properties/ObjectPropertiesEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/properties/ObjectPropertiesEditor.java
@@ -223,8 +223,6 @@ public class ObjectPropertiesEditor extends AbstractDatabaseObjectEditor<DBSObje
             }
         }
 
-        folderComposite.switchFolder(curFolderId);
-
         folderComposite.addFolderListener(folderId1 -> {
             if (CommonUtils.equalObjects(curFolderId, folderId1)) {
                 return;
@@ -265,6 +263,9 @@ public class ObjectPropertiesEditor extends AbstractDatabaseObjectEditor<DBSObje
                 }
             }
         });
+        
+        folderComposite.switchFolder(curFolderId);
+        
         return foldersPlaceholder;
     }
 
@@ -431,6 +432,10 @@ public class ObjectPropertiesEditor extends AbstractDatabaseObjectEditor<DBSObje
     public ITabbedFolder getActiveFolder()
     {
         return getActiveFolder(true);
+    }
+    
+    public String getActiveFolderId() {
+        return this.curFolderId;
     }
 
     private ITabbedFolder getActiveFolder(boolean activate)

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/properties/ObjectPropertiesTabFolderSwitchCommandHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/properties/ObjectPropertiesTabFolderSwitchCommandHandler.java
@@ -48,9 +48,7 @@ public class ObjectPropertiesTabFolderSwitchCommandHandler extends AbstractHandl
                 String activeFolderId = propsEditor.getActiveFolderId();
                 int activeFolderIndex = ArrayUtils.indexOf(foldersInfo, f -> f.getId().equals(activeFolderId));
                 int targetFolderIndex = (activeFolderIndex + indexDelta + foldersInfo.length) % foldersInfo.length;
-                if (targetFolderIndex >= 0 && targetFolderIndex < foldersInfo.length) {
-                    propsEditor.switchFolder(foldersInfo[targetFolderIndex].getId());
-                }
+                propsEditor.switchFolder(foldersInfo[targetFolderIndex].getId());
             }
         }
         return null;

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/properties/ObjectPropertiesTabFolderSwitchCommandHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/properties/ObjectPropertiesTabFolderSwitchCommandHandler.java
@@ -23,24 +23,21 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.part.MultiPageEditorPart;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ui.controls.folders.TabbedFolderInfo;
 import org.jkiss.utils.ArrayUtils;
 
-import java.util.Map;
 
 public class ObjectPropertiesTabFolderSwitchCommandHandler extends AbstractHandler {
     
     public static final String NEXT_PAGE_COMMAND_ID = "org.jkiss.dbeaver.entity.propsTab.nextPage";
     public static final String PREV_PAGE_COMMAND_ID = "org.jkiss.dbeaver.entity.propsTab.prevPage";
     
-    private static final Map<String, Integer> pageIndexDeltaByCommandId = Map.of(
-        NEXT_PAGE_COMMAND_ID, 1,
-        PREV_PAGE_COMMAND_ID, -1
-    );
-    
+    @Nullable
     @Override
-    public Object execute(ExecutionEvent event) throws ExecutionException {
-        Integer indexDelta = pageIndexDeltaByCommandId.get(event.getCommand().getId());
+    public Object execute(@NotNull ExecutionEvent event) throws ExecutionException {
+        Integer indexDelta = NEXT_PAGE_COMMAND_ID.equals(event.getCommand().getId()) ? 1 : -1;
         IEditorPart editor = HandlerUtil.getActiveEditor(event);
         if (indexDelta != null && editor instanceof MultiPageEditorPart) {
             MultiPageEditorPart pagedEditor = (MultiPageEditorPart) editor;
@@ -50,7 +47,7 @@ public class ObjectPropertiesTabFolderSwitchCommandHandler extends AbstractHandl
                 TabbedFolderInfo[] foldersInfo = propsEditor.collectFolders(propsEditor);
                 String activeFolderId = propsEditor.getActiveFolderId();
                 int activeFolderIndex = ArrayUtils.indexOf(foldersInfo, f -> f.getId().equals(activeFolderId));
-                int targetFolderIndex = activeFolderIndex + indexDelta;
+                int targetFolderIndex = (activeFolderIndex + indexDelta + foldersInfo.length) % foldersInfo.length;
                 if (targetFolderIndex >= 0 && targetFolderIndex < foldersInfo.length) {
                     propsEditor.switchFolder(foldersInfo[targetFolderIndex].getId());
                 }

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/properties/ObjectPropertiesTabFolderSwitchCommandHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/editors/entity/properties/ObjectPropertiesTabFolderSwitchCommandHandler.java
@@ -1,0 +1,62 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jkiss.dbeaver.ui.editors.entity.properties;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.part.MultiPageEditorPart;
+import org.jkiss.dbeaver.ui.controls.folders.TabbedFolderInfo;
+import org.jkiss.utils.ArrayUtils;
+
+import java.util.Map;
+
+public class ObjectPropertiesTabFolderSwitchCommandHandler extends AbstractHandler {
+    
+    public static final String NEXT_PAGE_COMMAND_ID = "org.jkiss.dbeaver.entity.propsTab.nextPage";
+    public static final String PREV_PAGE_COMMAND_ID = "org.jkiss.dbeaver.entity.propsTab.prevPage";
+    
+    private static final Map<String, Integer> pageIndexDeltaByCommandId = Map.of(
+        NEXT_PAGE_COMMAND_ID, 1,
+        PREV_PAGE_COMMAND_ID, -1
+    );
+    
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        Integer indexDelta = pageIndexDeltaByCommandId.get(event.getCommand().getId());
+        IEditorPart editor = HandlerUtil.getActiveEditor(event);
+        if (indexDelta != null && editor instanceof MultiPageEditorPart) {
+            MultiPageEditorPart pagedEditor = (MultiPageEditorPart) editor;
+            Object currentPage = pagedEditor.getSelectedPage();
+            if (currentPage instanceof ObjectPropertiesEditor) {
+                ObjectPropertiesEditor propsEditor = (ObjectPropertiesEditor) currentPage;
+                TabbedFolderInfo[] foldersInfo = propsEditor.collectFolders(propsEditor);
+                String activeFolderId = propsEditor.getActiveFolderId();
+                int activeFolderIndex = ArrayUtils.indexOf(foldersInfo, f -> f.getId().equals(activeFolderId));
+                int targetFolderIndex = activeFolderIndex + indexDelta;
+                if (targetFolderIndex >= 0 && targetFolderIndex < foldersInfo.length) {
+                    propsEditor.switchFolder(foldersInfo[targetFolderIndex].getId());
+                }
+            }
+        }
+        return null;
+    }
+    
+}

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/folders/TabbedFolderComposite.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/folders/TabbedFolderComposite.java
@@ -18,6 +18,11 @@
 package org.jkiss.dbeaver.ui.controls.folders;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.accessibility.ACC;
+import org.eclipse.swt.accessibility.AccessibleAdapter;
+import org.eclipse.swt.accessibility.AccessibleControlAdapter;
+import org.eclipse.swt.accessibility.AccessibleControlEvent;
+import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Color;
@@ -150,6 +155,18 @@ public class TabbedFolderComposite extends Composite implements ITabbedFolderCon
                 newContent = new Composite(editorPane, SWT.NONE);
                 newContent.setLayoutData(new GridData(GridData.FILL_BOTH));
                 newContent.setLayout(new FillLayout());
+                newContent.getAccessible().addAccessibleControlListener(new AccessibleControlAdapter() {
+                    @Override
+                    public void getRole(AccessibleControlEvent e) {
+                        e.detail = ACC.ROLE_TABITEM;
+                    }
+                });
+                newContent.getAccessible().addAccessibleListener(new AccessibleAdapter() {
+                    @Override
+                    public void getName(AccessibleEvent e) {
+                        e.result = folder.getTooltip();
+                    }
+                });
                 newFolder.createControl(newContent);
                 contentsMap.put(folder, newContent);
             }


### PR DESCRIPTION
Works for NVDA:
- New shortcut for switching between left-side vertical tabs is Alt+Shift+Arrow_Up/Alt+Shift+Arrow_Down
- On table Properties opening selected left-side vertical tab name should be read
- On switching between left-side vertical tab selected tab name should be read
- Whole hierarchy of elements should be read on table Properties opening: Properties tab, left-side tab name, content element type
