### PR TITLE
dbeaver/pro#1308 Improve accessibility for data grid

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/GridColumn.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/GridColumn.java
@@ -34,7 +34,7 @@ import java.util.List;
  *
  * @author serge@dbeaver.com
  */
-class GridColumn implements IGridColumn {
+public class GridColumn implements IGridColumn {
 
     /**
      * Default width of the column.

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/Spreadsheet.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/Spreadsheet.java
@@ -519,20 +519,32 @@ public class Spreadsheet extends LightGrid implements Listener {
                     String columnLabel = getLabelProvider().getText(cell.getColumn());
                     boolean isReadOnly = getContentProvider().isElementReadOnly(cell.getColumn());
                     Object rawValue = getContentProvider().getCellValue(cell.getColumn(), cell.getRow(), false);
-                    String valueStr = "";
+                    String valueStr;
+                    String valuePrefix = "";
                     String lobContentType = rawValue instanceof DBDContent ? ((DBDContent) rawValue).getContentType() : null;
                     String collType = rawValue instanceof DBDCollection ? ((DBDCollection) rawValue).getComponentType().getName() : null;
                     if (lobContentType != null && lobMimeTypeNames.get(lobContentType) != null) {
                         valueStr = "object of type " + lobMimeTypeNames.get(lobContentType);
                     } else if (collType != null) {
                         valueStr = "collection of type " + collType;
+                    } else if (rawValue instanceof Boolean) {
+                        valuePrefix = " boolean";
+                        valueStr = rawValue.toString();
                     } else {
+                        if (rawValue instanceof String) {
+                            valuePrefix = "string";
+                        } else if (rawValue instanceof Number) {
+                            valuePrefix = "numeric";
+                        }
                         valueStr = getContentProvider().getCellValue(cell.getColumn(), cell.getRow(), true).toString();
                     }
                     if (valueStr.isEmpty()) {
                         valueStr = "empty string";
                     }
-                    e.result = "at row " + rowLabel + " column " + columnLabel + (isReadOnly ? " readonly" : "") + " value is " + valueStr;
+                    if (isReadOnly) {
+                        valuePrefix = (isReadOnly ? " readonly" : "") + valuePrefix;
+                    }
+                    e.result = "at row " + rowLabel + " column " + columnLabel + valuePrefix + " value is " + valueStr;
                 } else if (rowsCount == 1) {
                     e.result = colsCount + " columns selected";
                 } else if (colsCount == 1) {


### PR DESCRIPTION
Works for NVDA:
- On table opening the screen reader should say the table name and that we are in a grid view.
- On cell selection changing the screen reader should say the column name and the row number, then the value of the cell. If a cell contains specific data that cannot be read (image, blob, json, xml), the screen reader must specify the cell type.

Please, test for different databases (PostgreSQL, SQLite, Oracle, MySQL) and for different data types (blob, image, array, xml).