### PR TITLE
#18319 fix filter when catalog parent is datasource

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNDatabaseNode.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNDatabaseNode.java
@@ -746,39 +746,30 @@ public abstract class DBNDatabaseNode extends DBNNode implements DBNLazyNode, DB
 
     public DBSObjectFilter getNodeFilter(DBXTreeItem meta, boolean firstMatch) {
         DBPDataSourceContainer dataSource = getDataSourceContainer();
-        if (this instanceof DBNContainer) {
-            Class<?> childrenClass = this.getChildrenOrFolderClass(meta);
-            if (childrenClass != null) {
-                Object valueObject = getValueObject();
-                DBSObject parentObject = null;
-                if (valueObject instanceof DBSObject && !(valueObject instanceof DBPDataSource)) {
-                    parentObject = (DBSObject) valueObject;
-                }
-                return dataSource.getObjectFilter(childrenClass, parentObject, firstMatch);
+        Class<?> childrenClass = this.getChildrenOrFolderClass(meta);
+        if (childrenClass != null) {
+            Object valueObject = getValueObject();
+            DBSObject parentObject = null;
+            if (valueObject instanceof DBSObject && !(valueObject instanceof DBPDataSource)) {
+                parentObject = (DBSObject) valueObject;
             }
+            return dataSource.getObjectFilter(childrenClass, parentObject, firstMatch);
         }
         return null;
     }
 
     public void setNodeFilter(DBXTreeItem meta, DBSObjectFilter filter) {
         DBPDataSourceContainer dataSource = getDataSourceContainer();
-        if (this instanceof DBNContainer) {
-            Class<?> childrenClass = this.getChildrenOrFolderClass(meta);
-            if (childrenClass != null) {
-                Object parentObject = getValueObject();
-                if (parentObject instanceof DBPDataSource) {
-                    parentObject = null;
-                }
-                dataSource.setObjectFilter(
-                    childrenClass,
-                    (DBSObject) parentObject,
-                    filter);
-                dataSource.persistConfiguration();
-            } else {
-                log.error("Cannot detect child node type - can't save filter configuration");
+        Class<?> childrenClass = this.getChildrenOrFolderClass(meta);
+        if (childrenClass != null) {
+            Object parentObject = getValueObject();
+            if (parentObject instanceof DBPDataSource) {
+                parentObject = null;
             }
+            dataSource.setObjectFilter(childrenClass, (DBSObject) parentObject, filter);
+            dataSource.persistConfiguration();
         } else {
-            log.error("No active datasource - can't save filter configuration");
+            log.error("Cannot detect child node type - can't save filter configuration");
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/actions/ObjectPropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/actions/ObjectPropertyTester.java
@@ -32,6 +32,7 @@ import org.jkiss.dbeaver.model.navigator.*;
 import org.jkiss.dbeaver.model.navigator.fs.DBNPath;
 import org.jkiss.dbeaver.model.rm.RMConstants;
 import org.jkiss.dbeaver.model.struct.*;
+import org.jkiss.dbeaver.model.struct.rdb.DBSCatalog;
 import org.jkiss.dbeaver.model.struct.rdb.DBSTableIndex;
 import org.jkiss.dbeaver.registry.ObjectManagerRegistry;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
@@ -213,7 +214,13 @@ public class ObjectPropertyTester extends PropertyTester {
                 break;
             }
             case PROP_HAS_FILTER: {
-                if (node instanceof DBNDatabaseNode && ((DBNDatabaseNode) node).getItemsMeta() != null) {
+
+                if (
+                    node instanceof DBNDatabaseNode
+                    && ((DBNDatabaseNode) node).getItemsMeta() != null
+                    && !DBSCatalog.class.isAssignableFrom(((DBNDatabaseNode) node)
+                        .getChildrenClass(((DBNDatabaseNode) node).getItemsMeta()))
+                ) {
                     DBSObjectFilter filter = ((DBNDatabaseNode) node).getNodeFilter(((DBNDatabaseNode) node).getItemsMeta(), true);
                     if ("defined".equals(expectedValue)) {
                         return filter != null && !filter.isEmpty();

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/actions/ObjectPropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/actions/ObjectPropertyTester.java
@@ -201,9 +201,6 @@ public class ObjectPropertyTester extends PropertyTester {
                 break;
             }
             case PROP_CAN_FILTER: {
-                if (node instanceof DBNDatabaseItem) {
-                    node = node.getParentNode();
-                }
                 if ((node instanceof DBNDatabaseNode && ((DBNDatabaseNode) node).getItemsMeta() != null)) {
                     return true;
                 }
@@ -216,9 +213,6 @@ public class ObjectPropertyTester extends PropertyTester {
                 break;
             }
             case PROP_HAS_FILTER: {
-                if (node instanceof DBNDatabaseItem) {
-                    node = node.getParentNode();
-                }
                 if (node instanceof DBNDatabaseNode && ((DBNDatabaseNode) node).getItemsMeta() != null) {
                     DBSObjectFilter filter = ((DBNDatabaseNode) node).getNodeFilter(((DBNDatabaseNode) node).getItemsMeta(), true);
                     if ("defined".equals(expectedValue)) {

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/actions/ObjectPropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/actions/ObjectPropertyTester.java
@@ -204,13 +204,15 @@ public class ObjectPropertyTester extends PropertyTester {
                 if (node instanceof DBNDatabaseItem) {
                     node = node.getParentNode();
                 }
-                if (node instanceof DBNDatabaseFolder && ((DBNDatabaseFolder) node).getItemsMeta() != null) {
+                if ((node instanceof DBNDatabaseFolder && ((DBNDatabaseFolder) node).getItemsMeta() != null)
+                    || (node instanceof DBNDataSource && ((DBNDataSource) node).getItemsMeta() != null)) {
                     return true;
                 }
                 break;
             }
             case PROP_CAN_FILTER_OBJECT: {
-                if (node.getParentNode() instanceof DBNDatabaseFolder && ((DBNDatabaseFolder) node.getParentNode()).getItemsMeta() != null) {
+                if ((node.getParentNode() instanceof DBNDatabaseFolder && ((DBNDatabaseFolder) node.getParentNode()).getItemsMeta() != null)
+                    || (node.getParentNode() instanceof DBNDataSource && ((DBNDataSource) node.getParentNode()).getItemsMeta() != null)) {
                     return true;
                 }
                 break;

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/actions/ObjectPropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/actions/ObjectPropertyTester.java
@@ -204,15 +204,13 @@ public class ObjectPropertyTester extends PropertyTester {
                 if (node instanceof DBNDatabaseItem) {
                     node = node.getParentNode();
                 }
-                if ((node instanceof DBNDatabaseFolder && ((DBNDatabaseFolder) node).getItemsMeta() != null)
-                    || (node instanceof DBNDataSource && ((DBNDataSource) node).getItemsMeta() != null)) {
+                if ((node instanceof DBNDatabaseNode && ((DBNDatabaseNode) node).getItemsMeta() != null)) {
                     return true;
                 }
                 break;
             }
             case PROP_CAN_FILTER_OBJECT: {
-                if ((node.getParentNode() instanceof DBNDatabaseFolder && ((DBNDatabaseFolder) node.getParentNode()).getItemsMeta() != null)
-                    || (node.getParentNode() instanceof DBNDataSource && ((DBNDataSource) node.getParentNode()).getItemsMeta() != null)) {
+                if ((node.getParentNode() instanceof DBNDatabaseNode && ((DBNDatabaseNode) node.getParentNode()).getItemsMeta() != null)) {
                     return true;
                 }
                 break;
@@ -221,8 +219,8 @@ public class ObjectPropertyTester extends PropertyTester {
                 if (node instanceof DBNDatabaseItem) {
                     node = node.getParentNode();
                 }
-                if (node instanceof DBNDatabaseFolder && ((DBNDatabaseFolder) node).getItemsMeta() != null) {
-                    DBSObjectFilter filter = ((DBNDatabaseFolder) node).getNodeFilter(((DBNDatabaseFolder) node).getItemsMeta(), true);
+                if (node instanceof DBNDatabaseNode && ((DBNDatabaseNode) node).getItemsMeta() != null) {
+                    DBSObjectFilter filter = ((DBNDatabaseNode) node).getNodeFilter(((DBNDatabaseNode) node).getItemsMeta(), true);
                     if ("defined".equals(expectedValue)) {
                         return filter != null && !filter.isEmpty();
                     } else {

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/NavigatorUtils.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/NavigatorUtils.java
@@ -715,11 +715,11 @@ public class NavigatorUtils {
     public static void filterSelection(final ISelection selection, boolean exclude)
     {
         if (selection instanceof IStructuredSelection) {
-            Map<DBNDatabaseFolder, DBSObjectFilter> folders = new HashMap<>();
+            Map<DBNDatabaseNode, DBSObjectFilter> folders = new HashMap<>();
             for (Object item : ((IStructuredSelection)selection).toArray()) {
                 if (item instanceof DBNNode) {
                     final DBNNode node = (DBNNode) item;
-                    DBNDatabaseFolder folder = (DBNDatabaseFolder) node.getParentNode();
+                    DBNDatabaseNode folder = (DBNDatabaseNode) node.getParentNode();
                     DBSObjectFilter nodeFilter = folders.get(folder);
                     if (nodeFilter == null) {
                         nodeFilter = folder.getNodeFilter(folder.getItemsMeta(), true);
@@ -737,7 +737,7 @@ public class NavigatorUtils {
                 }
             }
             // Save folders
-            for (Map.Entry<DBNDatabaseFolder, DBSObjectFilter> entry : folders.entrySet()) {
+            for (Map.Entry<DBNDatabaseNode, DBSObjectFilter> entry : folders.entrySet()) {
                 entry.getKey().setNodeFilter(entry.getKey().getItemsMeta(), entry.getValue());
             }
             // Refresh all folders

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerFilterClear.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerFilterClear.java
@@ -21,8 +21,7 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.handlers.HandlerUtil;
-import org.jkiss.dbeaver.model.navigator.DBNDatabaseFolder;
-import org.jkiss.dbeaver.model.navigator.DBNDatabaseItem;
+import org.jkiss.dbeaver.model.navigator.DBNDatabaseNode;
 import org.jkiss.dbeaver.model.navigator.DBNNode;
 import org.jkiss.dbeaver.model.navigator.meta.DBXTreeItem;
 import org.jkiss.dbeaver.model.struct.DBSObjectFilter;
@@ -36,11 +35,8 @@ public class NavigatorHandlerFilterClear extends AbstractHandler {
     public Object execute(ExecutionEvent event) throws ExecutionException {
         final ISelection selection = HandlerUtil.getCurrentSelection(event);
         DBNNode node = NavigatorUtils.getSelectedNode(selection);
-        if (node instanceof DBNDatabaseItem) {
-            node = node.getParentNode();
-        }
-        if (node instanceof DBNDatabaseFolder) {
-            final DBNDatabaseFolder folder = (DBNDatabaseFolder) node;
+        if (node instanceof DBNDatabaseNode) {
+            final DBNDatabaseNode folder = (DBNDatabaseNode) node;
             DBXTreeItem itemsMeta = folder.getItemsMeta();
             if (itemsMeta != null) {
                 folder.setNodeFilter(itemsMeta, new DBSObjectFilter());

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerFilterConfig.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerFilterConfig.java
@@ -44,9 +44,6 @@ public class NavigatorHandlerFilterConfig extends NavigatorHandlerObjectCreateBa
     public Object execute(ExecutionEvent event) throws ExecutionException {
         final ISelection selection = HandlerUtil.getCurrentSelection(event);
         DBNNode node = NavigatorUtils.getSelectedNode(selection);
-        if (node instanceof DBNDatabaseItem) {
-            node = node.getParentNode();
-        }
         if (node instanceof DBNDatabaseNode) {
             configureFilters(HandlerUtil.getActiveShell(event), node);
         }
@@ -105,9 +102,7 @@ public class NavigatorHandlerFilterConfig extends NavigatorHandlerObjectCreateBa
             return;
         }
         DBNNode node = NavigatorUtils.getSelectedNode(element);
-        if (node instanceof DBNDatabaseItem) {
-            node = node.getParentNode();
-        }
+
         if (node != null) {
             element.setText(NLS.bind(UINavigatorMessages.actions_navigator_filter_objects, node.getNodeType()));
         }

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerFilterConfig.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerFilterConfig.java
@@ -47,27 +47,26 @@ public class NavigatorHandlerFilterConfig extends NavigatorHandlerObjectCreateBa
         if (node instanceof DBNDatabaseItem) {
             node = node.getParentNode();
         }
-        if (node instanceof DBNDatabaseFolder || node instanceof DBNDataSource) {
+        if (node instanceof DBNDatabaseNode) {
             configureFilters(HandlerUtil.getActiveShell(event), node);
         }
-
         return null;
     }
 
     public static void configureFilters(Shell shell, DBNNode node)
     {
-        final DBNDatabaseNode databaseNode = (DBNDatabaseNode) node;
-        DBXTreeItem itemsMeta = databaseNode.getItemsMeta();
+        final DBNDatabaseNode folder = (DBNDatabaseNode) node;
+        DBXTreeItem itemsMeta = folder.getItemsMeta();
         if (itemsMeta != null) {
-            DBSObjectFilter objectFilter = databaseNode.getNodeFilter(itemsMeta, true);
+            DBSObjectFilter objectFilter = folder.getNodeFilter(itemsMeta, true);
             if (objectFilter == null) {
                 objectFilter = new DBSObjectFilter();
             }
-            final DBPDataSourceRegistry dsRegistry = databaseNode.getOwnerProject().getDataSourceRegistry();
-            final boolean globalFilter = databaseNode.getValueObject() instanceof DBPDataSource;
+            final DBPDataSourceRegistry dsRegistry = folder.getOwnerProject().getDataSourceRegistry();
+            final boolean globalFilter = folder.getValueObject() instanceof DBPDataSource;
             String parentName = "?";
-            if (databaseNode.getValueObject() instanceof DBSObject) {
-                parentName = ((DBSObject) databaseNode.getValueObject()).getName();
+            if (folder.getValueObject() instanceof DBSObject) {
+                parentName = ((DBSObject) folder.getValueObject()).getName();
             }
             EditObjectFilterDialog dialog = new EditObjectFilterDialog(
                 shell,
@@ -77,13 +76,11 @@ public class NavigatorHandlerFilterConfig extends NavigatorHandlerObjectCreateBa
                 globalFilter);
             switch (dialog.open()) {
                 case IDialogConstants.OK_ID:
-                    databaseNode.setNodeFilter(itemsMeta, dialog.getFilter());
-                    NavigatorHandlerRefresh.refreshNavigator(Collections.singletonList(databaseNode));
+                    folder.setNodeFilter(itemsMeta, dialog.getFilter());
+                    NavigatorHandlerRefresh.refreshNavigator(Collections.singletonList(folder));
                     break;
                 case EditObjectFilterDialog.SHOW_GLOBAL_FILTERS_ID:
-                    objectFilter = databaseNode.getDataSource()
-                        .getContainer()
-                        .getObjectFilter(((DBNContainer) databaseNode).getChildrenClass(), null, true);
+                    objectFilter = folder.getDataSource().getContainer().getObjectFilter(((DBNDataSource) folder).getChildrenClass(), null, true);
                     dialog = new EditObjectFilterDialog(
                         shell,
                             dsRegistry, "All " + node.getNodeType(),
@@ -91,14 +88,10 @@ public class NavigatorHandlerFilterConfig extends NavigatorHandlerObjectCreateBa
                         true);
                     if (dialog.open() == IDialogConstants.OK_ID) {
                         // Set global filter
-                        databaseNode.getDataSource()
-                            .getContainer()
-                            .setObjectFilter(((DBNContainer) databaseNode).getChildrenClass(),
-                                null,
-                                dialog.getFilter()
-                            );
-                        databaseNode.getDataSource().getContainer().persistConfiguration();
-                        NavigatorHandlerRefresh.refreshNavigator(Collections.singletonList(databaseNode));
+                        folder.getDataSource().getContainer().setObjectFilter((((DBNDataSource) folder).getChildrenClass()), null,
+                            dialog.getFilter());
+                        folder.getDataSource().getContainer().persistConfiguration();
+                        NavigatorHandlerRefresh.refreshNavigator(Collections.singletonList(folder));
                     }
                     break;
             }

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerFilterToggle.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerFilterToggle.java
@@ -21,8 +21,7 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.handlers.HandlerUtil;
-import org.jkiss.dbeaver.model.navigator.DBNDatabaseFolder;
-import org.jkiss.dbeaver.model.navigator.DBNDatabaseItem;
+import org.jkiss.dbeaver.model.navigator.DBNDatabaseNode;
 import org.jkiss.dbeaver.model.navigator.DBNNode;
 import org.jkiss.dbeaver.model.navigator.meta.DBXTreeItem;
 import org.jkiss.dbeaver.model.struct.DBSObjectFilter;
@@ -36,11 +35,8 @@ public class NavigatorHandlerFilterToggle extends AbstractHandler {
     public Object execute(ExecutionEvent event) throws ExecutionException {
         final ISelection selection = HandlerUtil.getCurrentSelection(event);
         DBNNode node = NavigatorUtils.getSelectedNode(selection);
-        if (node instanceof DBNDatabaseItem) {
-            node = node.getParentNode();
-        }
-        if (node instanceof DBNDatabaseFolder) {
-            final DBNDatabaseFolder folder = (DBNDatabaseFolder) node;
+        if (node instanceof DBNDatabaseNode) {
+            final DBNDatabaseNode folder = (DBNDatabaseNode) node;
             DBXTreeItem itemsMeta = folder.getItemsMeta();
             if (itemsMeta != null) {
                 final DBSObjectFilter nodeFilter = folder.getNodeFilter(itemsMeta, true);


### PR DESCRIPTION
Closes #18319
Acceptance criteria:
Catalogs in generic databases which have datasource as a parent in the tree should now have filter actions, and it should work properly  
Test filtering for relations without folders `datasource -> catalog -> schema -> table`
Test Redis hierarchy keys
Important:
No reason to test with simple view, unfortunately it returns incorrect metadata so we should tune it in different ticket