### PR TITLE
#15282 Add setting for line ending auto fix on sql query execution

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -291,7 +291,7 @@ public class SQLScriptParser {
                         continue;
                     }
                     String queryText = document.get(statementStart, tokenOffset - statementStart);
-                    queryText = SQLUtils.fixLineFeeds(queryText);
+                    queryText = SQLUtils.fixLineFeeds(queryText, context.getPreferenceStore());
 
                     if (isDelimiter &&
                         (keepDelimiters ||
@@ -629,7 +629,7 @@ public class SQLScriptParser {
                 element = parsedElement;
             } else {
                 // Use selected query as is
-                selText = SQLUtils.fixLineFeeds(selText);
+                selText = SQLUtils.fixLineFeeds(selText, context.getPreferenceStore());
                 element = new SQLQuery(context.getDataSource(), selText, region.getOffset(), region.getLength());
             }
         } else if (region.getOffset() >= 0) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/ModelPreferences.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/ModelPreferences.java
@@ -22,6 +22,7 @@ import org.jkiss.dbeaver.model.DBConstants;
 import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
 import org.jkiss.dbeaver.model.exec.DBCExecutionPurpose;
 import org.jkiss.dbeaver.model.impl.preferences.BundlePreferenceStore;
+import org.jkiss.dbeaver.model.messages.ModelMessages;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
 import org.jkiss.dbeaver.model.qm.QMConstants;
 import org.jkiss.dbeaver.model.qm.QMObjectType;
@@ -70,6 +71,39 @@ public final class ModelPreferences
         }
     }
     
+    public enum LineEndingNormalizationBehavior {
+        DEFAULT(ModelMessages.statement_line_ending_normalization_default, null),
+        LF(ModelMessages.statement_line_ending_normalization_unix, "\n"),
+        CRLF(ModelMessages.statement_line_ending_normalization_dos, "\r\n"),
+        CR(ModelMessages.statement_line_ending_normalization_mac, "\r"),
+        LFCR(ModelMessages.statement_line_ending_normalization_acron, "\n\r"),
+        NL(ModelMessages.statement_line_ending_normalization_ibm, "\025"),
+        AS_IS(ModelMessages.statement_line_ending_normalization_leave_as_is, null);
+        
+        private final String title;
+        private final String chars;
+        
+        LineEndingNormalizationBehavior(String title, String chars) {
+            this.title = title;
+            this.chars = chars;
+        }
+        
+        public String getTitle() {
+            return title;
+        }
+        
+        public String getChars() {
+            return chars;
+        }
+
+        /**
+         * Convert value to LineEndingNormalizationBehavior option
+         */
+        public static LineEndingNormalizationBehavior parse(String value) {
+            return CommonUtils.valueOf(LineEndingNormalizationBehavior.class, value, DEFAULT);
+        }
+    }
+    
     public static final String PLUGIN_ID = "org.jkiss.dbeaver.model";
     public static final String CLIENT_TIMEZONE = "java.client.timezone";
     public static final String CLIENT_BROWSER = "swt.client.browser";
@@ -96,6 +130,7 @@ public final class ModelPreferences
     public static final String SCRIPT_IGNORE_NATIVE_DELIMITER = "script.sql.ignoreNativeDelimiter"; //$NON-NLS-1$
     public static final String SCRIPT_STATEMENT_DELIMITER_BLANK = "script.sql.delimiter.blank"; //$NON-NLS-1$
     public static final String QUERY_REMOVE_TRAILING_DELIMITER = "script.sql.query.remove.trailing.delimiter"; //$NON-NLS-1$
+    public static final String STATEMENT_LINE_ENDING_NORMALIZATION = "script.sql.statement.lineEndingNormalization"; //$NON-NLS-1$
 
     public static final String MEMORY_CONTENT_MAX_SIZE = "content.memory.maxsize"; //$NON-NLS-1$
     public static final String CONTENT_HEX_ENCODING = "content.hex.encoding"; //$NON-NLS-1$
@@ -230,6 +265,7 @@ public final class ModelPreferences
         PrefUtils.setDefaultPreferenceValue(store, SCRIPT_IGNORE_NATIVE_DELIMITER, false);
         PrefUtils.setDefaultPreferenceValue(store, SCRIPT_STATEMENT_DELIMITER_BLANK, true);
         PrefUtils.setDefaultPreferenceValue(store, QUERY_REMOVE_TRAILING_DELIMITER, true);
+        PrefUtils.setDefaultPreferenceValue(store, STATEMENT_LINE_ENDING_NORMALIZATION, LineEndingNormalizationBehavior.DEFAULT.name());
 
         PrefUtils.setDefaultPreferenceValue(store, MEMORY_CONTENT_MAX_SIZE, 10000);
         PrefUtils.setDefaultPreferenceValue(store, META_SEPARATE_CONNECTION, SeparateConnectionBehavior.DEFAULT.name());

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelMessages.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelMessages.java
@@ -241,6 +241,14 @@ public class ModelMessages extends NLS {
 
     public static String no_corresponding_table_column_text;
     public static String cannot_determine_unique_row_identifier_text;
+    
+    public static String statement_line_ending_normalization_default;
+    public static String statement_line_ending_normalization_unix;
+    public static String statement_line_ending_normalization_dos;
+    public static String statement_line_ending_normalization_mac;
+    public static String statement_line_ending_normalization_acron;
+    public static String statement_line_ending_normalization_ibm;
+    public static String statement_line_ending_normalization_leave_as_is;
 
 	static {
 		// initialize resource bundle

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelResources.properties
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/messages/ModelResources.properties
@@ -208,3 +208,11 @@ jdbc_content_view_error_message_hint = The content cannot be read due to an erro
 
 no_corresponding_table_column_text = No corresponding table column
 cannot_determine_unique_row_identifier_text = Cannot determine unique row identifier
+
+statement_line_ending_normalization_default = Default
+statement_line_ending_normalization_unix = UNIX (LF)
+statement_line_ending_normalization_dos = DOS (CR LF)
+statement_line_ending_normalization_mac = MAC (CR)
+statement_line_ending_normalization_acron = Acron (LF CR)
+statement_line_ending_normalization_ibm = IBM (NL)
+statement_line_ending_normalization_leave_as_is = Leave as is

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.java
@@ -159,6 +159,8 @@ public class SQLEditorMessages extends NLS {
     public static String pref_page_sql_editor_enable_parameters_in_ddl_tip;
     public static String pref_page_sql_editor_enable_variables;
     public static String pref_page_sql_editor_enable_variables_tip;
+    public static String pref_page_sql_editor_label_line_ending_normalization;
+    public static String pref_page_sql_editor_line_ending_normalization_tip;
     // SQProposalsSearch
     public static String pref_page_sql_format_group_search;
     public static String pref_page_sql_completion_label_match_contains;

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorMessages.properties
@@ -142,6 +142,8 @@ pref_page_sql_editor_enable_parameters_in_ddl = Enable parameters in DDL and $$.
 pref_page_sql_editor_enable_parameters_in_ddl_tip = Usually DDL (like CREATE PROCEDURE) does not use input query parameters but may contain complex logic and scripting.\nIn some databases $$..$$ is a special block that may contain a string, including $.\nThis may conflict with the parameters prefix.\nIt is suggested to disable parameter parsing for such queries.
 pref_page_sql_editor_enable_variables = Enable variables
 pref_page_sql_editor_enable_variables_tip = Enable variables in SQL scripts.\nVariable is a special mark ${VAR_NAME} which will be replaced with user input before query execution.
+pref_page_sql_editor_label_line_ending_normalization = Line-ending normalization
+pref_page_sql_editor_line_ending_normalization_tip = Line-ending normalization behavior applied for SQL statement text before its execution
 
 # SQL Scripts: New script template
 pref_page_sql_editor_new_script_template_group=New SQL script template


### PR DESCRIPTION
We replaced \r to whitespace. SQL Server and probably some other databases don't like it.
Previously we replaced \r to \n which was weird and doesn't work correct for some users.
Let's have a setting for that
![image](https://user-images.githubusercontent.com/28875055/216012388-8fc22572-e7a5-4239-ba0c-008f01399c10.png)


Query from the issue works with CR LF for SQL Server.