### PR TITLE
#18583 fix routines statement call generation

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
@@ -42,6 +42,7 @@ import org.jkiss.dbeaver.model.sql.parser.tokens.predicates.TokenPredicatesCondi
 import org.jkiss.dbeaver.model.struct.DBSDataType;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 import org.jkiss.dbeaver.model.struct.rdb.DBSProcedure;
+import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
 import org.jkiss.utils.ArrayUtils;
 import org.jkiss.utils.CommonUtils;
 
@@ -469,8 +470,20 @@ public class OracleSQLDialect extends JDBCSQLDialect implements SQLDataTypeConve
 
     @Override
     protected String getStoredProcedureCallInitialClause(DBSProcedure proc) {
-        String schemaName = proc.getParentObject().getName();
-        return "CALL " + schemaName + "." + proc.getName();
+        if (proc.getProcedureType() == DBSProcedureType.FUNCTION) {
+            return SQLConstants.KEYWORD_SELECT + " " + proc.getFullyQualifiedName(DBPEvaluationContext.DML);
+        } else {
+            return "CALL " + proc.getFullyQualifiedName(DBPEvaluationContext.DML);
+        }
+    }
+
+    @NotNull
+    @Override
+    protected String getProcedureCallEndClause(DBSProcedure procedure) {
+        if (procedure.getProcedureType() == DBSProcedureType.FUNCTION) {
+            return "FROM DUAL";
+        }
+        return super.getProcedureCallEndClause(procedure);
     }
 
     @Override


### PR DESCRIPTION
+ correct functions call added

![2023-02-02 15_08_53-DBeaver 22 3 4 - _orcl_ Script-38](https://user-images.githubusercontent.com/45152336/216321907-fbfb194a-ccc7-458b-a98a-e0c9f0759ddc.png)

![2023-02-02 15_09_39-DBeaver 22 3 4 - _orcl_ Script-39](https://user-images.githubusercontent.com/45152336/216321966-0b95ccc8-caa4-437a-87f3-627d4a702938.png)

Check the following:

- [x] Result of the "Execute stored procedure" for a procedure
- [x] Result of the "Execute stored procedure" for a procedure with the complex name (must be quoted)
- [x] Result of the "Execute stored procedure" for a function
- [x] Result of the "Execute stored procedure" for a function with the complex name (must be quoted)

Result for the uncompiled function/procedure will not have parameters in the brackets - it is expected, first compile routine correctly.
