### PR TITLE
Icon for JKISS in About Eclipse IDE is too small/not good

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.office/about.ini
+++ b/plugins/org.jkiss.dbeaver.data.office/about.ini
@@ -8,4 +8,4 @@
 aboutText=%blurb
 
 # Property "featureImage" contains path to feature image (32x32)
-featureImage=icons/excel.png
+featureImage=icons/excel@2x.png


### PR DESCRIPTION
Fix : https://github.com/dbeaver/dbeaver/issues/18608