### PR TITLE
#17244 set maxLength by default to -1 in case of the number format error

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/struct/AbstractAttribute.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/struct/AbstractAttribute.java
@@ -142,7 +142,7 @@ public abstract class AbstractAttribute implements DBSAttributeBase, DBSTypedObj
                 String modifiers = fullTypeName.substring(divPos + 1, divPos2);
                 int divPos3 = modifiers.indexOf(',');
                 if (divPos3 == -1) {
-                    maxLength = precision = CommonUtils.toInt(modifiers);
+                    maxLength = precision = CommonUtils.toInt(modifiers, -1);
                 } else {
                     precision= CommonUtils.toInt(modifiers.substring(0, divPos3).trim());
                     scale = CommonUtils.toInt(modifiers.substring(divPos3 + 1).trim());


### PR DESCRIPTION
https://github.com/dbeaver/dbeaver/blob/71f0d3b8f33774c3b1304a18a8203b804ff09c6b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/struct/AbstractAttribute.java#L264

As in another method, I think that "-1" for the maxLenght parameter is better for recognition than "0" in side cases like varchar(max).

![2023-02-08 18_17_39-Configure metadata structure](https://user-images.githubusercontent.com/45152336/217574679-99329d5d-7db6-455d-8416-07e0f156131f.png)
