### PR TITLE
InterSystems IRIS driver: fix broken link, update to 3.6.1

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -501,7 +501,7 @@
                     supportedConfigurationTypes="MANUAL,URL"
                     categories="sql,object">
 <!--                    <replace provider="generic" driver="cache"/>-->
-                    <file type="jar" path="https://github.com/intersystems-community/iris-driver-distribution/raw/main/intersystems-jdbc-3.1.0.jar"/>
+                    <file type="jar" path="https://github.com/intersystems-community/iris-driver-distribution/raw/main/JDBC/JDK18/intersystems-jdbc-3.6.1.jar"/>
                 </driver>
                 <driver
                     id="ingres"


### PR DESCRIPTION
Old link is not working anymore, replaced jar link. Driver version 3.6.1 is compatible with old servers, so users who are using version 3.1.0 would not be affected.