### PR TITLE
dbeaver/pro#1360 read extra table/view/schema metadata; separate view…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.databricks/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ext.databricks/OSGI-INF/l10n/bundle.properties
@@ -1,2 +1,18 @@
 Bundle-Vendor = JKISS
 Bundle-Name = DBeaver Azure Databricks Support
+
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksSchema.location.name = Location
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksSchema.properties.name = Properties
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksSchema.owner.name = Owner
+
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksTable.location.name = Location
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksTable.owner.name = Owner
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksTable.provider.name = Provider
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksTable.storageProperties.name = Storage Properties
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksTable.tableProperties.name = Table Properties
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksTable.createdTime.name = Created Time
+
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksView.owner.name = Owner
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksView.storageProperties.name = Storage Properties
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksView.createdTime.name = Created Time
+meta.org.jkiss.dbeaver.ext.databricks.model.DatabricksView.tableProperties.name = Table Properties

--- a/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/DatabricksConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/DatabricksConstants.java
@@ -1,0 +1,25 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.databricks;
+
+public class DatabricksConstants {
+    public static final String PROP_LOCATION = "Location";
+    public static final String PROP_OWNER = "Owner";
+    public static final String PROP_CREATED_TIME = "Created Time";
+    public static final String PROP_TABLE_PROPERTIES = "Table Properties";
+    public static final String PROP_STORAGE_PROPERTIES = "Storage Properties";
+}

--- a/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksSchema.java
@@ -1,0 +1,131 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.databricks.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ext.databricks.DatabricksConstants;
+import org.jkiss.dbeaver.ext.generic.model.GenericCatalog;
+import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
+import org.jkiss.dbeaver.ext.generic.model.GenericSchema;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBPQualifiedObject;
+import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.meta.Property;
+import org.jkiss.dbeaver.model.meta.PropertyLength;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.utils.CommonUtils;
+
+import java.sql.SQLException;
+
+public class DatabricksSchema extends GenericSchema implements DBPQualifiedObject {
+
+    private static final Log log = Log.getLog(DatabricksSchema.class);
+
+    private volatile boolean additionalInfoLoaded = false;
+    private String owner;
+    private String location;
+    private String properties;
+
+    public DatabricksSchema(@NotNull GenericDataSource dataSource, @Nullable GenericCatalog catalog, @NotNull String schemaName) {
+        super(dataSource, catalog, schemaName);
+    }
+
+    @Property(viewable = true, order = 2)
+    public String getOwner(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return owner;
+    }
+
+    @Property(viewable = true, order = 3)
+    public String getLocation(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return location;
+    }
+
+    @Property(viewable = true, length = PropertyLength.MULTILINE, order = 7)
+    public String getProperties(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return properties;
+    }
+
+    private void checkExtraInfo(@NotNull DBRProgressMonitor monitor) {
+        if (!additionalInfoLoaded) {
+            loadAdditionalInfo(monitor);
+        }
+    }
+
+    private void loadAdditionalInfo(@NotNull DBRProgressMonitor monitor) {
+        if (!isPersisted()) {
+            additionalInfoLoaded = true;
+            return;
+        }
+        try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Load schema extra info")) {
+            try (JDBCPreparedStatement dbStat = session.prepareStatement(
+                "DESCRIBE SCHEMA EXTENDED " + getFullyQualifiedName(DBPEvaluationContext.DDL))) {
+                try (JDBCResultSet dbResult = dbStat.executeQuery()) {
+                    while (dbResult.next()) {
+                        // This is table of metadata, where column name is in the database_description_item column
+                        String key = JDBCUtils.safeGetString(dbResult, "database_description_item");
+                        String value = JDBCUtils.safeGetString(dbResult, "database_description_value");
+                        if (CommonUtils.isNotEmpty(key)) {
+                            switch (key) {
+                                case DatabricksConstants.PROP_LOCATION:
+                                    location = value;
+                                    break;
+                                case DatabricksConstants.PROP_OWNER:
+                                    owner = value;
+                                    break;
+                                case "Properties":
+                                    properties = value;
+                                    break;
+                            }
+                        }
+                    }
+                    additionalInfoLoaded = true;
+                }
+            } catch (SQLException e) {
+                log.error("Can't read additional schema info", e);
+            }
+        } catch (DBCException e) {
+            log.error("Can't read additional schema info", e);
+        }
+    }
+
+    @NotNull
+    @Override
+    public String getFullyQualifiedName(DBPEvaluationContext context) {
+        return DBUtils.getFullQualifiedName(
+            getDataSource(),
+            getCatalog(),
+            this);
+    }
+
+    @Override
+    public synchronized DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException {
+        additionalInfoLoaded = false;
+        return super.refreshObject(monitor);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksTable.java
@@ -158,6 +158,7 @@ public class DatabricksTable extends GenericTable {
     public String getFullyQualifiedName(DBPEvaluationContext context) {
         return DBUtils.getFullQualifiedName(
             getDataSource(),
+            getCatalog(),
             getSchema(),
             this);
     }

--- a/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksTable.java
@@ -1,0 +1,170 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.databricks.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ext.databricks.DatabricksConstants;
+import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
+import org.jkiss.dbeaver.ext.generic.model.GenericTable;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.meta.Property;
+import org.jkiss.dbeaver.model.meta.PropertyLength;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.utils.CommonUtils;
+
+import java.sql.SQLException;
+
+public class DatabricksTable extends GenericTable {
+
+    private static final Log log = Log.getLog(DatabricksTable.class);
+
+    private volatile boolean additionalInfoLoaded = false;
+    private String owner;
+    private String location;
+    private String createdTime;
+    private String tableProperties;
+    private String storageProperties;
+    private String description;
+
+    public DatabricksTable(
+        GenericStructContainer container,
+        @Nullable String tableName,
+        @Nullable String tableType,
+        @Nullable JDBCResultSet dbResult
+    ) {
+        super(container, tableName, tableType, dbResult);
+    }
+
+    @Property(viewable = true, order = 2)
+    public String getOwner(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return owner;
+    }
+
+    @Property(viewable = true, order = 3)
+    public String getLocation(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return location;
+    }
+
+    @Property(viewable = true, order = 4)
+    public String getCreatedTime(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return createdTime;
+    }
+
+    @Property(viewable = true, length = PropertyLength.MULTILINE, order = 98)
+    public String getTableProperties(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return tableProperties;
+    }
+
+    @Property(viewable = true, length = PropertyLength.MULTILINE, order = 99)
+    public String getStorageProperties(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return storageProperties;
+    }
+
+    @Nullable
+    @Override
+    @Property(viewable = true, updatable = true, length = PropertyLength.MULTILINE, order = 100)
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    private void checkExtraInfo(@NotNull DBRProgressMonitor monitor) {
+        if (!additionalInfoLoaded) {
+            loadAdditionalInfo(monitor);
+        }
+    }
+
+    private void loadAdditionalInfo(@NotNull DBRProgressMonitor monitor) {
+        if (!isPersisted()) {
+            additionalInfoLoaded = true;
+            return;
+        }
+        try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Load table extra info")) {
+            try (JDBCPreparedStatement dbStat = session.prepareStatement(
+                "DESCRIBE TABLE EXTENDED " + getFullyQualifiedName(DBPEvaluationContext.DDL))) {
+                try (JDBCResultSet dbResult = dbStat.executeQuery()) {
+                    while (dbResult.next()) {
+                        // This is table of metadata, where column name is in the col_name column
+                        String key = JDBCUtils.safeGetString(dbResult, "col_name");
+                        String value = JDBCUtils.safeGetString(dbResult, "data_type");
+                        if (CommonUtils.isNotEmpty(key)) {
+                            switch (key) {
+                                case "Comment":
+                                    description = value;
+                                    break;
+                                case DatabricksConstants.PROP_LOCATION:
+                                    location = value;
+                                    break;
+                                case DatabricksConstants.PROP_OWNER:
+                                    owner = value;
+                                    break;
+                                case DatabricksConstants.PROP_CREATED_TIME:
+                                    createdTime = value;
+                                    break;
+                                case DatabricksConstants.PROP_TABLE_PROPERTIES:
+                                    tableProperties = value;
+                                    break;
+                                case DatabricksConstants.PROP_STORAGE_PROPERTIES:
+                                    storageProperties = value;
+                                    break;
+                            }
+                        }
+                    }
+                    additionalInfoLoaded = true;
+                }
+            } catch (SQLException e) {
+                log.error("Can't read additional table info", e);
+            }
+        } catch (DBCException e) {
+            log.error("Can't read additional table info", e);
+        }
+    }
+
+    @NotNull
+    @Override
+    public String getFullyQualifiedName(DBPEvaluationContext context) {
+        return DBUtils.getFullQualifiedName(
+            getDataSource(),
+            getSchema(),
+            this);
+    }
+
+    @Override
+    public synchronized DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException {
+        additionalInfoLoaded = false;
+        return super.refreshObject(monitor);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksView.java
+++ b/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksView.java
@@ -139,6 +139,7 @@ public class DatabricksView extends GenericView {
     public String getFullyQualifiedName(DBPEvaluationContext context) {
         return DBUtils.getFullQualifiedName(
             getDataSource(),
+            getCatalog(),
             getSchema(),
             this);
     }

--- a/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksView.java
+++ b/plugins/org.jkiss.dbeaver.ext.databricks/src/org/jkiss/dbeaver/ext/databricks/model/DatabricksView.java
@@ -1,0 +1,151 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.databricks.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ext.databricks.DatabricksConstants;
+import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
+import org.jkiss.dbeaver.ext.generic.model.GenericView;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.meta.Property;
+import org.jkiss.dbeaver.model.meta.PropertyLength;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.utils.CommonUtils;
+
+import java.sql.SQLException;
+
+public class DatabricksView extends GenericView {
+
+    private static final Log log = Log.getLog(DatabricksView.class);
+
+    private volatile boolean additionalInfoLoaded = false;
+    private String owner;
+    private String createdTime;
+    private String tableProperties;
+    private String storageProperties;
+
+    public DatabricksView(
+        GenericStructContainer container,
+        @Nullable String tableName,
+        @Nullable String tableType,
+        @Nullable JDBCResultSet dbResult
+    ) {
+        super(container, tableName, tableType, dbResult);
+    }
+
+    @Property(viewable = true, order = 2)
+    public String getOwner(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return owner;
+    }
+
+    @Property(viewable = true, order = 3)
+    public String getCreatedTime(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return createdTime;
+    }
+
+    @Property(viewable = true, length = PropertyLength.MULTILINE, order = 98)
+    public String getTableProperties(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return tableProperties;
+    }
+
+    @Property(viewable = true, length = PropertyLength.MULTILINE, order = 99)
+    public String getStorageProperties(@NotNull DBRProgressMonitor monitor) {
+        checkExtraInfo(monitor);
+        return storageProperties;
+    }
+
+    @Nullable
+    @Override
+    public String getDescription() {
+        // Not supported
+        return null;
+    }
+
+    private void checkExtraInfo(@NotNull DBRProgressMonitor monitor) {
+        if (!additionalInfoLoaded) {
+            loadAdditionalInfo(monitor);
+        }
+    }
+
+    private void loadAdditionalInfo(@NotNull DBRProgressMonitor monitor) {
+        if (!isPersisted()) {
+            additionalInfoLoaded = true;
+            return;
+        }
+        try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Load view extra info")) {
+            try (JDBCPreparedStatement dbStat = session.prepareStatement(
+                "DESCRIBE TABLE EXTENDED " + getFullyQualifiedName(DBPEvaluationContext.DDL))) {
+                try (JDBCResultSet dbResult = dbStat.executeQuery()) {
+                    while (dbResult.next()) {
+                        // This is table of metadata, where column name is in the col_name column
+                        String key = JDBCUtils.safeGetString(dbResult, "col_name");
+                        String value = JDBCUtils.safeGetString(dbResult, "data_type");
+                        if (CommonUtils.isNotEmpty(key)) {
+                            switch (key) {
+                                case DatabricksConstants.PROP_OWNER:
+                                    owner = value;
+                                    break;
+                                case DatabricksConstants.PROP_CREATED_TIME:
+                                    createdTime = value;
+                                    break;
+                                case DatabricksConstants.PROP_TABLE_PROPERTIES:
+                                    tableProperties = value;
+                                    break;
+                                case DatabricksConstants.PROP_STORAGE_PROPERTIES:
+                                    storageProperties = value;
+                                    break;
+                            }
+                        }
+                    }
+                    additionalInfoLoaded = true;
+                }
+            } catch (SQLException e) {
+                log.error("Can't read additional table info", e);
+            }
+        } catch (DBCException e) {
+            log.error("Can't read additional table info", e);
+        }
+    }
+
+    @NotNull
+    @Override
+    public String getFullyQualifiedName(DBPEvaluationContext context) {
+        return DBUtils.getFullQualifiedName(
+            getDataSource(),
+            getSchema(),
+            this);
+    }
+
+    @Override
+    public synchronized DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException {
+        additionalInfoLoaded = false;
+        return super.refreshObject(monitor);
+    }
+}


### PR DESCRIPTION
read extra table/view/schema metadata;
do comment field for tables updatable
separate views from tables in the navigator tree
mark "global_temp" and "information_schema" as system schemas

![2023-02-15 01_50_13-Window](https://user-images.githubusercontent.com/45152336/218884245-0036ea52-62ed-4d1a-aad6-02520808bd5b.png)

![2023-02-15 01_50_49-Window](https://user-images.githubusercontent.com/45152336/218884251-6166bb42-513d-4e17-9378-d9ce2f7afebd.png)

![2023-02-15 02_00_33-Window](https://user-images.githubusercontent.com/45152336/218884254-827a2532-1ac2-4e54-b75c-a91351ba89f9.png)

![2023-02-15 02_04_59-Window](https://user-images.githubusercontent.com/45152336/218884255-22c47809-74a3-42a3-b2f9-9ad6f996cced.png)
