### PR TITLE
pro#1377 Fonts

### DIFF
--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/ERDUIConstants.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/ERDUIConstants.java
@@ -18,6 +18,7 @@
 package org.jkiss.dbeaver.erd.ui;
 
 import org.eclipse.draw2dl.PrintFigureOperation;
+import org.jkiss.dbeaver.ui.UIFonts;
 
 /**
  * ERD constants
@@ -36,7 +37,7 @@ public class ERDUIConstants {
     public static final int PRINT_MODE_DEFAULT = PrintFigureOperation.TILE;
     public static final int PRINT_MARGIN_DEFAULT = 0;
 
-    public static final String PROP_DIAGRAM_FONT = "org.jkiss.dbeaver.erd.diagram.font";
+    public static final String PROP_DIAGRAM_FONT = UIFonts.DIAGRAM_FONT;
 
     public static final String PREF_DIAGRAM_SHOW_VIEWS = "erd.diagram.show.views";
     public static final String PREF_DIAGRAM_SHOW_PARTITIONS = "erd.diagram.show.partitions";

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/ERDUIConstants.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/ERDUIConstants.java
@@ -37,7 +37,7 @@ public class ERDUIConstants {
     public static final int PRINT_MODE_DEFAULT = PrintFigureOperation.TILE;
     public static final int PRINT_MARGIN_DEFAULT = 0;
 
-    public static final String PROP_DIAGRAM_FONT = UIFonts.DIAGRAM_FONT;
+    public static final String PROP_DIAGRAM_FONT = "org.jkiss.dbeaver.erd.diagram.font";
 
     public static final String PREF_DIAGRAM_SHOW_VIEWS = "erd.diagram.show.views";
     public static final String PREF_DIAGRAM_SHOW_PARTITIONS = "erd.diagram.show.partitions";

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLConstants.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLConstants.java
@@ -658,7 +658,6 @@ public class SQLConstants {
     public static final String CONFIG_COLOR_TEXT = "org.jkiss.dbeaver.sql.editor.color.text.foreground";
     public static final String CONFIG_COLOR_BACKGROUND = "org.jkiss.dbeaver.sql.editor.color.text.background";
     public static final String CONFIG_COLOR_DISABLED = "org.jkiss.dbeaver.sql.editor.color.disabled.background";
-    public static final String CONFIG_FONT_OUTPUT = "org.jkiss.dbeaver.sql.editor.font.output";
 
     public static final char DEFAULT_PARAMETER_MARK = '?';
     public static final char DEFAULT_PARAMETER_PREFIX = ':';

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/META-INF/MANIFEST.MF
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/META-INF/MANIFEST.MF
@@ -36,5 +36,6 @@ Require-Bundle: org.eclipse.osgi,
  org.jkiss.dbeaver.core,
  org.jkiss.dbeaver.ui,
  org.jkiss.dbeaver.ui.editors.data,
- org.eclipse.ui.views.log
+ org.eclipse.ui.views.log,
+ org.jkiss.dbeaver.erd.ui
 Automatic-Module-Name: org.jkiss.dbeaver.ui.app.standalone

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchAdvisor.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchAdvisor.java
@@ -43,6 +43,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBeaverPreferences;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ModelPreferences;
+import org.jkiss.dbeaver.erd.ui.ERDUIConstants;
 import org.jkiss.dbeaver.model.DBIcon;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.app.DBPApplication;
@@ -56,6 +57,7 @@ import org.jkiss.dbeaver.ui.actions.datasource.DataSourceHandler;
 import org.jkiss.dbeaver.ui.app.standalone.internal.CoreApplicationActivator;
 import org.jkiss.dbeaver.ui.app.standalone.internal.CoreApplicationMessages;
 import org.jkiss.dbeaver.ui.app.standalone.update.DBeaverVersionChecker;
+import org.jkiss.dbeaver.ui.controls.resultset.ThemeConstants;
 import org.jkiss.dbeaver.ui.dialogs.ConfirmationDialog;
 import org.jkiss.dbeaver.ui.editors.EditorUtils;
 import org.jkiss.dbeaver.ui.editors.content.ContentEditorInput;
@@ -124,33 +126,41 @@ public class ApplicationWorkbenchAdvisor extends IDEWorkbenchAdvisor {
         "org.eclipse.debug.ui.DebugPreferencePage"                              // Debugger
     };
     
+    
+    /**
+     * Diagram font
+     */
+    public static String DIAGRAM_FONT = ERDUIConstants.PROP_DIAGRAM_FONT;
+
+    public static String RESULTS_GRID_FONT = ThemeConstants.FONT_SQL_RESULT_SET;
+    
     private static final Set<String> fontPrefIdsToHide = Set.of(
-        UIFonts.TEXT_EDITOR_BLOCK_SELECTION_FONT,
-        UIFonts.TEXT_FONT,
-        UIFonts.CONSOLE_FONT,
-        UIFonts.DETAIL_PANE_TEXT_FONT,
-        UIFonts.MEMORY_VIEW_TABLE_FONT,
-        UIFonts.COMPARE_TEXT_FONT,
-        UIFonts.DIALOG_FONT,
-        UIFonts.VARIABLE_TEXT_FONT,
-        UIFonts.PART_TITLE_FONT,
-        UIFonts.TREE_AND_TABLE_FONT_FOR_VIEWS
+        ApplicationWorkbenchWindowAdvisor.TEXT_EDITOR_BLOCK_SELECTION_FONT,
+        ApplicationWorkbenchWindowAdvisor.TEXT_FONT,
+        ApplicationWorkbenchWindowAdvisor.CONSOLE_FONT,
+        ApplicationWorkbenchWindowAdvisor.DETAIL_PANE_TEXT_FONT,
+        ApplicationWorkbenchWindowAdvisor.MEMORY_VIEW_TABLE_FONT,
+        ApplicationWorkbenchWindowAdvisor.COMPARE_TEXT_FONT,
+        ApplicationWorkbenchWindowAdvisor.DIALOG_FONT,
+        ApplicationWorkbenchWindowAdvisor.VARIABLE_TEXT_FONT,
+        ApplicationWorkbenchWindowAdvisor.PART_TITLE_FONT,
+        ApplicationWorkbenchWindowAdvisor.TREE_AND_TABLE_FONT_FOR_VIEWS
     );
     
     private static final Map<String, List<String>> fontOverrides = Map.of(
         UIFonts.DBEAVER_FONTS_MONOSPACE, List.of(
-            UIFonts.TEXT_EDITOR_BLOCK_SELECTION_FONT,
-            UIFonts.TEXT_FONT,
-            UIFonts.CONSOLE_FONT,
-            UIFonts.DETAIL_PANE_TEXT_FONT,
-            UIFonts.MEMORY_VIEW_TABLE_FONT,
-            UIFonts.COMPARE_TEXT_FONT
+            ApplicationWorkbenchWindowAdvisor.TEXT_EDITOR_BLOCK_SELECTION_FONT,
+            ApplicationWorkbenchWindowAdvisor.TEXT_FONT,
+            ApplicationWorkbenchWindowAdvisor.CONSOLE_FONT,
+            ApplicationWorkbenchWindowAdvisor.DETAIL_PANE_TEXT_FONT,
+            ApplicationWorkbenchWindowAdvisor.MEMORY_VIEW_TABLE_FONT,
+            ApplicationWorkbenchWindowAdvisor.COMPARE_TEXT_FONT
         ),
         UIFonts.DBEAVER_FONTS_MAIN_FONT, List.of(
-            UIFonts.DIALOG_FONT,
-            UIFonts.VARIABLE_TEXT_FONT,
-            UIFonts.PART_TITLE_FONT,
-            UIFonts.TREE_AND_TABLE_FONT_FOR_VIEWS
+            ApplicationWorkbenchWindowAdvisor.DIALOG_FONT,
+            ApplicationWorkbenchWindowAdvisor.VARIABLE_TEXT_FONT,
+            ApplicationWorkbenchWindowAdvisor.PART_TITLE_FONT,
+            ApplicationWorkbenchWindowAdvisor.TREE_AND_TABLE_FONT_FOR_VIEWS
         )
     ); 
     

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchAdvisor.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchAdvisor.java
@@ -51,6 +51,7 @@ import org.jkiss.dbeaver.model.task.DBTTaskManager;
 import org.jkiss.dbeaver.registry.DataSourceRegistry;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.ui.DBeaverIcons;
+import org.jkiss.dbeaver.ui.UIFonts;
 import org.jkiss.dbeaver.ui.actions.datasource.DataSourceHandler;
 import org.jkiss.dbeaver.ui.app.standalone.internal.CoreApplicationActivator;
 import org.jkiss.dbeaver.ui.app.standalone.internal.CoreApplicationMessages;
@@ -66,6 +67,8 @@ import org.jkiss.dbeaver.utils.RuntimeUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This workbench advisor creates the window advisor, and specifies
@@ -120,7 +123,37 @@ public class ApplicationWorkbenchAdvisor extends IDEWorkbenchAdvisor {
         "org.eclipse.equinox.internal.p2.ui.sdk.ProvisioningPreferencePage",    // Install-Update
         "org.eclipse.debug.ui.DebugPreferencePage"                              // Debugger
     };
-
+    
+    private static final Set<String> fontPrefIdsToHide = Set.of(
+        UIFonts.TEXT_EDITOR_BLOCK_SELECTION_FONT,
+        UIFonts.TEXT_FONT,
+        UIFonts.CONSOLE_FONT,
+        UIFonts.DETAIL_PANE_TEXT_FONT,
+        UIFonts.MEMORY_VIEW_TABLE_FONT,
+        UIFonts.COMPARE_TEXT_FONT,
+        UIFonts.DIALOG_FONT,
+        UIFonts.VARIABLE_TEXT_FONT,
+        UIFonts.PART_TITLE_FONT,
+        UIFonts.TREE_AND_TABLE_FONT_FOR_VIEWS
+    );
+    
+    private static final Map<String, List<String>> fontOverrides = Map.of(
+        UIFonts.DBEAVER_FONTS_MONOSPACE, List.of(
+            UIFonts.TEXT_EDITOR_BLOCK_SELECTION_FONT,
+            UIFonts.TEXT_FONT,
+            UIFonts.CONSOLE_FONT,
+            UIFonts.DETAIL_PANE_TEXT_FONT,
+            UIFonts.MEMORY_VIEW_TABLE_FONT,
+            UIFonts.COMPARE_TEXT_FONT
+        ),
+        UIFonts.DBEAVER_FONTS_MAIN_FONT, List.of(
+            UIFonts.DIALOG_FONT,
+            UIFonts.VARIABLE_TEXT_FONT,
+            UIFonts.PART_TITLE_FONT,
+            UIFonts.TREE_AND_TABLE_FONT_FOR_VIEWS
+        )
+    ); 
+    
     //processor must be created before we start event loop
     protected final DBPApplication application;
     private final DelayedEventsProcessor processor;
@@ -165,6 +198,8 @@ public class ApplicationWorkbenchAdvisor extends IDEWorkbenchAdvisor {
         WorkbenchImages.getImageRegistry().put(IDEInternalWorkbenchImages.IMG_OBJS_ERROR_PATH, DBeaverIcons.getImageDescriptor(DBIcon.SMALL_ERROR));
         WorkbenchImages.getDescriptors().put(IDEInternalWorkbenchImages.IMG_OBJS_ERROR_PATH, DBeaverIcons.getImageDescriptor(DBIcon.SMALL_ERROR));
 
+        FontPreferenceOverrides.overrideFontPrefValues(fontOverrides);
+            
 /*
         // Set default resource encoding to UTF-8
         String defEncoding = DBWorkbench.getPlatform().getPreferenceStore().getString(DBeaverPreferences.DEFAULT_RESOURCE_ENCODING);
@@ -203,11 +238,14 @@ public class ApplicationWorkbenchAdvisor extends IDEWorkbenchAdvisor {
             property.equals(DBeaverPreferences.LOGS_DEBUG_LOCATION) ||
             property.equals(ModelPreferences.PLATFORM_LANGUAGE);
     }
-
+    
+    
     private void filterPreferencePages() {
-        // Remove unneeded pref pages
+        // Remove unneeded pref pages and override font preferences page
         PreferenceManager pm = PlatformUI.getWorkbench().getPreferenceManager();
-
+        
+        FontPreferenceOverrides.hideFontPrefs(pm, fontPrefIdsToHide);
+        
         for (String epp : getExcludedPreferencePageIds()) {
             pm.remove(epp);
         }

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchWindowAdvisor.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchWindowAdvisor.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.swt.dnd.DropTargetAdapter;
 import org.eclipse.swt.dnd.FileTransfer;
@@ -54,6 +55,68 @@ import java.util.StringJoiner;
 
 public class ApplicationWorkbenchWindowAdvisor extends IDEWorkbenchWindowAdvisor implements DBPProjectListener, IResourceChangeListener {
     private static final Log log = Log.getLog(ApplicationWorkbenchWindowAdvisor.class);
+    
+    // Eclipse fonts
+    
+    /**
+     * Compare text font
+     */
+    public static String COMPARE_TEXT_FONT = "org.eclipse.compare.contentmergeviewer.TextMergeViewer";
+    
+    /**
+     * Detail pane text font
+     */
+    public static String DETAIL_PANE_TEXT_FONT = "org.eclipse.debug.ui.DetailPaneFont";
+    
+    /**
+     * Memory view table font
+     */
+    public static String MEMORY_VIEW_TABLE_FONT = "org.eclipse.debug.ui.MemoryViewTableFont";
+
+    /**
+     * Variable text font
+     */
+    public static String VARIABLE_TEXT_FONT = "org.eclipse.debug.ui.VariableTextFont";
+ 
+    /**
+     * Console font
+     */
+    public static String CONSOLE_FONT = "org.eclipse.debug.ui.consoleFont";
+
+    /**
+     * Part title font
+     */
+    public static String PART_TITLE_FONT = "org.eclipse.ui.workbench.TAB_TEXT_FONT";
+
+    /**
+     * Tree and Table font for views
+     */
+    public static String TREE_AND_TABLE_FONT_FOR_VIEWS = "org.eclipse.ui.workbench.TREE_TABLE_FONT";
+
+    /**
+     * Header Font
+     */
+    public static String HEADER_FONT = "org.eclipse.jface.headerfont";
+
+    /**
+     * Text Font
+     */
+    public static String TEXT_FONT = "org.eclipse.jface.textfont";
+
+    /**
+     * Text Editor Block Selection Font
+     */
+    public static String TEXT_EDITOR_BLOCK_SELECTION_FONT = "org.eclipse.ui.workbench.texteditor.blockSelectionModeFont";
+
+    /**
+     * Banner font
+     */
+    public static String BANNER_FONT = JFaceResources.BANNER_FONT;
+
+    /**
+     * Dialog font
+     */
+    public static String DIALOG_FONT = JFaceResources.DIALOG_FONT;
 
     private IEditorPart lastActiveEditor = null;
     private IPerspectiveDescriptor lastPerspective = null;

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/FontPreferenceOverrides.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/FontPreferenceOverrides.java
@@ -1,0 +1,517 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.app.standalone;
+
+import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.jface.preference.IPreferenceNode;
+import org.eclipse.jface.preference.IPreferencePage;
+import org.eclipse.jface.preference.IPreferencePageContainer;
+import org.eclipse.jface.preference.PreferenceManager;
+import org.eclipse.jface.preference.PreferenceNode;
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.jface.resource.FontRegistry;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.dialogs.FilteredTree;
+import org.eclipse.ui.internal.WorkbenchPlugin;
+import org.eclipse.ui.internal.themes.ColorDefinition;
+import org.eclipse.ui.internal.themes.FontDefinition;
+import org.eclipse.ui.internal.themes.ICategorizedThemeElementDefinition;
+import org.eclipse.ui.internal.themes.IHierarchalThemeElementDefinition;
+import org.eclipse.ui.internal.themes.IThemeElementDefinition;
+import org.eclipse.ui.internal.themes.IThemeRegistry;
+import org.eclipse.ui.internal.themes.ThemeElementCategory;
+import org.eclipse.ui.internal.themes.WorkbenchThemeManager;
+import org.eclipse.ui.themes.ITheme;
+import org.eclipse.ui.themes.IThemeManager;
+import org.jkiss.dbeaver.ui.DBIconBinary;
+import org.jkiss.dbeaver.ui.DBeaverIcons;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FontPreferenceOverrides {
+
+    // Original implementation at org.eclipse.ui.internal.themes.ColorsAndFontsPreferencePage.ThemeContentProvider
+    private static class FilteredThemeContentProvider implements ITreeContentProvider {
+        private final Set<String> prefIdsToHide;
+        
+        private final Map<String, Object[]> categoryMap = new HashMap<>(7);
+        private final IThemeRegistry themeRegistry = WorkbenchPlugin.getDefault().getThemeRegistry();
+        private final IThemeManager themeManager;
+        private IThemeRegistry registry;
+        private IPropertyChangeListener themeChangeListener;
+        private ITheme currentTheme;
+        
+        public FilteredThemeContentProvider(Set<String> prefIdsToHide) {
+            this.prefIdsToHide = prefIdsToHide;
+            
+            themeManager = PlatformUI.getWorkbench().getThemeManager();
+            themeChangeListener = event -> {
+                if (event.getProperty().equals(IThemeManager.CHANGE_CURRENT_THEME)) {
+                    currentTheme = themeManager.getCurrentTheme();
+                }
+            };
+            currentTheme = themeManager.getCurrentTheme();
+            themeManager.addPropertyChangeListener(themeChangeListener);
+        }
+
+        private boolean isIdToHide(String id) {
+            return id != null && prefIdsToHide.contains(id);
+        }
+
+        @Override
+        public Object[] getChildren(Object parentElement) {            
+            if (parentElement instanceof ThemeElementCategory) {
+                String categoryId = ((ThemeElementCategory) parentElement).getId();
+                Object[] defintions = categoryMap.get(categoryId);
+                if (defintions == null) {
+                    defintions = getCategoryChildren(categoryId);                    
+                    categoryMap.put(categoryId, defintions);
+                }
+                return defintions;
+            }
+
+            ArrayList<IHierarchalThemeElementDefinition> list = new ArrayList<>();
+            IHierarchalThemeElementDefinition def = (IHierarchalThemeElementDefinition) parentElement;
+            String id = def.getId();
+            IHierarchalThemeElementDefinition[] defs;
+            if (def instanceof ColorDefinition) {
+                defs = registry.getColors();
+            } else {
+                defs = registry.getFonts();
+            }
+
+            for (IHierarchalThemeElementDefinition elementDefinition : defs) {
+                if (id.equals(elementDefinition.getDefaultsTo()) && catIdEquals(
+                        ((ICategorizedThemeElementDefinition) def).getCategoryId(),
+                        ((ICategorizedThemeElementDefinition) elementDefinition).getCategoryId())) {
+                    list.add(elementDefinition);
+                }
+            }
+            return list.toArray();
+        }
+        
+        private boolean catIdEquals(String string, String string2) {
+            if ((string == null && string2 == null))
+                return true;
+            if (string == null || string2 == null)
+                return false;
+            if (string.equals(string2))
+                return true;
+            return false;
+        }
+
+        private Object[] getCategoryChildren(String categoryId) {
+            if (isIdToHide(categoryId)) {
+                return new Object[0];
+            }
+            
+            ArrayList<IThemeElementDefinition> list = new ArrayList<>();
+
+            if (categoryId != null) {
+                for (ThemeElementCategory category : registry.getCategories()) {
+                    if (categoryId.equals(category.getParentId()) && !isIdToHide(category.getId())) {
+                        Set<?> bindings = themeRegistry.getPresentationsBindingsFor(category);
+                        if (bindings == null) {
+                            list.add(category);
+                        }
+                    }
+                }
+            }
+            ColorDefinition[] colorDefinitions = themeRegistry.getColorsFor(currentTheme.getId());
+            for (ColorDefinition colorDefinition : colorDefinitions) {
+                if (!colorDefinition.isEditable() || isIdToHide(colorDefinition.getId())) {
+                    continue;
+                }
+                String catId = colorDefinition.getCategoryId();
+                if ((catId == null && categoryId == null)
+                        || (catId != null && categoryId != null && categoryId.equals(catId))) {
+                    if (colorDefinition.getDefaultsTo() != null && parentIsInSameCategory(colorDefinition)) {
+                        continue;
+                    }
+                    list.add(colorDefinition);
+                }
+            }
+            FontDefinition[] fontDefinitions = themeRegistry.getFontsFor(currentTheme.getId());
+            for (FontDefinition fontDefinition : fontDefinitions) {
+                if (!fontDefinition.isEditable() || isIdToHide(fontDefinition.getId())) {
+                    continue;
+                }
+                String catId = fontDefinition.getCategoryId();
+                if ((catId == null && categoryId == null)
+                        || (catId != null && categoryId != null && categoryId.equals(catId))) {
+                    if (fontDefinition.getDefaultsTo() != null && parentIsInSameCategory(fontDefinition)) {
+                        continue;
+                    }
+                    list.add(fontDefinition);
+                }
+            }
+            return list.toArray(new Object[list.size()]);
+        }
+
+        private boolean parentIsInSameCategory(ColorDefinition definition) {
+            String defaultsTo = definition.getDefaultsTo();
+            for (ColorDefinition colorDef : registry.getColors()) {
+                if (colorDef.getId().equals(defaultsTo)
+                    && catIdEquals(colorDef.getCategoryId(), definition.getCategoryId())
+                ) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean parentIsInSameCategory(FontDefinition definition) {
+            String defaultsTo = definition.getDefaultsTo();
+            for (FontDefinition fontDef : registry.getFonts()) {
+                if (fontDef.getId().equals(defaultsTo)
+                    && catIdEquals(fontDef.getCategoryId(), definition.getCategoryId())
+                ) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public Object getParent(Object element) {            
+            if (element instanceof ThemeElementCategory)
+                return registry;
+
+            if (element instanceof ColorDefinition) {
+                String defaultId = ((IHierarchalThemeElementDefinition) element).getDefaultsTo();
+                if (defaultId != null) {
+                    ColorDefinition defaultElement = registry.findColor(defaultId);
+                    if (parentIsInSameCategory(defaultElement))
+                        return defaultElement;
+                }
+                String categoryId = ((ColorDefinition) element).getCategoryId();
+                return registry.findCategory(categoryId);
+            }
+
+            if (element instanceof FontDefinition) {
+                String defaultId = ((FontDefinition) element).getDefaultsTo();
+                if (defaultId != null) {
+                    FontDefinition defaultElement = registry.findFont(defaultId);
+                    if (parentIsInSameCategory(defaultElement))
+                        return defaultElement;
+                }
+                String categoryId = ((FontDefinition) element).getCategoryId();
+                return registry.findCategory(categoryId);
+            }
+
+            return null;
+        }
+
+        @Override
+        public boolean hasChildren(Object element) {            
+            if (element instanceof ThemeElementCategory) {
+                if (isIdToHide(((ThemeElementCategory)element).getId())) {
+                    return false;
+                }
+                return true;
+            }
+
+            IHierarchalThemeElementDefinition def = (IHierarchalThemeElementDefinition) element;
+            String id = def.getId();
+            if (isIdToHide(id)) {
+                return false;
+            }
+            
+            IHierarchalThemeElementDefinition[] defs;
+            if (def instanceof ColorDefinition) {
+                defs = registry.getColors();
+            } else {
+                defs = registry.getFonts();
+            }
+
+            for (IHierarchalThemeElementDefinition elementDefinition : defs) {
+                if (id.equals(elementDefinition.getDefaultsTo())
+                    && catIdEquals(
+                        ((ICategorizedThemeElementDefinition) def).getCategoryId(),
+                        ((ICategorizedThemeElementDefinition) elementDefinition).getCategoryId()
+                    )
+                ) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public Object[] getElements(Object inputElement) {            
+            ArrayList<Object> list = new ArrayList<>();
+            Object[] uncatChildren = getCategoryChildren(null);
+            list.addAll(Arrays.asList(uncatChildren));
+            for (ThemeElementCategory category : ((IThemeRegistry) inputElement).getCategories()) {
+                if (category.getParentId() == null && !isIdToHide(category.getId())) {
+                    Set<?> bindings = themeRegistry.getPresentationsBindingsFor(category);
+                    if (bindings == null) {
+                        Object[] children = getChildren(category);
+                        if (children != null && children.length > 0) {
+                            list.add(category);
+                        }
+                    }
+                }
+            }
+            return list.toArray(new Object[list.size()]);
+        }
+
+        @Override
+        public void dispose() {
+            categoryMap.clear();
+            themeManager.removePropertyChangeListener(themeChangeListener);
+        }
+
+        @Override
+        public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+            categoryMap.clear();
+            registry = (IThemeRegistry) newInput;
+        }
+
+    }
+
+    private static class MyFontsPrefPage implements IPreferencePage, IMessageProvider {
+        private final PreferencePage fontsPage;
+        private final Set<String> prefIdsToHide;
+
+        public MyFontsPrefPage(PreferencePage fontsPage, Set<String> prefIdsToHide) {
+            this.fontsPage = fontsPage;
+            this.prefIdsToHide = prefIdsToHide;
+        }
+
+        @Override
+        public void createControl(Composite parent) {
+            fontsPage.createControl(parent);
+            
+            // see ColorsAndFontsPreferencePage.createContents(..)
+            Control[] prefsPageParts = parent.getChildren(); // page content container and defaults&apply buttons container 
+            Composite prefsPageContent = (Composite)prefsPageParts[Math.max(prefsPageParts.length - 1, 0)];
+            Composite advancedCompositeSash = (Composite)prefsPageContent.getChildren()[0];
+            Composite mainColumn = (Composite)advancedCompositeSash.getChildren()[0];
+            FilteredTree tree = (FilteredTree)mainColumn.getChildren()[1];
+            
+            tree.getViewer().setContentProvider(new FilteredThemeContentProvider(prefIdsToHide));
+        }
+
+        @Override
+        public void dispose() {
+            fontsPage.dispose();
+        }
+
+        @Override
+        public Control getControl() {
+            return fontsPage.getControl();
+        }
+
+        @Override
+        public String getDescription() {
+            return fontsPage.getDescription();
+        }
+
+        @Override
+        public String getErrorMessage() {
+            return fontsPage.getErrorMessage();
+        }
+
+        @Override
+        public Image getImage() {
+            return fontsPage.getImage();
+        }
+
+        @Override
+        public String getMessage() {
+            return fontsPage.getMessage();
+        }
+
+        @Override
+        public String getTitle() {
+            return fontsPage.getTitle();
+        }
+
+        @Override
+        public void performHelp() {
+            fontsPage.performHelp();
+        }
+
+        @Override
+        public void setDescription(String description) {
+            fontsPage.setDescription(description);
+        }
+
+        @Override
+        public void setImageDescriptor(ImageDescriptor image) {
+            fontsPage.setImageDescriptor(image);
+        }
+
+        @Override
+        public void setTitle(String title) {
+            fontsPage.setTitle(title);
+        }
+
+        @Override
+        public void setVisible(boolean visible) {
+            fontsPage.setVisible(visible);
+        }
+
+        @Override
+        public int getMessageType() {
+            return fontsPage.getMessageType();
+        }
+
+        @Override
+        public Point computeSize() {
+            return fontsPage.computeSize();
+        }
+
+        @Override
+        public boolean isValid() {
+            return fontsPage.isValid();
+        }
+
+        @Override
+        public boolean okToLeave() {
+            return fontsPage.okToLeave();
+        }
+
+        @Override
+        public boolean performCancel() {
+            return fontsPage.performCancel();
+        }
+
+        @Override
+        public boolean performOk() {
+            return fontsPage.performOk();
+        }
+
+        @Override
+        public void setContainer(IPreferencePageContainer preferencePageContainer) {
+            fontsPage.setContainer(preferencePageContainer);
+        }
+
+        @Override
+        public void setSize(Point size) {
+            fontsPage.setSize(size);
+        }
+    }
+    
+    private static class FontPreferenceNodePageOverride extends PreferenceNode {
+        private PreferenceNode originalNode;
+        private Set<String> prefIdsToHide;
+        private IPreferencePage page = null;
+        
+        public FontPreferenceNodePageOverride(PreferenceNode originalNode, Set<String> prefIdsToHide) {
+            super(originalNode.getId());
+            this.originalNode = originalNode;
+            this.prefIdsToHide = prefIdsToHide;
+        }
+
+        @Override
+        public String getLabelText() {
+            return originalNode.getLabelText();
+        }
+        
+        @Override
+        public Image getLabelImage() {
+            return originalNode.getLabelImage();
+        }
+        
+        @Override
+        public void createPage() {
+            originalNode.createPage();
+            IPreferencePage originalPage = originalNode.getPage();
+            if (originalPage instanceof PreferencePage) {
+                page = new MyFontsPrefPage((PreferencePage)originalPage, prefIdsToHide);
+                if (getLabelImage() != null) {
+                    page.setImageDescriptor(DBeaverIcons.getImageDescriptor(new DBIconBinary(null, originalNode.getLabelImage())));
+                }
+                page.setTitle(getLabelText());
+            } else {
+                page = originalPage;
+            }
+        }
+        
+        @Override
+        public IPreferencePage getPage() {
+            return page;
+        }
+        
+        @Override 
+        public void setPage(IPreferencePage page) {
+            this.page = page;
+            if (page == null) {
+                originalNode.setPage(null);
+            }
+        }
+        
+        @Override
+        public void disposeResources() {
+            super.disposeResources();
+            if (page != null) {
+                page.dispose();
+                page = null;
+            }
+            originalNode.disposeResources();
+        }   
+    }
+
+    public static void hideFontPrefs(PreferenceManager pm, Set<String> prefIdsToHide) {
+        String wbPrefPageId = ApplicationWorkbenchAdvisor.WORKBENCH_PREF_PAGE_ID ;
+        String viewsCatId = wbPrefPageId  + "/org.eclipse.ui.preferencePages.Views";
+        String fontsPrefPageId = wbPrefPageId + "/org.eclipse.ui.preferencePages.Views/org.eclipse.ui.preferencePages.ColorsAndFonts";
+        
+        IPreferenceNode catNode = pm.find(viewsCatId);
+        IPreferenceNode rawFontsNode = pm.find(fontsPrefPageId);
+        
+        if (rawFontsNode instanceof PreferenceNode) {
+            catNode.remove(rawFontsNode);
+            catNode.add(new FontPreferenceNodePageOverride((PreferenceNode)rawFontsNode, prefIdsToHide));
+        }
+    }
+
+    public static void overrideFontPrefValues(Map<String, List<String>> fontOverrides) {
+        WorkbenchThemeManager.getInstance().addPropertyChangeListener(new IPropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent event) {
+                String fontPropertyId = event.getProperty();
+                List<String> fontIdsToOverride = fontOverrides.get(fontPropertyId);
+                if (fontIdsToOverride != null) {
+                    FontRegistry fonts = WorkbenchThemeManager.getInstance().getCurrentTheme().getFontRegistry();
+                    FontData[] data = fonts.getFontData(fontPropertyId);
+                    for (String fontId: fontIdsToOverride) {
+                        fonts.put(fontId, data);
+                    }
+                }
+            }
+        });        
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ThemeConstants.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ThemeConstants.java
@@ -17,8 +17,6 @@
 
 package org.jkiss.dbeaver.ui.controls.resultset;
 
-import org.jkiss.dbeaver.ui.UIFonts;
-
 /**
  * ThemeConstants
  */
@@ -26,7 +24,7 @@ public class ThemeConstants
 {
     public static final String RESULTS_PROP_PREFIX = "org.jkiss.dbeaver.sql.resultset.";
 
-    public static final String FONT_SQL_RESULT_SET = UIFonts.RESULTS_GRID_FONT; //$NON-NLS-1$
+    public static final String FONT_SQL_RESULT_SET = RESULTS_PROP_PREFIX + "font"; //$NON-NLS-1$
     public static final String COLOR_SQL_RESULT_SET_SELECTION_FORE = RESULTS_PROP_PREFIX + "color.selection.foreground"; //$NON-NLS-1$
     public static final String COLOR_SQL_RESULT_SET_SELECTION_BACK = RESULTS_PROP_PREFIX + "color.selection.background"; //$NON-NLS-1$
     public static final String COLOR_SQL_RESULT_SET_PREVIEW_BACK = RESULTS_PROP_PREFIX + "color.preview.background"; //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ThemeConstants.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ThemeConstants.java
@@ -17,6 +17,8 @@
 
 package org.jkiss.dbeaver.ui.controls.resultset;
 
+import org.jkiss.dbeaver.ui.UIFonts;
+
 /**
  * ThemeConstants
  */
@@ -24,7 +26,7 @@ public class ThemeConstants
 {
     public static final String RESULTS_PROP_PREFIX = "org.jkiss.dbeaver.sql.resultset.";
 
-    public static final String FONT_SQL_RESULT_SET = RESULTS_PROP_PREFIX + "font"; //$NON-NLS-1$
+    public static final String FONT_SQL_RESULT_SET = UIFonts.RESULTS_GRID_FONT; //$NON-NLS-1$
     public static final String COLOR_SQL_RESULT_SET_SELECTION_FORE = RESULTS_PROP_PREFIX + "color.selection.foreground"; //$NON-NLS-1$
     public static final String COLOR_SQL_RESULT_SET_SELECTION_BACK = RESULTS_PROP_PREFIX + "color.selection.background"; //$NON-NLS-1$
     public static final String COLOR_SQL_RESULT_SET_PREVIEW_BACK = RESULTS_PROP_PREFIX + "color.preview.background"; //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.ui.editors.hex/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.hex/plugin.xml
@@ -18,16 +18,6 @@
             <description>%themeElementCategory.org.jkiss.dbeaver.ui.presentation.hex.description</description>
         </themeElementCategory>
 
-        <fontDefinition
-            id="org.jkiss.dbeaver.hex.editor.font.output"
-            categoryId="org.jkiss.dbeaver.ui.presentation.hex"
-            label="%fontDefinition.org.jkiss.dbeaver.hex.editor.font.label"
-            value="Courier New-regular-10">
-            <description>%fontDefinition.org.jkiss.dbeaver.hex.editor.font.description</description>
-            <fontValue os="linux" value="Monospace-regular-10"/>
-            <fontValue os="macosx" value="Courier-regular-11"/>
-        </fontDefinition>
-
         <colorDefinition
             label="%colorDefinition.org.jkiss.dbeaver.hex.editor.color.caret.label"
             categoryId="org.jkiss.dbeaver.ui.presentation.hex"

--- a/plugins/org.jkiss.dbeaver.ui.editors.hex/src/org/jkiss/dbeaver/ui/editors/binary/HexEditControl.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.hex/src/org/jkiss/dbeaver/ui/editors/binary/HexEditControl.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.*;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.themes.ITheme;
 import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ui.UIFonts;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.editors.binary.pref.HexPreferencesPage;
 import org.jkiss.dbeaver.utils.GeneralUtils;
@@ -194,7 +195,7 @@ public class HexEditControl extends Composite {
         this.colorCaretLine = currentTheme.getColorRegistry().get("org.jkiss.dbeaver.hex.editor.color.caret");
         this.colorText = currentTheme.getColorRegistry().get("org.jkiss.dbeaver.hex.editor.color.text");
         this.colorHighlightText = UIUtils.getSharedColor(UIUtils.blend(this.colorText.getRGB(), this.colorCaretLine.getRGB(), 50));
-        this.fontDefault = currentTheme.getFontRegistry().get("org.jkiss.dbeaver.hex.editor.font.output");
+        this.fontDefault = currentTheme.getFontRegistry().get(UIFonts.DBEAVER_FONTS_MONOSPACE);
     }
 
     /**

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
@@ -159,9 +159,6 @@ menu.org.jkiss.dbeaver.ui.editors.sql.SQLEditor.extraPanels.label = Panels
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.label = SQL Editor
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.description = SQL Editor
 
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label = SQL output font
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description = Font to show SQL output. Preferred to be a monospace font.
-
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.label = SQL keyword color
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.description = SQL keyword color
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.datatype.foreground.label = SQL datatype color

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_de.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_de.properties
@@ -93,8 +93,6 @@ menu.org.jkiss.dbeaver.ui.editors.sql.SQLEditor.layout.label  = Layout
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.description     = SQL-Editor
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.label           = SQL-Editor
 
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description = Schriftart, um die SQL-Ausgabe anzuzeigen. Bevorzugt wird eine Monospace-Schriftart.
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label       = SQL-Ausgabeschriftart
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.command.foreground.description            = Textfarbe Steuerbefehl
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.command.foreground.label                  = Textfarbe SQL-Befehl
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.comment.foreground.description            = SQL-Kommentarfarbe

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_es.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_es.properties
@@ -116,9 +116,6 @@ editor.sql.name = Editor SQL
 
 extension-point.org.jkiss.dbeaver.sql.covertname = Conversiones de texto SQL
 
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description = Fuente para mostrar salida SQL. Se prefiere una fuente monoespaciada.
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label       = Fuente de salida SQL
-
 menu.database.sql.generate                                    = &Generar SQL
 menu.org.jkiss.dbeaver.core.connection.sqleditor = Editor SQL
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_fr.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_fr.properties
@@ -96,10 +96,6 @@ menu.org.jkiss.dbeaver.ui.editors.sql.SQLEditor.layout.label = Agencement
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.label = Editeur SQL
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.description = Editeur SQL
 
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label = Police de sortie SQL
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description = Police pour l'affichage de la sortie SQL. Pref\u00E9rer une police \u00E0 chasse fixe.
-
-
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.label = Couleur de texte des mots-clefs SQL
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.description = Couleur de texte des mots-clefs SQL
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.datatype.foreground.label = Couleur de texte des types de donn\u00E9es SQL

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_ja.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_ja.properties
@@ -117,9 +117,6 @@ menu.org.jkiss.dbeaver.ui.editors.sql.SQLEditor.extraPanels.label = \u30D1\u30CD
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.label =SQL\u30A8\u30C7\u30A3\u30BF
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.description =SQL\u30A8\u30C7\u30A3\u30BF
 
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label =SQL\u51FA\u529B\u30D5\u30A9\u30F3\u30C8
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description =SQL\u51FA\u529B\u3092\u8868\u793A\u3059\u308B\u30D5\u30A9\u30F3\u30C8\u3002\u30E2\u30CE\u30B9\u30DA\u30FC\u30B9\u30D5\u30A9\u30F3\u30C8\u3067\u3042\u308B\u3053\u3068\u304C\u671B\u307E\u3057\u3044
-
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.label =SQL\u30AD\u30FC\u30EF\u30FC\u30C9\u306E\u8272
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.description =SQL\u30AD\u30FC\u30EF\u30FC\u30C9\u306E\u8272
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.datatype.foreground.label =SQL\u30C7\u30FC\u30BF\u578B\u306E\u8272

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_ko.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_ko.properties
@@ -125,9 +125,6 @@ menu.org.jkiss.dbeaver.ui.editors.sql.SQLEditor.layout.label = \uB808\uC774\uC54
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.label = SQL \uD3B8\uC9D1\uAE30
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.description = SQL \uD3B8\uC9D1\uAE30
 
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label = SQL \uCD9C\uB825 \uAE00\uAF34
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description = SQL \uCD9C\uB825 \uAE00\uAF34. \uD3ED\uC774 \uC77C\uC815\uD55C \uAE00\uAF34 \uC0AC\uC6A9 \uAD8C\uC7A5.
-
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.label = SQL keyword color
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.description = SQL keyword color
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.datatype.foreground.label = SQL datatype color

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_pt_BR.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_pt_BR.properties
@@ -118,9 +118,6 @@ editor.sql.name = Editor de SQL
 
 extension-point.org.jkiss.dbeaver.sql.covertname = Convers\u00F5es de texto SQL 
 
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description = Fonte para mostrar a sa\u00EDda SQL. Prefere ser uma fonte monoespa\u00E7ada.
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label       = Fonte de saida SQL
-
 menu.database.sql.generate                                    = &Gerador de SQL
 menu.org.jkiss.dbeaver.core.connection.sqleditor      = Editor de SQL
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_tw.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_tw.properties
@@ -139,9 +139,6 @@ menu.org.jkiss.dbeaver.ui.editors.sql.SQLEditor.layout.label =\u4F48\u5C40
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.label = SQL\u7DE8\u8F2F\u5668
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.description = SQL\u7DE8\u8F2F\u5668
 
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label = SQL\u8F38\u51FA\u5B57\u9AD4
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description =\u986F\u793ASQL\u8F38\u51FA\u7684\u5B57\u9AD4\u3002\u9996\u9078\u70BA\u7B49\u5BEC\u5B57\u9AD4\u3002
-
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.label = SQL\u95DC\u9375\u5B57\u984F\u8272
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.description = SQL\u95DC\u9375\u5B57\u984F\u8272
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.datatype.foreground.label = SQL\u6578\u64DA\u985E\u578B\u984F\u8272

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_zh.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle_zh.properties
@@ -141,9 +141,6 @@ editor.sql.name = SQL \u7F16\u8F91\u5668
 
 extension-point.org.jkiss.dbeaver.sql.covertname = SQL \u6587\u672C\u8F6C\u6362
 
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description = \u663E\u793A SQL \u8F93\u51FA\u7684\u5B57\u4F53\u3002\u63A8\u8350\u4F7F\u7528\u7B49\u5BBD\u5B57\u4F53\u3002
-fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label       = SQL \u8F93\u51FA\u5B57\u4F53
-
 menu.database.sql.generate                                        = \u751F\u6210 SQL
 menu.org.jkiss.dbeaver.core.connection.sqleditor                  = SQL \u7F16\u8F91\u5668
 menu.org.jkiss.dbeaver.ui.editors.sql.SQLEditor.execute.label     = \u6267\u884C

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
@@ -1073,16 +1073,6 @@
             <description>%themeElementCategory.org.jkiss.dbeaver.ui.presentation.sql.description</description>
         </themeElementCategory>
 
-        <fontDefinition
-            id="org.jkiss.dbeaver.sql.editor.font.output"
-            categoryId="org.jkiss.dbeaver.ui.presentation.sql"
-            label="%fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.label"
-            value="Courier New-regular-10">
-            <description>%fontDefinition.org.jkiss.dbeaver.sql.editor.font.output.description</description>
-            <fontValue os="linux" value="Monospace-regular-10"/>
-            <fontValue os="macosx" value="Courier-regular-11"/>
-        </fontDefinition>
-
         <colorDefinition
             label="%colorDefinition.org.jkiss.dbeaver.sql.editor.color.keyword.foreground.label"
             categoryId="org.jkiss.dbeaver.ui.presentation.sql"

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorOutputConsoleViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorOutputConsoleViewer.java
@@ -29,6 +29,7 @@ import org.eclipse.ui.console.TextConsoleViewer;
 import org.eclipse.ui.themes.ITheme;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.sql.SQLConstants;
+import org.jkiss.dbeaver.ui.UIFonts;
 import org.jkiss.dbeaver.ui.UIStyles;
 import org.jkiss.dbeaver.ui.controls.StyledTextUtils;
 import org.jkiss.dbeaver.ui.editors.TextEditorUtils;
@@ -119,7 +120,7 @@ public class SQLEditorOutputConsoleViewer extends TextConsoleViewer {
 
     public void refreshStyles() {
         ITheme currentTheme = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme();
-        Font outputFont = currentTheme.getFontRegistry().get(SQLConstants.CONFIG_FONT_OUTPUT);
+        Font outputFont = currentTheme.getFontRegistry().get(UIFonts.DBEAVER_FONTS_MONOSPACE);
         if (outputFont != null) {
             getTextWidget().setFont(outputFont);
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.xml/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.xml/OSGI-INF/l10n/bundle.properties
@@ -4,9 +4,6 @@ Bundle-Name = DBeaver UI Editors - XML
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.xml.label = XML Editor
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.xml.description = XML Editor
 
-fontDefinition.org.jkiss.dbeaver.ui.editors.xml.font.label = XML Font
-fontDefinition.org.jkiss.dbeaver.xml.editor.font.description = XML text font
-
 colorDefinition.org.jkiss.dbeaver.xml.editor.color.tag.label = XML Tag
 colorDefinition.org.jkiss.dbeaver.xml.editor.color.tag.description = XML tag color
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.xml/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.xml/plugin.xml
@@ -27,16 +27,6 @@
             <description>%themeElementCategory.org.jkiss.dbeaver.ui.presentation.xml.description</description>
         </themeElementCategory>
 
-        <fontDefinition
-                id="org.jkiss.dbeaver.ui.editors.xml.font.output"
-                categoryId="org.jkiss.dbeaver.ui.presentation.xml"
-                label="%fontDefinition.org.jkiss.dbeaver.ui.editors.xml.font.label"
-                value="Courier New-regular-10">
-            <description>%fontDefinition.org.jkiss.dbeaver.xml.editor.font.description</description>
-            <fontValue os="linux" value="Monospace-regular-10"/>
-            <fontValue os="macosx" value="Courier-regular-11"/>
-        </fontDefinition>
-
         <colorDefinition
                 label="%colorDefinition.org.jkiss.dbeaver.xml.editor.color.tag.label"
                 categoryId="org.jkiss.dbeaver.ui.presentation.xml"

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ItemListControl.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ItemListControl.java
@@ -73,7 +73,6 @@ public class ItemListControl extends NodeListControl
     // FIXME: copied from editors.data constants. Need to move it in general colors configuration
     private static final String COLOR_NEW = "org.jkiss.dbeaver.sql.resultset.color.cell.new.background";
     private static final String COLOR_MODIFIED = "org.jkiss.dbeaver.sql.resultset.color.cell.modified.background";
-    public static final String TREE_TABLE_FONT = "org.eclipse.ui.workbench.TREE_TABLE_FONT";
 
     private final IPropertyChangeListener themeChangeListener;
     private final ISearchExecutor searcher;
@@ -95,8 +94,8 @@ public class ItemListControl extends NodeListControl
         super(parent, style, workbenchSite, node, metaNode);
         this.themeChangeListener = e -> {
             final ITheme theme = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme();
-            normalFont = theme.getFontRegistry().get(TREE_TABLE_FONT);
-            boldFont = theme.getFontRegistry().getBold(TREE_TABLE_FONT);
+            normalFont = theme.getFontRegistry().get(UIFonts.DBEAVER_FONTS_MAIN_FONT);
+            boldFont = theme.getFontRegistry().getBold(UIFonts.DBEAVER_FONTS_MAIN_FONT);
             super.getItemsViewer().refresh();
             super.getNavigatorViewer().refresh();
         };

--- a/plugins/org.jkiss.dbeaver.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jkiss.dbeaver.ui/META-INF/MANIFEST.MF
@@ -42,4 +42,3 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.forms,
  org.eclipse.ui.workbench.texteditor
 Automatic-Module-Name: org.jkiss.dbeaver.ui
-

--- a/plugins/org.jkiss.dbeaver.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui/OSGI-INF/l10n/bundle.properties
@@ -5,3 +5,8 @@ Bundle-Name = DBeaver UI
 category.dbconnection.name=Connection
 category.dbconnection.description=Database Connection Commands
 category.org.jkiss.dbeaver.core.new.general.name = DBeaver
+
+themeElementCategory.org.jkiss.dbeaver.dbeaver.ui.fonts.label = DBeaver Fonts
+themeElementCategory.org.jkiss.dbeaver.ui.fonts.description = Fonts declared by DBeaver application
+fontDefinition.org.jkiss.dbeaver.ui.fonts.monospace.label = Monospace font
+fontDefinition.org.jkiss.dbeaver.ui.fonts.monospace.description = Font used in SQL output, HEX editor. Preferred to be a monospace font.

--- a/plugins/org.jkiss.dbeaver.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui/OSGI-INF/l10n/bundle.properties
@@ -9,4 +9,6 @@ category.org.jkiss.dbeaver.core.new.general.name = DBeaver
 themeElementCategory.org.jkiss.dbeaver.dbeaver.ui.fonts.label = DBeaver Fonts
 themeElementCategory.org.jkiss.dbeaver.ui.fonts.description = Fonts declared by DBeaver application
 fontDefinition.org.jkiss.dbeaver.ui.fonts.monospace.label = Monospace font
-fontDefinition.org.jkiss.dbeaver.ui.fonts.monospace.description = Font used in SQL output, HEX editor. Preferred to be a monospace font.
+fontDefinition.org.jkiss.dbeaver.ui.fonts.monospace.description = Font used in sql output, HEX editor, text editor, debugger and text compare. Preferred to be a monospace font.
+fontDefinition.org.jkiss.dbeaver.ui.fonts.main.label = Main font
+fontDefinition.org.jkiss.dbeaver.ui.fonts.main.description = Font used in most part of application.

--- a/plugins/org.jkiss.dbeaver.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui/plugin.xml
@@ -95,4 +95,19 @@
         </handler>
     </extension>
 
+    <extension point="org.eclipse.ui.themes">
+        <themeElementCategory label="%themeElementCategory.org.jkiss.dbeaver.dbeaver.ui.fonts.label" id="org.jkiss.dbeaver.ui.fonts">
+            <description>%themeElementCategory.org.jkiss.dbeaver.ui.fonts.description</description>
+        </themeElementCategory>
+    
+        <fontDefinition
+                id="org.jkiss.dbeaver.dbeaver.ui.fonts.monospace"
+                categoryId="org.jkiss.dbeaver.ui.fonts"
+                label="%fontDefinition.org.jkiss.dbeaver.ui.fonts.monospace.label"
+                value="Courier New-regular-10">
+            <description>%fontDefinition.org.jkiss.dbeaver.ui.fonts.monospace.description</description>
+            <fontValue os="linux" value="Monospace-regular-10"/>
+            <fontValue os="macosx" value="Courier-regular-11"/>
+        </fontDefinition>
+    </extension>
 </plugin>

--- a/plugins/org.jkiss.dbeaver.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui/plugin.xml
@@ -109,5 +109,13 @@
             <fontValue os="linux" value="Monospace-regular-10"/>
             <fontValue os="macosx" value="Courier-regular-11"/>
         </fontDefinition>
+        <fontDefinition
+                id="org.jkiss.dbeaver.dbeaver.ui.fonts.main"
+                categoryId="org.jkiss.dbeaver.ui.fonts"
+                label="%fontDefinition.org.jkiss.dbeaver.ui.fonts.main.label"
+                value="Segoe UI-regular-9">
+            <description>%fontDefinition.org.jkiss.dbeaver.ui.fonts.main.description</description>
+        </fontDefinition>
+       
     </extension>
 </plugin>

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIFonts.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIFonts.java
@@ -1,0 +1,22 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui;
+
+public class UIFonts {
+
+    public static String DBEAVER_FONTS_MONOSPACE =  "org.jkiss.dbeaver.dbeaver.ui.fonts.monospace";
+}

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIFonts.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIFonts.java
@@ -16,12 +16,8 @@
  */
 package org.jkiss.dbeaver.ui;
 
-import org.eclipse.jface.resource.JFaceResources;
-
 public class UIFonts {
 
-    // DBeaver fonts
-    
     /**
      * Monospace font
      */
@@ -31,76 +27,5 @@ public class UIFonts {
      * Main font
      */
     public static String DBEAVER_FONTS_MAIN_FONT =  "org.jkiss.dbeaver.dbeaver.ui.fonts.main";
-    
-    /**
-     * Diagram font
-     */
-    public static String DIAGRAM_FONT = "org.jkiss.dbeaver.erd.diagram.font";
-    
-    /**
-     * Results grid font
-     */
-    public static String RESULTS_GRID_FONT = "org.jkiss.dbeaver.sql.resultset.font"; // TODO: refactoring
-    
-    // Eclipse fonts
-    
-    /**
-     * Compare text font
-     */
-    public static String COMPARE_TEXT_FONT = "org.eclipse.compare.contentmergeviewer.TextMergeViewer";
-    
-    /**
-     * Detail pane text font
-     */
-    public static String DETAIL_PANE_TEXT_FONT = "org.eclipse.debug.ui.DetailPaneFont";
-    
-    /**
-     * Memory view table font
-     */
-    public static String MEMORY_VIEW_TABLE_FONT = "org.eclipse.debug.ui.MemoryViewTableFont";
 
-    /**
-     * Variable text font
-     */
-    public static String VARIABLE_TEXT_FONT = "org.eclipse.debug.ui.VariableTextFont";
- 
-    /**
-     * Console font
-     */
-    public static String CONSOLE_FONT = "org.eclipse.debug.ui.consoleFont";
-
-    /**
-     * Part title font
-     */
-    public static String PART_TITLE_FONT = "org.eclipse.ui.workbench.TAB_TEXT_FONT";
-
-    /**
-     * Tree and Table font for views
-     */
-    public static String TREE_AND_TABLE_FONT_FOR_VIEWS = "org.eclipse.ui.workbench.TREE_TABLE_FONT";
-
-    /**
-     * Header Font
-     */
-    public static String HEADER_FONT = "org.eclipse.jface.headerfont";
-
-    /**
-     * Text Font
-     */
-    public static String TEXT_FONT = "org.eclipse.jface.textfont";
-
-    /**
-     * Text Editor Block Selection Font
-     */
-    public static String TEXT_EDITOR_BLOCK_SELECTION_FONT = "org.eclipse.ui.workbench.texteditor.blockSelectionModeFont";
-
-    /**
-     * Banner font
-     */
-    public static String BANNER_FONT = JFaceResources.BANNER_FONT;
-
-    /**
-     * Dialog font
-     */
-    public static String DIALOG_FONT = JFaceResources.DIALOG_FONT;
 }

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIFonts.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIFonts.java
@@ -16,7 +16,91 @@
  */
 package org.jkiss.dbeaver.ui;
 
+import org.eclipse.jface.resource.JFaceResources;
+
 public class UIFonts {
 
+    // DBeaver fonts
+    
+    /**
+     * Monospace font
+     */
     public static String DBEAVER_FONTS_MONOSPACE =  "org.jkiss.dbeaver.dbeaver.ui.fonts.monospace";
+    
+    /**
+     * Main font
+     */
+    public static String DBEAVER_FONTS_MAIN_FONT =  "org.jkiss.dbeaver.dbeaver.ui.fonts.main";
+    
+    /**
+     * Diagram font
+     */
+    public static String DIAGRAM_FONT = "org.jkiss.dbeaver.erd.diagram.font";
+    
+    /**
+     * Results grid font
+     */
+    public static String RESULTS_GRID_FONT = "org.jkiss.dbeaver.sql.resultset.font"; // TODO: refactoring
+    
+    // Eclipse fonts
+    
+    /**
+     * Compare text font
+     */
+    public static String COMPARE_TEXT_FONT = "org.eclipse.compare.contentmergeviewer.TextMergeViewer";
+    
+    /**
+     * Detail pane text font
+     */
+    public static String DETAIL_PANE_TEXT_FONT = "org.eclipse.debug.ui.DetailPaneFont";
+    
+    /**
+     * Memory view table font
+     */
+    public static String MEMORY_VIEW_TABLE_FONT = "org.eclipse.debug.ui.MemoryViewTableFont";
+
+    /**
+     * Variable text font
+     */
+    public static String VARIABLE_TEXT_FONT = "org.eclipse.debug.ui.VariableTextFont";
+ 
+    /**
+     * Console font
+     */
+    public static String CONSOLE_FONT = "org.eclipse.debug.ui.consoleFont";
+
+    /**
+     * Part title font
+     */
+    public static String PART_TITLE_FONT = "org.eclipse.ui.workbench.TAB_TEXT_FONT";
+
+    /**
+     * Tree and Table font for views
+     */
+    public static String TREE_AND_TABLE_FONT_FOR_VIEWS = "org.eclipse.ui.workbench.TREE_TABLE_FONT";
+
+    /**
+     * Header Font
+     */
+    public static String HEADER_FONT = "org.eclipse.jface.headerfont";
+
+    /**
+     * Text Font
+     */
+    public static String TEXT_FONT = "org.eclipse.jface.textfont";
+
+    /**
+     * Text Editor Block Selection Font
+     */
+    public static String TEXT_EDITOR_BLOCK_SELECTION_FONT = "org.eclipse.ui.workbench.texteditor.blockSelectionModeFont";
+
+    /**
+     * Banner font
+     */
+    public static String BANNER_FONT = JFaceResources.BANNER_FONT;
+
+    /**
+     * Dialog font
+     */
+    public static String DIALOG_FONT = JFaceResources.DIALOG_FONT;
 }


### PR DESCRIPTION
New `DBeaver Fonts` category was added.
The following fonts are overridden by `Main font`
    `Dialog font`
    `Variable text font`
    `Part title font`
    `Tree and table font for views`
`Main font` changes font for trees and lists in entity Properties and maybe in some other places (which was not working by changing `Tree and table font for views` before)

The following fonts are overridden by `Monospace` font:
    `Hex output font`
    `SQL Output font`
    `Text Editor Block Selection Font`
    `Text Font` 
    `Detail pane text font`
    `Memory view table font`
     `Compare text fonts`
     
 See also https://github.com/dbeaver/pro/issues/1377#issuecomment-1429362866