### PR TITLE
#19089 Fix variables resolution in commands

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandEcho.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandEcho.java
@@ -20,8 +20,6 @@ import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.sql.SQLControlCommand;
 import org.jkiss.dbeaver.model.sql.SQLControlCommandHandler;
 import org.jkiss.dbeaver.model.sql.SQLScriptContext;
-import org.jkiss.dbeaver.model.sql.eval.ScriptVariablesResolver;
-import org.jkiss.dbeaver.utils.GeneralUtils;
 
 /**
  * Control command handler
@@ -32,7 +30,7 @@ public class SQLCommandEcho implements SQLControlCommandHandler {
     public boolean handleCommand(SQLControlCommand command, SQLScriptContext scriptContext) throws DBException {
         String parameter = command.getParameter();
         if (parameter != null) {
-            parameter = GeneralUtils.replaceVariables(parameter, new ScriptVariablesResolver(scriptContext));
+            parameter = scriptContext.fillVariables(parameter);
         }
         scriptContext.getOutputWriter().println(null, parameter);
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
@@ -24,8 +24,6 @@ import org.jkiss.dbeaver.model.sql.SQLControlCommandHandler;
 import org.jkiss.dbeaver.model.sql.SQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLScriptContext;
 import org.jkiss.dbeaver.model.sql.parser.rules.ScriptParameterRule;
-import org.jkiss.dbeaver.utils.GeneralUtils;
-import org.jkiss.utils.CommonUtils;
 
 import java.util.Locale;
 
@@ -54,8 +52,8 @@ public class SQLCommandSet implements SQLControlCommandHandler {
                 "Expected syntax:\n@set varName = value or expression"
             );
         }
-        String varValue = parameter.substring(divPos + 1).trim();
-        varValue = GeneralUtils.replaceVariables(varValue, name -> CommonUtils.toString(scriptContext.getVariable(name)));
+        String rawVarValue = parameter.substring(divPos + 1).trim();
+        String varValue = scriptContext.fillVariables(rawVarValue);
         scriptContext.setVariable(varName, varValue);
 
         return true;

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLSyntaxManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLSyntaxManager.java
@@ -132,6 +132,14 @@ public class SQLSyntaxManager {
         return variablesEnabled;
     }
 
+    /**
+     * Disable rules for parameters and anonymous parameters
+     */
+    public void setParametersEnabled(boolean value) {
+        parametersEnabled = value;
+        anonymousParametersEnabled = value;
+    }
+
     public void init(@NotNull SQLDialect dialect, @NotNull DBPPreferenceStore preferenceStore)
     {
         this.statementDelimiters = new String[0];

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
@@ -1089,19 +1089,28 @@ public final class SQLUtils {
     }
 
     public static void fillQueryParameters(SQLQuery sqlStatement, List<SQLQueryParameter> parameters) {
+        String rawQuery = sqlStatement.getText();
+        String query = fillParameters(rawQuery, parameters);
+        sqlStatement.setText(query);
+        //sqlStatement.setOriginalText(query);
+    }
+
+    /**
+     * Substitute variable values to the provided text
+     */
+    public static String fillParameters(String text, List<SQLQueryParameter> parameters) {
         // Set values for all parameters
         // Replace parameter tokens with parameter values
-        String query = sqlStatement.getText();
+        String result = text;
         for (int i = parameters.size(); i > 0; i--) {
             SQLQueryParameter parameter = parameters.get(i - 1);
             String paramValue = parameter.getValue();
             if (paramValue == null || paramValue.isEmpty()) {
                 paramValue = SQLConstants.NULL_VALUE;
             }
-            query = query.substring(0, parameter.getTokenOffset()) + paramValue + query.substring(parameter.getTokenOffset() + parameter.getTokenLength());
-        }
-        sqlStatement.setText(query);
-        //sqlStatement.setOriginalText(query);
+            result = result.substring(0, parameter.getTokenOffset()) + paramValue + result.substring(parameter.getTokenOffset() + parameter.getTokenLength());
+        }   
+        return result;
     }
 
     public static boolean needQueryDelimiter(SQLDialect sqlDialect, String query) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/commands/SQLCommandInclude.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/commands/SQLCommandInclude.java
@@ -56,7 +56,7 @@ public class SQLCommandInclude implements SQLControlCommandHandler {
         if (CommonUtils.isEmpty(fileName)) {
             throw new DBException("Empty input file");
         }
-        fileName = GeneralUtils.replaceVariables(fileName, new ScriptVariablesResolver(scriptContext)).trim();
+        fileName = scriptContext.fillVariables(fileName).trim();
         fileName = DBUtils.getUnQuotedIdentifier(scriptContext.getExecutionContext().getDataSource(), fileName);
 
         File curFile = scriptContext.getSourceFile();


### PR DESCRIPTION
Example script to check. What was wrong - usage of variables ${var} in commands `@set`, `@echo`, `@include`.
```
@set t = _20230215
@set o = Order${t}

select ${o};

@echo ${t}

@include x${o}y
```

I hope we discuss the possibility of covering such functionality by tests here https://github.com/dbeaver/pro/issues/1419 