### PR TITLE
#19089 FIx variables replacement in echo, set, include commands

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandEcho.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandEcho.java
@@ -32,7 +32,7 @@ public class SQLCommandEcho implements SQLControlCommandHandler {
     public boolean handleCommand(SQLControlCommand command, SQLScriptContext scriptContext) throws DBException {
         String parameter = command.getParameter();
         if (parameter != null) {
-            parameter = GeneralUtils.replaceVariables(parameter, new ScriptVariablesResolver(scriptContext));
+            parameter = GeneralUtils.replaceVariables(parameter, new ScriptVariablesResolver(scriptContext), true);
         }
         scriptContext.getOutputWriter().println(null, parameter);
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/commands/SQLCommandSet.java
@@ -55,7 +55,7 @@ public class SQLCommandSet implements SQLControlCommandHandler {
             );
         }
         String varValue = parameter.substring(divPos + 1).trim();
-        varValue = GeneralUtils.replaceVariables(varValue, name -> CommonUtils.toString(scriptContext.getVariable(name)));
+        varValue = GeneralUtils.replaceVariables(varValue, name -> CommonUtils.toString(scriptContext.getVariable(name)), true);
         scriptContext.setVariable(varName, varValue);
 
         return true;

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
@@ -482,9 +482,14 @@ public class GeneralUtils {
         }
         return null;
     }
-
+    
     @NotNull
     public static String replaceVariables(@NotNull String string, IVariableResolver resolver) {
+        return replaceVariables(string, resolver, false);
+    }
+
+    @NotNull
+    public static String replaceVariables(@NotNull String string, IVariableResolver resolver, boolean isUpperCaseVarName) {
         if (CommonUtils.isEmpty(string)) {
             return string;
         }
@@ -495,7 +500,8 @@ public class GeneralUtils {
             int pos = 0;
             while (matcher.find(pos)) {
                 pos = matcher.end();
-                String varName = matcher.group(2);
+                String matchedName = matcher.group(2);
+                String varName = isUpperCaseVarName ? matchedName.toUpperCase(Locale.ENGLISH) : matchedName;
                 String varValue = null;
                 if (resolvedVars != null) {
                     varValue = resolvedVars.get(varName); 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/commands/SQLCommandInclude.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/commands/SQLCommandInclude.java
@@ -56,7 +56,7 @@ public class SQLCommandInclude implements SQLControlCommandHandler {
         if (CommonUtils.isEmpty(fileName)) {
             throw new DBException("Empty input file");
         }
-        fileName = GeneralUtils.replaceVariables(fileName, new ScriptVariablesResolver(scriptContext)).trim();
+        fileName = GeneralUtils.replaceVariables(fileName, new ScriptVariablesResolver(scriptContext), true).trim();
         fileName = DBUtils.getUnQuotedIdentifier(scriptContext.getExecutionContext().getDataSource(), fileName);
 
         File curFile = scriptContext.getSourceFile();


### PR DESCRIPTION
Fixed usage of variables ${var} in commands `@set`, `@echo`, `@include`.

Example script to check.
```
@set t = _20230215
@set o = Order${t}

select ${o};

@echo ${t}

@include x${o}y
```