### PR TITLE
#19088 Update Dremio driver to the version 24.0.0

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -1160,7 +1160,7 @@
                         supportedConfigurationTypes="MANUAL,URL"
                         webURL="https://docs.dremio.com/drivers/dremio-jdbc-driver.html"
                         categories="analytic,hadoop,sql">
-                    <file type="jar" path="https://download.dremio.com/jdbc-driver/3.0.6-201812082352540436-1f684f9/dremio-jdbc-driver-3.0.6-201812082352540436-1f684f9.jar"/>
+                    <file type="jar" path="https://download.dremio.com/jdbc-driver/24.0.0-202302100528110223-3a169b7c/dremio-jdbc-driver-24.0.0-202302100528110223-3a169b7c.jar"/>
                     <parameter name="omit-catalog" value="true"/>
                 </driver>
 


### PR DESCRIPTION
I do not think that we need an environment to test it. 
The connection error is the same as with the old driver.
The user said that the new driver with the new DBeaver also works fine for him.