### PR TITLE
#19026 Fix attributes binding for all columns, columns in quotes

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
@@ -688,6 +688,8 @@ public class DBExecUtils {
                 if (attrMeta == null) {
                     continue;
                 }
+
+                SQLSelectItem selectItem = sqlQuery == null ? null : sqlQuery.getSelectItem(attrMeta.getOrdinalPosition());
                 // We got table name and column name
                 // To be editable we need this resultset contain set of columns from the same table
                 // which construct any unique key
@@ -695,7 +697,6 @@ public class DBExecUtils {
                 if (sourceEntity == null) {
                     DBCEntityMetaData attrEntityMeta = attrMeta.getEntityMetaData();
                     if (attrEntityMeta == null && sqlQuery != null) {
-                        SQLSelectItem selectItem = sqlQuery.getSelectItem(attrMeta.getOrdinalPosition());
                         if (selectItem != null && selectItem.isPlainColumn()) {
                             attrEntityMeta = selectItem.getEntityMetaData();
                         }
@@ -753,8 +754,7 @@ public class DBExecUtils {
                         if ((asteriskIndex < 0 || asteriskIndex > attrMeta.getOrdinalPosition()) &&
                             attrMeta.getOrdinalPosition() < sqlQuery.getSelectItemCount())
                         {
-                            SQLSelectItem selectItem = sqlQuery.getSelectItem(attrMeta.getOrdinalPosition());
-                            if (selectItem.isPlainColumn()) {
+                            if (selectItem != null && selectItem.isPlainColumn()) {
                                 String realColumnName = selectItem.getName();
                                 if (!realColumnName.equalsIgnoreCase(columnName)) {
                                     if (DBUtils.isQuotedIdentifier(dataSource, realColumnName)) {
@@ -781,13 +781,6 @@ public class DBExecUtils {
                         if (sqlQuery == null) {
                             tableColumn = attrEntity.getAttribute(monitor, columnName);
                         } else {
-                            SQLSelectItem selectItem = sqlQuery.getSelectItem(columnName);
-                            // if column name was quoted, we can't find select item by column name as we removed quotes earlier
-                            // so let's try to get select item by position
-                            if (selectItem == null) {
-                                selectItem = sqlQuery.getSelectItem(attrMeta.getOrdinalPosition());
-                            }
-                            
                             boolean isAllColumns = sqlQuery.getSelectItemAsteriskIndex() != -1;
                             if (isAllColumns || (selectItem != null && (selectItem.isPlainColumn() || selectItem.getName().equals("*")))) {
                                 tableColumn = attrEntity.getAttribute(monitor, columnName);

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
@@ -781,9 +781,11 @@ public class DBExecUtils {
                         if (sqlQuery == null) {
                             tableColumn = attrEntity.getAttribute(monitor, columnName);
                         } else {
-                            SQLSelectItem selectItem = sqlQuery.getSelectItem(attrMeta.getOrdinalPosition());
+                            SQLSelectItem selectItem = sqlQuery.getSelectItem(columnName);
+                            // if column name was quoted, we can't find select item by column name as we removed quotes earlier
+                            // so let's try to get select item by position
                             if (selectItem == null) {
-                                selectItem = sqlQuery.getSelectItem(columnName);
+                                selectItem = sqlQuery.getSelectItem(attrMeta.getOrdinalPosition());
                             }
                             
                             boolean isAllColumns = sqlQuery.getSelectItemAsteriskIndex() != -1;

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
@@ -781,9 +781,13 @@ public class DBExecUtils {
                         if (sqlQuery == null) {
                             tableColumn = attrEntity.getAttribute(monitor, columnName);
                         } else {
-                            SQLSelectItem selectItem = sqlQuery.getSelectItem(columnName);
-                            boolean isAllColumns = sqlQuery.getSelectItemCount() == 1 && sqlQuery.getSelectItemAsteriskIndex() != -1;
-                            if (isAllColumns || (selectItem != null && selectItem.isPlainColumn())) {
+                            SQLSelectItem selectItem = sqlQuery.getSelectItem(attrMeta.getOrdinalPosition());
+                            if (selectItem == null) {
+                                selectItem = sqlQuery.getSelectItem(columnName);
+                            }
+                            
+                            boolean isAllColumns = sqlQuery.getSelectItemAsteriskIndex() != -1;
+                            if (isAllColumns || (selectItem != null && (selectItem.isPlainColumn() || selectItem.getName().equals("*")))) {
                                 tableColumn = attrEntity.getAttribute(monitor, columnName);
                             }
                         }


### PR DESCRIPTION
At least following should be tested.

- [x] Data read.
Select queries with and without column aliases, including:
- [x] column and alias are the same
- [x] column and alias are not the same, but alias is the same with another column name
- [x] method call with or without some alias
- [x] selecting all columns

I tested on these cases:

```
SELECT TO_CHAR("ArtistId") AS "ArtistId" FROM MATVEY.ALBUM a ;

SELECT TO_CHAR(a."AlbumId") FROM MATVEY.ALBUM a ;

SELECT TO_CHAR("AlbumId") FROM MATVEY.ALBUM a ;

SELECT TO_CHAR(a."AlbumId") AS "AlbumId" FROM MATVEY.ALBUM a ;

SELECT TO_CHAR(a.AUDIT_NUMBER) AS AUDIT_NUMBER FROM IRAIDA.AUDITS a;

SELECT TO_CHAR(a.AUDIT_NUMBER) AS X FROM IRAIDA.AUDITS a;

SELECT TO_CHAR(AUDIT_NUMBER) AS AUDIT_NUMBER FROM IRAIDA.AUDITS a;

SELECT TO_CHAR(AUDIT_NUMBER) AS X FROM IRAIDA.AUDITS a;


SELECT "ArtistId" AS "ArtistId" FROM MATVEY.ALBUM a ;

SELECT a."AlbumId" FROM MATVEY.ALBUM a ;

SELECT "AlbumId" FROM MATVEY.ALBUM a ;

SELECT a."AlbumId", a.* FROM MATVEY.ALBUM a ;

SELECT a.*, a."AlbumId" FROM MATVEY.ALBUM a ;


SELECT * FROM IRAIDA.AUDITS a;

SELECT a.* FROM IRAIDA.AUDITS a;

SELECT a.AUDIT_NUMBER FROM IRAIDA.AUDITS a;

SELECT a.AUDIT_NUMBER, a.* FROM IRAIDA.AUDITS a;

SELECT a.*, a.AUDIT_NUMBER FROM IRAIDA.AUDITS a;

SELECT a.AUDIT_NUMBER AS AUDIT_NUMBER FROM IRAIDA.AUDITS a;
```