### PR TITLE
#15519 Use separate connection for sql console if it was set in settings

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/UIServiceSQLImpl.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/UIServiceSQLImpl.java
@@ -138,7 +138,12 @@ public class UIServiceSQLImpl implements UIServiceSQL {
 
     @Override
     public Object openSQLConsole(@NotNull DBPDataSourceContainer dataSourceContainer, DBCExecutionContext executionContext, DBSObject selectedObject, String name, String sqlText) {
-        SQLNavigatorContext navigatorContext = executionContext != null ? new SQLNavigatorContext(executionContext) : new SQLNavigatorContext(dataSourceContainer);
+        SQLNavigatorContext navigatorContext;
+        if (executionContext == null || SQLEditorUtils.isOpenSeparateConnection(dataSourceContainer)) {
+            navigatorContext = new SQLNavigatorContext(dataSourceContainer);
+        } else {
+            navigatorContext = new SQLNavigatorContext(executionContext);
+        }
         if (selectedObject != null) {
             navigatorContext.setSelectedObject(selectedObject);
         }


### PR DESCRIPTION
SQL Console should be opened in a separate connection when separate connection setting was set and focus is in navigator.