### PR TITLE
Fix tns import

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.import_config/src/org/jkiss/dbeaver/ext/import_config/wizards/ImportConnectionInfo.java
+++ b/plugins/org.jkiss.dbeaver.ext.import_config/src/org/jkiss/dbeaver/ext/import_config/wizards/ImportConnectionInfo.java
@@ -157,7 +157,7 @@ public class ImportConnectionInfo {
 
     public void setProviderProperty(String name, String value)
     {
-        properties.put(name, value);
+        providerProperties.put(name, value);
     }
 
     public void setHost(String host)

--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
@@ -28,6 +28,7 @@ import org.jkiss.dbeaver.ext.import_config.wizards.ImportConnectionInfo;
 import org.jkiss.dbeaver.ext.import_config.wizards.ImportData;
 import org.jkiss.dbeaver.ext.import_config.wizards.ImportDriverInfo;
 import org.jkiss.dbeaver.ext.oracle.model.OracleConstants;
+import org.jkiss.dbeaver.ext.oracle.model.dict.OracleConnectionRole;
 import org.jkiss.dbeaver.ext.oracle.model.dict.OracleConnectionType;
 import org.jkiss.dbeaver.ext.oracle.oci.OCIUtils;
 import org.jkiss.dbeaver.ext.oracle.oci.OracleHomeDescriptor;
@@ -293,7 +294,8 @@ public class ConfigImportWizardPageSqlDeveloper extends ConfigImportWizardPage {
                     if (!CommonUtils.isEmpty(info.getRole())) {
                         connectionInfo.setProviderProperty(OracleConstants.PROP_INTERNAL_LOGON, info.getRole());
                         // dbeaver only supports SYSDBA, SYSOPER, and default auth logon roles
-                        if (info.getRole().equals("SYSDBA") || info.getRole().equals("SYSOPER")) {
+                        if (info.getRole().equals(OracleConnectionRole.SYSDBA.getTitle())
+                                || info.getRole().equals(OracleConnectionRole.SYSOPER.getTitle())) {
                             connectionInfo.setProviderProperty(OracleConstants.PROP_AUTH_LOGON_AS, info.getRole());
                         }
                     }

--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
@@ -246,7 +246,7 @@ public class ConfigImportWizardPageSqlDeveloper extends ConfigImportWizardPage {
             return connectionType;
         }
 
-        public void setOsAuth(OracleConstants.ConnectionType connectionType) {
+        public void setConnectionType(OracleConstants.ConnectionType connectionType) {
             this.connectionType = connectionType;
         }
 
@@ -276,9 +276,12 @@ public class ConfigImportWizardPageSqlDeveloper extends ConfigImportWizardPage {
 
                     // database name should be set to network alias as with connections
                     // created within dbeaver
-                    String dbName = isTnsConnection ? info.getUrl() : CommonUtils.isEmpty(info.getSID()) ? info.getServiceName() : info.getSID();
+                    String dbName = isTnsConnection ? info.getUrl() 
+                        : CommonUtils.isEmpty(info.getSID()) ? info.getServiceName() : info.getSID();
 
-                    ImportConnectionInfo connectionInfo = new ImportConnectionInfo(oraDriver, null, conn.getName(), url, info.getHost(), info.getPort(), dbName, info.getUser(), null);
+                    ImportConnectionInfo connectionInfo = new ImportConnectionInfo(
+                            oraDriver, null, conn.getName(), url, info.getHost(), info.getPort(), dbName, info.getUser(), null
+                        );
                     if (!CommonUtils.isEmpty(info.getSID())) {
                         connectionInfo.setProviderProperty(OracleConstants.PROP_SID_SERVICE, OracleConnectionType.SID.name());
                     } else if (!CommonUtils.isEmpty(info.getServiceName())) {
@@ -368,7 +371,7 @@ public class ConfigImportWizardPageSqlDeveloper extends ConfigImportWizardPage {
         url.append("jdbc:oracle:thin:@");
 
         // look for tnsNames
-        Map<String,String> tnsNames = OCIUtils.readTnsNames(OCIUtils.getDefaultOraHomePath(), false);
+        Map<String, String> tnsNames = OCIUtils.readTnsNames(OCIUtils.getDefaultOraHomePath(), false);
         // if not found, check tnsAdmin
         if (tnsNames == null) {
             tnsNames = OCIUtils.readTnsNames(null, true);

--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
@@ -388,10 +388,18 @@ public class ConfigImportWizardPageSqlDeveloper extends ConfigImportWizardPage {
     }
     
     private String getDefaultTnsNamesPath() {
-        String tnsNamesPath = System.getenv(OracleConstants.VAR_TNS_ADMIN);
-        if (tnsNamesPath == null) {
-            tnsNamesPath = OCIUtils.getDefaultOraHomePath() + "/" + OCIUtils.TNSNAMES_FILE_PATH;
+        String tnsNamesPath;
+        // try tnsAdmin by default
+        tnsNamesPath = System.getenv(OracleConstants.VAR_TNS_ADMIN);
+        // if found, return as is
+        if (tnsNamesPath != null) {
+            return tnsNamesPath;
         }
-        return tnsNamesPath;
+        // else check default oraHome
+        else {
+            tnsNamesPath = OCIUtils.getDefaultOraHomePath().getPath();
+        }
+        // if found append tns path and return, else return nothing
+        return tnsNamesPath == null ? null : tnsNamesPath + "/" + OCIUtils.TNSNAMES_FILE_PATH;
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/tools/sqldeveloper/ConfigImportWizardPageSqlDeveloper.java
@@ -391,12 +391,11 @@ public class ConfigImportWizardPageSqlDeveloper extends ConfigImportWizardPage {
         String tnsNamesPath;
         // try tnsAdmin by default
         tnsNamesPath = System.getenv(OracleConstants.VAR_TNS_ADMIN);
-        // if found, return as is
         if (tnsNamesPath != null) {
+            // if found, return as is
             return tnsNamesPath;
-        }
-        // else check default oraHome
-        else {
+        } else {
+            // else check default oraHome
             tnsNamesPath = OCIUtils.getDefaultOraHomePath().getPath();
         }
         // if found append tns path and return, else return nothing

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/OracleDataSourceProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/OracleDataSourceProvider.java
@@ -163,7 +163,8 @@ public class OracleDataSourceProvider extends JDBCDataSourceProvider implements
     @Override
     public DBPNativeClientLocation getDefaultLocalClientLocation()
     {
-        return OCIUtils.getDefaultOraHome();    }
+        return OCIUtils.getDefaultOraHome();
+    }
 
     @Override
     public String getProductName(DBPNativeClientLocation location) {

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/OracleDataSourceProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/OracleDataSourceProvider.java
@@ -163,12 +163,7 @@ public class OracleDataSourceProvider extends JDBCDataSourceProvider implements
     @Override
     public DBPNativeClientLocation getDefaultLocalClientLocation()
     {
-        List<OracleHomeDescriptor> oraHomes = OCIUtils.getOraHomes();
-        if (!oraHomes.isEmpty()) {
-            return oraHomes.get(0);
-        }
-        return null;
-    }
+        return OCIUtils.getDefaultOraHome();    }
 
     @Override
     public String getProductName(DBPNativeClientLocation location) {

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/oci/OCIUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/oci/OCIUtils.java
@@ -66,6 +66,7 @@ public class OCIUtils
     /** 
      * Return first element of oraHomes, or null
      */
+    @Nullable
     public static OracleHomeDescriptor getDefaultOraHome() {
         List<OracleHomeDescriptor> oraHomes = getOraHomes();
         return oraHomes.isEmpty() ? null : oraHomes.get(0);
@@ -74,6 +75,7 @@ public class OCIUtils
     /** 
      * Return path to first element of oraHomes, or null
      */
+    @Nullable
     public static File getDefaultOraHomePath() {
         OracleHomeDescriptor defaultOraHome = getDefaultOraHome();
         return defaultOraHome == null ? null : defaultOraHome.getPath();

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/oci/OCIUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/oci/OCIUtils.java
@@ -62,6 +62,16 @@ public class OCIUtils
         checkOraHomes();
         return oraHomes;
     }
+    
+    public static OracleHomeDescriptor getDefaultOraHome() {
+        List<OracleHomeDescriptor> oraHomes = getOraHomes();
+        return oraHomes.isEmpty() ? null : oraHomes.get(0);
+    }
+    
+    public static File getDefaultOraHomePath() {
+        OracleHomeDescriptor defaultOraHome = getDefaultOraHome();
+        return defaultOraHome == null ? null : defaultOraHome.getPath();
+    }
 
     private static boolean checkOraHomes() {
         if (!oraHomesSearched) {

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/oci/OCIUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/oci/OCIUtils.java
@@ -63,11 +63,17 @@ public class OCIUtils
         return oraHomes;
     }
     
+    /** 
+     * Return first element of oraHomes, or null
+     */
     public static OracleHomeDescriptor getDefaultOraHome() {
         List<OracleHomeDescriptor> oraHomes = getOraHomes();
         return oraHomes.isEmpty() ? null : oraHomes.get(0);
     }
     
+    /** 
+     * Return path to first element of oraHomes, or null
+     */
     public static File getDefaultOraHomePath() {
         OracleHomeDescriptor defaultOraHome = getDefaultOraHome();
         return defaultOraHome == null ? null : defaultOraHome.getPath();


### PR DESCRIPTION
This pull request includes several changes to improve how tns connections are imported from SQL Developer into DBeaver. A couple of notes: 1) I have intentionally not modified the code which imports connections from xml connections files as it appears that this format is not supported in more recent versions of SQLDeveloper, please let me know if we need to support this format as well and I will make the necessary changes, 2) I was not sure where to add tests for these changes since it seemed to me we would need additional test utilities to get working, if that is not the case please let me know where to add the relevant tests