### PR TITLE
#19366 show default values for domain procedures parameters

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/FireBirdUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/FireBirdUtils.java
@@ -217,16 +217,16 @@ public class FireBirdUtils {
         String domainName = domainNames.get(paramName.trim());
         if (domainName != null) {
             sql.append(domainName);
-            return;
-        }
-        sql.append(param.getTypeName());
-        String typeModifiers = SQLUtils.getColumnTypeModifiers(param.getDataSource(), param, param.getTypeName(), param.getDataKind());
-        if (typeModifiers != null) {
-            sql.append(typeModifiers);
-        }
-        boolean notNull = param.isRequired();
-        if (notNull) {
-            sql.append(" NOT NULL");
+        } else {
+            sql.append(param.getTypeName());
+            String typeModifiers = SQLUtils.getColumnTypeModifiers(param.getDataSource(), param, param.getTypeName(), param.getDataKind());
+            if (typeModifiers != null) {
+                sql.append(typeModifiers);
+            }
+            boolean notNull = param.isRequired();
+            if (notNull) {
+                sql.append(" NOT NULL");
+            }
         }
         if (param instanceof FireBirdProcedureParameter && param.getParameterKind() == DBSProcedureParameterKind.IN) {
             String defaultValue = ((FireBirdProcedureParameter) param).getDefaultValue();


### PR DESCRIPTION
Domain parameter names do not contain info about default values. 

we can do this 

`CREATE DOMAIN TMP_MOEDA NUMERIC(15,2) DEFAULT 42`

but this query will also correct 

```sql
CREATE OR ALTER PROCEDURE test_moeda_2 (P_STOLPEC TMP_MOEDA DEFAULT 42)
RETURNS (
   P_ID INTEGER
)
AS
begin
  p_id = 123;
  suspend;
end
```

So we can show default values for domain parameters also - I just removed the "return" statement from the code.

![2023-03-15 11_48_51-DBeaver Ultimate 23 0 0 - DBS$SYSTEMLOG_ADD_TEST](https://user-images.githubusercontent.com/45152336/225258837-1146d689-f647-4d7b-bef0-6ac60bd18e0e.png)