### PR TITLE
#3371 add TOP limit support for Sybase and old SQL Server

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/generic/SQLServerMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/generic/SQLServerMetaModel.java
@@ -38,6 +38,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.impl.sql.QueryTransformerTop;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSObjectFilter;
@@ -254,7 +255,7 @@ public class SQLServerMetaModel extends GenericMetaModel implements DBCQueryTran
     @Override
     public DBCQueryTransformer createQueryTransformer(@NotNull DBCQueryTransformType type) {
         if (type == DBCQueryTransformType.RESULT_SET_LIMIT) {
-            //return new QueryTransformerTop();
+            return new QueryTransformerTop();
         }
         return null;
     }


### PR DESCRIPTION
A TOP limit will be added in the query for Sybase/SQL Server if the setting "Use SQL to limit fetch size" is enabled:

 
![2023-03-20 12_43_57-Preferences](https://user-images.githubusercontent.com/45152336/226303461-ec4d2e63-c305-4d86-a2b4-a25d79d85271.png)
