### PR TITLE
#19418 ability to drop generic triggers via UI added

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdDatabaseTrigger.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdDatabaseTrigger.java
@@ -16,7 +16,10 @@
  */
 package org.jkiss.dbeaver.ext.firebird.model;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.struct.rdb.DBSTable;
 
 public class FireBirdDatabaseTrigger extends FireBirdTrigger<GenericStructContainer> {
@@ -28,5 +31,11 @@ public class FireBirdDatabaseTrigger extends FireBirdTrigger<GenericStructContai
     @Override
     public DBSTable getTable() {
         return null;
+    }
+
+    @NotNull
+    @Override
+    public String getFullyQualifiedName(DBPEvaluationContext context) {
+        return DBUtils.getFullQualifiedName(getDataSource(), this);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdTableTrigger.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdTableTrigger.java
@@ -16,8 +16,11 @@
  */
 package org.jkiss.dbeaver.ext.firebird.model;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.DBPSystemObject;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.struct.rdb.DBSTable;
 
@@ -31,5 +34,11 @@ public class FireBirdTableTrigger extends FireBirdTrigger<GenericTableBase> impl
     @Property(viewable = true, order = 4)
     public DBSTable getTable() {
         return (DBSTable) getParentObject();
+    }
+
+    @NotNull
+    @Override
+    public String getFullyQualifiedName(DBPEvaluationContext context) {
+        return DBUtils.getFullQualifiedName(getDataSource(), this);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -1699,6 +1699,7 @@
         <manager class="org.jkiss.dbeaver.ext.generic.edit.GenericForeignKeyManager"    objectType="org.jkiss.dbeaver.ext.generic.model.GenericTableForeignKey"/>
         <manager class="org.jkiss.dbeaver.ext.generic.edit.GenericIndexManager"         objectType="org.jkiss.dbeaver.ext.generic.model.GenericTableIndex"/>
         <manager class="org.jkiss.dbeaver.ext.generic.edit.GenericProcedureManager"     objectType="org.jkiss.dbeaver.ext.generic.model.GenericProcedure"/>
+        <manager class="org.jkiss.dbeaver.ext.generic.edit.GenericTriggerManager"       objectType="org.jkiss.dbeaver.ext.generic.model.GenericTrigger"/>
     </extension>
 
     <extension point="org.jkiss.dbeaver.generic.meta">

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/edit/GenericTriggerManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/edit/GenericTriggerManager.java
@@ -1,0 +1,81 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.generic.edit;
+
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.generic.model.*;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.edit.DBECommandContext;
+import org.jkiss.dbeaver.model.edit.DBEPersistAction;
+import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
+import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
+import org.jkiss.dbeaver.model.impl.sql.edit.struct.SQLTriggerManager;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.dbeaver.model.struct.cache.DBSObjectCache;
+import org.jkiss.dbeaver.model.struct.cache.ListCache;
+
+import java.util.List;
+import java.util.Map;
+
+public class GenericTriggerManager extends SQLTriggerManager<GenericTrigger, GenericTableBase> {
+
+    @Override
+    public boolean canCreateObject(Object container) {
+        return false;
+    }
+
+    @Override
+    public boolean canDeleteObject(GenericTrigger object) {
+        return true;
+    }
+
+    @Override
+    protected void createOrReplaceTriggerQuery(
+        DBRProgressMonitor monitor,
+        DBCExecutionContext executionContext,
+        List<DBEPersistAction> actions,
+        GenericTrigger trigger,
+        boolean create
+    ) {
+
+    }
+
+    @Override
+    protected GenericTableTrigger createDatabaseObject(
+        DBRProgressMonitor monitor,
+        DBECommandContext context,
+        Object container,
+        Object copyFrom,
+        Map<String, Object> options
+    ) throws DBException {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    @Nullable
+    @Override
+    public DBSObjectCache<? extends DBSObject, GenericTrigger> getObjectsCache(GenericTrigger object) {
+        DBSObject container = object.getContainer();
+        if (container instanceof GenericStructContainer) {
+            return ((GenericStructContainer) container).getTableTriggerCache();
+        } else if (container instanceof GenericTableBase) {
+            return ((GenericTableBase) container).getContainer().getTableTriggerCache();
+        }
+        return null;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/edit/GenericTriggerManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/edit/GenericTriggerManager.java
@@ -19,16 +19,13 @@ package org.jkiss.dbeaver.ext.generic.edit;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.generic.model.*;
-import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.edit.DBECommandContext;
 import org.jkiss.dbeaver.model.edit.DBEPersistAction;
 import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
-import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
 import org.jkiss.dbeaver.model.impl.sql.edit.struct.SQLTriggerManager;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.cache.DBSObjectCache;
-import org.jkiss.dbeaver.model.struct.cache.ListCache;
 
 import java.util.List;
 import java.util.Map;
@@ -53,7 +50,7 @@ public class GenericTriggerManager extends SQLTriggerManager<GenericTrigger, Gen
         GenericTrigger trigger,
         boolean create
     ) {
-
+        throw new IllegalStateException("Not implemented");
     }
 
     @Override
@@ -64,7 +61,7 @@ public class GenericTriggerManager extends SQLTriggerManager<GenericTrigger, Gen
         Object copyFrom,
         Map<String, Object> options
     ) throws DBException {
-        throw new IllegalStateException("Not implemented");
+        throw new DBException("Not Implemented");
     }
 
     @Nullable

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericContainerTrigger.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericContainerTrigger.java
@@ -17,6 +17,8 @@
 package org.jkiss.dbeaver.ext.generic.model;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.struct.rdb.DBSTable;
 
 public class GenericContainerTrigger extends GenericTrigger<GenericStructContainer> {
@@ -28,5 +30,11 @@ public class GenericContainerTrigger extends GenericTrigger<GenericStructContain
     @Override
     public DBSTable getTable() {
         return null;
+    }
+
+    @NotNull
+    @Override
+    public String getFullyQualifiedName(DBPEvaluationContext context) {
+        return DBUtils.getFullQualifiedName(getDataSource(), getParentObject(), this);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTableBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTableBase.java
@@ -283,6 +283,7 @@ public abstract class GenericTableBase extends JDBCTable<GenericDataSource, Gene
 
     @Override
     public DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException {
+        this.getContainer().getTableTriggerCache().clearObjectCache(this);
         this.getContainer().getIndexCache().clearObjectCache(this);
         this.getContainer().getConstraintKeysCache().clearObjectCache(this);
         this.getContainer().getForeignKeysCache().clearObjectCache(this);

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTableBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTableBase.java
@@ -61,7 +61,6 @@ public abstract class GenericTableBase extends JDBCTable<GenericDataSource, Gene
     private boolean isUtility;
     private String description;
     private Long rowCount;
-    private List<? extends GenericTrigger> triggers;
     private final String tableCatalogName;
     private final String tableSchemaName;
 
@@ -496,31 +495,14 @@ public abstract class GenericTableBase extends JDBCTable<GenericDataSource, Gene
     @Nullable
     @Association
     public List<? extends GenericTrigger> getTriggers(@NotNull DBRProgressMonitor monitor) throws DBException {
-        if (triggers == null) {
-            GenericStructContainer parentObject = getParentObject();
-            if (parentObject != null) {
-                TableTriggerCache tableTriggerCache = parentObject.getTableTriggerCache();
-                if (tableTriggerCache != null) {
-                    triggers = tableTriggerCache.getObjects(monitor, parentObject, this);
-                }
-            } else {
-                loadTriggers(monitor);
+        GenericStructContainer parentObject = getParentObject();
+        if (parentObject != null) {
+            TableTriggerCache tableTriggerCache = parentObject.getTableTriggerCache();
+            if (tableTriggerCache != null) {
+                return tableTriggerCache.getObjects(monitor, parentObject, this);
             }
         }
-        return triggers;
-    }
-
-    private void loadTriggers(DBRProgressMonitor monitor) throws DBException {
-        triggers = getDataSource().getMetaModel().loadTriggers(monitor, getContainer(), this);
-        if (triggers == null) {
-            triggers = new ArrayList<>();
-        } else {
-            DBUtils.orderObjects(triggers);
-        }
-    }
-
-    public List<? extends GenericTrigger> getTriggerCache() {
-        return triggers;
+        return null;
     }
 
     public boolean supportUniqueIndexes() {

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTableTrigger.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTableTrigger.java
@@ -17,6 +17,8 @@
 package org.jkiss.dbeaver.ext.generic.model;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.meta.Property;
 
 public class GenericTableTrigger extends GenericTrigger<GenericTableBase> {
@@ -29,5 +31,11 @@ public class GenericTableTrigger extends GenericTrigger<GenericTableBase> {
     @Property(viewable = true, order = 4)
     public GenericTableBase getTable() {
         return getParentObject();
+    }
+
+    @NotNull
+    @Override
+    public String getFullyQualifiedName(DBPEvaluationContext context) {
+        return DBUtils.getFullQualifiedName(getDataSource(), getTable().getCatalog(), getTable().getSchema(), this);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTrigger.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericTrigger.java
@@ -20,6 +20,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.DBPNamedObject2;
+import org.jkiss.dbeaver.model.DBPQualifiedObject;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.meta.PropertyLength;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
@@ -31,7 +32,11 @@ import java.util.Map;
 /**
  * GenericTrigger
  */
-public abstract class GenericTrigger<OWNER extends DBSObject> implements DBSTrigger, GenericScriptObject, DBPNamedObject2
+public abstract class GenericTrigger<OWNER extends DBSObject> implements
+    DBSTrigger,
+    GenericScriptObject,
+    DBPNamedObject2,
+    DBPQualifiedObject
 {
     @NotNull
     private final OWNER container;

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/generic/SQLServerGenericTriggerManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/generic/SQLServerGenericTriggerManager.java
@@ -17,19 +17,14 @@
 
 package org.jkiss.dbeaver.ext.mssql.edit.generic;
 
-import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.ext.mssql.model.generic.SQLServerGenericTable;
+import org.jkiss.dbeaver.ext.generic.edit.GenericTriggerManager;
 import org.jkiss.dbeaver.ext.mssql.model.generic.SQLServerGenericTrigger;
 import org.jkiss.dbeaver.model.DBUtils;
-import org.jkiss.dbeaver.model.edit.DBECommandContext;
 import org.jkiss.dbeaver.model.edit.DBEPersistAction;
 import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
 import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
-import org.jkiss.dbeaver.model.impl.sql.edit.struct.SQLTriggerManager;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
-import org.jkiss.dbeaver.model.struct.cache.DBSObjectCache;
-import org.jkiss.dbeaver.model.struct.cache.ListCache;
 
 import java.util.List;
 import java.util.Map;
@@ -37,38 +32,11 @@ import java.util.Map;
 /**
  * SQLServerTableTriggerManager
  */
-public class SQLServerGenericTriggerManager extends SQLTriggerManager<SQLServerGenericTrigger, SQLServerGenericTable> {
-    @Override
-    public boolean canCreateObject(Object container) {
-        return false;
-    }
-
-    @Override
-    public boolean canEditObject(SQLServerGenericTrigger object) {
-        return false;
-    }
-
-    @Nullable
-    @Override
-    public DBSObjectCache<? extends DBSObject, SQLServerGenericTrigger> getObjectsCache(SQLServerGenericTrigger object)
-    {
-        return new ListCache<SQLServerGenericTable, SQLServerGenericTrigger>(
-            (List<SQLServerGenericTrigger>) object.getTable().getTriggerCache());
-    }
-
-    @Override
-    protected SQLServerGenericTrigger createDatabaseObject(DBRProgressMonitor monitor, DBECommandContext context, final Object container, Object copyFrom, Map<String, Object> options)
-    {
-        return null;
-    }
-
-    protected void createOrReplaceTriggerQuery(DBRProgressMonitor monitor, DBCExecutionContext executionContext, List<DBEPersistAction> actions, SQLServerGenericTrigger trigger, boolean create) {
-
-    }
+public class SQLServerGenericTriggerManager extends GenericTriggerManager {
 
     @Override
     protected void addObjectDeleteActions(DBRProgressMonitor monitor, DBCExecutionContext executionContext, List<DBEPersistAction> actions, ObjectDeleteCommand command, Map<String, Object> options) {
-        SQLServerGenericTrigger trigger = command.getObject();
+        SQLServerGenericTrigger trigger = (SQLServerGenericTrigger) command.getObject();
         DBSObject defaultDatabase = DBUtils.getDefaultContext(trigger.getDataSource(), true).getContextDefaults().getDefaultCatalog();
         if (defaultDatabase != trigger.getTable().getCatalog()) {
             actions.add(new SQLDatabasePersistAction("Set current database", "USE " + DBUtils.getQuotedIdentifier(trigger.getTable().getCatalog()), false)); //$NON-NLS-2$


### PR DESCRIPTION
DROP statement is already implemented in SQLTriggerManager

![2023-03-22 13_24_40-Window](https://user-images.githubusercontent.com/45152336/226885475-344b2345-6f4b-4d81-b078-2c4c612b2319.png)

Please check the following:

- [ ] trigger can be deleted in
- [x] SQLite
- [x] Firebird (database and table triggers)
- [x] HSQL
- [x] Informix/HANA
- [x] trigger can not be created in Generic databases

in EE

- [x] ability to drop trigger in Teradata
- [x] ability to rename trigger in Teradata
- [x] ability to add comment to trigger in Teradata