### PR TITLE
#18300 Return back default buttons to the toolbar

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql.ai/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql.ai/plugin.xml
@@ -56,7 +56,7 @@
 	
     <extension point="org.jkiss.dbeaver.toolBarConfiguration">
         <toolBar key="sqlEditor.side.top">
-            <item commandId="org.jkiss.dbeaver.ui.editors.sql.ai.showCompletion" defaultVisibility="false"/>
+            <item commandId="org.jkiss.dbeaver.ui.editors.sql.ai.showCompletion" defaultVisibility="true"/>
         </toolBar>
     </extension>
 </plugin>

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql.terminal/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql.terminal/plugin.xml
@@ -48,7 +48,7 @@
     
     <extension point="org.jkiss.dbeaver.toolBarConfiguration">
         <toolBar key="sqlEditor.side.top">
-            <item commandId="org.jkiss.dbeaver.ui.editors.sql.show.terminalView" defaultVisibility="false"/>
+            <item commandId="org.jkiss.dbeaver.ui.editors.sql.show.terminalView" defaultVisibility="true"/>
         </toolBar>
     </extension>
     

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
@@ -1374,7 +1374,7 @@
     <extension point="org.jkiss.dbeaver.toolBarConfiguration">
         <toolBar key="sqlEditor.side.top" name="%org.jkiss.dbeaver.toolBarConfiguration.sqlEditor.side.top">
             <item commandId="org.jkiss.dbeaver.ui.editors.sql.run.statement" defaultVisibility="true"/>
-            <item commandId="org.jkiss.dbeaver.ui.editors.sql.run.statementNew" defaultVisibility="false"/>
+            <item commandId="org.jkiss.dbeaver.ui.editors.sql.run.statementNew" defaultVisibility="true"/>
             <item commandId="org.jkiss.dbeaver.ui.editors.sql.run.script" defaultVisibility="true"/>
             <item commandId="org.jkiss.dbeaver.ui.editors.sql.run.scriptNew" defaultVisibility="false"/>
             <item commandId="org.jkiss.dbeaver.ui.editors.sql.run.explain" defaultVisibility="true"/>
@@ -1383,9 +1383,9 @@
             <item commandId="org.jkiss.dbeaver.ui.editors.sql.cancel.query" defaultVisibility="false"/>
         </toolBar>
         <toolBar key="sqlEditor.side.bottom" name="%org.jkiss.dbeaver.toolBarConfiguration.sqlEditor.side.bottom">
-            <item commandId="org.jkiss.dbeaver.ui.editors.sql.show.output" defaultVisibility="false"/>
-            <item commandId="org.jkiss.dbeaver.ui.editors.sql.show.log" defaultVisibility="false"/>
-            <item commandId="org.jkiss.dbeaver.ui.editors.sql.show.variables" defaultVisibility="false"/>
+            <item commandId="org.jkiss.dbeaver.ui.editors.sql.show.output" defaultVisibility="true"/>
+            <item commandId="org.jkiss.dbeaver.ui.editors.sql.show.log" defaultVisibility="true"/>
+            <item commandId="org.jkiss.dbeaver.ui.editors.sql.show.variables" defaultVisibility="true"/>
         </toolBar>
     </extension>
 </plugin>


### PR DESCRIPTION
By default, all buttons from the pic should be visible as in the previous DBeaver version:
![image](https://user-images.githubusercontent.com/28875055/227535344-7c7cfb19-9409-4332-9c8a-4308371d0d27.png)
