### PR TITLE
dbeaver/pro#1494 remove disabled models & update SDK & add gpt turbo

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/gpt3/GPTModel.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/gpt3/GPTModel.java
@@ -22,17 +22,17 @@ import java.util.Arrays;
 import java.util.Optional;
 
 public enum GPTModel {
-    CODE_CUSHMAN("code-cushman-001", 2048),
-    CODE_DAVINCI("code-davinci-002", 2048),
-    TEXT_ADA("text-ada-001", 2048),
-    TEXT_CURIE("text-curie-001", 2048),
-    TEXT_BABBAGE("text-babbage-001", 2048),
-    TEXT_DAVINCI01("text-davinci-003", 4096),
-    TEXT_DAVINCI02("text-davinci-002", 4096),
-    TEXT_DAVINCI03("text-davinci-001", 2048);
+    GPT_TURBO("gpt-3.5-turbo", 2048, true),
+    TEXT_ADA("text-ada-001", 2048, false),
+    TEXT_CURIE("text-curie-001", 2048, false),
+    TEXT_BABBAGE("text-babbage-001", 2048, false),
+    TEXT_DAVINCI01("text-davinci-003", 4096, false),
+    TEXT_DAVINCI02("text-davinci-002", 4096, false),
+    TEXT_DAVINCI03("text-davinci-001", 2048, false);
 
     private final String name;
     private final int maxTokens;
+    private final boolean isChatAPI;
 
     /**
      * Gets GPT model by name
@@ -40,16 +40,21 @@ public enum GPTModel {
     @NotNull
     public static GPTModel getByName(@NotNull String name) {
         Optional<GPTModel> model = Arrays.stream(values()).filter(it -> it.name.equals(name)).findFirst();
-        return model.orElse(CODE_DAVINCI);
+        return model.orElse(GPT_TURBO);
     }
 
-    GPTModel(String name, int maxTokens) {
+    GPTModel(String name, int maxTokens, boolean isChatAPI) {
         this.name = name;
         this.maxTokens = maxTokens;
+        this.isChatAPI = isChatAPI;
     }
 
     public int getMaxTokens() {
         return maxTokens;
+    }
+
+    public boolean isChatAPI() {
+        return isChatAPI;
     }
 
     public String getName() {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql.ai/src/org/jkiss/dbeaver/ui/editors/sql/ai/preferences/AIConfiguratorDefault.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql.ai/src/org/jkiss/dbeaver/ui/editors/sql/ai/preferences/AIConfiguratorDefault.java
@@ -129,7 +129,8 @@ public class AIConfiguratorDefault implements IObjectPropertyConfigurator<GPTCom
             for (GPTModel model : GPTModel.values()) {
                 modelCombo.add(model.getName());
             }
-            UIUtils.createInfoLabel(modelGroup, "code-davinci model suits the best for SQL code completion", GridData.FILL_HORIZONTAL, 2);
+            UIUtils.createInfoLabel(modelGroup, "gpt-3.5-turbo model suits the best for SQL code completion",
+                GridData.FILL_HORIZONTAL, 2);
             {
                 Group modelAdvancedGroup = UIUtils.createControlGroup(placeholder,
                     AIUIMessages.gpt_preference_page_group_model_advanced,

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql.ai/src/org/jkiss/dbeaver/ui/editors/sql/ai/preferences/AIPreferencesInitializer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql.ai/src/org/jkiss/dbeaver/ui/editors/sql/ai/preferences/AIPreferencesInitializer.java
@@ -34,7 +34,7 @@ public class AIPreferencesInitializer extends AbstractPreferenceInitializer {
         PrefUtils.setDefaultPreferenceValue(store, AICompletionConstants.AI_COMPLETION_MAX_CHOICES, 1);
         PrefUtils.setDefaultPreferenceValue(store, AICompletionConstants.AI_INCLUDE_SOURCE_TEXT_IN_QUERY_COMMENT, true);
 
-        PrefUtils.setDefaultPreferenceValue(store, GPTConstants.GPT_MODEL, GPTModel.CODE_DAVINCI.getName());
+        PrefUtils.setDefaultPreferenceValue(store, GPTConstants.GPT_MODEL, GPTModel.GPT_TURBO.getName());
         PrefUtils.setDefaultPreferenceValue(store, GPTConstants.GPT_MODEL_TEMPERATURE, 0.0f);
         PrefUtils.setDefaultPreferenceValue(store, GPTConstants.GPT_LOG_QUERY, false);
     }


### PR DESCRIPTION
Closes dbeaver/pro#1494
Removes models disabled by OpenAI, and adds gpt-3.5-turbo. Unfortunately, this leads to dual API because it requires a chat Endpoint. 
**Requires bundle update**
Acceptance:
* `code-*` models are now removed(Due to OpenAI disabling them)
* turbo model now exists and works properly
* test for other models