### PR TITLE
#19319 Fix q-string rule chars unreading

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/sql/OracleDialectRules.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/sql/OracleDialectRules.java
@@ -71,10 +71,12 @@ class OracleDialectRules implements TPRuleProvider {
                             scanner.unread();
                         }
                     }
-                } else {
+                }
+                if (!resume) {
                     scanner.unread();
                 }
-            } else {
+            }
+            if (!resume) {
                 scanner.unread();
             }
             return TPTokenAbstract.UNDEFINED;

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/sql/OracleDialectRules.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/sql/OracleDialectRules.java
@@ -57,7 +57,7 @@ class OracleDialectRules implements TPRuleProvider {
                     }
                     if (!quoteCharRead) {
                         quoteStartChar = (char) scanner.read();
-                        quoteCharRead = true;
+                        quoteCharNeedsToBeUnread = true;
                     }
 
                     if (!Character.isLetterOrDigit(quoteStartChar)) {
@@ -67,14 +67,14 @@ class OracleDialectRules implements TPRuleProvider {
                         if (tryReadQString(scanner, quoteEndChar)) {
                             return stringToken;
                         }
+                        if (quoteCharNeedsToBeUnread) {
+                            scanner.unread();
+                        }
                     } else {
                         quoteStartChar = (char) -1;
-                        if (quoteCharRead) {
-                            //scanner.unread();
+                        if (quoteCharRead || quoteCharNeedsToBeUnread) {
+                            scanner.unread();
                         }
-                    }
-                    if (quoteCharRead) {
-                        scanner.unread();
                     }
                 }
                 if (!resume) {

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/sql/OracleDialectRules.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/sql/OracleDialectRules.java
@@ -51,11 +51,13 @@ class OracleDialectRules implements TPRuleProvider {
                 c = resume ? '\'' : scanner.read();
                 if (c == '\'') {
                     boolean quoteCharRead = false;
+                    boolean quoteCharNeedsToBeUnread = false;
                     if (resume && quoteStartChar != -1) {
                         quoteCharRead = true;
                     }
                     if (!quoteCharRead) {
                         quoteStartChar = (char) scanner.read();
+                        quoteCharRead = true;
                     }
 
                     if (!Character.isLetterOrDigit(quoteStartChar)) {
@@ -68,8 +70,11 @@ class OracleDialectRules implements TPRuleProvider {
                     } else {
                         quoteStartChar = (char) -1;
                         if (quoteCharRead) {
-                            scanner.unread();
+                            //scanner.unread();
                         }
+                    }
+                    if (quoteCharRead) {
+                        scanner.unread();
                     }
                 }
                 if (!resume) {

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/text/parser/TPRuleBasedScanner.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/text/parser/TPRuleBasedScanner.java
@@ -173,9 +173,13 @@ public class TPRuleBasedScanner implements TPCharacterScanner, TPTokenScanner, T
 
 		if (fRules != null) {
 			for (TPRule fRule : fRules) {
+				int offset = fOffset;
 				TPToken token= (fRule.evaluate(this));
-				if (!token.isUndefined())
+				if (!token.isUndefined()) {
 					return token;
+				} else if (fOffset != offset) {
+					throw new java.lang.IllegalStateException("Text parser rule inconsistency: rule failed and the scanned should have been fallbacked, but the current offset is different after attempt to evaluate " + fRule);
+				}
 			}
 		}
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/text/parser/TPRuleBasedScanner.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/text/parser/TPRuleBasedScanner.java
@@ -20,6 +20,7 @@ package org.jkiss.dbeaver.model.text.parser;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
+import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.sql.parser.rules.SQLDelimiterRule;
 
 
@@ -28,6 +29,8 @@ import org.jkiss.dbeaver.model.sql.parser.rules.SQLDelimiterRule;
  */
 public class TPRuleBasedScanner implements TPCharacterScanner, TPTokenScanner, TPEvalScanner {
 
+    Log log = Log.getLog(TPRuleBasedScanner.class);
+    
 	/** The list of rules of this scanner */
 	private TPRule[] fRules;
 	/** The token to be returned by default if no rule fires */
@@ -178,7 +181,10 @@ public class TPRuleBasedScanner implements TPCharacterScanner, TPTokenScanner, T
 				if (!token.isUndefined()) {
 					return token;
 				} else if (fOffset != offset) {
-					throw new java.lang.IllegalStateException("Text parser rule inconsistency: rule failed and the scanned should have been fallbacked, but the current offset is different after attempt to evaluate " + fRule);
+					log.debug("Text parser rule inconsistency: "
+							+ "rule failed and the scanned should have been fallbacked, "
+							+ "but the current offset is different after attempt to evaluate " + fRule);
+					fOffset = offset;
 				}
 			}
 		}

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/text/parser/TPRuleBasedScanner.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/text/parser/TPRuleBasedScanner.java
@@ -29,7 +29,7 @@ import org.jkiss.dbeaver.model.sql.parser.rules.SQLDelimiterRule;
  */
 public class TPRuleBasedScanner implements TPCharacterScanner, TPTokenScanner, TPEvalScanner {
 
-    Log log = Log.getLog(TPRuleBasedScanner.class);
+	Log log = Log.getLog(TPRuleBasedScanner.class);
     
 	/** The list of rules of this scanner */
 	private TPRule[] fRules;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/text/parser/TPRuleBasedScanner.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/text/parser/TPRuleBasedScanner.java
@@ -29,111 +29,128 @@ import org.jkiss.dbeaver.model.sql.parser.rules.SQLDelimiterRule;
  */
 public class TPRuleBasedScanner implements TPCharacterScanner, TPTokenScanner, TPEvalScanner {
 
-	Log log = Log.getLog(TPRuleBasedScanner.class);
-    
-	/** The list of rules of this scanner */
-	private TPRule[] fRules;
-	/** The token to be returned by default if no rule fires */
-	private TPToken fDefaultReturnToken;
-	/** The document to be scanned */
-	private IDocument fDocument;
-	/** The cached legal line delimiters of the document */
-	private char[][] fDelimiters;
-	/** The offset of the next character to be read */
-	private int fOffset;
-	/** The end offset of the range to be scanned */
-	private int fRangeEnd;
-	/** The offset of the last read token */
-	private int fTokenOffset;
-	/** The cached column of the current scanner position */
-	private int fColumn;
-	/** Internal setting for the un-initialized column cache. */
-	private static final int UNDEFINED= -1;
+    private static final Log log = Log.getLog(TPRuleBasedScanner.class);
 
-	private boolean evalMode;
+    /**
+     * Internal setting for the un-initialized column cache.
+     */
+    private static final int UNDEFINED = -1;
+    /**
+     * The list of rules of this scanner
+     */
+    private TPRule[] fRules;
+    /**
+     * The token to be returned by default if no rule fires
+     */
+    private TPToken fDefaultReturnToken;
+    /**
+     * The document to be scanned
+     */
+    private IDocument fDocument;
+    /**
+     * The cached legal line delimiters of the document
+     */
+    private char[][] fDelimiters;
+    /**
+     * The offset of the next character to be read
+     */
+    private int fOffset;
+    /**
+     * The end offset of the range to be scanned
+     */
+    private int fRangeEnd;
+    /**
+     * The offset of the last read token
+     */
+    private int fTokenOffset;
+    /**
+     * The cached column of the current scanner position
+     */
+    private int fColumn;
+    private boolean evalMode;
 
-	/**
-	 * Creates a new rule based scanner which does not have any rule.
-	 */
-	public TPRuleBasedScanner() {
-	}
+    /**
+     * Creates a new rule based scanner which does not have any rule.
+     */
+    public TPRuleBasedScanner() {
+    }
 
-	/**
-	 * Configures the scanner with the given sequence of rules.
-	 *
-	 * @param rules the sequence of rules controlling this scanner
-	 */
-	public void setRules(TPRule[] rules) {
-		if (rules != null) {
-			fRules= new TPRule[rules.length];
-			System.arraycopy(rules, 0, fRules, 0, rules.length);
-		} else
-			fRules= null;
-	}
+    /**
+     * Configures the scanner with the given sequence of rules.
+     *
+     * @param rules the sequence of rules controlling this scanner
+     */
+    public void setRules(TPRule[] rules) {
+        if (rules != null) {
+            fRules = new TPRule[rules.length];
+            System.arraycopy(rules, 0, fRules, 0, rules.length);
+        } else
+            fRules = null;
+    }
 
-	/**
-	 * Configures the scanner's default return token. This is the token
-	 * which is returned when none of the rules fired and EOF has not been
-	 * reached.
-	 *
-	 * @param defaultReturnToken the default return token
-	 * @since 2.0
-	 */
-	public void setDefaultReturnToken(TPToken defaultReturnToken) {
-		Assert.isNotNull(defaultReturnToken.getData());
-		fDefaultReturnToken= defaultReturnToken;
-	}
+    /**
+     * Configures the scanner's default return token. This is the token
+     * which is returned when none of the rules fired and EOF has not been
+     * reached.
+     *
+     * @param defaultReturnToken the default return token
+     * @since 2.0
+     */
+    public void setDefaultReturnToken(TPToken defaultReturnToken) {
+        Assert.isNotNull(defaultReturnToken.getData());
+        fDefaultReturnToken = defaultReturnToken;
+    }
 
-	@Override
-	public void setRange(final IDocument document, int offset, int length) {
-		Assert.isLegal(document != null);
-		final int documentLength = document.getLength();
+    @Override
+    public void setRange(final IDocument document, int offset, int length) {
+        Assert.isLegal(document != null);
+        final int documentLength = document.getLength();
 
-		// Sometimes we have length longer than document length
-		while (offset + length > documentLength) {
-			length--;
-		}
-		checkRange(offset, length, documentLength);
+        // Sometimes we have length longer than document length
+        while (offset + length > documentLength) {
+            length--;
+        }
+        checkRange(offset, length, documentLength);
 
-		fDocument= document;
-		fOffset= offset;
-		fColumn= UNDEFINED;
-		fRangeEnd= offset + length;
+        fDocument = document;
+        fOffset = offset;
+        fColumn = UNDEFINED;
+        fRangeEnd = offset + length;
 
-		String[] delimiters= fDocument.getLegalLineDelimiters();
-		fDelimiters= new char[delimiters.length][];
-		for (int i= 0; i < delimiters.length; i++)
-			fDelimiters[i]= delimiters[i].toCharArray();
+        String[] delimiters = fDocument.getLegalLineDelimiters();
+        fDelimiters = new char[delimiters.length][];
+        for (int i = 0; i < delimiters.length; i++)
+            fDelimiters[i] = delimiters[i].toCharArray();
 
-		if (fDefaultReturnToken == null)
-			fDefaultReturnToken= TPTokenAbstract.UNDEFINED;
-	}
+        if (fDefaultReturnToken == null)
+            fDefaultReturnToken = TPTokenAbstract.UNDEFINED;
+    }
 
-	/**
-	 * Checks that the given range is valid.
-	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=69292
-	 *
-	 * @param offset the offset of the document range to scan
-	 * @param length the length of the document range to scan
-	 * @param documentLength the document's length
-	 * @since 3.3
-	 */
-	private void checkRange(int offset, int length, int documentLength) {
-		Assert.isLegal(offset > -1);
-		Assert.isLegal(length > -1);
-		Assert.isLegal(offset + length <= documentLength);
-	}
+    /**
+     * Checks that the given range is valid.
+     * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=69292
+     *
+     * @param offset         the offset of the document range to scan
+     * @param length         the length of the document range to scan
+     * @param documentLength the document's length
+     * @since 3.3
+     */
+    private void checkRange(int offset, int length, int documentLength) {
+        Assert.isLegal(offset > -1);
+        Assert.isLegal(length > -1);
+        Assert.isLegal(offset + length <= documentLength);
+    }
 
-	@Override
-	public int getTokenOffset() {
-		return fTokenOffset;
-	}
+    @Override
+    public int getTokenOffset() {
+        return fTokenOffset;
+    }
 
-	@Override
-	public int getTokenLength() {
-		if (fOffset < fRangeEnd)
-			return fOffset - getTokenOffset();
-		return fRangeEnd - getTokenOffset();
+    @Override
+    public int getTokenLength() {
+        if (fOffset < fRangeEnd)
+            return fOffset - getTokenOffset();
+        return fRangeEnd - getTokenOffset();
     }
 
     /**
@@ -143,105 +160,104 @@ public class TPRuleBasedScanner implements TPCharacterScanner, TPTokenScanner, T
         return Math.min(fOffset, fRangeEnd);
     }
 
-	@Override
-	public int getColumn() {
-		if (fColumn == UNDEFINED) {
-			try {
-				int line= fDocument.getLineOfOffset(fOffset);
-				int start= fDocument.getLineOffset(line);
+    @Override
+    public int getColumn() {
+        if (fColumn == UNDEFINED) {
+            try {
+                int line = fDocument.getLineOfOffset(fOffset);
+                int start = fDocument.getLineOffset(line);
 
-				fColumn= fOffset - start;
+                fColumn = fOffset - start;
+            } catch (BadLocationException ex) {
+            }
+        }
+        return fColumn;
+    }
 
-			} catch (BadLocationException ex) {
-			}
-		}
-		return fColumn;
-	}
+    @Override
+    public int getOffset() {
+        return fOffset;
+    }
 
-	@Override
-	public int getOffset() {
-		return fOffset;
-	}
+    @Override
+    public char[][] getLegalLineDelimiters() {
+        return fDelimiters;
+    }
 
-	@Override
-	public char[][] getLegalLineDelimiters() {
-		return fDelimiters;
-	}
+    @Override
+    public TPToken nextToken() {
 
-	@Override
-	public TPToken nextToken() {
+        fTokenOffset = fOffset;
+        fColumn = UNDEFINED;
 
-		fTokenOffset= fOffset;
-		fColumn= UNDEFINED;
+        if (fRules != null) {
+            for (TPRule fRule : fRules) {
+                int offset = fOffset;
+                TPToken token = (fRule.evaluate(this));
+                if (!token.isUndefined()) {
+                    return token;
+                } else if (fOffset != offset) {
+                    log.debug("Text parser rule inconsistency: "
+                            + "rule failed and the scanned should have been fallbacked, "
+                            + "but the current offset is different after attempt to evaluate " + fRule);
+                    fOffset = offset;
+                }
+            }
+        }
 
-		if (fRules != null) {
-			for (TPRule fRule : fRules) {
-				int offset = fOffset;
-				TPToken token= (fRule.evaluate(this));
-				if (!token.isUndefined()) {
-					return token;
-				} else if (fOffset != offset) {
-					log.debug("Text parser rule inconsistency: "
-							+ "rule failed and the scanned should have been fallbacked, "
-							+ "but the current offset is different after attempt to evaluate " + fRule);
-					fOffset = offset;
-				}
-			}
-		}
+        if (read() == EOF)
+            return TPTokenAbstract.EOF;
+        return fDefaultReturnToken;
+    }
 
-		if (read() == EOF)
-			return TPTokenAbstract.EOF;
-		return fDefaultReturnToken;
-	}
+    @Override
+    public int read() {
 
-	@Override
-	public int read() {
+        try {
 
-		try {
+            if (fOffset < fRangeEnd) {
+                try {
+                    return fDocument.getChar(fOffset);
+                } catch (BadLocationException e) {
+                }
+            }
 
-			if (fOffset < fRangeEnd) {
-				try {
-					return fDocument.getChar(fOffset);
-				} catch (BadLocationException e) {
-				}
-			}
+            return EOF;
 
-			return EOF;
+        } finally {
+            ++fOffset;
+            fColumn = UNDEFINED;
+        }
+    }
 
-		} finally {
-			++ fOffset;
-			fColumn= UNDEFINED;
-		}
-	}
+    @Override
+    public void unread() {
+        --fOffset;
+        fColumn = UNDEFINED;
+    }
 
-	@Override
-	public void unread() {
-		--fOffset;
-		fColumn= UNDEFINED;
-	}
+    //////////////////////////////////////////////////////
+    // Eval
 
-	//////////////////////////////////////////////////////
-	// Eval
+    @Override
+    public boolean isEvalMode() {
+        return evalMode;
+    }
 
-	@Override
-	public boolean isEvalMode() {
-		return evalMode;
-	}
+    public void startEval() {
+        this.evalMode = true;
+    }
 
-	public void startEval() {
-		this.evalMode = true;
-	}
-
-	public void endEval() {
-		this.evalMode = false;
-		if (fRules != null) {
-			for (TPRule rule : fRules) {
-				if (rule instanceof SQLDelimiterRule) {
-					((SQLDelimiterRule)rule).changeDelimiter(null);
-				}
-			}
-		}
-	}
+    public void endEval() {
+        this.evalMode = false;
+        if (fRules != null) {
+            for (TPRule rule : fRules) {
+                if (rule instanceof SQLDelimiterRule) {
+                    ((SQLDelimiterRule) rule).changeDelimiter(null);
+                }
+            }
+        }
+    }
 
 }
 

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
@@ -522,10 +522,8 @@ public class SQLScriptParserTest {
             SQLParserContext context = createParserContext(setDialect("oracle"), query);
             TPRuleBasedScanner scanner = context.getScanner();
             scanner.setRange(context.getDocument(), 0, query.length());
-            TPToken token = scanner.nextToken();
-            int tokenLength = scanner.getTokenLength();
-            Assert.assertEquals(SQLTokenType.T_STRING, token.getData());
-            Assert.assertEquals(query.length() - 1, tokenLength);
+            Assert.assertEquals(SQLTokenType.T_STRING, scanner.nextToken().getData());
+            Assert.assertEquals(query.length() - 1, scanner.getTokenLength());
             scanner.nextToken();
         }
         final List<String> badQueries = List.of(
@@ -542,10 +540,8 @@ public class SQLScriptParserTest {
             SQLParserContext context = createParserContext(setDialect("oracle"), query);
             TPRuleBasedScanner scanner = context.getScanner();
             scanner.setRange(context.getDocument(), 0, query.length());
-            TPToken token = scanner.nextToken();
-            int tokenLength = scanner.getTokenLength();
-            Assert.assertNotEquals(SQLTokenType.T_STRING, token.getData());
-            Assert.assertNotEquals(query.length() - 1, tokenLength);
+            Assert.assertNotEquals(SQLTokenType.T_STRING, scanner.nextToken().getData());
+            Assert.assertNotEquals(query.length() - 1, scanner.getTokenLength());
         }
     }
     


### PR DESCRIPTION
The case in the issue should not be reproducible anymore.

Also q-strings should work. Example: `q'[What's a quote among friends?]'`

Only for Oracle.