### PR TITLE
dbeaver/dbeaver#16776 refresh visuals without layout call

### DIFF
--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/editor/ERDEditorPart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/editor/ERDEditorPart.java
@@ -1120,17 +1120,23 @@ public abstract class ERDEditorPart extends GraphicalEditorWithFlyoutPalette
                 for (ERDEntity entity : diagram.getEntities()) {
                     entity.reloadAttributes(diagram);
                 }
+                for (Object object : getGraphicalViewer().getContents().getChildren()) {
+                    if (object instanceof EntityPart) {
+                        ((EntityPart) object).refresh();
+                    }
+                }
             } else {
                 for (Object object : ((IStructuredSelection)getGraphicalViewer().getSelection()).toArray()) {
                     if (object instanceof EntityPart) {
                         ((EntityPart) object).getEntity().setAttributeVisibility(visibility);
-                        UIUtils.asyncExec(() -> ((EntityPart) object).getEntity().reloadAttributes(diagram));
+                        UIUtils.asyncExec(() -> {
+                            ((EntityPart) object).getEntity().reloadAttributes(diagram);
+                            ((EntityPart) object).refresh();
+                        });
+
                     }
                 }
             }
-            diagram.setNeedsAutoLayout(true);
-
-            UIUtils.asyncExec(() -> getGraphicalViewer().setContents(diagram));
         }
     }
 
@@ -1158,9 +1164,11 @@ public abstract class ERDEditorPart extends GraphicalEditorWithFlyoutPalette
                 for (ERDEntity entity : diagram.getEntities()) {
                     entity.reloadAttributes(diagram);
                 }
-                diagram.setNeedsAutoLayout(true);
-
-                UIUtils.asyncExec(() -> graphicalViewer.setContents(diagram));
+                for (Object object : getGraphicalViewer().getContents().getChildren()) {
+                    if (object instanceof EntityPart) {
+                        ((EntityPart) object).refresh();
+                    }
+                }
             } else if (ERDConstants.PREF_ATTR_STYLES.equals(event.getProperty())) {
                 refreshDiagram(true, false);
             } else if (ERDUIConstants.PREF_DIAGRAM_SHOW_VIEWS.equals(event.getProperty()) || ERDUIConstants.PREF_DIAGRAM_SHOW_PARTITIONS.equals(event.getProperty())) {


### PR DESCRIPTION
Closes dbeaver/dbeaver#16776 
Refreshes attribute visibility without calling relayout. We possibly want this for attribute styles.

https://user-images.githubusercontent.com/20579256/228212533-f28cd8ad-c6c1-4e9f-8185-74130081546b.mp4

