### PR TITLE
dbeaver/pro#1241 update icon

### DIFF
--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/editor/ERDEditorPart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/editor/ERDEditorPart.java
@@ -1028,7 +1028,7 @@ public abstract class ERDEditorPart extends GraphicalEditorWithFlyoutPalette
                     getDiagram().setAttributeStyles(ERDViewStyle.getDefaultStyles(ERDUIActivator.getDefault().getPreferences()));
                 }
             };
-            configAction.setImageDescriptor(DBeaverIcons.getImageDescriptor(UIIcon.CONFIGURATION));
+            configAction.setImageDescriptor(DBeaverIcons.getImageDescriptor(UIIcon.PANEL_CUSTOMIZE));
             toolBarManager.add(configAction);
         }
     }


### PR DESCRIPTION
Closes dbeaver/pro#1241
Updated icon to avoid confusion of having two same icons for a different types of preferences when opened in VQB. 
![image](https://user-images.githubusercontent.com/20579256/228275706-befcd971-9932-42e7-a170-b4079e09dc81.png)
