### PR TITLE
dbeaver/pro#1516 change Confirmations page dialog behaviour - keep st…

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreMessages.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreMessages.java
@@ -259,16 +259,18 @@ public class CoreMessages extends NLS {
 	public static String model_project_Script;
 	public static String model_project_Scripts;
 
-	public static String pref_page_confirmations_combo_always;
-	public static String pref_page_confirmations_combo_never;
-	public static String pref_page_confirmations_combo_prompt;
-	public static String pref_page_confirmations_group_general_actions;
-	public static String pref_page_confirmations_group_object_editor;
-	public static String pref_page_confirmations_table_column_confirmation;
-	public static String pref_page_confirmations_table_column_confirmation_tip;
-	public static String pref_page_confirmations_table_column_group;
-	public static String pref_page_confirmations_table_column_value;
-	public static String pref_page_confirmations_table_column_value_tip;
+    public static String pref_page_confirmations_combo_always;
+    public static String pref_page_confirmations_combo_never;
+    public static String pref_page_confirmations_combo_prompt;
+    public static String pref_page_confirmations_group_general_actions;
+    public static String pref_page_confirmations_group_object_editor;
+    public static String pref_page_confirmations_table_column_confirmation;
+    public static String pref_page_confirmations_table_column_confirmation_tip;
+    public static String pref_page_confirmations_table_column_group;
+    public static String pref_page_confirmations_table_column_value;
+    public static String pref_page_confirmations_table_column_value_tip;
+    public static String pref_page_confirmations_table_column_confirm;
+    public static String pref_page_confirmations_table_column_confirm_tip;
 
 	public static String pref_page_database_general_separate_meta_connection;
 	public static String pref_page_database_general_checkbox_case_sensitive_names;
@@ -608,7 +610,7 @@ public class CoreMessages extends NLS {
     public static String pref_page_transactions_notifications_show_check_label;
     public static String pref_page_transactions_notifications_show_check_description;
 
-    public static String pref_page_label_edit_permissions; 
+    public static String pref_page_label_edit_permissions;
     public static String pref_page_logs_files_max_size_label;
     public static String pref_page_logs_files_max_count_label;
 

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreResources.properties
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreResources.properties
@@ -282,6 +282,8 @@ pref_page_confirmations_table_column_confirmation_tip = Confirmation title and d
 pref_page_confirmations_table_column_group=Group
 pref_page_confirmations_table_column_value=Show dialog
 pref_page_confirmations_table_column_value_tip = Show confirmation dialog?
+pref_page_confirmations_table_column_confirm = Confirm
+pref_page_confirmations_table_column_confirm_tip = Perform this action by default if the dialogue of confirmation is not shown
 
 pref_page_database_general_checkbox_case_sensitive_names = Use case-sensitive names in DDL statements
 pref_page_database_general_checkbox_rollback_on_error = Rollback on error

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConfirmations.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConfirmations.java
@@ -52,9 +52,10 @@ import java.util.stream.Collectors;
 public class PrefPageConfirmations extends AbstractPrefPage implements IWorkbenchPreferencePage {
     public static final String PAGE_ID = "org.jkiss.dbeaver.preferences.main.confirmations"; //$NON-NLS-1$
 
+    private TableViewer tableViewer;
     private Table confirmTable;
     private List<ConfirmationWithStatus> confirmations = new ArrayList<>();
-    private Map<ConfirmationDescriptor, Object> changedConfirmations = new HashMap<>();
+    private Map<ConfirmationDescriptor, String> changedConfirmations = new HashMap<>();
 
     @Override
     public void init(IWorkbench workbench)
@@ -67,7 +68,7 @@ public class PrefPageConfirmations extends AbstractPrefPage implements IWorkbenc
     protected Control createPreferenceContent(@NotNull Composite parent) {
         Composite composite = UIUtils.createPlaceholder(parent, 1);
 
-        TableViewer tableViewer = new TableViewer(
+        tableViewer = new TableViewer(
             composite,
             SWT.BORDER | SWT.UNDERLINE_SINGLE | SWT.V_SCROLL | SWT.H_SCROLL | SWT.FULL_SELECTION);
 
@@ -114,8 +115,8 @@ public class PrefPageConfirmations extends AbstractPrefPage implements IWorkbenc
             true,
             item -> {
                 if (item instanceof ConfirmationWithStatus) {
-                return  ((ConfirmationWithStatus) item).enabled;
-            }
+                    return ConfirmationDialog.PROMPT.equals(((ConfirmationWithStatus) item).status);
+                }
             return false;
         }, new EditingSupport(tableViewer) {
 
@@ -132,7 +133,7 @@ public class PrefPageConfirmations extends AbstractPrefPage implements IWorkbenc
                 @Override
                 protected Object getValue(Object element) {
                     if (element instanceof ConfirmationWithStatus) {
-                        return ((ConfirmationWithStatus) element).enabled;
+                        return ConfirmationDialog.PROMPT.equals(((ConfirmationWithStatus) element).status);
                     }
                     return false;
                 }
@@ -141,10 +142,72 @@ public class PrefPageConfirmations extends AbstractPrefPage implements IWorkbenc
                 protected void setValue(Object element, Object value) {
                     if (element instanceof ConfirmationWithStatus) {
                         ConfirmationWithStatus confirmation = (ConfirmationWithStatus) element;
-                        confirmation.enabled = CommonUtils.getBoolean(value, true);
-                        changedConfirmations.put((confirmation).confirmation, value);
+                        boolean enabled = CommonUtils.getBoolean(value, true);
+                        if (enabled && !ConfirmationDialog.PROMPT.equals(confirmation.status)) {
+                            confirmation.status = ConfirmationDialog.PROMPT;
+                            changedConfirmations.put((confirmation).confirmation, ConfirmationDialog.PROMPT);
+                        } else if (!enabled) {
+                            // Then set to default - ALWAYS - value.
+                            confirmation.status = ConfirmationDialog.ALWAYS;
+                            changedConfirmations.put((confirmation).confirmation, ConfirmationDialog.ALWAYS);
+                        }
                     }
+                }
+            });
 
+        columnsController.addBooleanColumn(
+            CoreMessages.pref_page_confirmations_table_column_confirm,
+            CoreMessages.pref_page_confirmations_table_column_confirm_tip,
+            SWT.CENTER,
+            true,
+            true,
+            item -> {
+                if (item instanceof ConfirmationWithStatus) {
+                    // PROMPT and ALWAYS are true by default
+                    return !ConfirmationDialog.NEVER.equals(((ConfirmationWithStatus) item).status);
+                }
+                return false;
+            }, new EditingSupport(tableViewer) {
+
+                @Override
+                protected CellEditor getCellEditor(Object element) {
+                    return new CustomCheckboxCellEditor(tableViewer.getTable());
+                }
+
+                @Override
+                protected boolean canEdit(Object element) {
+                    if (element instanceof ConfirmationWithStatus) {
+                        // Can't change this value if dialog showing is enabled to avoid mess.
+                        return !ConfirmationDialog.PROMPT.equals(((ConfirmationWithStatus) element).status);
+                    }
+                    return false;
+                }
+
+                @Override
+                protected Object getValue(Object element) {
+                    if (element instanceof ConfirmationWithStatus) {
+                        return !ConfirmationDialog.NEVER.equals(((ConfirmationWithStatus) element).status);
+                    }
+                    return false;
+                }
+
+                @Override
+                protected void setValue(Object element, Object value) {
+                    if (element instanceof ConfirmationWithStatus) {
+                        ConfirmationWithStatus confirmation = (ConfirmationWithStatus) element;
+                        if (ConfirmationDialog.PROMPT.equals(confirmation.status)) {
+                            // Something went wrong. We do not want to change confirm value if the "show dialog" is enabled.
+                            return;
+                        }
+                        boolean enabled = CommonUtils.getBoolean(value, true);
+                        if (enabled && !ConfirmationDialog.ALWAYS.equals(confirmation.status)) {
+                            confirmation.status = ConfirmationDialog.ALWAYS;
+                            changedConfirmations.put((confirmation).confirmation, ConfirmationDialog.ALWAYS);
+                        } else if (!enabled && !ConfirmationDialog.NEVER.equals(confirmation.status)) {
+                            confirmation.status = ConfirmationDialog.NEVER;
+                            changedConfirmations.put((confirmation).confirmation, ConfirmationDialog.NEVER);
+                        }
+                    }
                 }
             });
 
@@ -186,31 +249,29 @@ public class PrefPageConfirmations extends AbstractPrefPage implements IWorkbenc
         return composite;
     }
 
-    private Boolean getCurrentConfirmValue(String id) {
+    private String getCurrentConfirmValue(String id) {
         DBPPreferenceStore store = DBWorkbench.getPlatform().getPreferenceStore();
 
         String value = store.getString(ConfirmationDialog.PREF_KEY_PREFIX + id);
         if (CommonUtils.isEmpty(value)) {
-            return Boolean.TRUE;
+            return ConfirmationDialog.PROMPT;
         }
 
-        switch (value) {
-            case ConfirmationDialog.NEVER: // backward compatibility
-            case "false":
-                return Boolean.FALSE;
-            case ConfirmationDialog.ALWAYS: // backward compatibility
-            default: return Boolean.TRUE;
+        if (ConfirmationDialog.NEVER.equals(value) || ConfirmationDialog.ALWAYS.equals(value)) {
+            return value;
         }
+
+        // Better to ask in other cases
+        return ConfirmationDialog.PROMPT;
     }
 
 
     @Override
     public boolean performOk() {
         DBPPreferenceStore store = DBWorkbench.getPlatform().getPreferenceStore();
-        for (Map.Entry<ConfirmationDescriptor, Object> entry : changedConfirmations.entrySet()) {
+        for (Map.Entry<ConfirmationDescriptor, String> entry : changedConfirmations.entrySet()) {
             String id = entry.getKey().getId();
-            // Store values as String and not as boolean because of the backward compatibility problems
-            store.setValue(ConfirmationDialog.PREF_KEY_PREFIX + id, entry.getValue().toString());
+            store.setValue(ConfirmationDialog.PREF_KEY_PREFIX + id, entry.getValue());
         }
         PrefUtils.savePreferenceStore(store);
         return super.performOk();
@@ -218,24 +279,26 @@ public class PrefPageConfirmations extends AbstractPrefPage implements IWorkbenc
 
     @Override
     protected void performDefaults() {
-        // All elements true by default
+        // All elements are true by default
         for (ConfirmationWithStatus confirmation : confirmations) {
-            if (!confirmation.enabled) {
-                confirmation.enabled = true;
-                changedConfirmations.put(confirmation.confirmation, Boolean.TRUE);
+            if (!ConfirmationDialog.PROMPT.equals(confirmation.status)) {
+                confirmation.status = ConfirmationDialog.PROMPT;
+                changedConfirmations.put(confirmation.confirmation, ConfirmationDialog.PROMPT);
             }
         }
+        tableViewer.refresh();
+        UIUtils.asyncExec(() -> UIUtils.packColumns(confirmTable, true));
         super.performDefaults();
     }
 
     private class ConfirmationWithStatus {
 
         private ConfirmationDescriptor confirmation;
-        private boolean enabled;
+        private String status;
 
-        ConfirmationWithStatus(ConfirmationDescriptor confirmation, boolean enabled) {
+        ConfirmationWithStatus(ConfirmationDescriptor confirmation, String status) {
             this.confirmation = confirmation;
-            this.enabled = enabled;
+            this.status = status;
         }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/dialogs/ConfirmationDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/dialogs/ConfirmationDialog.java
@@ -85,12 +85,17 @@ public class ConfirmationDialog extends MessageDialogWithToggle {
     {
         DBPPreferenceStore prefStore = DBWorkbench.getPlatform().getPreferenceStore();
         if (toggleMessage != null) {
-            String storeString = prefStore.getString(key);
-            if (ConfirmationDialog.ALWAYS.equals(storeString) || !CommonUtils.getBoolean(storeString, true)) {
+            if (ConfirmationDialog.ALWAYS.equals(prefStore.getString(key))) {
                 if (kind == QUESTION || kind == QUESTION_WITH_CANCEL) {
                     return IDialogConstants.YES_ID;
                 } else {
                     return IDialogConstants.OK_ID;
+                }
+            } else if (ConfirmationDialog.NEVER.equals(prefStore.getString(key))) {
+                if (kind == QUESTION || kind == QUESTION_WITH_CANCEL) {
+                    return IDialogConstants.NO_ID;
+                } else {
+                    return IDialogConstants.CANCEL_ID;
                 }
             }
         }
@@ -215,10 +220,12 @@ public class ConfirmationDialog extends MessageDialogWithToggle {
         IPreferenceStore prefStore = getPrefStore();
         String prefKey = getPrefKey();
 
-        if (buttonId != IDialogConstants.CANCEL_ID && getToggleState()
-            && prefStore != null && CommonUtils.isNotEmpty(prefKey)) {
-            // Do not ask again in this case
-            prefStore.setValue(prefKey, Boolean.FALSE.toString());
+        if (buttonId != IDialogConstants.CANCEL_ID && getToggleState() && prefStore != null && CommonUtils.isNotEmpty(prefKey)) {
+            if (buttonId == IDialogConstants.NO_ID) {
+                prefStore.setValue(prefKey, ConfirmationDialog.NEVER);
+            } else {
+                prefStore.setValue(prefKey, ConfirmationDialog.ALWAYS);
+            }
         }
     }
 }


### PR DESCRIPTION
Change Confirmations page dialog behavior - keep the status of the confirmation dialog

![2023-03-30 14_33_40-DBeaver Ultimate 23 0 1 - _language](https://user-images.githubusercontent.com/45152336/228830373-527df6d8-3284-49aa-9698-71fd911a01a6.png)

Important - the "Confirm" column values are not editable if the "Show" column has been checked (we can't store value from the "Confirm" status then)

Behavior for now:

A confirmation dialog will be shown if the "Show dialog" button is enabled. The "Confirm" button is also enabled in this case.
If the "Show dialog" button is enabled, the "Confirm" button status will be used instead of the dialog showing. 
If the "Confirm" button is enabled - it means always do the action (ex: Revert changes during the object refresh). 
If disabled - it means "Never" (ex: Do not revert changes after object refreshing enabled action - do not refresh, wait for the user actions)
