### PR TITLE
dbeaver/pro#1311 improve accessibility erd

### DIFF
--- a/plugins/org.jkiss.dbeaver.erd.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.erd.ui/OSGI-INF/l10n/bundle.properties
@@ -24,6 +24,17 @@ command.org.jkiss.dbeaver.erd.diagram.saveAs.description = Save diagram in exter
 command.org.jkiss.dbeaver.erd.toggleHand.name = Toggle hand tool
 command.org.jkiss.dbeaver.erd.toggleHand.description = Cycle through hand tool and previously used tool
 
+command.org.jkiss.dbeaver.erd.focus.diagram.name = Focus on diagram
+command.org.jkiss.dbeaver.erd.focus.palette.name = Focus on palette
+command.org.jkiss.dbeaver.erd.focus.outline.name = Focus on outline
+command.org.jkiss.dbeaver.erd.focus.parameters.name = Focus on parameters
+
+command.org.jkiss.dbeaver.erd.focus.diagram.description = Changes focus to diagram
+command.org.jkiss.dbeaver.erd.focus.palette.description = Changes focus to palette
+command.org.jkiss.dbeaver.erd.focus.outline.description = Changes focus to outline
+command.org.jkiss.dbeaver.erd.focus.parameters.description = Changes focus to parameters
+
+
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.erd.label = ER Diagrams
 themeElementCategory.org.jkiss.dbeaver.ui.presentation.erd.description = ER Diagrams
 

--- a/plugins/org.jkiss.dbeaver.erd.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.erd.ui/plugin.xml
@@ -411,6 +411,11 @@
         <command id="org.jkiss.dbeaver.erd.diagram.create" name="%command.org.jkiss.dbeaver.erd.diagram.create.name" description="%command.org.jkiss.dbeaver.erd.diagram.create.description" categoryId="org.jkiss.dbeaver.core.navigator"/>
         <command id="org.jkiss.dbeaver.erd.diagram.saveAs" name="%command.org.jkiss.dbeaver.erd.diagram.saveAs.name" description="%command.org.jkiss.dbeaver.erd.diagram.saveAs.description" categoryId="org.eclipse.gef3.category.view"/>
         <command id="org.jkiss.dbeaver.erd.toggleHand" name="%command.org.jkiss.dbeaver.erd.toggleHand.name" description="%command.org.jkiss.dbeaver.erd.toggleHand.description" categoryId="org.eclipse.gef3.category.view"/>
+
+        <command id="org.jkiss.dbeaver.erd.focus.diagram" name="%command.org.jkiss.dbeaver.erd.focus.diagram.name" description="%command.org.jkiss.dbeaver.erd.focus.diagram.description" categoryId="org.eclipse.gef3.category.view"/>
+        <command id="org.jkiss.dbeaver.erd.focus.palette" name="%command.org.jkiss.dbeaver.erd.focus.palette.name" description="%command.org.jkiss.dbeaver.erd.focus.palette.description" categoryId="org.eclipse.gef3.category.view"/>
+        <command id="org.jkiss.dbeaver.erd.focus.outline" name="%command.org.jkiss.dbeaver.erd.focus.outline.name" description="%command.org.jkiss.dbeaver.erd.focus.outline.description" categoryId="org.eclipse.gef3.category.view"/>
+        <command id="org.jkiss.dbeaver.erd.focus.parameter" name="%command.org.jkiss.dbeaver.erd.focus.parameters.name" description="%command.org.jkiss.dbeaver.erd.focus.parameters.description" categoryId="org.eclipse.gef3.category.view"/>
     </extension>
 
     <extension point="org.eclipse.ui.commandImages">
@@ -421,7 +426,12 @@
     </extension>
 
     <extension point="org.eclipse.ui.bindings">
+        <key commandId="org.jkiss.dbeaver.erd.focus.diagram" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+1"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.palette" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+2"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.outline" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+3"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.parameter" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+4"/>
         <key commandId="org.jkiss.dbeaver.erd.toggleHand" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="TAB"/>
+        <key commandId="org.jkiss.dbeaver.erd.diagram.view" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+ENTER"/>
     </extension>
 
     <extension point="org.eclipse.ui.handlers">
@@ -445,6 +455,10 @@
                 </with>
             </enabledWhen>
         </handler>
+        <handler commandId="org.jkiss.dbeaver.erd.focus.diagram" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus"/>
+        <handler commandId="org.jkiss.dbeaver.erd.focus.palette" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus"/>
+        <handler commandId="org.jkiss.dbeaver.erd.focus.outline" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus"/>
+        <handler commandId="org.jkiss.dbeaver.erd.focus.parameter" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus"/>
     </extension>
 
     <extension point="org.eclipse.ui.menus">

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/ERDUIUtils.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/ERDUIUtils.java
@@ -18,6 +18,7 @@ package org.jkiss.dbeaver.erd.ui;
 
 import org.eclipse.gef3.palette.PaletteContainer;
 import org.eclipse.gef3.palette.PaletteEntry;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
@@ -28,6 +29,7 @@ import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.erd.model.ERDEntityAttribute;
 import org.jkiss.dbeaver.erd.model.ERDObject;
 import org.jkiss.dbeaver.erd.ui.editor.ERDViewStyle;
+import org.jkiss.dbeaver.erd.ui.internal.ERDUIMessages;
 import org.jkiss.dbeaver.erd.ui.model.EntityDiagram;
 import org.jkiss.dbeaver.model.navigator.DBNDatabaseNode;
 import org.jkiss.dbeaver.model.navigator.DBNUtils;
@@ -105,27 +107,33 @@ public class ERDUIUtils {
         String attributeLabel = attribute.getName();
         if (includeType && diagram.hasAttributeStyle(ERDViewStyle.TYPES)) {
             if (accessible) {
-                attributeLabel += "Attribute type: ";
+                attributeLabel += NLS.bind(ERDUIMessages.erd_accessibility_attribute_part_type, attribute.getObject().getFullTypeName());
+            } else {
+                attributeLabel += ": " + attribute.getObject().getFullTypeName();
             }
-            attributeLabel += ": " + attribute.getObject().getFullTypeName();
         }
         if (includeType && diagram.hasAttributeStyle(ERDViewStyle.NULLABILITY)) {
-            if (accessible) {
-                attributeLabel += "Attribute Nullability: ";
-            }
+            String type = "";
             if (attribute.getObject().isRequired()) {
-                attributeLabel += " NOT NULL";
+                type += " NOT NULL";
             } else if (accessible) {
-                attributeLabel += " CAN BE NULL";
+                type += " CAN BE NULL";
             }
+            if (accessible) {
+                attributeLabel += NLS.bind(ERDUIMessages.erd_accessibility_attribute_part_nullability, type);
+            } else {
+                attributeLabel += type;
+            }
+
         }
         if (diagram.hasAttributeStyle(ERDViewStyle.COMMENTS)) {
             String comment = attribute.getObject().getDescription();
             if (!CommonUtils.isEmpty(comment)) {
                 if (accessible) {
-                    attributeLabel += "Attribute Comments: ";
+                    attributeLabel += NLS.bind(ERDUIMessages.erd_accessibility_attribute_part_comments, comment);
+                } else {
+                    attributeLabel += " - " + comment;
                 }
-                attributeLabel += " - " + comment;
             }
         }
         return attributeLabel;

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/ERDUIUtils.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/ERDUIUtils.java
@@ -90,7 +90,7 @@ public class ERDUIUtils {
                 propsView.setFocus();
             }
         } catch (PartInitException e) {
-            DBWorkbench.getPlatformUI().showError("Object open", "Can't open property view", e);
+            DBWorkbench.getPlatformUI().showError("Object open", "Can't open outline view", e);
         }
     }
 
@@ -98,6 +98,14 @@ public class ERDUIUtils {
         return getFullAttributeLabel(diagram, attribute, includeType, false);
     }
 
+    /**
+     *
+     * @param diagram diagram
+     * @param attribute attribute to provide label from
+     * @param includeType is type included in the label
+     * @param accessible is accessibility text needed
+     * @return attribute label
+     */
     public static String getFullAttributeLabel(
         EntityDiagram diagram,
         ERDEntityAttribute attribute,

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/action/ERDHandlerFocus.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/action/ERDHandlerFocus.java
@@ -31,10 +31,11 @@ import org.jkiss.dbeaver.erd.ui.editor.ERDEditorPart;
 
 public class ERDHandlerFocus extends AbstractHandler {
     
-    private static final String DIAGRAM_FOCUS= "org.jkiss.dbeaver.erd.focus.diagram";
-    private static final String PALETTE_FOCUS= "org.jkiss.dbeaver.erd.focus.palette";
-    private static final String OUTLINE_FOCUS= "org.jkiss.dbeaver.erd.focus.outline";
+    private static final String DIAGRAM_FOCUS = "org.jkiss.dbeaver.erd.focus.diagram";
+    private static final String PALETTE_FOCUS = "org.jkiss.dbeaver.erd.focus.palette";
+    private static final String OUTLINE_FOCUS = "org.jkiss.dbeaver.erd.focus.outline";
     private static final String PARAMETER_FOCUS= "org.jkiss.dbeaver.erd.focus.parameter";
+
     @Override
     public Object execute(ExecutionEvent event) throws ExecutionException {
         ERDEditorPart part = getPart(event);
@@ -47,7 +48,7 @@ public class ERDHandlerFocus extends AbstractHandler {
                 break;
             case PALETTE_FOCUS:
                 Object adapter = part.getAdapter(PalettePage.class);
-                if(adapter instanceof EditDomain && ((EditDomain) adapter).getPaletteViewer() != null) {
+                if (adapter instanceof EditDomain && ((EditDomain) adapter).getPaletteViewer() != null) {
                     ((EditDomain) adapter).getPaletteViewer().getControl().setFocus();
                 }
                 break;

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/action/ERDHandlerFocus.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/action/ERDHandlerFocus.java
@@ -1,0 +1,80 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.erd.ui.action;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.gef3.EditDomain;
+import org.eclipse.gef3.ui.views.palette.PalettePage;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.ISources;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.jkiss.dbeaver.erd.ui.ERDUIUtils;
+import org.jkiss.dbeaver.erd.ui.editor.ERDEditorAdapter;
+import org.jkiss.dbeaver.erd.ui.editor.ERDEditorPart;
+
+
+public class ERDHandlerFocus extends AbstractHandler {
+    
+    private static final String DIAGRAM_FOCUS= "org.jkiss.dbeaver.erd.focus.diagram";
+    private static final String PALETTE_FOCUS= "org.jkiss.dbeaver.erd.focus.palette";
+    private static final String OUTLINE_FOCUS= "org.jkiss.dbeaver.erd.focus.outline";
+    private static final String PARAMETER_FOCUS= "org.jkiss.dbeaver.erd.focus.parameter";
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        ERDEditorPart part = getPart(event);
+        if (part == null) {
+            return null;
+        }
+        switch (event.getCommand().getId()) {
+            case DIAGRAM_FOCUS:
+                part.getViewer().getControl().forceFocus();
+                break;
+            case PALETTE_FOCUS:
+                Object adapter = part.getAdapter(PalettePage.class);
+                if(adapter instanceof EditDomain && ((EditDomain) adapter).getPaletteViewer() != null) {
+                    ((EditDomain) adapter).getPaletteViewer().getControl().setFocus();
+                }
+                break;
+            case OUTLINE_FOCUS:
+                ERDUIUtils.openOutline();
+                break;
+            case PARAMETER_FOCUS:
+                ERDUIUtils.openProperties();
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + event.getCommand().getId());
+        }
+        return null;
+    }
+
+    private ERDEditorPart getPart(ExecutionEvent event) {
+        ERDEditorPart editor = null;
+        Control control = (Control) HandlerUtil.getVariable(event, ISources.ACTIVE_FOCUS_CONTROL_NAME);
+        if (control != null) {
+            editor = ERDEditorAdapter.getEditor(control);
+        }
+        if (editor == null) {
+            Object activeEditor = HandlerUtil.getVariable(event, ISources.ACTIVE_EDITOR_NAME);
+            if (activeEditor != null) {
+                editor = new ERDEditorAdapter().getAdapter(activeEditor, ERDEditorPart.class);
+            }
+        }
+        return editor;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/editor/ERDEditorContextMenuProvider.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/editor/ERDEditorContextMenuProvider.java
@@ -24,7 +24,10 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.IWorkbenchCommandConstants;
+import org.jkiss.dbeaver.erd.ui.ERDUIConstants;
 import org.jkiss.dbeaver.erd.ui.action.DiagramLayoutAction;
+import org.jkiss.dbeaver.erd.ui.action.DiagramToggleGridAction;
+import org.jkiss.dbeaver.erd.ui.action.DiagramTogglePersistAction;
 import org.jkiss.dbeaver.ui.ActionUtils;
 import org.jkiss.dbeaver.ui.IActionConstants;
 import org.jkiss.dbeaver.ui.navigator.NavigatorCommands;
@@ -68,7 +71,10 @@ public class ERDEditorContextMenuProvider extends MenuManager implements IMenuLi
             menu.add(new Separator());
             editor.fillAttributeVisibilityMenu(menu);
             menu.add(new DiagramLayoutAction(editor));
-
+            menu.add(new DiagramToggleGridAction());
+            if (editor instanceof ERDEditorEmbedded) {
+                menu.add(new DiagramTogglePersistAction((ERDEditorEmbedded) editor));
+            }
             menu.add(new Separator());
 
             menu.add(ActionUtils.makeCommandContribution(editor.getSite(), IWorkbenchCommandConstants.EDIT_COPY));
@@ -77,7 +83,7 @@ public class ERDEditorContextMenuProvider extends MenuManager implements IMenuLi
             }
 
             menu.add(new Separator());
-
+            menu.add(ActionUtils.makeCommandContribution(editor.getSite(), ERDUIConstants.CMD_SAVE_AS));
             menu.add(new GroupMarker(NavigatorCommands.GROUP_TOOLS));
 //            menu.add(new GroupMarker(NavigatorCommands.GROUP_NAVIGATOR_ADDITIONS));
 //            menu.add(new GroupMarker(NavigatorCommands.GROUP_NAVIGATOR_ADDITIONS_END));

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/editor/ERDEditorPart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/editor/ERDEditorPart.java
@@ -34,7 +34,6 @@ import org.eclipse.gef3.ui.actions.*;
 import org.eclipse.gef3.ui.palette.FlyoutPaletteComposite;
 import org.eclipse.gef3.ui.palette.PaletteViewerProvider;
 import org.eclipse.gef3.ui.parts.GraphicalEditorWithFlyoutPalette;
-import org.eclipse.gef3.ui.parts.GraphicalViewerKeyHandler;
 import org.eclipse.gef3.ui.properties.UndoablePropertySheetEntry;
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -81,10 +80,7 @@ import org.jkiss.dbeaver.erd.ui.model.ERDContentProviderDecorated;
 import org.jkiss.dbeaver.erd.ui.model.ERDDecorator;
 import org.jkiss.dbeaver.erd.ui.model.ERDDecoratorDefault;
 import org.jkiss.dbeaver.erd.ui.model.EntityDiagram;
-import org.jkiss.dbeaver.erd.ui.part.DiagramPart;
-import org.jkiss.dbeaver.erd.ui.part.EntityPart;
-import org.jkiss.dbeaver.erd.ui.part.NodePart;
-import org.jkiss.dbeaver.erd.ui.part.NotePart;
+import org.jkiss.dbeaver.erd.ui.part.*;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBPDataSourceTask;
 import org.jkiss.dbeaver.model.DBPNamedObject;
@@ -486,7 +482,7 @@ public abstract class ERDEditorPart extends GraphicalEditorWithFlyoutPalette
         // configure the viewer
         viewer.getControl().setBackground(UIUtils.getColorRegistry().get(ERDUIConstants.COLOR_ERD_DIAGRAM_BACKGROUND));
         viewer.setRootEditPart(rootPart);
-        viewer.setKeyHandler(new GraphicalViewerKeyHandler(viewer));
+        viewer.setKeyHandler(new DBeaverNavigationKeyHandler(viewer));
 
         registerDropTargetListeners(viewer);
 
@@ -617,7 +613,7 @@ public abstract class ERDEditorPart extends GraphicalEditorWithFlyoutPalette
      */
     protected ERDOutlinePage getOverviewOutlinePage()
     {
-        if (null == outlinePage && null != getGraphicalViewer()) {
+        if ((null == outlinePage || outlinePage.getControl().isDisposed()) && null != getGraphicalViewer()) {
             RootEditPart rootEditPart = getGraphicalViewer().getRootEditPart();
             if (rootEditPart instanceof ScalableFreeformRootEditPart) {
                 outlinePage = new ERDOutlinePage((ScalableFreeformRootEditPart) rootEditPart);

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/internal/ERDUIMessages.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/internal/ERDUIMessages.java
@@ -129,6 +129,18 @@ public class ERDUIMessages extends NLS {
 
 	public static String erd_entity_add_command_select_table_dialog;
 
+	public static String erd_accessibility_note_part;
+	public static String erd_accessibility_entity_part;
+	public static String erd_accessibility_attribute_part;
+
+	public static String erd_accessibility_association_part_logical;
+	public static String erd_accessibility_association_part;
+	public static String erd_accessibility_association_part_attribute;
+
+	public static String erd_accessibility_attribute_part_type;
+	public static String erd_accessibility_attribute_part_nullability;
+	public static String erd_accessibility_attribute_part_comments;
+
 	private ERDUIMessages() {
 	}
 }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/internal/ERDUIMessages.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/internal/ERDUIMessages.java
@@ -21,126 +21,126 @@ package org.jkiss.dbeaver.erd.ui.internal;
 import org.eclipse.osgi.util.NLS;
 
 public class ERDUIMessages extends NLS {
-	static final String BUNDLE_NAME = "org.jkiss.dbeaver.erd.ui.internal.ERDUIMessages"; //$NON-NLS-1$
+    static final String BUNDLE_NAME = "org.jkiss.dbeaver.erd.ui.internal.ERDUIMessages"; //$NON-NLS-1$
 
     static {
-		// initialize resource bundle
-		NLS.initializeMessages(BUNDLE_NAME, ERDUIMessages.class);
-	}
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, ERDUIMessages.class);
+    }
 
     public static String action_diagram_layout_name;
-	public static String column_;
+    public static String column_;
     public static String entity_diagram_;
     public static String part_note_title;
-	public static String pref_page_erd_checkbox_grid_enabled;
-	public static String pref_page_erd_checkbox_snap_to_grid;
+    public static String pref_page_erd_checkbox_grid_enabled;
+    public static String pref_page_erd_checkbox_snap_to_grid;
     public static String pref_page_erd_combo_page_mode;
-	public static String pref_page_erd_group_grid;
-	public static String pref_page_erd_group_print;
-	public static String pref_page_erd_item_fit_height;
-	public static String pref_page_erd_item_fit_page;
-	public static String pref_page_erd_item_fit_width;
-	public static String pref_page_erd_item_tile;
-	public static String pref_page_erd_spinner_grid_height;
-	public static String pref_page_erd_spinner_grid_width;
-	public static String pref_page_erd_spinner_margin_bottom;
-	public static String pref_page_erd_spinner_margin_left;
-	public static String pref_page_erd_spinner_margin_right;
-	public static String pref_page_erd_spinner_margin_top;
+    public static String pref_page_erd_group_grid;
+    public static String pref_page_erd_group_print;
+    public static String pref_page_erd_item_fit_height;
+    public static String pref_page_erd_item_fit_page;
+    public static String pref_page_erd_item_fit_width;
+    public static String pref_page_erd_item_tile;
+    public static String pref_page_erd_spinner_grid_height;
+    public static String pref_page_erd_spinner_grid_width;
+    public static String pref_page_erd_spinner_margin_bottom;
+    public static String pref_page_erd_spinner_margin_left;
+    public static String pref_page_erd_spinner_margin_right;
+    public static String pref_page_erd_spinner_margin_top;
 
     public static String wizard_diagram_create_title;
 
-	public static String wizard_page_diagram_create_description;
-	public static String wizard_page_diagram_create_group_settings;
-	public static String wizard_page_diagram_create_label_init_content;
-	public static String wizard_page_diagram_create_name;
-	public static String wizard_page_diagram_create_title;
+    public static String wizard_page_diagram_create_description;
+    public static String wizard_page_diagram_create_group_settings;
+    public static String wizard_page_diagram_create_label_init_content;
+    public static String wizard_page_diagram_create_name;
+    public static String wizard_page_diagram_create_title;
 
-	//ERD editor action item control
-	public static String erd_editor_control_action_toggle_grid;
-	public static String erd_editor_control_action_refresh_diagram;
-	public static String erd_editor_control_action_print_diagram;
-	public static String erd_editor_control_action_configuration;
-	//ERD editor action item control
+    //ERD editor action item control
+    public static String erd_editor_control_action_toggle_grid;
+    public static String erd_editor_control_action_refresh_diagram;
+    public static String erd_editor_control_action_print_diagram;
+    public static String erd_editor_control_action_configuration;
+    //ERD editor action item control
 
-	public static String erd_preference_page_title_routing;
-	public static String erd_preference_page_title_attribute_style;
-	public static String erd_preference_page_title_attributes_visibility;
-	public static String erd_preference_page_title_diagram_contents;
-	public static String erd_preference_page_title_shows_views;
-	public static String erd_preference_page_title_shows_partitions;
-	public static String erd_preference_page_title_routing_combo;
-	public static String erd_preference_page_title_color_pref;
-	public static String erd_preference_page_title_change_border_colors;
-	public static String erd_preference_page_title_change_header_colors;
-	public static String erd_tool_color_action_text_set_color;
+    public static String erd_preference_page_title_routing;
+    public static String erd_preference_page_title_attribute_style;
+    public static String erd_preference_page_title_attributes_visibility;
+    public static String erd_preference_page_title_diagram_contents;
+    public static String erd_preference_page_title_shows_views;
+    public static String erd_preference_page_title_shows_partitions;
+    public static String erd_preference_page_title_routing_combo;
+    public static String erd_preference_page_title_color_pref;
+    public static String erd_preference_page_title_change_border_colors;
+    public static String erd_preference_page_title_change_header_colors;
+    public static String erd_tool_color_action_text_set_color;
     public static String erd_tool_color_action_tip_text_set_figure_color;
-	public static String erd_tool_color_action_text_reset_color;
-	public static String erd_tool_color_action_tip_text_reset_figure_color;
+    public static String erd_tool_color_action_text_reset_color;
+    public static String erd_tool_color_action_tip_text_reset_figure_color;
     public static String erd_tool_create_connection;
-	public static String erd_tool_create_connection_tip;
-	public static String erd_tool_create_note;
-	public static String erd_tool_create_note_tip;
-	public static String erd_tool_create_default;
+    public static String erd_tool_create_connection_tip;
+    public static String erd_tool_create_note;
+    public static String erd_tool_create_note_tip;
+    public static String erd_tool_create_default;
     public static String erd_tool_set_text_text_bring_to_front;
     public static String erd_tool_set_text_text_send_to_back;
     public static String erd_tool_set_text_tip_text_bring_to_front;
     public static String erd_tool_set_text_tip_text_send_to_back;
 
-	public static String erd_view_style_selection_item_comments;
-	public static String erd_view_style_selection_item_comments_action;
-	public static String erd_view_style_selection_item_data_types;
-	public static String erd_view_style_selection_item_data_types_action;
-	public static String erd_view_style_selection_item_fully_qualified_names;
-	public static String erd_view_style_selection_item_fully_qualified_names_action;
-	public static String erd_view_style_selection_item_icons;
-	public static String erd_view_style_selection_item_icons_action;
-	public static String erd_view_style_selection_item_nullability;
-	public static String erd_view_style_selection_item_nullability_action;
-	public static String erd_view_style_selection_item_alphabetical_order;
-	public static String erd_view_style_selection_item_alphabetical_order_action;
-	public static String menu_view_style;
-	public static String menu_attribute_visibility;
-	public static String menu_attribute_visibility_default;
-	public static String menu_attribute_visibility_entity;
+    public static String erd_view_style_selection_item_comments;
+    public static String erd_view_style_selection_item_comments_action;
+    public static String erd_view_style_selection_item_data_types;
+    public static String erd_view_style_selection_item_data_types_action;
+    public static String erd_view_style_selection_item_fully_qualified_names;
+    public static String erd_view_style_selection_item_fully_qualified_names_action;
+    public static String erd_view_style_selection_item_icons;
+    public static String erd_view_style_selection_item_icons_action;
+    public static String erd_view_style_selection_item_nullability;
+    public static String erd_view_style_selection_item_nullability_action;
+    public static String erd_view_style_selection_item_alphabetical_order;
+    public static String erd_view_style_selection_item_alphabetical_order_action;
+    public static String menu_view_style;
+    public static String menu_attribute_visibility;
+    public static String menu_attribute_visibility_default;
+    public static String menu_attribute_visibility_entity;
 
-	public static String erd_settings_action_customize;
-	public static String erd_settings_action_customize_tip;
-	public static String erd_settings_dialog_text_title;
-	public static String erd_settings_dialog_group_label;
-	public static String erd_settings_checkbox_transparent_label;
-	public static String erd_settings_checkbox_transparent_tip;
-	public static String erd_settings_color_picker_background_label;
-	public static String erd_settings_color_picker_foreground_label;
-	public static String erd_settings_border_width_label;
-	public static String erd_settings_font_label;
-	public static String erd_settings_button_change_font_label;
-	public static String erd_settings_font_preview_text;
+    public static String erd_settings_action_customize;
+    public static String erd_settings_action_customize_tip;
+    public static String erd_settings_dialog_text_title;
+    public static String erd_settings_dialog_group_label;
+    public static String erd_settings_checkbox_transparent_label;
+    public static String erd_settings_checkbox_transparent_tip;
+    public static String erd_settings_color_picker_background_label;
+    public static String erd_settings_color_picker_foreground_label;
+    public static String erd_settings_border_width_label;
+    public static String erd_settings_font_label;
+    public static String erd_settings_button_change_font_label;
+    public static String erd_settings_font_preview_text;
 
-	public static String erd_action_delete_text;
-	public static String erd_action_remove_text;
-	public static String erd_action_diagram_toggle_persist_text;
-	public static String erd_action_diagram_toggle_persist_description;
-	public static String erd_action_diagram_toggle_persist_confirmation_title;
-	public static String erd_action_diagram_toggle_persist_confirmation_description;
-	public static String erd_action_diagram_toggle_hand_checkbox_text;
+    public static String erd_action_delete_text;
+    public static String erd_action_remove_text;
+    public static String erd_action_diagram_toggle_persist_text;
+    public static String erd_action_diagram_toggle_persist_description;
+    public static String erd_action_diagram_toggle_persist_confirmation_title;
+    public static String erd_action_diagram_toggle_persist_confirmation_description;
+    public static String erd_action_diagram_toggle_hand_checkbox_text;
 
-	public static String erd_navigator_entity_diagram_name;
+    public static String erd_navigator_entity_diagram_name;
 
-	public static String erd_entity_add_command_select_table_dialog;
+    public static String erd_entity_add_command_select_table_dialog;
 
-	public static String erd_accessibility_note_part;
-	public static String erd_accessibility_entity_part;
-	public static String erd_accessibility_attribute_part;
+    public static String erd_accessibility_note_part;
+    public static String erd_accessibility_entity_part;
+    public static String erd_accessibility_attribute_part;
 
-	public static String erd_accessibility_association_part_logical;
-	public static String erd_accessibility_association_part;
-	public static String erd_accessibility_association_part_attribute;
+    public static String erd_accessibility_association_part_logical;
+    public static String erd_accessibility_association_part;
+    public static String erd_accessibility_association_part_attribute;
 
-	public static String erd_accessibility_attribute_part_type;
-	public static String erd_accessibility_attribute_part_nullability;
-	public static String erd_accessibility_attribute_part_comments;
+    public static String erd_accessibility_attribute_part_type;
+    public static String erd_accessibility_attribute_part_nullability;
+    public static String erd_accessibility_attribute_part_comments;
 
-	private ERDUIMessages() {
-	}
+    private ERDUIMessages() {
+    }
 }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/internal/ERDUIMessages.properties
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/internal/ERDUIMessages.properties
@@ -100,3 +100,15 @@ erd_action_diagram_toggle_hand_checkbox_text = Toggle Hand Tool
 erd_navigator_entity_diagram_name = <Diagram>
 
 erd_entity_add_command_select_table_dialog = Select a table
+
+erd_accessibility_note_part = Note with following contents: {0}
+erd_accessibility_entity_part = Table name {0}, table contains: {1} attribute, is source of {2} associations and target of {3} associations
+erd_accessibility_attribute_part = "Attribute: {0}"
+
+erd_accessibility_association_part_logical = Logical
+erd_accessibility_association_part = Association: {0}, source entity: {1}, has following source attributes: {2}, target entity: {3}, has following attributes: {4}
+erd_accessibility_association_part_attribute = Attribute name: {0}
+
+erd_accessibility_attribute_part_type = Attribute type: {0}
+erd_accessibility_attribute_part_nullability = Attribute nullability: {0}
+erd_accessibility_attribute_part_comments = Attribute comments: {0}

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AssociationPart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AssociationPart.java
@@ -27,11 +27,9 @@ import org.eclipse.draw2dl.geometry.Rectangle;
 import org.eclipse.gef3.*;
 import org.eclipse.gef3.editpolicies.ConnectionEndpointEditPolicy;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.graphics.Color;
-import org.jkiss.dbeaver.erd.model.ERDAssociation;
-import org.jkiss.dbeaver.erd.model.ERDAttributeVisibility;
-import org.jkiss.dbeaver.erd.model.ERDEntity;
-import org.jkiss.dbeaver.erd.model.ERDUtils;
+import org.jkiss.dbeaver.erd.model.*;
 import org.jkiss.dbeaver.erd.ui.ERDUIConstants;
 import org.jkiss.dbeaver.erd.ui.ERDUIUtils;
 import org.jkiss.dbeaver.erd.ui.editor.ERDGraphicalViewer;
@@ -62,6 +60,7 @@ public class AssociationPart extends PropertyAwareConnectionPart {
     private Integer oldLineWidth;
 
     private ERDHighlightingHandle associatedAttributesHighlighing = null;
+    private AccessibleGraphicalEditPart accPart;
 
     public AssociationPart() {
     }
@@ -414,4 +413,37 @@ public class AssociationPart extends PropertyAwareConnectionPart {
         }
     }
 
+    @Override
+    protected AccessibleEditPart getAccessibleEditPart() {
+        if (this.accPart == null) {
+            this.accPart = new AccessibleGraphicalEditPart() {
+                public void getName(AccessibleEvent e) {
+                    StringBuilder stringBuilder = new StringBuilder(100);
+                    ERDAssociation association = AssociationPart.this.getAssociation();
+                    if (association.isLogical()) {
+                        stringBuilder.append("Logical ");
+                    }
+                    stringBuilder.append("association: ").append(association.getName()).append(", ");
+                    stringBuilder.append("source entity: ").append(association.getSourceEntity().getName()).append(" ");
+                    stringBuilder.append("has following source attributes: ");
+                    for (ERDEntityAttribute sourceAttribute : association.getSourceAttributes()) {
+                        stringBuilder.append("Attribute name: ").append(sourceAttribute.getName()).append(" ");
+                    }
+                    stringBuilder.append("target entity: ").append(association.getTargetEntity().getName()).append(" ");
+                    stringBuilder.append("has following target attributes: ");
+                    for (ERDEntityAttribute targetAttribute : association.getTargetAttributes()) {
+                        stringBuilder.append("Attribute name: ").append(targetAttribute.getName());
+                    }
+
+                    e.result = stringBuilder.toString();
+                }
+
+                public void getDescription(AccessibleEvent e) {
+                    e.result = null;
+                }
+            };
+        }
+
+        return this.accPart;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AssociationPart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AssociationPart.java
@@ -26,6 +26,7 @@ import org.eclipse.draw2dl.geometry.PointList;
 import org.eclipse.draw2dl.geometry.Rectangle;
 import org.eclipse.gef3.*;
 import org.eclipse.gef3.editpolicies.ConnectionEndpointEditPolicy;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.graphics.Color;
@@ -36,6 +37,7 @@ import org.jkiss.dbeaver.erd.ui.editor.ERDGraphicalViewer;
 import org.jkiss.dbeaver.erd.ui.editor.ERDHighlightingHandle;
 import org.jkiss.dbeaver.erd.ui.editor.ERDViewStyle;
 import org.jkiss.dbeaver.erd.ui.internal.ERDUIActivator;
+import org.jkiss.dbeaver.erd.ui.internal.ERDUIMessages;
 import org.jkiss.dbeaver.erd.ui.policy.AssociationBendEditPolicy;
 import org.jkiss.dbeaver.erd.ui.policy.AssociationEditPolicy;
 import org.jkiss.dbeaver.model.DBIcon;
@@ -418,28 +420,30 @@ public class AssociationPart extends PropertyAwareConnectionPart {
         if (this.accPart == null) {
             this.accPart = new AccessibleGraphicalEditPart() {
                 public void getName(AccessibleEvent e) {
-                    StringBuilder stringBuilder = new StringBuilder(100);
                     ERDAssociation association = AssociationPart.this.getAssociation();
+                    String result = "";
                     if (association.isLogical()) {
-                        stringBuilder.append("Logical ");
+                        result += ERDUIMessages.erd_accessibility_association_part_logical;
                     }
-                    stringBuilder.append("association: ").append(association.getName()).append(", ");
-                    stringBuilder.append("source entity: ").append(association.getSourceEntity().getName()).append(" ");
-                    stringBuilder.append("has following source attributes: ");
+                    StringBuilder sourceString = new StringBuilder();
                     for (ERDEntityAttribute sourceAttribute : association.getSourceAttributes()) {
-                        stringBuilder.append("Attribute name: ").append(sourceAttribute.getName()).append(" ");
+                        sourceString.append(NLS.bind(ERDUIMessages.erd_accessibility_association_part_attribute,
+                            sourceAttribute.getName()));
                     }
-                    stringBuilder.append("target entity: ").append(association.getTargetEntity().getName()).append(" ");
-                    stringBuilder.append("has following target attributes: ");
+                    StringBuilder targetString = new StringBuilder();
                     for (ERDEntityAttribute targetAttribute : association.getTargetAttributes()) {
-                        stringBuilder.append("Attribute name: ").append(targetAttribute.getName());
+                        targetString.append(NLS.bind(
+                            ERDUIMessages.erd_accessibility_association_part_attribute,
+                            targetAttribute.getName()));
                     }
-
-                    e.result = stringBuilder.toString();
-                }
-
-                public void getDescription(AccessibleEvent e) {
-                    e.result = null;
+                    result += NLS.bind(ERDUIMessages.erd_accessibility_association_part, new Object[]{
+                        association.getName(),
+                        association.getSourceEntity().getName(),
+                        sourceString.toString(),
+                        association.getTargetEntity().getName(),
+                        targetString.toString()
+                    });
+                    e.result = result;
                 }
             };
         }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AttributePart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AttributePart.java
@@ -21,6 +21,7 @@ import org.eclipse.draw2dl.ConnectionAnchor;
 import org.eclipse.draw2dl.IFigure;
 import org.eclipse.gef3.*;
 import org.eclipse.gef3.tools.DragEditPartsTracker;
+import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.graphics.Color;
 import org.jkiss.dbeaver.erd.model.*;
 import org.jkiss.dbeaver.erd.ui.ERDUIConstants;
@@ -53,6 +54,7 @@ public class AttributePart extends NodePart {
     public static final String PROP_CHECKED = "CHECKED";
 
     private ERDHighlightingHandle associatedRelationsHighlighing = null;
+    private AccessibleGraphicalEditPart accPart;
 
     public AttributePart() {
 
@@ -288,5 +290,23 @@ public class AttributePart extends NodePart {
     @Override
     public ConnectionAnchor getTargetConnectionAnchor(Request request) {
         return new ChopboxAnchor(getFigure());
+    }
+
+    @Override
+    protected AccessibleEditPart getAccessibleEditPart() {
+        if (this.accPart == null) {
+            this.accPart = new AccessibleGraphicalEditPart() {
+                public void getName(AccessibleEvent e) {
+                    e.result =
+                        "Attribute: " + ERDUIUtils.getFullAttributeLabel(getDiagram(), getAttribute(), true, true);
+                }
+
+                public void getDescription(AccessibleEvent e) {
+                    e.result = null;
+                }
+            };
+        }
+
+        return this.accPart;
     }
 }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AttributePart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AttributePart.java
@@ -298,8 +298,8 @@ public class AttributePart extends NodePart {
         if (this.accPart == null) {
             this.accPart = new AccessibleGraphicalEditPart() {
                 public void getName(AccessibleEvent e) {
-                    e.result = NLS.bind(ERDUIMessages.erd_accessibility_attribute_part,ERDUIUtils.getFullAttributeLabel(getDiagram(), getAttribute(),
-                        true, true));
+                    e.result = NLS.bind(ERDUIMessages.erd_accessibility_attribute_part,
+                        ERDUIUtils.getFullAttributeLabel(getDiagram(), getAttribute(), true, true));
                 }
             };
         }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AttributePart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/AttributePart.java
@@ -21,6 +21,7 @@ import org.eclipse.draw2dl.ConnectionAnchor;
 import org.eclipse.draw2dl.IFigure;
 import org.eclipse.gef3.*;
 import org.eclipse.gef3.tools.DragEditPartsTracker;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.graphics.Color;
 import org.jkiss.dbeaver.erd.model.*;
@@ -297,12 +298,8 @@ public class AttributePart extends NodePart {
         if (this.accPart == null) {
             this.accPart = new AccessibleGraphicalEditPart() {
                 public void getName(AccessibleEvent e) {
-                    e.result =
-                        "Attribute: " + ERDUIUtils.getFullAttributeLabel(getDiagram(), getAttribute(), true, true);
-                }
-
-                public void getDescription(AccessibleEvent e) {
-                    e.result = null;
+                    e.result = NLS.bind(ERDUIMessages.erd_accessibility_attribute_part,ERDUIUtils.getFullAttributeLabel(getDiagram(), getAttribute(),
+                        true, true));
                 }
             };
         }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/DBeaverNavigationKeyHandler.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/DBeaverNavigationKeyHandler.java
@@ -1,0 +1,53 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.erd.ui.part;
+
+import org.eclipse.gef3.GraphicalViewer;
+import org.eclipse.gef3.ui.parts.GraphicalViewerKeyHandler;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyEvent;
+
+public class DBeaverNavigationKeyHandler extends GraphicalViewerKeyHandler {
+    public DBeaverNavigationKeyHandler(GraphicalViewer viewer) {
+        super(viewer);
+    }
+
+    boolean additionalAcceptIntoContainer(KeyEvent event) {
+        return event.keyCode == SWT.CR;
+    }
+
+    boolean additionalOutOfContainer(KeyEvent event) {
+        return event.keyCode == 8;
+    }
+
+    @Override
+    public boolean keyPressed(KeyEvent event) {
+        if (additionalAcceptIntoContainer(event)) {
+            if (getFocusEditPart() instanceof NotePart) {
+                ((NotePart) getFocusEditPart()).performDirectEdit();
+                return true;
+            }
+            event.stateMask = SWT.ALT;
+            event.keyCode = SWT.ARROW_DOWN;
+        }
+        if (additionalOutOfContainer(event)) {
+            event.stateMask = SWT.ALT;
+            event.keyCode = SWT.ARROW_UP;
+        }
+        return super.keyPressed(event);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/DBeaverNavigationKeyHandler.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/DBeaverNavigationKeyHandler.java
@@ -31,6 +31,7 @@ public class DBeaverNavigationKeyHandler extends GraphicalViewerKeyHandler {
     }
 
     boolean additionalOutOfContainer(KeyEvent event) {
+        // Backspace
         return event.keyCode == 8;
     }
 

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/EntityPart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/EntityPart.java
@@ -25,6 +25,7 @@ import org.eclipse.draw2dl.geometry.Point;
 import org.eclipse.draw2dl.geometry.Rectangle;
 import org.eclipse.gef3.*;
 import org.eclipse.gef3.tools.DirectEditManager;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.jkiss.dbeaver.erd.model.*;
 import org.jkiss.dbeaver.erd.ui.ERDUIConstants;
@@ -34,6 +35,7 @@ import org.jkiss.dbeaver.erd.ui.figures.AttributeItemFigure;
 import org.jkiss.dbeaver.erd.ui.figures.EditableLabel;
 import org.jkiss.dbeaver.erd.ui.figures.EntityFigure;
 import org.jkiss.dbeaver.erd.ui.internal.ERDUIActivator;
+import org.jkiss.dbeaver.erd.ui.internal.ERDUIMessages;
 import org.jkiss.dbeaver.erd.ui.model.EntityDiagram;
 import org.jkiss.dbeaver.erd.ui.policy.EntityConnectionEditPolicy;
 import org.jkiss.dbeaver.erd.ui.policy.EntityContainerEditPolicy;
@@ -349,13 +351,13 @@ public class EntityPart extends NodePart {
         if (this.accPart == null) {
             this.accPart = new AccessibleGraphicalEditPart() {
                 public void getName(AccessibleEvent e) {
-                    e.result =
-                        "Table name: " + EntityPart.this.getName() + " table contains : " + EntityPart.this.getEntity().getAttributes().size() + " attributes";
-                    e.result += " is source of " + sourceConnections.size() + " associations and target of " + targetConnections.size() + " associations";
-                }
+                    e.result = NLS.bind(ERDUIMessages.erd_accessibility_entity_part, new Object[]{
+                        EntityPart.this.getName(),
+                        EntityPart.this.getEntity().getAttributes().size(),
+                        sourceConnections == null ? 0 : sourceConnections.size(),
+                        targetConnections == null ? 0 : targetConnections.size(),
 
-                public void getDescription(AccessibleEvent e) {
-                    e.result = null;
+                    });
                 }
             };
         }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/EntityPart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/EntityPart.java
@@ -25,6 +25,7 @@ import org.eclipse.draw2dl.geometry.Point;
 import org.eclipse.draw2dl.geometry.Rectangle;
 import org.eclipse.gef3.*;
 import org.eclipse.gef3.tools.DirectEditManager;
+import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.jkiss.dbeaver.erd.model.*;
 import org.jkiss.dbeaver.erd.ui.ERDUIConstants;
 import org.jkiss.dbeaver.erd.ui.ERDUIUtils;
@@ -55,6 +56,7 @@ import java.util.Map;
  */
 public class EntityPart extends NodePart {
     protected DirectEditManager manager;
+    private AccessibleGraphicalEditPart accPart;
 
     public EntityPart() {
     }
@@ -340,5 +342,24 @@ public class EntityPart extends NodePart {
     @Override
     public ConnectionAnchor getTargetConnectionAnchor(Request request) {
         return new ChopboxAnchor(getFigure());
+    }
+
+    @Override
+    protected AccessibleEditPart getAccessibleEditPart() {
+        if (this.accPart == null) {
+            this.accPart = new AccessibleGraphicalEditPart() {
+                public void getName(AccessibleEvent e) {
+                    e.result =
+                        "Table name: " + EntityPart.this.getName() + " table contains : " + EntityPart.this.getEntity().getAttributes().size() + " attributes";
+                    e.result += " is source of " + sourceConnections.size() + " associations and target of " + targetConnections.size() + " associations";
+                }
+
+                public void getDescription(AccessibleEvent e) {
+                    e.result = null;
+                }
+            };
+        }
+
+        return this.accPart;
     }
 }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/NotePart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/NotePart.java
@@ -124,6 +124,9 @@ public class NotePart extends NodePart
         return figure.containsPoint(requestLoc);
     }
 
+    /**
+     * Open edit box
+     */
     public void performDirectEdit() {
         if (manager == null) {
             NoteFigure figure = (NoteFigure) getFigure();

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/NotePart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/NotePart.java
@@ -26,6 +26,7 @@ import org.eclipse.gef3.*;
 import org.eclipse.gef3.commands.Command;
 import org.eclipse.gef3.requests.DirectEditRequest;
 import org.eclipse.gef3.tools.DirectEditManager;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.jkiss.dbeaver.erd.model.ERDElement;
 import org.jkiss.dbeaver.erd.model.ERDNote;
@@ -33,6 +34,7 @@ import org.jkiss.dbeaver.erd.ui.ERDUIConstants;
 import org.jkiss.dbeaver.erd.ui.directedit.ExtendedDirectEditManager;
 import org.jkiss.dbeaver.erd.ui.directedit.FigureEditorLocator;
 import org.jkiss.dbeaver.erd.ui.figures.NoteFigure;
+import org.jkiss.dbeaver.erd.ui.internal.ERDUIMessages;
 import org.jkiss.dbeaver.erd.ui.model.EntityDiagram;
 import org.jkiss.dbeaver.erd.ui.policy.EntityConnectionEditPolicy;
 import org.jkiss.dbeaver.erd.ui.policy.NoteDirectEditPolicy;
@@ -283,11 +285,7 @@ public class NotePart extends NodePart
         if (this.accPart == null) {
             this.accPart = new AccessibleGraphicalEditPart() {
                 public void getName(AccessibleEvent e) {
-                    e.result = "Note with following contents: " + NotePart.this.getName();
-                }
-
-                public void getDescription(AccessibleEvent e) {
-                    e.result = null;
+                    e.result = NLS.bind(ERDUIMessages.erd_accessibility_note_part, NotePart.this.getName());
                 }
             };
         }

--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/NotePart.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/part/NotePart.java
@@ -26,6 +26,7 @@ import org.eclipse.gef3.*;
 import org.eclipse.gef3.commands.Command;
 import org.eclipse.gef3.requests.DirectEditRequest;
 import org.eclipse.gef3.tools.DirectEditManager;
+import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.jkiss.dbeaver.erd.model.ERDElement;
 import org.jkiss.dbeaver.erd.model.ERDNote;
 import org.jkiss.dbeaver.erd.ui.ERDUIConstants;
@@ -49,6 +50,7 @@ import java.beans.PropertyChangeEvent;
 public class NotePart extends NodePart
 {
     private DirectEditManager manager;
+    private AccessibleGraphicalEditPart accPart;
 
     public NotePart() {
     }
@@ -120,7 +122,7 @@ public class NotePart extends NodePart
         return figure.containsPoint(requestLoc);
     }
 
-    private void performDirectEdit() {
+    public void performDirectEdit() {
         if (manager == null) {
             NoteFigure figure = (NoteFigure) getFigure();
             manager = new ExtendedDirectEditManager(
@@ -274,5 +276,21 @@ public class NotePart extends NodePart
     @Override
     public ERDElement getElement() {
         return getNote();
+    }
+
+    @Override
+    protected AccessibleEditPart getAccessibleEditPart() {
+        if (this.accPart == null) {
+            this.accPart = new AccessibleGraphicalEditPart() {
+                public void getName(AccessibleEvent e) {
+                    e.result = "Note with following contents: " + NotePart.this.getName();
+                }
+
+                public void getDescription(AccessibleEvent e) {
+                    e.result = null;
+                }
+            };
+        }
+        return accPart;
     }
 }


### PR DESCRIPTION
Closes dbeaver/pro#1311
It contains the following changes:
1. NVDA accessibility(now tables, relations and attributes are voiced by it)
2. ENTER/BACKSPACE to focus on attributes in the table.
3. ALT + 1 - focus on diagram, ALT + 2 - focus on palette(can't expand closed palette due to gef limitations), ALT + 3 focus/open the outline, ALT + 4 focus on parameter view.
4. Context menu should now contain most of the toolbar bindings if they are not already bound on the keyboard.
5. CTRL + ENTER on the table opens its diagram

What was already supported by GEF in the scope of the ticket:
1. pressing `.` allows manipulating the diagram by moving or resizing it with the keyboards
2. Associations can be navigated with `|`, `?`, `\`
3. Multiple selection is already supported, `SHIFT + ARROWS`
4. Traversing using arrows 

What is not supported and requires additional tickets:
1. Requires additional changes for VQB
2. Can't add new table/relations without DnD
4. Palette expanding(possibly contribution to GEF)