### PR TITLE
#18330 actualize result set columns descriptions before export to XLSX

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.office/src/org/jkiss/dbeaver/data/office/export/DataExporterXLSX.java
+++ b/plugins/org.jkiss.dbeaver.data.office/src/org/jkiss/dbeaver/data/office/export/DataExporterXLSX.java
@@ -329,9 +329,13 @@ public class DataExporterXLSX extends StreamExporterAbstract implements IAppenda
     }
 
     @Override
-    public void exportHeader(DBCSession session) {
+    public void exportHeader(DBCSession session) throws DBException {
 
         columns = getSite().getAttributes();
+        if (headerFormat.hasDescription()) {
+            DBSEntity srcEntity = DBUtils.getAdapter(DBSEntity.class, getSite().getSource());
+            DBExecUtils.bindAttributes(session, srcEntity, null, columns, null);
+        }
         decorator = GeneralUtils.adapt(getSite().getSource(), DBDAttributeDecorator.class);
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/AttributeMetaDataProxy.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/AttributeMetaDataProxy.java
@@ -102,6 +102,10 @@ public class AttributeMetaDataProxy implements DBCAttributeMetaData, DBPImagePro
     @Nullable
     @Override
     public DBCEntityMetaData getEntityMetaData() {
+        DBSAttributeBase proxyAttribute = getProxyAttribute();
+        if (proxyAttribute instanceof DBCAttributeMetaData) {
+            return ((DBCAttributeMetaData) proxyAttribute).getEntityMetaData();
+        }
         return null;
     }
 


### PR DESCRIPTION
I can't reproduce export to CSV, so please check 

- [x] - export from the ResultSet to CSV with the header format: description
- [x] - export from the ResultSet to CSV with the header format: both
- [x] - export from the table to CSV with the header format: description
- [x] - export from the table to CSV with the header format: both
- [ ] - export from the ResultSet to XLSX with the header format: description
- [ ] - export from the ResultSet to XLSX with the header format: both
- [x] - export from the table to XLSX with the header format: description
- [x] - export from the table to XLSX with the header format: both