### PR TITLE
#18974 Allow toggling native formatting for special IEEE values

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/model/SQLiteSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/model/SQLiteSQLDialect.java
@@ -23,6 +23,8 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCDatabaseMetaData;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCDataSource;
 import org.jkiss.dbeaver.model.impl.sql.BasicSQLDialect;
+import org.jkiss.dbeaver.model.struct.DBSTypedObject;
+import org.jkiss.utils.CommonUtils;
 
 import java.util.Set;
 
@@ -31,6 +33,16 @@ public class SQLiteSQLDialect extends GenericSQLDialect {
     public SQLiteSQLDialect() {
         super("SQLite", "sqlite");
         addKeywords(Set.of("STRICT"), DBPKeywordType.OTHER);
+    }
+
+    @NotNull
+    @Override
+    public String escapeScriptValue(DBSTypedObject attribute, @NotNull Object value, @NotNull String strValue) {
+        if (CommonUtils.isNaN(value) || CommonUtils.isInfinite(value)) {
+            // SQLite doesn't have special literals for IEEE special values
+            return "'" + value + "'";
+        }
+        return super.escapeScriptValue(attribute, value, strValue);
     }
 
     public void initDriverSettings(JDBCSession session, JDBCDataSource dataSource, JDBCDatabaseMetaData metaData) {

--- a/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/model/data/SQLiteValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.sqlite/src/org/jkiss/dbeaver/ext/sqlite/model/data/SQLiteValueHandler.java
@@ -35,7 +35,9 @@ import org.jkiss.dbeaver.model.impl.jdbc.data.handlers.JDBCAbstractValueHandler;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.Date;
+import java.util.Locale;
 
 
 /**
@@ -77,6 +79,23 @@ public class SQLiteValueHandler extends JDBCAbstractValueHandler implements DBDV
     @Nullable
     @Override
     public Object getValueFromObject(@NotNull DBCSession session, @NotNull DBSTypedObject type, @Nullable Object object, boolean copy, boolean validateValue) throws DBCException {
+        if (object instanceof String && (type.getTypeID() == Types.REAL || type.getTypeID() == Types.DOUBLE)) {
+            switch (((String) object).toLowerCase(Locale.ROOT)) {
+                case "inf":
+                case "infinity":
+                case "+inf":
+                case "+infinity":
+                    return Double.POSITIVE_INFINITY;
+                case "-inf":
+                case "-infinity":
+                    return Double.NEGATIVE_INFINITY;
+                case "nan":
+                    return Double.NaN;
+                default:
+                    break;
+            }
+        }
+
         return object;
     }
 

--- a/plugins/org.jkiss.dbeaver.model/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.model/OSGI-INF/l10n/bundle.properties
@@ -53,6 +53,8 @@ DateFormatter.number.general.useTypeScale.label=Use data type scale for fraction
 DateFormatter.number.general.useTypeScale.description=Use column/attribute data type scale as minimum fraction digits number
 DateFormatter.number.general.roundingMode.label=Rounding mode
 DateFormatter.number.general.roundingMode.description=Rounding mode
+DateFormatter.number.general.nativeSpecialValues.label=Use native formatting for special values
+DateFormatter.number.general.nativeSpecialValues.description=Uses native formatting for special values (such as NaN, Infinity, -Infinity)
 
 meta.org.jkiss.dbeaver.model.DBPNamedObject.name.name=Name
 meta.org.jkiss.dbeaver.model.DBPScriptObject.objectDefinitionText.name=Definition

--- a/plugins/org.jkiss.dbeaver.model/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.model/plugin.xml
@@ -56,6 +56,7 @@
                 <property id="minFractionDigits" label="%DateFormatter.number.general.minFractDigits.label" type="integer" description="%DateFormatter.number.general.minFractDigits.description"/>
                 <property id="useTypeScale" label="%DateFormatter.number.general.useTypeScale.label" type="boolean" description="%DateFormatter.number.general.useTypeScale.description"/>
                 <property id="roundingMode" label="%DateFormatter.number.general.roundingMode.label" type="string" description="%DateFormatter.number.general.roundingMode.description" validValues="UP,DOWN,CEILING,FLOOR,HALF_UP,HALF_DOWN,HALF_EVEN,UNNECESSARY"/>
+                <property id="nativeSpecialValues" label="%DateFormatter.number.general.nativeSpecialValues.label" type="boolean" description="%DateFormatter.number.general.nativeSpecialValues.description"/>
             </propertyGroup>
         </formatter>
         <formatter id="timestamp" label="%DateFormatter.timestamp.label" class="org.jkiss.dbeaver.model.impl.data.formatters.DateTimeDataFormatter" sampleClass="org.jkiss.dbeaver.model.impl.data.formatters.TimestampFormatSample">

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/NumberDataFormatter.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/NumberDataFormatter.java
@@ -41,6 +41,7 @@ public class NumberDataFormatter implements DBDDataFormatter {
     private DecimalFormat numberFormat;
     private StringBuffer buffer;
     private FieldPosition position;
+    private boolean nativeSpecialValues;
 
     public NumberDataFormatter() {
     }
@@ -114,6 +115,7 @@ public class NumberDataFormatter implements DBDDataFormatter {
         }
         buffer = new StringBuffer();
         position = new FieldPosition(0);
+        nativeSpecialValues = CommonUtils.toBoolean(properties.get(NumberFormatSample.PROP_NATIVE_SPECIAL_VALUES));
     }
 
     @Nullable
@@ -129,6 +131,9 @@ public class NumberDataFormatter implements DBDDataFormatter {
     {
         if (value == null) {
             return null;
+        }
+        if (nativeSpecialValues && (CommonUtils.isNaN(value) || CommonUtils.isInfinite(value))) {
+            return value.toString();
         }
         try {
             synchronized (this) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/NumberFormatSample.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/NumberFormatSample.java
@@ -34,6 +34,7 @@ public class NumberFormatSample implements DBDDataFormatterSample {
     public static final String PROP_MIN_FRACT_DIGITS  ="minFractionDigits";
     public static final String PROP_USE_TYPE_SCALE  ="useTypeScale";
     public static final String PROP_ROUNDING_MODE ="roundingMode";
+    public static final String PROP_NATIVE_SPECIAL_VALUES = "nativeSpecialValues";
 
     @Override
     public Map<String, Object> getDefaultProperties(Locale locale)

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/handlers/JDBCNumberValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/jdbc/data/handlers/JDBCNumberValueHandler.java
@@ -70,18 +70,6 @@ public class JDBCNumberValueHandler extends JDBCAbstractValueHandler implements 
             // Binary string
             return (String)value;
         }
-        if (value instanceof Double) {
-            Double d = (Double) value;
-            if (d.isNaN() || d.isInfinite()) {
-                return d.toString();
-            }
-        }
-        if (value instanceof Float) {
-            Float f = (Float) value;
-            if (f.isNaN() || f.isInfinite()) {
-                return f.toString();
-            }
-        }
         if (value instanceof Number && (format == DBDDisplayFormat.NATIVE || format == DBDDisplayFormat.EDIT)) {
             if (useScientificNotation < 0) {
                 this.useScientificNotation =


### PR DESCRIPTION
|With native formatting enabled|With native formatting disabled|
|---|---|
|![R4pG0e8pc6](https://user-images.githubusercontent.com/35821147/229934638-e8659ee6-c00a-4772-9b9f-e5ed5939d828.png)|![java_D3JFHzhfDc](https://user-images.githubusercontent.com/35821147/229934658-00bcea87-406a-401d-8e5e-7dccd654ad83.png)|

Native formatting is disabled by default, so the old behavior was changed. I think it's acceptable (can be discussed).

Can be configured in the preferences: <kbd>Editors</kbd> &rArr; <kbd>Data Editors</kbd> &rArr; <kbd>Data Formats</kbd> &rArr; <kbd>Numbers</kbd> &rArr; <kbd>Show special values natively</kbd>.

Sample script (SQLite):

```sql
CREATE TABLE IEEE (
	Id INTEGER PRIMARY KEY AUTOINCREMENT,
	Value REAL,
	String TEXT
);

INSERT INTO
	IEEE (Value, String)
VALUES
	('NaN', 'NaN'),
	('+Infinity', '+Infinity'),
	('-Infinity', '-Infinity'),
	('+INF', '+INF'),
	('-INF', '-INF');
```