### PR TITLE
#19455 avoid NPE during the grant catalogs comparison

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLGrant.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLGrant.java
@@ -178,9 +178,14 @@ public class MySQLGrant implements DBSObject, DBAPrivilegeGrant {
         return privileges.isEmpty() && !isAllPrivileges() && !isGrantOption();
     }
 
-    public boolean matches(MySQLCatalog catalog)
-    {
-        return (catalog == null && isAllCatalogs()) || (catalog != null && !isAllCatalogs() && SQLUtils.matchesLike(catalog.getName(), catalogName));
+    /**
+     * Returns true if the given catalog exists and it is comparable to this grant catalog
+     * or the given catalog is empty, but the grant applies to all catalogs.
+     */
+    public boolean matches(@Nullable MySQLCatalog catalog) {
+        return (catalog == null && isAllCatalogs())
+            || (catalog != null && CommonUtils.isNotEmpty(catalogName) && !isAllCatalogs()
+            && SQLUtils.matchesLike(catalog.getName(), catalogName));
     }
 
     public boolean matches(MySQLTableBase table)


### PR DESCRIPTION
For testers: Just follow the user's steps. You can check the MariaDB instance and the MySQL instance.