### PR TITLE
#19633 Fix export json and blob files to txt

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterTXT.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/exporter/DataExporterTXT.java
@@ -211,10 +211,13 @@ public class DataExporterTXT extends StreamExporterAbstract implements IAppendab
         if (this.maxColumnSize > 0) {
             this.maxColumnSize = Math.max(this.maxColumnSize, this.minColumnSize);
         }
-        
-        this.blobContentMaxLength = Math.min(this.maxColumnSize, Integer.MAX_VALUE) - BLOB_OVERFLOW_MARK.length();
-        if (this.blobContentMaxLength < 0) {
-            this.blobContentMaxLength = this.BLOB_CONTENT_MIN_LENGTH;
+        if (this.maxColumnSize == 0) {
+            this.blobContentMaxLength = Integer.MAX_VALUE - BLOB_OVERFLOW_MARK.length();
+        } else {
+            this.blobContentMaxLength = Math.min(this.maxColumnSize, Integer.MAX_VALUE) - BLOB_OVERFLOW_MARK.length();
+            if (this.blobContentMaxLength < 0) {
+                this.blobContentMaxLength = this.BLOB_CONTENT_MIN_LENGTH;
+            }
         }
     }
 
@@ -267,7 +270,6 @@ public class DataExporterTXT extends StreamExporterAbstract implements IAppendab
     private String stringifyContent(Reader reader) throws IOException {
         try {
             blobContentBuffer.setLength(0);
-            blobContentBuffer.insert(batchSize, "");
             
             int rest = blobContentMaxLength;
             if (QUOTE_BLOBS) {


### PR DESCRIPTION
The error should gone.
Please, test for "max column length" option set to 0 and to some value.