### PR TITLE
#18701 Fix editor area node drag-n-drop

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/NavigatorUtils.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/NavigatorUtils.java
@@ -367,8 +367,8 @@ public class NavigatorUtils {
             final List<Transfer> dragTransferTypes = new ArrayList<>(List.of(
                 TreeNodeTransfer.getInstance(),
                 DatabaseObjectTransfer.getInstance(),
-                EditorInputTransfer.getInstance(),
-                FileTransfer.getInstance()
+                FileTransfer.getInstance(),
+                EditorInputTransfer.getInstance()
             ));
             
             if (RuntimeUtils.isGtk()) { 


### PR DESCRIPTION
Please make sure the fix works on **all platforms!!!**

Acceptance criteria:
- [ ] Dragging resource nodes (scripts, etc) to the desktop copies them
- [ ] Dragging database nodes (tables, views, etc) to the editor area opens them
- [ ] Dragging any navigator nodes to the text editor inserts their names
- [ ] #17415