### PR TITLE
dbeaver/pro#1386 improve external file reader for txt, xml, json

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/AbstractTextPanelEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/AbstractTextPanelEditor.java
@@ -51,10 +51,11 @@ import org.jkiss.dbeaver.model.data.DBDContent;
 import org.jkiss.dbeaver.model.data.storage.StringContentStorage;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.controls.StyledTextUtils;
 import org.jkiss.dbeaver.ui.controls.resultset.internal.ResultSetMessages;
-import org.jkiss.dbeaver.ui.data.IStreamValueEditor;
+import org.jkiss.dbeaver.ui.data.IStreamValueEditorPersistent;
 import org.jkiss.dbeaver.ui.data.IValueController;
 import org.jkiss.dbeaver.ui.dialogs.BaseDialog;
 import org.jkiss.dbeaver.ui.editors.StringEditorInput;
@@ -65,13 +66,17 @@ import org.jkiss.dbeaver.ui.editors.data.internal.DataEditorsActivator;
 import org.jkiss.dbeaver.ui.editors.text.BaseTextEditor;
 import org.jkiss.dbeaver.utils.RuntimeUtils;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
 * AbstractTextPanelEditor
 */
-public abstract class AbstractTextPanelEditor<EDITOR extends BaseTextEditor> implements IStreamValueEditor<StyledText>, IAdaptable {
+public abstract class AbstractTextPanelEditor<EDITOR extends BaseTextEditor>
+    implements IStreamValueEditorPersistent<StyledText>, IAdaptable {
 
     private static final String PREF_TEXT_EDITOR_WORD_WRAP = "content.text.editor.word-wrap";
     private static final String PREF_TEXT_EDITOR_AUTO_FORMAT = "content.text.editor.auto-format";
@@ -293,6 +298,24 @@ public abstract class AbstractTextPanelEditor<EDITOR extends BaseTextEditor> imp
             monitor.done();
         }
     }
+
+    @Nullable
+    @Override
+    public Path getExternalFilePath(@NotNull StyledText control) {
+        try {
+            Path file = Files.createTempFile(DBWorkbench.getPlatform()
+                .getTempFolder(new VoidProgressMonitor(), getFileFolderName()), "file", getFileExtension());
+            Files.writeString(file, control.getText());
+            return file;
+        } catch (IOException e) {
+            log.error(e);
+            return null;
+        }
+    }
+
+    protected abstract String getFileFolderName();
+
+    protected abstract String getFileExtension();
 
     @Override
     public void extractEditorValue(@NotNull DBRProgressMonitor monitor, @NotNull StyledText control, @NotNull DBDContent value) throws DBException

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/stream/TextPanelEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/stream/TextPanelEditor.java
@@ -43,4 +43,14 @@ public class TextPanelEditor extends AbstractTextPanelEditor<TextEditorPart> {
             }
         };
     }
+
+    @Override
+    protected String getFileFolderName() {
+        return "dbeaver-txt";
+    }
+
+    @Override
+    protected String getFileExtension() {
+        return ".txt";
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.json/src/org/jkiss/dbeaver/ui/data/managers/stream/JSONPanelEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.json/src/org/jkiss/dbeaver/ui/data/managers/stream/JSONPanelEditor.java
@@ -45,4 +45,15 @@ public class JSONPanelEditor extends AbstractTextPanelEditor<JSONTextEditor> {
         };
     }
 
+    @Override
+    protected String getFileFolderName() {
+        return "dbeaver-json";
+    }
+
+    @Override
+    protected String getFileExtension() {
+        return ".json";
+    }
+
+
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.xml/src/org/jkiss/dbeaver/ui/data/managers/stream/XMLPanelEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.xml/src/org/jkiss/dbeaver/ui/data/managers/stream/XMLPanelEditor.java
@@ -44,4 +44,14 @@ public class XMLPanelEditor extends AbstractTextPanelEditor<XMLEditor> {
             }
         };
     }
+
+    @Override
+    protected String getFileFolderName() {
+        return "dbeaver-xml";
+    }
+
+    @Override
+    protected String getFileExtension() {
+        return ".xml";
+    }
 }


### PR DESCRIPTION
Closes dbeaver/pro#1386
Now if txt, JSON or XML editor is opened, an external file will be opened with the .txt,.json or .XML extension