### PR TITLE
#19305 Render non-displayable characters in the grid

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/GridCellRenderer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/GridCellRenderer.java
@@ -55,6 +55,36 @@ class GridCellRenderer extends AbstractRenderer {
         {"\t",     "\u00bb"},
         {"\u3000", "\u00b0"}, // ideographic whitespace
         {"\u200b", "\u2588"}, // zero-width whitespace
+        {"\u0000", "NUL"},
+        {"\u0001", "SOH"},
+        {"\u0002", "STX"},
+        {"\u0003", "ETX"},
+        {"\u0004", "EOT"},
+        {"\u0005", "ENQ"},
+        {"\u0006", "ACK"},
+        {"\u0007", "BEL"},
+        {"\u0008", "BS"},
+        {"\u000B", "VT"},
+        {"\u000C", "FF"},
+        {"\u000E", "SO"},
+        {"\u000F", "SI"},
+        {"\u0010", "DLE"},
+        {"\u0011", "DC1"},
+        {"\u0012", "DC2"},
+        {"\u0013", "DC3"},
+        {"\u0014", "DC4"},
+        {"\u0015", "NAK"},
+        {"\u0016", "SYN"},
+        {"\u0017", "ETB"},
+        {"\u0018", "CAN"},
+        {"\u0019", "EM"},
+        {"\u001A", "SUB"},
+        {"\u001B", "ESC"},
+        {"\u001C", "FS"},
+        {"\u001D", "GS"},
+        {"\u001E", "RS"},
+        {"\u001F", "US"},
+        {"\u007F", "DEL"}
     };
 
     protected Color colorLineFocused;
@@ -293,36 +323,42 @@ class GridCellRenderer extends AbstractRenderer {
         final Color activeBackground = cellInfo.background;
         final Color disabledForeground = UIUtils.getSharedColor(UIUtils.blend(activeForeground.getRGB(), activeBackground.getRGB(), 50));
 
-        for (int start = 0; start < text.length(); ) {
-            boolean matches = false;
+        int start = 0;
 
+        for (int index = 0; index < text.length(); index++) {
             for (String[] mapping : SPECIAL_CHARACTERS_MAP) {
                 final String expected = mapping[0];
                 final String replacement = mapping[1];
-                final int index = text.indexOf(expected, start);
+                final boolean regionMatches = text.regionMatches(index, expected, 0, expected.length());
 
-                if (index >= 0) {
-                    if (drawCellTextSegment(gc, text.substring(start, index), bounds, activeForeground, disabledForeground)) {
+                if (regionMatches) {
+                    if (drawCellTextSegment(gc, text.substring(start, index), bounds, activeForeground, disabledForeground, false)) {
                         return;
                     }
 
-                    if (drawCellTextSegment(gc, replacement, bounds, disabledForeground, disabledForeground)) {
+                    if (drawCellTextSegment(gc, replacement, bounds, disabledForeground, disabledForeground, replacement.length() > 1)) {
                         return;
                     }
 
                     start = index + expected.length();
-                    matches = true;
+                    index += expected.length() - 1;
                 }
             }
+        }
 
-            if (!matches) {
-                drawCellTextSegment(gc, text.substring(start), bounds, activeForeground, disabledForeground);
-                return;
-            }
+        if (start < text.length()) {
+            drawCellTextSegment(gc, text.substring(start), bounds, activeForeground, disabledForeground, false);
         }
     }
 
-    private boolean drawCellTextSegment(@NotNull GC gc, @NotNull String segment, @NotNull Rectangle bounds, @NotNull Color activeForeground, @NotNull Color disabledForeground) {
+    private boolean drawCellTextSegment(
+        @NotNull GC gc,
+        @NotNull String segment,
+        @NotNull Rectangle bounds,
+        @NotNull Color activeForeground,
+        @NotNull Color disabledForeground,
+        boolean highlight
+    ) {
         final Point extent = gc.textExtent(segment);
 
         if (extent.x > bounds.width) {
@@ -348,23 +384,41 @@ class GridCellRenderer extends AbstractRenderer {
                 }
             }
 
-            drawTextAndAdvance(gc, clipped, activeForeground, bounds);
-            drawTextAndAdvance(gc, "...", disabledForeground, bounds);
+            drawTextAndAdvance(gc, clipped, activeForeground, bounds, false);
+            drawTextAndAdvance(gc, "...", disabledForeground, bounds, false);
 
             return true;
         } else {
-            drawTextAndAdvance(gc, segment, activeForeground, bounds);
+            drawTextAndAdvance(gc, segment, activeForeground, bounds, highlight);
 
             return false;
         }
     }
 
-    private void drawTextAndAdvance(@NotNull GC gc, @NotNull String text, @NotNull Color foreground, @NotNull Rectangle bounds) {
+    private void drawTextAndAdvance(
+        @NotNull GC gc,
+        @NotNull String text,
+        @NotNull Color foreground,
+        @NotNull Rectangle bounds,
+        boolean highlight
+    ) {
+        gc.setTextAntialias(SWT.ON);
         gc.setForeground(foreground);
-        gc.drawString(text, bounds.x, bounds.y);
 
-        final int extent = gc.textExtent(text).x + 1 /* HACK: antialiasing occupies one extra pixel */;
-        bounds.x += extent;
-        bounds.width -= extent;
+        final Point extent = gc.stringExtent(text);
+
+        if (highlight) {
+            extent.x += 2;
+
+            gc.drawRoundRectangle(bounds.x, bounds.y, extent.x, extent.y - 1, 2, 2);
+
+            bounds.x += 2;
+            bounds.width -= 2;
+        }
+
+        gc.drawString(text, bounds.x, bounds.y, true);
+
+        bounds.x += extent.x;
+        bounds.width -= extent.x;
     }
 }


### PR DESCRIPTION
Demonstration (click to enlarge)
![java_Rbe8qn2UI6](https://user-images.githubusercontent.com/35821147/230954456-a5d5c1e4-b440-4996-869f-6fe3e917dc06.png)

The query for testing:
```sql
select CHR(  1) || CHR(  2) || CHR(  3) || CHR(  4) || CHR(  5) || CHR(  6) || CHR(  7) || CHR(  8)
    || CHR(  9) || CHR( 10) || CHR( 11) || CHR( 12) || CHR( 13) || CHR( 14) || CHR( 15) || CHR( 16)
    || CHR( 17) || CHR( 18) || CHR( 19) || CHR( 20) || CHR( 21) || CHR( 22) || CHR( 23) || CHR( 24)
    || CHR( 25) || CHR( 26) || CHR( 27) || CHR( 28) || CHR( 29) || CHR( 30) || CHR( 31) || CHR( 32)
    || CHR( 33) || CHR( 34) || CHR( 35) || CHR( 36) || CHR( 37) || CHR( 38) || CHR( 39) || CHR( 40)
    || CHR( 41) || CHR( 42) || CHR( 43) || CHR( 44) || CHR( 45) || CHR( 46) || CHR( 47) || CHR( 48)
    || CHR( 49) || CHR( 50) || CHR( 51) || CHR( 52) || CHR( 53) || CHR( 54) || CHR( 55) || CHR( 56)
    || CHR( 57) || CHR( 58) || CHR( 59) || CHR( 60) || CHR( 61) || CHR( 62) || CHR( 63) || CHR( 64)
    || CHR( 65) || CHR( 66) || CHR( 67) || CHR( 68) || CHR( 69) || CHR( 70) || CHR( 71) || CHR( 72)
    || CHR( 73) || CHR( 74) || CHR( 75) || CHR( 76) || CHR( 77) || CHR( 78) || CHR( 79) || CHR( 80)
    || CHR( 81) || CHR( 82) || CHR( 83) || CHR( 84) || CHR( 85) || CHR( 86) || CHR( 87) || CHR( 88)
    || CHR( 89) || CHR( 90) || CHR( 91) || CHR( 92) || CHR( 93) || CHR( 94) || CHR( 95) || CHR( 96)
    || CHR( 97) || CHR( 98) || CHR( 99) || CHR(100) || CHR(101) || CHR(102) || CHR(103) || CHR(104)
    || CHR(105) || CHR(106) || CHR(107) || CHR(108) || CHR(109) || CHR(110) || CHR(111) || CHR(112)
    || CHR(113) || CHR(114) || CHR(115) || CHR(116) || CHR(117) || CHR(118) || CHR(119) || CHR(120)
    || CHR(121) || CHR(122) || CHR(123) || CHR(124) || CHR(125) || CHR(126) || CHR(127);
```