### PR TITLE
dbeaver/dbeaver#19582 fix focus on palette

### DIFF
--- a/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/action/ERDHandlerFocus.java
+++ b/plugins/org.jkiss.dbeaver.erd.ui/src/org/jkiss/dbeaver/erd/ui/action/ERDHandlerFocus.java
@@ -20,7 +20,6 @@ import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.gef3.EditDomain;
-import org.eclipse.gef3.ui.views.palette.PalettePage;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.ISources;
 import org.eclipse.ui.handlers.HandlerUtil;
@@ -47,7 +46,7 @@ public class ERDHandlerFocus extends AbstractHandler {
                 part.getViewer().getControl().forceFocus();
                 break;
             case PALETTE_FOCUS:
-                Object adapter = part.getAdapter(PalettePage.class);
+                Object adapter = part.getAdapter(EditDomain.class);
                 if (adapter instanceof EditDomain && ((EditDomain) adapter).getPaletteViewer() != null) {
                     ((EditDomain) adapter).getPaletteViewer().getControl().setFocus();
                 }


### PR DESCRIPTION
Closes dbeaver/dbeaver#19582
Now palette viewer should be focused on ALT+2, but, unfortunately, it still can't be expanded via keyboard.