### PR TITLE
#18836 update Firebird procedure parameters data types recognition

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdFieldType.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdFieldType.java
@@ -21,20 +21,25 @@ import org.jkiss.dbeaver.model.DBPDataKind;
 import java.sql.Types;
 
 public enum FireBirdFieldType {
-	SMALLINT(7, Types.SMALLINT, DBPDataKind.NUMERIC, "SMALLINT"),
-	INTEGER(8, Types.INTEGER, DBPDataKind.NUMERIC, "INTEGER"),
-	FLOAT(10, Types.FLOAT, DBPDataKind.NUMERIC, "FLOAT"),
-	DATE(12, Types.DATE, DBPDataKind.DATETIME, "DATE"),
-	TIME(13, Types.TIME, DBPDataKind.DATETIME, "TIME"),
-	CHAR(14, Types.CHAR, DBPDataKind.STRING, "CHAR"),
-	BIGINT(16, Types.BIGINT, DBPDataKind.NUMERIC, "BIGINT"),
+    SMALLINT(7, Types.SMALLINT, DBPDataKind.NUMERIC, "SMALLINT"),
+    INTEGER(8, Types.INTEGER, DBPDataKind.NUMERIC, "INTEGER"),
+    FLOAT(10, Types.FLOAT, DBPDataKind.NUMERIC, "FLOAT"),
+    DECFLOAT(11, Types.FLOAT, DBPDataKind.NUMERIC, "DECFLOAT"),
+    DATE(12, Types.DATE, DBPDataKind.DATETIME, "DATE"),
+    TIME(13, Types.TIME, DBPDataKind.DATETIME, "TIME"),
+    CHAR(14, Types.CHAR, DBPDataKind.STRING, "CHAR"),
+    BIGINT(16, Types.BIGINT, DBPDataKind.NUMERIC, "BIGINT"),
     NUMERIC(16, Types.NUMERIC, DBPDataKind.NUMERIC, "NUMERIC"), // Equal id, but another subtype - 1
     DECIMAL(16, Types.DECIMAL, DBPDataKind.NUMERIC, "DECIMAL"), // Equal id, but another subtype - 2
     BOOLEAN(23, Types.BOOLEAN, DBPDataKind.BOOLEAN, "BOOLEAN"),
-	DOUBLE_PRECISION(27, Types.DOUBLE, DBPDataKind.NUMERIC, "DOUBLE PRECISION"),
-	TIMESTAMP(35, Types.TIMESTAMP, DBPDataKind.DATETIME, "TIMESTAMP"),
-	VARCHAR(37, Types.VARCHAR, DBPDataKind.STRING, "VARCHAR"),
-	BLOB(261, Types.BLOB, DBPDataKind.CONTENT, "BLOB");
+    INT128(26, Types.BIGINT, DBPDataKind.NUMERIC, "INT128"),
+    DOUBLE_PRECISION(27, Types.DOUBLE, DBPDataKind.NUMERIC, "DOUBLE PRECISION"),
+    TIME_WITH_TIMEZONE(28, Types.TIME_WITH_TIMEZONE, DBPDataKind.DATETIME, "TIME WITH TIMEZONE"),
+    TIMESTAMP_WITH_TIMEZONE(29, Types.TIMESTAMP_WITH_TIMEZONE, DBPDataKind.DATETIME, "TIMESTAMP WITH TIMEZONE"),
+    TIMESTAMP(35, Types.TIMESTAMP, DBPDataKind.DATETIME, "TIMESTAMP"),
+    VARCHAR(37, Types.VARCHAR, DBPDataKind.STRING, "VARCHAR"),
+    CSTRING(40, Types.VARCHAR, DBPDataKind.STRING, "CSTRING"),
+    BLOB(261, Types.BLOB, DBPDataKind.CONTENT, "BLOB");
 
     private final int typeID;
     private final int valueType;
@@ -65,14 +70,14 @@ public enum FireBirdFieldType {
     }
 
     public static FireBirdFieldType getById(int id, int subTypeId) {
-        if (id == 16) {
+        if (id == 16 || id == 8) {
             switch (subTypeId) {
                 case 1:
                     return NUMERIC;
                 case 2:
                     return DECIMAL;
                 default:
-                    return BIGINT;
+                    return id == 16 ? BIGINT : INTEGER;
             }
         }
         for (FireBirdFieldType ft : values()) {


### PR DESCRIPTION
I used this query for testing

```sql
CREATE OR ALTER PROCEDURE DIFFERENT_TYPES (IDTBPRORECIPE NUMERIC, IDTBPROMACHINE BIGINT, PLANSTART TIMESTAMP, PLANFINISH DOUBLE PRECISION, BATCH_COMMENT VARCHAR(1000), 
LOADINGTIME INTEGER, TOTALUNITS DECIMAL)
RETURNS (
	IDTBPROBATCH BIGINT
)
AS
BEGIN SUSPEND; END
```

https://github.com/FirebirdSQL/firebird/blob/master/doc/sql.extensions/README.time_zone.md about timezones
https://docwiki.embarcadero.com/InterBase/2020/en/RDB$FIELDS
https://github.com/FirebirdSQL/jaybird/blob/e094382a964df93f3c555ce2547416c419ee8138/src/test/org/firebirdsql/jdbc/DecfloatSupportTest.java - DECFLOAT
https://firebirdsql.org/refdocs/langrefupd21-notes-cstring.html - CSTRING

https://github.com/FirebirdSQL/jaybird/blob/e094382a964df93f3c555ce2547416c419ee8138/src/main/org/firebirdsql/jdbc/metadata/FbMetadataConstants.java