### PR TITLE
#18576 read depended for identity table column sequence; add sequence…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreTableColumnManager.java
@@ -91,6 +91,19 @@ public class PostgreTableColumnManager extends SQLTableColumnManager<PostgreTabl
         if (identity != null) {
             sql.append(" ").append(identity.getDefinitionClause());
         }
+        if (column.getDepObjectId() != 0) {
+            // This column has dependency with object
+            try {
+                PostgreTableBase table = column.getSchema().getTable(monitor, column.getDepObjectId());
+                if (table instanceof PostgreSequence) {
+                    sql.append("(");
+                    ((PostgreSequence) table).getSequenceBody(monitor, sql, false);
+                    sql.append(")");
+                }
+            } catch (DBException e) {
+                log.debug("Can't find the depended object.");
+            }
+        }
     };
 
     protected final ColumnModifier<PostgreTableColumn> PostgreCollateModifier = (monitor, column, sql, command) -> {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreAttribute.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreAttribute.java
@@ -74,6 +74,7 @@ public abstract class PostgreAttribute<OWNER extends DBSEntity & PostgreObject> 
     private String defaultValue;
     @Nullable
     private boolean isGeneratedColumn;
+    private long depObjectId;
 
     protected PostgreAttribute(
         OWNER table)
@@ -200,6 +201,14 @@ public abstract class PostgreAttribute<OWNER extends DBSEntity & PostgreObject> 
         }
 
         setPersisted(true);
+
+        if (getTable() instanceof PostgreTable) {
+            PostgreTable postgreTable = (PostgreTable) getTable();
+            if (postgreTable.getDepObjectAttrNumber() == getOrdinalPosition()) {
+                // ID of object which has dependency with this column
+                this.depObjectId = (postgreTable).getDepObjectId();
+            }
+        }
     }
 
     @NotNull
@@ -356,6 +365,10 @@ public abstract class PostgreAttribute<OWNER extends DBSEntity & PostgreObject> 
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public long getDepObjectId() {
+        return depObjectId;
     }
 
     @Property(viewable = true, editableExpr = "!object.table.view", order = 30, listProvider = CollationListProvider.class)

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependency.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependency.java
@@ -116,6 +116,8 @@ public class PostgreDependency implements PostgreObject, DBPOverloadedObject, DB
             return "Attribute";
         } else if (objectType.startsWith("T")) {
             return "Trigger";
+        } else if (objectType.startsWith("S")) {
+            return "Sequence";
         }
         return objectType;
     }
@@ -181,6 +183,12 @@ public class PostgreDependency implements PostgreObject, DBPOverloadedObject, DB
                 return ((PostgreTable)tableBase).getTrigger(monitor, name);
             }
             return null;
+        } else if (objectType.startsWith("S")) {
+            if (tableBase != null) {
+                return tableBase.getSchema().getSequence(monitor, name);
+            } else {
+                return schema.getSequence(monitor, name);
+            }
         }
         return null;
     }
@@ -210,6 +218,8 @@ public class PostgreDependency implements PostgreObject, DBPOverloadedObject, DB
             return DBIcon.TREE_COLUMN;
         } else if (objectType.startsWith("T")) {
             return DBIcon.TREE_TRIGGER;
+        } else if (objectType.startsWith("S")) {
+            return DBIcon.TREE_SEQUENCE;
         }
         return DBIcon.TREE_REFERENCE;
     }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
@@ -739,13 +739,22 @@ public class PostgreSchema implements
         @Override
         public JDBCStatement prepareLookupStatement(@NotNull JDBCSession session, @NotNull PostgreTableContainer container, @Nullable PostgreTableBase object, @Nullable String objectName) throws SQLException {
             StringBuilder sql = new StringBuilder();
+            PostgreDataSource dataSource = getDataSource();
+            boolean supportsSequences = dataSource.getServerType().supportsSequences();
             sql.append("SELECT c.oid,c.*,d.description");
-            if (getDataSource().isServerVersionAtLeast(10, 0)) {
+            if (dataSource.isServerVersionAtLeast(10, 0)) {
                 sql.append(",pg_catalog.pg_get_expr(c.relpartbound, c.oid) as partition_expr,  pg_catalog.pg_get_partkeydef(c.oid) as partition_key ");
             }
+            if (supportsSequences) {
+                sql.append(", dep.objid, dep.refobjsubid");
+            }
             sql.append("\nFROM pg_catalog.pg_class c\n")
-                .append("LEFT OUTER JOIN pg_catalog.pg_description d ON d.objoid=c.oid AND d.objsubid=0 AND d.classoid='pg_class'::regclass\n")
-                .append("WHERE c.relnamespace=? AND c.relkind not in ('i','I','c')")
+                .append("LEFT OUTER JOIN pg_catalog.pg_description d ON d.objoid=c.oid AND d.objsubid=0 AND d.classoid='pg_class'::regclass\n");
+            if (supportsSequences) {
+                // Search connection with sequence object
+                sql.append("LEFT OUTER JOIN pg_depend dep on dep.refobjid = c.\"oid\" AND dep.deptype = 'i' and dep.refobjsubid <> 0\n");
+            }
+            sql.append("WHERE c.relnamespace=? AND c.relkind not in ('i','I','c')")
                 .append(object == null && objectName == null ? "" : " AND relname=?");
             final JDBCPreparedStatement dbStat = session.prepareStatement(sql.toString());
             dbStat.setLong(1, getObjectId());

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSequence.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSequence.java
@@ -268,31 +268,11 @@ public class PostgreSequence extends PostgreTableBase implements DBSSequence, DB
 
     @Override
     public String getObjectDefinitionText(DBRProgressMonitor monitor, Map<String, Object> options) throws DBException {
-        AdditionalInfo info = getAdditionalInfo(monitor);
         StringBuilder sql = new StringBuilder()
             .append("-- DROP SEQUENCE ").append(getFullyQualifiedName(DBPEvaluationContext.DDL)).append(";\n\n")
             .append("CREATE SEQUENCE ").append(getFullyQualifiedName(DBPEvaluationContext.DDL));
 
-        if (info.getIncrementBy() > 0) {
-            sql.append("\n\tINCREMENT BY ").append(info.getIncrementBy());
-        }
-        if (info.getMinValue() > 0) {
-            sql.append("\n\tMINVALUE ").append(info.getMinValue());
-        } else {
-            sql.append("\n\tNO MINVALUE");
-        }
-        if (info.getMaxValue() > 0) {
-            sql.append("\n\tMAXVALUE ").append(info.getMaxValue());
-        } else {
-            sql.append("\n\tNO MAXVALUE");
-        }
-        if (info.getStartValue() > 0) {
-            sql.append("\n\tSTART ").append(info.getStartValue());
-        }
-        if (info.getCacheValue() > 0) {
-            sql.append("\n\tCACHE ").append(info.getCacheValue());
-            sql.append("\n\t").append(info.isCycled ? "" : "NO ").append("CYCLE");
-        }
+        getSequenceBody(monitor, sql, true);
         sql.append(';');
 
 		if (!CommonUtils.isEmpty(getDescription())) {
@@ -308,6 +288,55 @@ public class PostgreSequence extends PostgreTableBase implements DBSSequence, DB
         }
 
         return sql.toString();
+    }
+
+    /**
+     * Adds sequence body parts - only parameters - into the StringBuilder
+     *
+     * @param monitor to read additional info about sequence
+     * @param sql StringBuilder to append query parts
+     * @param hasIndentation add or not add tabulation and new line in the result
+     * @throws DBCException can happen during the additional info reading
+     */
+    public void getSequenceBody(@NotNull DBRProgressMonitor monitor, @NotNull StringBuilder sql, boolean hasIndentation)
+        throws DBCException {
+        AdditionalInfo info = getAdditionalInfo(monitor);
+        if (info.getIncrementBy() > 0) {
+            addIndentation(sql, hasIndentation);
+            sql.append("INCREMENT BY ").append(info.getIncrementBy());
+        }
+        if (info.getMinValue() > 0) {
+            addIndentation(sql, hasIndentation);
+            sql.append("MINVALUE ").append(info.getMinValue());
+        } else {
+            addIndentation(sql, hasIndentation);
+            sql.append("NO MINVALUE");
+        }
+        if (info.getMaxValue() > 0) {
+            addIndentation(sql, hasIndentation);
+            sql.append("MAXVALUE ").append(info.getMaxValue());
+        } else {
+            addIndentation(sql, hasIndentation);
+            sql.append("NO MAXVALUE");
+        }
+        if (info.getStartValue() > 0) {
+            addIndentation(sql, hasIndentation);
+            sql.append("START ").append(info.getStartValue());
+        }
+        if (info.getCacheValue() > 0) {
+            addIndentation(sql, hasIndentation);
+            sql.append("CACHE ").append(info.getCacheValue());
+        }
+        addIndentation(sql, hasIndentation);
+        sql.append(info.isCycled() ? "" : "NO ").append("CYCLE");
+    }
+
+    private void addIndentation(@NotNull StringBuilder sql, boolean hasIndentation) {
+        if (hasIndentation) {
+            sql.append("\n\t");
+        } else {
+            sql.append(" ");
+        }
     }
 
     public String generateChangeOwnerQuery(String owner) {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -74,6 +74,8 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
     private boolean hasRowLevelSecurity;
     private String partitionKey;
     private String partitionRange;
+    private long depObjectId;
+    private long depObjectAttrNumber;
 
     public PostgreTable(PostgreTableContainer container)
     {
@@ -96,6 +98,8 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
         this.hasPartitions = this.partitionKey != null;
         this.hasRowLevelSecurity = getDataSource().getServerType().supportsRowLevelSecurity()
             && JDBCUtils.safeGetBoolean(dbResult, "relrowsecurity");
+        this.depObjectId = JDBCUtils.safeGetLong(dbResult, "objid");
+        this.depObjectAttrNumber = JDBCUtils.safeGetLong(dbResult, "refobjsubid");
     }
 
     // Copy constructor
@@ -186,6 +190,14 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
 
     public void setPartitionKey(String partitionKey) {
         this.partitionKey = partitionKey;
+    }
+
+    public long getDepObjectId() {
+        return depObjectId;
+    }
+
+    public long getDepObjectAttrNumber() {
+        return depObjectAttrNumber;
     }
 
     @Override


### PR DESCRIPTION
read depended on identity table column sequence -> add sequence body in the table DDL

![2023-04-18 17_02_28-DBeaver Ultimate 23 0 3 - color1](https://user-images.githubusercontent.com/45152336/232805745-affaad5d-6078-4ca5-ac07-5cb0b4d7a5d2.png)

The table reading was changed, so please check not just the case from the ticket but also:
- table reading in Redshift (table from ticket can be created, so this code is not for Redshift)
- table reading in Greenplum
- table reading in Cockroach

https://www.postgresql.org/docs/7.3/catalog-pg-depend.html this is the base system view from a long time ago, and this is great.
