### PR TITLE
#19231 change generation of ALTER table SQL for foreign tables

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreTableManager.java
@@ -154,7 +154,8 @@ public class PostgreTableManager extends PostgreTableManagerBase implements DBEO
 
     private void generateAlterActions(DBRProgressMonitor monitor, List<DBEPersistAction> actionList, ObjectChangeCommand command) throws DBException {
         final PostgreTable table = (PostgreTable) command.getObject();
-        final String alterPrefix = "ALTER TABLE " + command.getObject().getFullyQualifiedName(DBPEvaluationContext.DDL) + " ";//$NON-NLS-1$ //$NON-NLS-2$
+        final String alterPrefix = "ALTER " + table.getTableTypeName() + " " + //$NON-NLS-1$
+            command.getObject().getFullyQualifiedName(DBPEvaluationContext.DDL) + " ";
 
         if (command.hasProperty("partitionKey")) {//$NON-NLS-1$
             actionList.add(new SQLDatabasePersistAction(alterPrefix + "PARTITION BY " + table.getPartitionKey()));//$NON-NLS-1$
@@ -180,11 +181,14 @@ public class PostgreTableManager extends PostgreTableManagerBase implements DBEO
     @Override
     protected void addObjectRenameActions(DBRProgressMonitor monitor, DBCExecutionContext executionContext, List<DBEPersistAction> actions, ObjectRenameCommand command, Map<String, Object> options)
     {
+        PostgreTableBase table = command.getObject();
         actions.add(
             new SQLDatabasePersistAction(
                 "Rename table",
-                "ALTER TABLE " + DBUtils.getQuotedIdentifier(command.getObject().getSchema()) + "." + DBUtils.getQuotedIdentifier(command.getObject().getDataSource(), command.getOldName()) + //$NON-NLS-1$
-                    " RENAME TO " + DBUtils.getQuotedIdentifier(command.getObject().getDataSource(), command.getNewName())) //$NON-NLS-1$
+                "ALTER " + table.getTableTypeName() + " " + //$NON-NLS-1$
+                    DBUtils.getQuotedIdentifier(table.getSchema()) + "." +
+                    DBUtils.getQuotedIdentifier(table.getDataSource(), command.getOldName()) +
+                    " RENAME TO " + DBUtils.getQuotedIdentifier(table.getDataSource(), command.getNewName())) //$NON-NLS-1$
         );
     }
 


### PR DESCRIPTION
![2023-04-20 14_05_35-fb_test_table2 - Persist Changes](https://user-images.githubusercontent.com/45152336/233349618-ac7a1909-7901-4de6-8aaf-19a858a54dff.png)

Please check 
- Foreign tables changing (alter table / rename table / add column / drop column / rename column / alter column) (some changes are not allowed for foreign tables - it is expected (like changing the row level security)
- Ordinary tables changing (alter table / rename table / add column / drop column / rename column / alter column)
- view/materialized view changing (must be VIEW/Materialized view in the query)


https://www.postgresql.org/docs/current/sql-alterforeigntable.html
