### PR TITLE
#19782 fix events reading for quoted schemas for MySQL/MariaDB

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLCatalog.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLCatalog.java
@@ -1006,7 +1006,7 @@ public class MySQLCatalog implements
         {
             final JDBCPreparedStatement dbStat = session.prepareStatement(
                 "SELECT * FROM information_schema.EVENTS WHERE EVENT_SCHEMA=?");
-            dbStat.setString(1, DBUtils.getQuotedIdentifier(owner));
+            dbStat.setString(1, owner.getName());
             return dbStat;
         }
 


### PR DESCRIPTION
Please check the events reading:

- [x] in catalog with name **data**
- [x] in the catalog with the name with special characters
- [x] in the catalog without special characters