### PR TITLE
#19807 Correctly handle `\r\n` sequence

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/GridCellRenderer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/lightgrid/GridCellRenderer.java
@@ -340,8 +340,8 @@ class GridCellRenderer extends AbstractRenderer {
                         return;
                     }
 
-                    start = index + expected.length();
-                    index += expected.length() - 1;
+                    index += expected.length();
+                    start = index;
                 }
             }
         }


### PR DESCRIPTION
Test cases:
- [x] `select 'abc' || chr(10) || 'def'`
- [x] `select 'abc' || chr(13) || 'def'`
- [x] `select 'abc' || chr(13) || chr(10) || 'def'`
- [x] `select 'abc' || chr(10) || chr(13) || 'def'`
- [x] Other cases from #19660

The `chr(10)` expression yields `\n`, `chr(13)` yields `\r`