### PR TITLE
#19813 fix DATE data reading in result set with the setting

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleTimestampValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleTimestampValueHandler.java
@@ -57,8 +57,12 @@ public class OracleTimestampValueHandler extends JDBCDateTimeValueHandler {
 
     //private static Method TIMESTAMP_READ_METHOD = null, TIMESTAMPTZ_READ_METHOD = null, TIMESTAMPLTZ_READ_METHOD = null;
 
-    public OracleTimestampValueHandler(DBDFormatSettings formatSettings) {
+    @NotNull
+    private DBPDataSource dataSource;
+
+    OracleTimestampValueHandler(DBDFormatSettings formatSettings, @NotNull DBPDataSource dataSource) {
         super(formatSettings);
+        this.dataSource = dataSource;
     }
 
     @Override
@@ -195,17 +199,10 @@ public class OracleTimestampValueHandler extends JDBCDateTimeValueHandler {
     }
 
     @NotNull
-    protected String getFormatterId(DBSTypedObject column)
-    {
-        boolean showDateAsDate = false;
-        if (column instanceof DBSObject) {
-            DBPDataSource dataSource = ((DBSObject) column).getDataSource();
-            if (dataSource != null) {
-                showDateAsDate = CommonUtils.getBoolean(
-                    dataSource.getContainer().getConnectionConfiguration().getProviderProperty(OracleConstants.PROP_SHOW_DATE_AS_DATE),
-                    false);
-            }
-        }
+    protected String getFormatterId(DBSTypedObject column) {
+        boolean showDateAsDate = CommonUtils.getBoolean(
+                dataSource.getContainer().getConnectionConfiguration().getProviderProperty(OracleConstants.PROP_SHOW_DATE_AS_DATE),
+                false);
         if (showDateAsDate && OracleConstants.TYPE_NAME_DATE.equals(column.getTypeName())) {
             return DBDDataFormatter.TYPE_NAME_DATE;
         }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleValueHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleValueHandlerProvider.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.ext.oracle.data;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.ext.oracle.model.OracleConstants;
 import org.jkiss.dbeaver.ext.oracle.model.OracleDataSource;
 import org.jkiss.dbeaver.model.DBPDataKind;
@@ -33,7 +34,7 @@ import java.sql.Types;
 public class OracleValueHandlerProvider implements DBDValueHandlerProvider {
 
     @Override
-    public DBDValueHandler getValueHandler(DBPDataSource dataSource, DBDFormatSettings preferences, DBSTypedObject typedObject)
+    public DBDValueHandler getValueHandler(@NotNull DBPDataSource dataSource, DBDFormatSettings preferences, DBSTypedObject typedObject)
     {
         switch (typedObject.getTypeID()) {
             case Types.BLOB:
@@ -47,7 +48,7 @@ public class OracleValueHandlerProvider implements DBDValueHandlerProvider {
                 if (((OracleDataSource)dataSource).isDriverVersionAtLeast(12, 2)) {
                     return new OracleTemporalAccessorValueHandler(preferences);
                 } else {
-                    return new OracleTimestampValueHandler(preferences);
+                    return new OracleTimestampValueHandler(preferences, dataSource);
                 }
             case Types.STRUCT:
                 return OracleObjectValueHandler.INSTANCE;
@@ -67,7 +68,7 @@ public class OracleValueHandlerProvider implements DBDValueHandlerProvider {
         }
 
         if (typeName.contains(OracleConstants.TYPE_NAME_TIMESTAMP) || typedObject.getDataKind() == DBPDataKind.DATETIME) {
-            return new OracleTimestampValueHandler(preferences);
+            return new OracleTimestampValueHandler(preferences, dataSource);
         } else {
             return null;
         }


### PR DESCRIPTION
![2023-04-27 11_11_23-Connection _Oracle - ora-database-1_ configuration](https://user-images.githubusercontent.com/45152336/234806017-09095a92-d027-4d19-9e63-29aa13c8aa34.png)

![2023-04-27 11_30_04-DBeaver Ultimate Asya  23 0 4 - _orcl_ Script-59](https://user-images.githubusercontent.com/45152336/234806024-c4365a12-780b-4154-9992-19ef424916ff.png)

Please check:

- [x] with enabled setting "Show DATE values specifically as DATE" date values in a result set
- [x] with enabled setting "Show DATE values specifically as DATE" date values in a table
- [x] with disabled setting "Show DATE values specifically as DATE" date values in a result set
- [x] with disabled setting "Show DATE values specifically as DATE" date values in a table
