### PR TITLE
#19451 trim meta objects names for Informix

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.informix/src/org/jkiss/dbeaver/ext/informix/model/InformixMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.informix/src/org/jkiss/dbeaver/ext/informix/model/InformixMetaModel.java
@@ -164,4 +164,10 @@ public class InformixMetaModel extends GenericMetaModel
     public boolean hasFunctionSupport() {
         return false;
     }
+
+    @Override
+    public boolean isTrimObjectNames() {
+        // Some old drivers can return object names with spaces around. And we can't create names with spaces. So let's trim them.
+        return true;
+    }
 }


### PR DESCRIPTION
Informix has a highly complex story with quotes around names. Actually, there are no quotes for Informix, so we can't create a table or column with extra spaces around the columns. So let's trim all these extra spaces by default.

Please just check our Informix test database.