### PR TITLE
Sign copyright NOTICE in License files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/root/licenses/commons_license.txt
+++ b/docs/root/licenses/commons_license.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/root/licenses/gis-license.txt
+++ b/docs/root/licenses/gis-license.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/root/licenses/sshj-license.txt
+++ b/docs/root/licenses/sshj-license.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/features/org.jkiss.dbeaver.app.base.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.app.base.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.appstore.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.appstore.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.ce.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.ce.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.debug.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.debug.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.ext.ai.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.ext.ai.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.ext.office.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.ext.office.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.ext.ui.svg.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.ext.ui.svg.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.git.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.git.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.rcp.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.rcp.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.runtime.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.runtime.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/features/org.jkiss.dbeaver.standalone.feature/feature.properties
+++ b/features/org.jkiss.dbeaver.standalone.feature/feature.properties
@@ -192,7 +192,7 @@ license=\
       same "printed page" as the copyright notice for easier\n\
       identification within third-party archives.\n\
 \n\
-   Copyright [yyyy] [name of copyright owner]\n\
+   Copyright 2010 DBeaver Corp\n\
 \n\
    Licensed under the Apache License, Version 2.0 (the "License");\n\
    you may not use this file except in compliance with the License.\n\

--- a/plugins/org.jkiss.dbeaver.ext.athena.ui/LICENSE.txt
+++ b/plugins/org.jkiss.dbeaver.ext.athena.ui/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugins/org.jkiss.dbeaver.ext.athena/LICENSE.txt
+++ b/plugins/org.jkiss.dbeaver.ext.athena/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugins/org.jkiss.dbeaver.ext.bigquery.ui/LICENSE.txt
+++ b/plugins/org.jkiss.dbeaver.ext.bigquery.ui/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugins/org.jkiss.dbeaver.ext.bigquery/LICENSE.txt
+++ b/plugins/org.jkiss.dbeaver.ext.bigquery/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugins/org.jkiss.dbeaver.ext.derby/LICENSE.txt
+++ b/plugins/org.jkiss.dbeaver.ext.derby/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugins/org.jkiss.dbeaver.ext.elasticsearch/LICENSE.txt
+++ b/plugins/org.jkiss.dbeaver.ext.elasticsearch/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugins/org.jkiss.dbeaver.ext.opendistro/LICENSE.txt
+++ b/plugins/org.jkiss.dbeaver.ext.opendistro/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.ui/LICENSE.txt
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.ui/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2010 DBeaver Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Copyright Notices were left at Apache 2.0 default. Not sure if this was intentional since it appears in many places.