### PR TITLE
#18621 add Snowflake data types aliases; add numeric column modifiers…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/SnowflakeConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/SnowflakeConstants.java
@@ -41,4 +41,18 @@ public class SnowflakeConstants
     public static final String METADATA_COLUMN_LAST_ALTERED = "LAST_ALTERED";
     public static final String METADATA_COLUMN_COMMENT = "COMMENT";
 
+    public static final String TYPE_NUMBER = "NUMBER";
+    public static final String TYPE_NUMERIC = "NUMERIC";
+    public static final String TYPE_DECIMAL = "DECIMAL";
+    public static final String TYPE_FLOAT = "FLOAT";
+    public static final String TYPE_DOUBLE = "DOUBLE";
+    public static final String TYPE_DOUBLE_PRECISION = "DOUBLE PRECISION";
+    public static final String TYPE_REAL = "REAL";
+    public static final String TYPE_INT = "INT";
+    public static final String TYPE_INTEGER = "INTEGER";
+    public static final String TYPE_BIGINT = "BIGINT";
+
+    public static final int NUMERIC_MAX_PRECISION = 38;
+    public static final int NUMERIC_MAX_SCALE = 35;
+
 }

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataTypeCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataTypeCache.java
@@ -101,9 +101,9 @@ public class SnowflakeDataTypeCache extends GenericDataTypeCache {
                 SnowflakeConstants.TYPE_DECIMAL,
                 false,
                 false,
-                38,
+                SnowflakeConstants.NUMERIC_MAX_PRECISION,
                 0,
-                37));
+                SnowflakeConstants.NUMERIC_MAX_PRECISION - 1));
         }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataTypeCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataTypeCache.java
@@ -1,0 +1,109 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.snowflake.model;
+
+import org.jkiss.dbeaver.ext.generic.model.GenericDataType;
+import org.jkiss.dbeaver.ext.generic.model.GenericDataTypeCache;
+import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
+import org.jkiss.dbeaver.ext.snowflake.SnowflakeConstants;
+import org.jkiss.dbeaver.model.DBUtils;
+
+import java.sql.Types;
+import java.util.List;
+
+public class SnowflakeDataTypeCache extends GenericDataTypeCache {
+
+    SnowflakeDataTypeCache(GenericStructContainer owner) {
+        super(owner);
+    }
+
+    @Override
+    protected void addCustomObjects(List<GenericDataType> genericDataTypes) {
+        if (DBUtils.findObject(genericDataTypes, SnowflakeConstants.TYPE_BIGINT) == null) {
+            genericDataTypes.add(new GenericDataType(
+                owner,
+                Types.BIGINT,
+                SnowflakeConstants.TYPE_BIGINT,
+                SnowflakeConstants.TYPE_BIGINT,
+                false,
+                false,
+                0,
+                0,
+                0));
+        }
+        if (DBUtils.findObject(genericDataTypes, SnowflakeConstants.TYPE_INT) == null) {
+            genericDataTypes.add(new GenericDataType(
+                owner,
+                Types.INTEGER,
+                SnowflakeConstants.TYPE_INT,
+                SnowflakeConstants.TYPE_INT,
+                false,
+                false,
+                0,
+                0,
+                0));
+        }
+        if (DBUtils.findObject(genericDataTypes, SnowflakeConstants.TYPE_DOUBLE_PRECISION) == null) {
+            genericDataTypes.add(new GenericDataType(
+                owner,
+                Types.DOUBLE,
+                SnowflakeConstants.TYPE_DOUBLE_PRECISION,
+                SnowflakeConstants.TYPE_DOUBLE_PRECISION,
+                false,
+                false,
+                0,
+                0,
+                0));
+        }
+        if (DBUtils.findObject(genericDataTypes, SnowflakeConstants.TYPE_REAL) == null) {
+            genericDataTypes.add(new GenericDataType(
+                owner,
+                Types.REAL,
+                SnowflakeConstants.TYPE_REAL,
+                SnowflakeConstants.TYPE_REAL,
+                false,
+                false,
+                0,
+                0,
+                0));
+        }
+        if (DBUtils.findObject(genericDataTypes, SnowflakeConstants.TYPE_FLOAT) == null) {
+            genericDataTypes.add(new GenericDataType(
+                owner,
+                Types.FLOAT,
+                SnowflakeConstants.TYPE_FLOAT,
+                SnowflakeConstants.TYPE_FLOAT,
+                false,
+                false,
+                0,
+                0,
+                0));
+        }
+        if (DBUtils.findObject(genericDataTypes, SnowflakeConstants.TYPE_DECIMAL) == null) {
+            genericDataTypes.add(new GenericDataType(
+                owner,
+                Types.DECIMAL,
+                SnowflakeConstants.TYPE_DECIMAL,
+                SnowflakeConstants.TYPE_DECIMAL,
+                false,
+                false,
+                38,
+                0,
+                37));
+        }
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeMetaModel.java
@@ -33,6 +33,8 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCBasicDataTypeCache;
+import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCDataType;
 import org.jkiss.dbeaver.model.impl.sql.QueryTransformerLimit;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
@@ -55,6 +57,13 @@ public class SnowflakeMetaModel extends GenericMetaModel implements DBCQueryTran
     @Override
     public GenericDataSource createDataSourceImpl(DBRProgressMonitor monitor, DBPDataSourceContainer container) throws DBException {
         return new SnowflakeDataSource(monitor, container, this);
+    }
+
+    @Override
+    public JDBCBasicDataTypeCache<GenericStructContainer, ? extends JDBCDataType> createDataTypeCache(
+        @NotNull GenericStructContainer container
+    ) {
+        return new SnowflakeDataTypeCache(container);
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
@@ -20,7 +20,10 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.generic.model.GenericSQLDialect;
 import org.jkiss.dbeaver.ext.snowflake.SnowflakeConstants;
+import org.jkiss.dbeaver.model.DBPDataKind;
+import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCDatabaseMetaData;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCDataSource;
@@ -28,7 +31,10 @@ import org.jkiss.dbeaver.model.sql.SQLConstants;
 import org.jkiss.dbeaver.model.sql.parser.rules.SQLDollarQuoteRule;
 import org.jkiss.dbeaver.model.sql.parser.rules.SQLMultiWordRule;
 import org.jkiss.dbeaver.model.sql.parser.tokens.SQLTokenType;
+import org.jkiss.dbeaver.model.struct.DBSDataType;
+import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 import org.jkiss.dbeaver.model.text.parser.*;
+import org.jkiss.utils.CommonUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -94,5 +100,46 @@ public class SnowflakeSQLDialect extends GenericSQLDialect implements TPRuleProv
     @Override
     public MultiValueInsertMode getDefaultMultiValueInsertMode() {
         return MultiValueInsertMode.GROUP_ROWS;
+    }
+
+    @Override
+    public String getColumnTypeModifiers(
+        @NotNull DBPDataSource dataSource,
+        @NotNull DBSTypedObject column,
+        @NotNull String typeName,
+        @NotNull DBPDataKind dataKind
+    ) {
+        Integer scale;
+        switch (typeName) {
+            case SnowflakeConstants.TYPE_NUMBER:
+            case SnowflakeConstants.TYPE_NUMERIC:
+            case SnowflakeConstants.TYPE_DECIMAL:
+                DBSDataType dataType = DBUtils.getDataType(column);
+                scale = column.getScale();
+                int precision = CommonUtils.toInt(column.getPrecision());
+                if (precision == 0 && dataType != null && scale != null && scale == dataType.getMinScale()) {
+                    return "";
+                }
+                if (precision == 0 || precision > SnowflakeConstants.NUMERIC_MAX_PRECISION) {
+                    precision = SnowflakeConstants.NUMERIC_MAX_PRECISION;
+                }
+                if (scale != null || precision > 0) {
+                    // 38 - is default precision value. And we can not add scale here.
+                    // It will be changed to 0 automatically after table creation from the database side.
+                    return "(" + (precision > 0 ? precision : SnowflakeConstants.NUMERIC_MAX_PRECISION) +
+                        (scale != null && scale > 0 ? "," + scale : "") +  ")";
+                }
+                break;
+            case SnowflakeConstants.TYPE_DOUBLE:
+            case SnowflakeConstants.TYPE_DOUBLE_PRECISION:
+            case SnowflakeConstants.TYPE_REAL:
+            case SnowflakeConstants.TYPE_FLOAT:
+            case SnowflakeConstants.TYPE_INT:
+            case SnowflakeConstants.TYPE_INTEGER:
+            case SnowflakeConstants.TYPE_BIGINT:
+                // These types do not have parameters
+                return null;
+        }
+        return super.getColumnTypeModifiers(dataSource, column, typeName, dataKind);
     }
 }


### PR DESCRIPTION
… rules;

also BIGINT, INT, REAL, FLOAT, DOUBLE PRECISION, and DECIMAL were added as data types aliases. Only DECIMAL has parameters.

![2023-04-29 00_01_13-Configure metadata structure](https://user-images.githubusercontent.com/45152336/235254654-7306297a-3628-4285-8a08-37426e94b8a6.png)

https://docs.snowflake.com/en/sql-reference/data-types-numeric