### PR TITLE
#19854 Disable SSHJ hostname verification when "Bypass host verification" is enabled

### DIFF
--- a/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationSshj.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationSshj.java
@@ -161,6 +161,7 @@ public class SSHImplementationSshj extends SSHImplementationAbstract {
             configuration.getBooleanProperty(SSHConstants.PROP_BYPASS_HOST_VERIFICATION)
         ) {
             client.addHostKeyVerifier(new PromiscuousVerifier());
+            client.getTransport().getConfig().setVerifyHostKeyCertificates(false);
         } else {
             client.addHostKeyVerifier(new KnownHostsVerifier(SSHUtils.getKnownSshHostsFileOrDefault(), actualHostConfiguration));
         }


### PR DESCRIPTION
Setup:
- An SSH server (e.g., `database-host.example.com:22`)
- The server uses a signed host cert, where `database-host.example.com` is **not present** in the certs allowed host names

To reproduce:
- Create a new database connection, using `SSHJ` as the SSH implementation
- Tick `Disable host verification`

DBeaver correctly uses `PromiscuousVerifier` to skip the host certificate signature check.

However, the hostname `database-host.example.com` will still be checked against the cert.

<br />

This commit makes it so `Disable host verification` also disables the host certificate "hostname check".

See #19854 for more context.