### PR TITLE
#19854 Use SSHJ tunneling for jump server support

### DIFF
--- a/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationSshj.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/SSHImplementationSshj.java
@@ -18,6 +18,7 @@ package org.jkiss.dbeaver.model.net.ssh;
 
 import com.jcraft.jsch.Identity;
 import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.connection.channel.direct.DirectConnection;
 import net.schmizz.sshj.connection.channel.direct.LocalPortForwarder;
 import net.schmizz.sshj.connection.channel.direct.Parameters;
 import net.schmizz.sshj.sftp.SFTPClient;
@@ -86,14 +87,17 @@ public class SSHImplementationSshj extends SSHImplementationAbstract {
 
             try {
                 if (index > 0) {
-                    final int port = setPortForwarding(clients[index - 1], host.getHostname(), host.getPort());
+                    final SSHClient prevClient = clients[index - 1];
 
                     monitor.subTask(String.format(
-                        "Instantiate tunnel %s:%d -> %s:%d",
-                        hosts[index - 1].getHostname(), port,
-                        host.getHostname(), host.getPort()));
+                        "Instantiate tunnel to %s:%d via %s:%d",
+                        host.getHostname(), host.getPort(),
+                        prevClient.getRemoteHostname(), prevClient.getRemotePort()));
 
-                    client.connect("localhost", port);
+                    final DirectConnection tunnel = prevClient.newDirectConnection(
+                        host.getHostname(), host.getPort()
+                    );
+                    client.connectVia(tunnel);
                 } else {
                     monitor.subTask(String.format(
                         "Instantiate tunnel to %s:%d",


### PR DESCRIPTION
Consider the following setup:
- An SSH `jump-server` at `jump.example.com:22`
- A main `ssh-server` at `10.0.0.1:22`, requires jumping through `jump-server`
- The SSH host certificates are signed with `jump.example.com` and `10.0.0.1` respectively

Currently DBeaver will:
- Connect to the `jump-server`
- Set up a port forward (tunnel) from `localhost:12345` -> `10.0.0.1:22` via `jump-server`
- Connect to `localhost:12345`

However, the SSH host certificate check fails because `localhost` is not in the cert (only `10.0.0.1` is).

The fix is to follow DBeaver's [`Jump.java` example](https://github.com/hierynomus/sshj/blob/9e8bef24c5dcf5353677333037d5a52ac3f3a34f/examples/src/main/java/net/schmizz/sshj/examples/Jump.java), where they suggest using [`jumpServer.newDirectConnection()`](https://github.com/hierynomus/sshj/blob/9e8bef24c5dcf5353677333037d5a52ac3f3a34f/src/main/java/net/schmizz/sshj/SSHClient.java#L676-L688).

This method will correctly check `10.0.0.1` against the host certificate. 

<br />

See #19854 for more context.