### PR TITLE
#19318 Fix if-exists parsing for Oracle

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
@@ -68,7 +68,6 @@ public class OracleSQLDialect extends JDBCSQLDialect implements SQLDataTypeConve
 
     private static final String[][] ORACLE_BEGIN_END_BLOCK = new String[][]{
         {SQLConstants.BLOCK_BEGIN, SQLConstants.BLOCK_END},
-        {"IF", SQLConstants.BLOCK_END},
         {"LOOP", SQLConstants.BLOCK_END + " LOOP"},
         {SQLConstants.KEYWORD_CASE, SQLConstants.BLOCK_END + " " + SQLConstants.KEYWORD_CASE},
     };
@@ -661,6 +660,11 @@ public class OracleSQLDialect extends JDBCSQLDialect implements SQLDataTypeConve
                                 tt.sequence("procedure", SQLTokenType.T_OTHER),
                                 tt.sequence(SQLTokenType.T_OTHER, SQLTokenType.T_TYPE)
                         ), ";")
+                ),
+                new TokenPredicatesCondition(
+                    SQLParserActionKind.BEGIN_BLOCK,
+                    tt.sequence(),
+                    tt.sequence(tt.not("END"), "IF", tt.not("EXISTS"))
                 )
         );
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -86,6 +86,7 @@ public class SQLScriptParser {
         SQLDialect dialect = context.getDialect();
         SQLTokenPredicateEvaluator predicateEvaluator = new SQLTokenPredicateEvaluator(dialect.getSkipTokenPredicates());
         boolean isPredicateEvaluationEnabled = isPredicateEvaluationEnabled();
+        boolean newTokenCaptured = false;
 
         // Parse range
         TPRuleBasedScanner ruleScanner = context.getScanner();
@@ -115,7 +116,8 @@ public class SQLScriptParser {
             try {
                 if (isPredicateEvaluationEnabled && tokenLength > 0 && !token.isWhitespace()) {
                     String tokenText = document.get(tokenOffset, tokenLength);
-                    predicateEvaluator.captureToken(new SQLTokenEntry(tokenText, tokenType));
+                    predicateEvaluator.captureToken(new SQLTokenEntry(tokenText, tokenType, false));
+                    newTokenCaptured = true;
                 }
 
                 boolean isDelimiter = (tokenType == SQLTokenType.T_DELIMITER) ||
@@ -211,7 +213,8 @@ public class SQLScriptParser {
                     }
                 }
 
-                if (isPredicateEvaluationEnabled && !token.isEOF()) {
+                if (isPredicateEvaluationEnabled && !token.isEOF() && newTokenCaptured) {
+                    newTokenCaptured = false;
                     SQLParserActionKind actionKind = predicateEvaluator.evaluatePredicates();
                     if (actionKind == SQLParserActionKind.BEGIN_BLOCK) {
                         // header blocks seems optional and we are in the block either way

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/DefaultTokenPredicateFactory.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/DefaultTokenPredicateFactory.java
@@ -29,8 +29,8 @@ class DefaultTokenPredicateFactory extends TokenPredicateFactory {
 
     @Override
     @NotNull
-    protected TokenPredicateNode classifyToken(@NotNull String tokenString) {
+    protected SQLTokenEntry classifyToken(@NotNull String tokenString) {
         // Knows nothing about particular dialect or used in dialect-agnostic context
-        return new SQLTokenEntry(tokenString, SQLTokenType.T_UNKNOWN);
+        return new SQLTokenEntry(tokenString, SQLTokenType.T_UNKNOWN, false);
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/SQLTokenEntry.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/SQLTokenEntry.java
@@ -31,10 +31,12 @@ import java.util.Objects;
 public class SQLTokenEntry extends TokenPredicateNode implements TokenEntry {
     private final String string;
     private final SQLTokenType type;
+    private final boolean isInverted;
 
-    public SQLTokenEntry(@Nullable String string, @Nullable SQLTokenType type) {
+    public SQLTokenEntry(@Nullable String string, @Nullable SQLTokenType type, boolean isInverted) {
         this.string = string;
         this.type = type;
+        this.isInverted = isInverted;
     }
 
     @Override
@@ -45,21 +47,30 @@ public class SQLTokenEntry extends TokenPredicateNode implements TokenEntry {
 
     @Override
     @Nullable
-    public Enum getTokenType() {
+    public SQLTokenType getTokenType() {
         return this.type;
+    }
+    
+    public boolean isInverted() {
+        return this.isInverted;
     }
 
     @Override
     public boolean matches(@NotNull TokenEntry other) {
         boolean stringMatches = this.getString() == null || other.getString() == null || this.string.equalsIgnoreCase(other.getString());
         boolean typeMatches = this.getTokenType() == null || other.getTokenType() == null || this.type.equals(other.getTokenType());
+        if (this.isInverted) {
+            stringMatches = !stringMatches;
+            typeMatches = !typeMatches;
+        }
         return stringMatches && typeMatches;
     }
 
     public boolean equals(@NotNull TokenEntry other) {
         boolean stringEquals = (this.getString() == null && other.getString() == null) || (this.getString() != null && other.getString() != null && this.getString().equals(other.getString()));
         boolean typeEquals = (this.getTokenType() == null && other.getTokenType() == null) || (this.getTokenType() != null && other.getTokenType() != null && this.getTokenType().equals(other.getTokenType()));
-        return stringEquals && typeEquals;
+        boolean invertedEquals = this.isInverted() == other.isInverted();
+        return stringEquals && typeEquals && invertedEquals;
     }
 
     @Override
@@ -69,11 +80,14 @@ public class SQLTokenEntry extends TokenPredicateNode implements TokenEntry {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.getString(), this.getTokenType());
+        return Objects.hash(this.getString(), this.getTokenType(), this.isInverted());
     }
 
     @NotNull
     public StringBuilder format(@NotNull StringBuilder sb) {
+        if (this.isInverted) {
+            sb.append("!");
+        }
         return sb.append("<").append(type != null ? type.name() : "?").append(">")
                 .append(this.string != null ? "'" + this.string + "'" : "any");
     }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/SQLTokenEntry.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/SQLTokenEntry.java
@@ -59,11 +59,11 @@ public class SQLTokenEntry extends TokenPredicateNode implements TokenEntry {
     public boolean matches(@NotNull TokenEntry other) {
         boolean stringMatches = this.getString() == null || other.getString() == null || this.string.equalsIgnoreCase(other.getString());
         boolean typeMatches = this.getTokenType() == null || other.getTokenType() == null || this.type.equals(other.getTokenType());
+        boolean result = stringMatches && typeMatches;
         if (this.isInverted) {
-            stringMatches = !stringMatches;
-            typeMatches = !typeMatches;
+            result = !result;
         }
-        return stringMatches && typeMatches;
+        return result; 
     }
 
     public boolean equals(@NotNull TokenEntry other) {

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/SQLTokenPredicateFactory.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/SQLTokenPredicateFactory.java
@@ -86,13 +86,13 @@ class SQLTokenPredicateFactory extends TokenPredicateFactory {
                 TPToken token = fRule.evaluate(scanner);
                 if (!token.isUndefined()) {
                     SQLTokenType tokenType = token instanceof TPTokenDefault ? (SQLTokenType) ((TPTokenDefault) token).getData() : SQLTokenType.T_OTHER;
-                    return new SQLTokenEntry(string, tokenType);
+                    return new SQLTokenEntry(string, tokenType, false);
                 }
             } catch (Throwable e) {
                 // some rules raise exceptions in a certain situations when the string does not correspond the rule
                 log.debug(e.getMessage());
             }
         }
-        return new SQLTokenEntry(string, null);
+        return new SQLTokenEntry(string, null, false);
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/TokenEntryMatchingComparator.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/TokenEntryMatchingComparator.java
@@ -35,12 +35,12 @@ class TokenEntryMatchingComparator extends TokenEntryComparatorBase implements T
 
     @Override
     public boolean isStronglyComparable(@NotNull TokenEntry term) {
-        return term.getString() != null && term.getTokenType() != null;
+        return term.getString() != null && term.getTokenType() != null && !term.isInverted();
     }
 
     @Override
     public boolean isPartiallyComparable(@NotNull TokenEntry term) {
-        return term.getTokenType() != null;
+        return term.getTokenType() != null && !term.isInverted();
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/TokenPredicateFactory.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/TokenPredicateFactory.java
@@ -65,7 +65,7 @@ public abstract class TokenPredicateFactory {
      * @return predicate node carrying information about the token entry
      */
     @NotNull
-    protected abstract TokenPredicateNode classifyToken(@NotNull String tokenString);
+    protected abstract SQLTokenEntry classifyToken(@NotNull String tokenString);
 
     /**
      * Materialize token predicate node carrying information about token entry described in a certain way.
@@ -75,13 +75,13 @@ public abstract class TokenPredicateFactory {
     @NotNull
     private TokenPredicateNode makeNode(@Nullable Object obj) {
         if (obj == null) {
-            return new SQLTokenEntry(null, null);
+            return new SQLTokenEntry(null, null, false);
         } else if (obj instanceof TokenPredicateNode) {
             return (TokenPredicateNode)obj;
         } else if (obj instanceof String) {
             return this.classifyToken((String)obj);
         } else if (obj instanceof SQLTokenType) {
-            return new SQLTokenEntry(null, (SQLTokenType) obj);
+            return new SQLTokenEntry(null, (SQLTokenType) obj, false);
         } else {
             throw new IllegalArgumentException();
         }
@@ -125,5 +125,16 @@ public abstract class TokenPredicateFactory {
     @NotNull
     public TokenPredicateNode optional(@NotNull Object ... obj) {
         return new OptionalTokenPredicateNode(obj.length == 1 ? this.makeNode(obj[0]) : this.sequence(obj));
+    }
+    
+    @NotNull
+    public TokenPredicateNode not(@NotNull String str) {
+        SQLTokenEntry entry = this.classifyToken(str);
+        return new SQLTokenEntry(entry.getString(), entry.getTokenType(), true);
+    }
+
+    @NotNull
+    public TokenPredicateNode not(@NotNull SQLTokenType token) {
+        return new SQLTokenEntry(null, token, true);
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/TokenPredicateNode.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/TokenPredicateNode.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.model.sql.parser.tokens.predicates;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.sql.parser.TokenEntry;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -44,7 +45,8 @@ public abstract class TokenPredicateNode {
      */
     @NotNull
     public List<List<TokenEntry>> expand() {
-        return TokenPredicateExpander.expand(this);
+        List<List<TokenEntry>> result = TokenPredicateExpander.expand(this);
+        return result.isEmpty() ? List.of(Collections.emptyList()) : result;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/Trie.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/predicates/Trie.java
@@ -141,7 +141,7 @@ public class Trie<T, V> {
 
         @Nullable
         private ListNode<TrieNode<T, V>> accumulateNonComparableSubnodes(@NotNull T term, @NotNull ListNode<TrieNode<T, V>> results) {
-            TrieLookupComparator comparer = Trie.this.lookupPartialComparer;
+            TrieLookupComparator<T> comparer = Trie.this.lookupPartialComparer;
             ListNode<TrieNode<T, V>> accumulatedResults = results;
             for (int i = 0; i < this.childKeys.size(); i++) {
                 if (comparer.match(this.childKeys.get(i), term)) {
@@ -153,7 +153,7 @@ public class Trie<T, V> {
 
         @NotNull
         private ListNode<TrieNode<T, V>> accumulatePartiallyComparableSubnodes(@NotNull T term, @NotNull ListNode<TrieNode<T, V>> results) {
-            TrieLookupComparator comparer = Trie.this.lookupPartialComparer;
+            TrieLookupComparator<T> comparer = Trie.this.lookupPartialComparer;
             ListNode<TrieNode<T, V>> accumulatedResults = results;
             int index = Collections.binarySearch(this.childKeys, term, comparer);
             if (index >= 0) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/parser/TokenEntry.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/parser/TokenEntry.java
@@ -35,6 +35,8 @@ public interface TokenEntry {
      */
     @Nullable
     Enum getTokenType();
+    
+    boolean isInverted();
 
     /**
      * Checks if two entries could possibly describe the same concrete token

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
@@ -317,7 +317,7 @@ public class SQLScriptParserTest {
                 "        i := i + 1;\n" +
                 "        DBMS_OUTPUT.PUT_LINE ('This is: '||i);\n" +
                 "    END IF;\n" +
-                "END;\n",
+                "END;",
 
                 "CREATE TRIGGER TRI_CODE_SYSTEM\n" +
                 "BEFORE INSERT ON CODE_SYSTEM\n" +

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
@@ -180,6 +180,16 @@ public class SQLScriptParserTest {
             "    dbms_output.put_line(test_v||chr(9)||test_f(test_v));\n" +
             "    dbms_output.put_line('End');\n" +
             "END;\n" +
+            
+            "DECLARE\n" +
+            "    i int;\n" +
+            "BEGIN\n" +
+            "    i := 0;\n" +
+            "    IF i < 5 THEN\n" +
+            "        i := i + 1;\n" +
+            "        DBMS_OUTPUT.PUT_LINE ('This is: '||i);\n" +
+            "    END IF;\n" +
+            "END;\n" +
 
             "CREATE TRIGGER TRI_CODE_SYSTEM\n" +
             "BEFORE INSERT ON CODE_SYSTEM\n" +
@@ -298,6 +308,16 @@ public class SQLScriptParserTest {
                 "    dbms_output.put_line(test_v||chr(9)||test_f(test_v));\n" +
                 "    dbms_output.put_line('End');\n" +
                 "END;",
+                
+                "DECLARE\n" +
+                "    i int;\n" +
+                "BEGIN\n" +
+                "    i := 0;\n" +
+                "    IF i < 5 THEN\n" +
+                "        i := i + 1;\n" +
+                "        DBMS_OUTPUT.PUT_LINE ('This is: '||i);\n" +
+                "    END IF;\n" +
+                "END;\n",
 
                 "CREATE TRIGGER TRI_CODE_SYSTEM\n" +
                 "BEFORE INSERT ON CODE_SYSTEM\n" +


### PR DESCRIPTION
All of the following statements should be correctly determined. DECLARE block should end on END: and so on.
```
DECLARE
i int;
BEGIN
i := 0;
IF i < 5 THEN
i := i + 1;
DBMS_OUTPUT.PUT_LINE ('This is: '||i);
END IF;
END;

DROP TABLE
IF EXISTS test;

select * FROM
YM8.TIMETEST t ;
```

Note: Oracle don't have if exists inside drop table statement, so execution will lead to an error from the database, but the correct statement part should be send, which you can see in query manager.