### PR TITLE
dbeaver/dbeaver#19671 improve time handling for MySQL5 and MySQL8

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/data/MySQLDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/data/MySQLDateTimeValueHandler.java
@@ -67,14 +67,13 @@ public class MySQLDateTimeValueHandler extends JDBCDateTimeValueHandler {
                 }
                 /*
                   We want to handle time as a String for MariaDB due to it silently cutting the values
-                  after 24H, we only want this by default for Maria because MySQL5 will
+                  after 24H. We only want this by default for Maria because MySQL5 will
                   fail regardless of used method for value bigger than 24h. And MySQL8 will
-                  try to getTime() if it fails we will get value via getString()
+                  try to getTime(). If it fails, we will get value via getString()
                  */
-                if (MySQLUtils.isMariaDB(session.getDataSource().getContainer().getDriver())) {
-                    if (type.getTypeID() == Types.TIME) {
-                        return dbResults.getString(index + 1);
-                    }
+                if (MySQLUtils.isMariaDB(session.getDataSource().getContainer().getDriver())
+                    && type.getTypeID() == Types.TIME) {
+                    return dbResults.getString(index + 1);
                 }
             } catch (SQLException e) {
                 log.debug("Exception caught when fetching date/time value", e);

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/data/MySQLDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/data/MySQLDateTimeValueHandler.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.mysql.data;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.mysql.MySQLConstants;
+import org.jkiss.dbeaver.ext.mysql.MySQLUtils;
 import org.jkiss.dbeaver.model.data.DBDDisplayFormat;
 import org.jkiss.dbeaver.model.data.DBDFormatSettings;
 import org.jkiss.dbeaver.model.exec.DBCException;
@@ -64,8 +65,16 @@ public class MySQLDateTimeValueHandler extends JDBCDateTimeValueHandler {
                     }
                     return year;
                 }
-                if (type.getTypeID() == Types.TIME) {
-                    return dbResults.getString(index + 1);
+                /*
+                  We want to handle time as a String for MariaDB due to it silently cutting the values
+                  after 24H, we only want this by default for Maria because MySQL5 will
+                  fail regardless of used method for value bigger than 24h. And MySQL8 will
+                  try to getTime() if it fails we will get value via getString()
+                 */
+                if (MySQLUtils.isMariaDB(session.getDataSource().getContainer().getDriver())) {
+                    if (type.getTypeID() == Types.TIME) {
+                        return dbResults.getString(index + 1);
+                    }
                 }
             } catch (SQLException e) {
                 log.debug("Exception caught when fetching date/time value", e);


### PR DESCRIPTION
Closes dbeaver/dbeaver#19671
Now MySQL will handle Time as java.sql.Time by default, in the case of MySQL 8, if the value in the field is bigger than 24h, it will be handled as String, MySQL 5 will still fail for values bigger than 24h but now handles other values in java.sql.Time. No changes for MariaDB because it works as expected.