### PR TITLE
#19678 fix tables subpartitions reading; fix cache invalidate

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/edit/MySQLTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/edit/MySQLTableManager.java
@@ -66,6 +66,16 @@ public class MySQLTableManager extends SQLTableManager<MySQLTableBase, MySQLCata
     }
 
     @Override
+    public boolean canRenameObject(MySQLTableBase object) {
+        return !object.isPartition();
+    }
+
+    @Override
+    public boolean canDeleteObject(MySQLTableBase object) {
+        return !object.isPartition();
+    }
+
+    @Override
     protected MySQLTableBase createDatabaseObject(DBRProgressMonitor monitor, DBECommandContext context, Object container, Object copyFrom, Map<String, Object> options) throws DBException {
         final MySQLTable table;
         MySQLCatalog catalog = (MySQLCatalog) container;

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLPartition.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLPartition.java
@@ -18,28 +18,38 @@ package org.jkiss.dbeaver.ext.mysql.model;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.mysql.MySQLConstants;
 import org.jkiss.dbeaver.model.DBConstants;
+import org.jkiss.dbeaver.model.DBPDataSource;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.data.DBDDataFilter;
+import org.jkiss.dbeaver.model.data.DBDPseudoAttribute;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
-import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTableObject;
+import org.jkiss.dbeaver.model.meta.Association;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.meta.PropertyLength;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSEntity;
 import org.jkiss.dbeaver.model.struct.rdb.DBSTablePartition;
 
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * MySQLPartition
  */
-public class MySQLPartition extends JDBCTableObject<MySQLTable> implements DBSTablePartition {
+public class MySQLPartition extends MySQLTable implements DBSTablePartition {
 
+    private MySQLTable table;
     private MySQLPartition parent;
     private List<MySQLPartition> subPartitions;
     private int position;
+    private String name;
     private String method;
     private String expression;
     private String description;
@@ -58,7 +68,10 @@ public class MySQLPartition extends JDBCTableObject<MySQLTable> implements DBSTa
 
     protected MySQLPartition(MySQLTable mySQLTable, MySQLPartition parent, String name, ResultSet dbResult)
     {
-        super(mySQLTable, name, true);
+        super(mySQLTable.getContainer(), dbResult);
+        this.name = name;
+        this.table = mySQLTable;
+        setPartition(true);
         this.parent = parent;
         if (parent != null) {
             parent.addSubPartitions(this);
@@ -90,15 +103,17 @@ public class MySQLPartition extends JDBCTableObject<MySQLTable> implements DBSTa
         this.nodegroup = JDBCUtils.safeGetString(dbResult, MySQLConstants.COL_NODEGROUP);
     }
 
-    protected MySQLPartition(JDBCTableObject<MySQLTable> source)
-    {
-        super(source);
-    }
-
     // Copy constructor
-    protected MySQLPartition(DBRProgressMonitor monitor, MySQLTable table, MySQLPartition source)
-    {
-        super(table, source.getName(), false);
+    protected MySQLPartition(
+        DBRProgressMonitor monitor,
+        MySQLTable table,
+        MySQLPartition source,
+        DBSEntity sourceEntity
+    ) throws DBException {
+        super(monitor, table.getContainer(), sourceEntity);
+        setPartition(true);
+        this.name = source.name;
+        this.table = source.table;
         this.position = source.position;
         this.method = source.method;
         this.expression = source.expression;
@@ -120,6 +135,7 @@ public class MySQLPartition extends JDBCTableObject<MySQLTable> implements DBSTa
         return parent;
     }
 
+    @Association
     public List<MySQLPartition> getSubPartitions()
     {
         return subPartitions;
@@ -127,17 +143,10 @@ public class MySQLPartition extends JDBCTableObject<MySQLTable> implements DBSTa
 
     @NotNull
     @Override
-    public MySQLDataSource getDataSource()
-    {
-        return getTable().getDataSource();
-    }
-
-    @NotNull
-    @Override
-    @Property(viewable = true, order = 1)
+    @Property(viewable = true, editable = false, updatable = false, order = 1)
     public String getName()
     {
-        return super.getName();
+        return name;
     }
 
     @Property(viewable = true, order = 2)
@@ -238,4 +247,28 @@ public class MySQLPartition extends JDBCTableObject<MySQLTable> implements DBSTa
         return checksum;
     }
 
+    @Override
+    public String getObjectDefinitionText(DBRProgressMonitor monitor, Map<String, Object> options) throws DBException {
+        return table.getObjectDefinitionText(monitor, options);
+    }
+
+    @Override
+    protected boolean needAliasInSelect(
+        @Nullable DBDDataFilter dataFilter,
+        @Nullable DBDPseudoAttribute rowIdAttribute,
+        @NotNull DBPDataSource dataSource
+    ) {
+        return false;
+    }
+
+    @NotNull
+    @Override
+    protected String getTableName() {
+        return table.getFullyQualifiedName(DBPEvaluationContext.DML);
+    }
+
+    @Override
+    protected void appendExtraSelectParameters(@NotNull StringBuilder query) {
+        query.append(" PARTITION (").append(DBUtils.getQuotedIdentifier(this)).append(")");
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
@@ -559,15 +559,14 @@ public class MySQLTable extends MySQLTableBase implements DBPObjectStatistics, D
                     parentPartition = new MySQLPartition(table, null, partitionName, dbResult);
                     partitionMap.put(partitionName, parentPartition);
                 }
-                new MySQLPartition(table, parentPartition, subPartitionName, dbResult);
-                return null;
+                return new MySQLPartition(table, parentPartition, subPartitionName, dbResult);
             }
         }
 
         @Override
         protected void invalidateObjects(DBRProgressMonitor monitor, MySQLTable owner, Iterator<MySQLPartition> objectIter)
         {
-            partitionMap = null;
+            partitionMap.clear();
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTableBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTableBase.java
@@ -52,6 +52,8 @@ public abstract class MySQLTableBase extends JDBCTable<MySQLDataSource, MySQLCat
 {
     private static final Log log = Log.getLog(MySQLTableBase.class);
 
+    private boolean isPartition;
+
     protected MySQLTableBase(MySQLCatalog catalog)
     {
         super(catalog, false);
@@ -77,6 +79,14 @@ public abstract class MySQLTableBase extends JDBCTable<MySQLDataSource, MySQLCat
         ResultSet dbResult)
     {
         super(catalog, JDBCUtils.safeGetString(dbResult, 1), true);
+    }
+
+    public boolean isPartition() {
+        return isPartition;
+    }
+
+    public void setPartition(boolean partition) {
+        isPartition = partition;
     }
 
     @Override


### PR DESCRIPTION
![2023-05-04 12_26_39-DBeaver Ultimate Asya  23 0 4 - _Google Cloud SQL - MySQL - test-mysql-instance_](https://user-images.githubusercontent.com/45152336/236165700-71c8e984-ca4b-4c17-bda3-780dc0b9bd65.png)

Please check the following:

- [ ] Tables with partitions https://dev.mysql.com/doc/refman/8.0/en/create-table.html
- [ ] Tables with subpartitions https://dev.mysql.com/doc/mysql-partitioning-excerpt/8.0/en/partitioning-subpartitions.html
- [ ] Refreshing these tables
- [ ] Ability to read data in partitioned tables
- [ ] Ability to read data in subpartitioned tables
- [ ] Ability to read data in ordinary tables - please check with filters and in different databases, general code was changed for all jdbc tables

Knowing issue for now for partitioned tables for MySQL - the ERD tab is empty, and the table name is changeable