### PR TITLE
dbeaver/dbeaver#18770 save previous user dialog size

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
@@ -16,9 +16,11 @@
  */
 package org.jkiss.dbeaver.ui.dialogs.connection;
 
+import org.eclipse.e4.tools.emf.ui.internal.common.component.HandlerEditor;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
@@ -49,6 +51,8 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
     private static final Map<DBPDataSourceContainer, EditConnectionDialog> openDialogs = Collections.synchronizedMap(new IdentityHashMap<>());
 
     private static final int TEST_BUTTON_ID = 2000;
+    private static final String PROP_DIALOG_RECOMMENDED_SIZE_HEIGHT = "dialog.preferredSize.height";
+    private static final String PROP_DIALOG_RECOMMENDED_SIZE_WIDTH = "dialog.preferredSize.width";
     private static String lastActivePage;
 
     private Button testButton;
@@ -75,8 +79,7 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
 
     @Override
     protected Control createContents(Composite parent) {
-        Control contents = super.createContents(parent);
-
+        Control contents = super.createContents(parent);;
         String activePage = defaultPageName;
         if (CommonUtils.isEmpty(activePage)) {
             activePage = lastActivePage;
@@ -94,7 +97,27 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
         if (items.length > 0) {
             items[0].setExpanded(true);
         }
+        computeDesiredSize(contents);
+        contents.getShell().addListener(SWT.Resize, event -> {
+            Shell shell = getShell();
+            if (shell != null && !shell.isDisposed()) {
+                Point size = shell.getSize();
+                getDialogBoundsSettings().put(PROP_DIALOG_RECOMMENDED_SIZE_HEIGHT, size.y);
+                getDialogBoundsSettings().put(PROP_DIALOG_RECOMMENDED_SIZE_WIDTH, size.x);
+            }
+        });
         return contents;
+    }
+
+    private void computeDesiredSize(@NotNull Control contents) {
+        try {
+            int height = getDialogBoundsSettings().getInt(PROP_DIALOG_RECOMMENDED_SIZE_HEIGHT);
+            int width = getDialogBoundsSettings().getInt(PROP_DIALOG_RECOMMENDED_SIZE_WIDTH);
+            contents.getShell().setSize(width, height);
+        } catch (NumberFormatException ignore) {
+            // ignore
+        }
+        contents.getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT);
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
@@ -50,8 +50,6 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
 
     private static final int TEST_BUTTON_ID = 2000;
 
-    private static final String DIALOG_WIDTH = "DIALOG_WIDTH";
-    private static final String DIALOG_HEIGHT = "DIALOG_HEIGHT";
     private static String lastActivePage;
 
     private Button testButton;
@@ -96,25 +94,6 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
             items[0].setExpanded(true);
         }
         return contents;
-    }
-
-    @Override
-    protected Point getInitialSize() {
-        Point size = super.getInitialSize();
-        IDialogSettings settings = getDialogBoundsSettings();
-        try {
-            // Get the stored width and height.
-            int width = settings.getInt(DIALOG_WIDTH);
-            if (width != DIALOG_DEFAULT_BOUNDS) {
-                size.x = Math.max(width, size.x);
-            }
-            int height = settings.getInt(DIALOG_HEIGHT);
-            if (height != DIALOG_DEFAULT_BOUNDS) {
-                size.y = Math.max(height, size.y);
-            }
-        } catch (NumberFormatException ignored) {
-        }
-        return size;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
@@ -112,8 +112,7 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
             if (height != DIALOG_DEFAULT_BOUNDS) {
                 size.y = Math.max(height, size.y);
             }
-        }
-        catch (NumberFormatException ignored) {
+        } catch (NumberFormatException ignored) {
         }
         return size;
     }

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
@@ -49,8 +49,9 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
     private static final Map<DBPDataSourceContainer, EditConnectionDialog> openDialogs = Collections.synchronizedMap(new IdentityHashMap<>());
 
     private static final int TEST_BUTTON_ID = 2000;
-    private static final String PROP_DIALOG_RECOMMENDED_SIZE_HEIGHT = "dialog.preferredSize.height";
-    private static final String PROP_DIALOG_RECOMMENDED_SIZE_WIDTH = "dialog.preferredSize.width";
+
+    private static final String DIALOG_WIDTH = "DIALOG_WIDTH";
+    private static final String DIALOG_HEIGHT = "DIALOG_HEIGHT";
     private static String lastActivePage;
 
     private Button testButton;
@@ -99,23 +100,23 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
 
     @Override
     protected Point getInitialSize() {
-        Point minSize = super.getInitialSize();
+        Point size = super.getInitialSize();
         IDialogSettings settings = getDialogBoundsSettings();
-        Point proposedSize = new Point(minSize.x, minSize.y);
         try {
             // Get the stored width and height.
-            int width = settings.getInt("DIALOG_WIDTH");
+            int width = settings.getInt(DIALOG_WIDTH);
             if (width != DIALOG_DEFAULT_BOUNDS) {
-                proposedSize.x = Math.max(width, proposedSize.x);
+                size.x = Math.max(width, size.x);
             }
-            int height = settings.getInt("DIALOG_HEIGHT");
+            int height = settings.getInt(DIALOG_HEIGHT);
             if (height != DIALOG_DEFAULT_BOUNDS) {
-                proposedSize.y = Math.max(height, proposedSize.y);
+                size.y = Math.max(height, size.y);
             }
         }
-        catch (NumberFormatException e) {
+        catch (NumberFormatException ignored) {
+
         }
-        return proposedSize;
+        return size;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
@@ -114,7 +114,6 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
             }
         }
         catch (NumberFormatException ignored) {
-
         }
         return size;
     }

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
@@ -29,7 +29,6 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.core.CoreFeatures;
 import org.jkiss.dbeaver.core.CoreMessages;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
-import org.jkiss.dbeaver.model.connection.DBPDriverSubstitutionDescriptor;
 import org.jkiss.dbeaver.registry.DataSourceDescriptor;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.dialogs.MultiPageWizardDialog;
@@ -89,34 +88,34 @@ public class EditConnectionDialog extends MultiPageWizardDialog {
                 getWizard().openSettingsPage(finalActivePage);
             });
         }
-
         // Expand first page
         Tree pagesTree = getPagesTree();
         TreeItem[] items = pagesTree.getItems();
         if (items.length > 0) {
             items[0].setExpanded(true);
         }
-        computeDesiredSize(contents);
-        contents.getShell().addListener(SWT.Resize, event -> {
-            Shell shell = getShell();
-            if (shell != null && !shell.isDisposed()) {
-                Point size = shell.getSize();
-                getDialogBoundsSettings().put(PROP_DIALOG_RECOMMENDED_SIZE_HEIGHT, size.y);
-                getDialogBoundsSettings().put(PROP_DIALOG_RECOMMENDED_SIZE_WIDTH, size.x);
-            }
-        });
         return contents;
     }
 
-    private void computeDesiredSize(@NotNull Control contents) {
+    @Override
+    protected Point getInitialSize() {
+        Point minSize = super.getInitialSize();
+        IDialogSettings settings = getDialogBoundsSettings();
+        Point proposedSize = new Point(minSize.x, minSize.y);
         try {
-            int height = getDialogBoundsSettings().getInt(PROP_DIALOG_RECOMMENDED_SIZE_HEIGHT);
-            int width = getDialogBoundsSettings().getInt(PROP_DIALOG_RECOMMENDED_SIZE_WIDTH);
-            contents.getShell().setSize(width, height);
-        } catch (NumberFormatException ignore) {
-            // ignore
+            // Get the stored width and height.
+            int width = settings.getInt("DIALOG_WIDTH");
+            if (width != DIALOG_DEFAULT_BOUNDS) {
+                proposedSize.x = Math.max(width, proposedSize.x);
+            }
+            int height = settings.getInt("DIALOG_HEIGHT");
+            if (height != DIALOG_DEFAULT_BOUNDS) {
+                proposedSize.y = Math.max(height, proposedSize.y);
+            }
         }
-        contents.getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT);
+        catch (NumberFormatException e) {
+        }
+        return proposedSize;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionDialog.java
@@ -16,7 +16,6 @@
  */
 package org.jkiss.dbeaver.ui.dialogs.connection;
 
-import org.eclipse.e4.tools.emf.ui.internal.common.component.HandlerEditor;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.swt.SWT;

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/dialogs/MultiPageWizardDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/dialogs/MultiPageWizardDialog.java
@@ -90,7 +90,9 @@ public class MultiPageWizardDialog extends TitleAreaDialog implements IWizardCon
     }
 
     protected Point getInitialSize() {
-        return new Point(700, 500);
+        Point minSize = new Point(700, 500);
+        Point suggestedSize = super.getInitialSize();
+        return new Point(Math.max(minSize.x, suggestedSize.x), Math.max(minSize.y, suggestedSize.y));
     }
 
     public IWizard getWizard() {


### PR DESCRIPTION
Closes dbeaver/dbeaver#18770
The edit connection dialog now should remember the previous user size and try to adjust if it is too small for the current page.