### PR TITLE
#19951 Fix data ordering switching

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
@@ -2300,7 +2300,7 @@ public class ResultSetViewer extends Viewer
             constraint.setOrderDescending(false);
         } else if (forceOrder == ColumnOrder.DESC) {
             constraint.setOrderDescending(true);
-        } else if (constraint.getOrderPosition() > 0 && !constraint.isOrderDescending()) {
+        } else if (forceOrder == null && constraint.getOrderPosition() > 0 && !constraint.isOrderDescending()) {
             // Toggle to DESC ordering
             constraint.setOrderDescending(true);
         } else {


### PR DESCRIPTION
Please, check
- [x] the case from the issue
- [x] ordering by clicking on an arrow in header (arrow in header can be turned on in preferences Data Editor -> Appearance -> Grid ->Show attribute ordering)
- [x] different scenarios of ordering of multiple columns
- [x] ordering with Result Set Order/Filter Settings dialog