### PR TITLE
#20019 Add logging listeners, fix potential NPE

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMAnalysis.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMAnalysis.java
@@ -16,6 +16,8 @@
  */
 package org.jkiss.dbeaver.model.lsm;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.utils.Pair;
 
 import java.util.List;
@@ -23,8 +25,10 @@ import java.util.concurrent.Future;
 
 
 public interface LSMAnalysis<T extends LSMElement> {    
-    
+
+    @Nullable
     Future<T> getModel();
 
+    @Nullable
     List<Pair<String, String>> getTableAndAliasFromSources();
 }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMAnalysisCase.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMAnalysisCase.java
@@ -17,17 +17,22 @@
 package org.jkiss.dbeaver.model.lsm;
 
 import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.lsm.mapping.AbstractSyntaxNode;
 
 public interface LSMAnalysisCase<T extends LSMElement, M extends AbstractSyntaxNode & LSMElement> extends LSMObject<LSMAnalysisCase<T, M>> {
-    
+    @NotNull
     Class<T> getModelContractType();
-    
+
+    @NotNull
     Class<M> getModelRootType();
 
 
-    LSMParser createParser(LSMSource source);
-    
+    @Nullable
+    LSMParser createParser(@NotNull LSMSource source);
+
+    @Nullable
     LSMParser createParser(LSMSource source, ANTLRErrorListener errorListener);
 
     

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMAnalysisCase.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMAnalysisCase.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.model.lsm;
 
+import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.jkiss.dbeaver.model.lsm.mapping.AbstractSyntaxNode;
 
 public interface LSMAnalysisCase<T extends LSMElement, M extends AbstractSyntaxNode & LSMElement> extends LSMObject<LSMAnalysisCase<T, M>> {
@@ -23,8 +24,11 @@ public interface LSMAnalysisCase<T extends LSMElement, M extends AbstractSyntaxN
     Class<T> getModelContractType();
     
     Class<M> getModelRootType();
-    
+
+
     LSMParser createParser(LSMSource source);
+    
+    LSMParser createParser(LSMSource source, ANTLRErrorListener errorListener);
 
     
 }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMDialect.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMDialect.java
@@ -16,6 +16,8 @@
  */
 package org.jkiss.dbeaver.model.lsm;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.lsm.mapping.AbstractSyntaxNode;
 
 import java.util.Collection;
@@ -26,11 +28,15 @@ public interface LSMDialect {
     
     Collection<LSMAnalysisCase<? extends LSMElement, ? extends AbstractSyntaxNode>> getSupportedCases();
 
-    <T extends LSMElement> LSMAnalysisCase<T, ? extends AbstractSyntaxNode> findAnalysisCase(Class<T> expectedModelType) throws LSMException;
-    
+    @Nullable
+    <T extends LSMElement> LSMAnalysisCase<T, ? extends AbstractSyntaxNode> findAnalysisCase(
+        @NotNull Class<T> expectedModelType
+    ) throws LSMException;
+
+    @NotNull
     <T extends LSMElement> Future<LSMAnalysis<T>> prepareAnalysis(
-        LSMSource source,
-        LSMAnalysisCase<T, ? extends AbstractSyntaxNode> analysisCase
+        @NotNull LSMSource source,
+        @NotNull LSMAnalysisCase<T, ? extends AbstractSyntaxNode> analysisCase
     );
     
 }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMException.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMException.java
@@ -16,23 +16,25 @@
  */
 package org.jkiss.dbeaver.model.lsm;
 
+import org.jkiss.code.NotNull;
+
 public class LSMException extends Exception {
     public LSMException() {
     }
 
-    public LSMException(String message) {
+    public LSMException(@NotNull String message) {
         super(message);
     }
 
-    public LSMException(String message, Throwable cause) {
+    public LSMException(@NotNull String message, @NotNull Throwable cause) {
         super(message, cause);
     }
 
-    public LSMException(Throwable cause) {
+    public LSMException(@NotNull Throwable cause) {
         super(cause);
     }
 
-    public LSMException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    public LSMException(@NotNull String message, @NotNull Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMLoggingErrorListener.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMLoggingErrorListener.java
@@ -1,0 +1,55 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.lsm;
+
+import java.util.BitSet;
+
+import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.dfa.DFA;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LSMLoggingErrorListener implements ANTLRErrorListener {
+    
+    private static final Logger log = LoggerFactory.getLogger(LSMLoggingErrorListener.class);
+
+
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer, Object o, int i, int i1, String s, RecognitionException e) {
+        log.debug("Recognition error", e);
+    }
+
+    @Override
+    public void reportAmbiguity(Parser parser, DFA dfa, int i, int i1, boolean b, BitSet bitSet, ATNConfigSet atnConfigSet) {
+        // do nothing
+    }
+
+    @Override
+    public void reportAttemptingFullContext(Parser parser, DFA dfa, int i, int i1, BitSet bitSet, ATNConfigSet atnConfigSet) {
+        // do nothing
+    }
+
+    @Override
+    public void reportContextSensitivity(Parser parser, DFA dfa, int i, int i1, int i2, ATNConfigSet atnConfigSet) {
+        // do nothing
+    }
+
+}

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMObject.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMObject.java
@@ -16,9 +16,11 @@
  */
 package org.jkiss.dbeaver.model.lsm;
 
+import org.jkiss.code.NotNull;
+
 public interface LSMObject<T> {
     @SuppressWarnings("unchecked")
-    default <T2 extends T> T2 coerce(Class<T2> desired) {
+    default <T2 extends T> T2 coerce(@NotNull Class<T2> desired) {
         if (desired.isAssignableFrom(this.getClass())) {
             return (T2) this;
         } else {

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMParser.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMParser.java
@@ -17,8 +17,10 @@
 package org.jkiss.dbeaver.model.lsm;
 
 import org.antlr.v4.runtime.tree.Tree;
+import org.jkiss.code.Nullable;
 
 public interface LSMParser extends LSMObject<LSMParser> {
-    
+
+    @Nullable
     Tree parse();
 }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMSkippingErrorListener.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMSkippingErrorListener.java
@@ -1,0 +1,49 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.lsm;
+
+import java.util.BitSet;
+
+import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.dfa.DFA;
+
+public class LSMSkippingErrorListener implements ANTLRErrorListener {
+
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer, Object o, int i, int i1, String s, RecognitionException e) {
+
+    }
+
+    @Override
+    public void reportAmbiguity(Parser parser, DFA dfa, int i, int i1, boolean b, BitSet bitSet, ATNConfigSet atnConfigSet) {
+
+    }
+
+    @Override
+    public void reportAttemptingFullContext(Parser parser, DFA dfa, int i, int i1, BitSet bitSet, ATNConfigSet atnConfigSet) {
+
+    }
+
+    @Override
+    public void reportContextSensitivity(Parser parser, DFA dfa, int i, int i1, int i2, ATNConfigSet atnConfigSet) {
+
+    }
+}

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMSource.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/LSMSource.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.model.lsm;
 
 import org.antlr.v4.runtime.CharStream;
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.lsm.impl.LSMSourceImpl;
 
 import java.io.IOException;
@@ -27,7 +28,8 @@ public interface LSMSource extends LSMObject<LSMSource> {
 
     CharStream getStream();
 
-    public static LSMSource fromReader(Reader reader) throws IOException {
+    @NotNull
+    public static LSMSource fromReader(@NotNull Reader reader) throws IOException {
         return new LSMSourceImpl(reader);
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/impl/LSMAnalysisCaseImpl.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/impl/LSMAnalysisCaseImpl.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.model.lsm.impl;
 
+import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.jkiss.dbeaver.model.lsm.LSMAnalysisCase;
 import org.jkiss.dbeaver.model.lsm.LSMElement;
 import org.jkiss.dbeaver.model.lsm.LSMParser;
@@ -46,5 +47,5 @@ public abstract class LSMAnalysisCaseImpl<T extends LSMElement, M extends Abstra
     }
 
     @Override
-    public abstract LSMParser createParser(LSMSource source);
+    public abstract LSMParser createParser(LSMSource source, ANTLRErrorListener errorListener);
 }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/impl/LSMAnalysisCaseImpl.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/impl/LSMAnalysisCaseImpl.java
@@ -17,35 +17,41 @@
 package org.jkiss.dbeaver.model.lsm.impl;
 
 import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.lsm.LSMAnalysisCase;
 import org.jkiss.dbeaver.model.lsm.LSMElement;
 import org.jkiss.dbeaver.model.lsm.LSMParser;
 import org.jkiss.dbeaver.model.lsm.LSMSource;
 import org.jkiss.dbeaver.model.lsm.mapping.AbstractSyntaxNode;
 
-public abstract class LSMAnalysisCaseImpl<T extends LSMElement, M extends AbstractSyntaxNode & LSMElement> implements LSMAnalysisCase<T, M> {
+public abstract class LSMAnalysisCaseImpl<T extends LSMElement, M extends AbstractSyntaxNode & LSMElement>
+    implements LSMAnalysisCase<T, M> {
 
     private final Class<T> modelContractType;
     private final Class<M> modelRootType;
     
     public LSMAnalysisCaseImpl(
-        Class<T> modelContractType,
-        Class<M> modelRootType
+        @NotNull Class<T> modelContractType,
+        @NotNull Class<M> modelRootType
     ) {
         this.modelContractType = modelContractType;
         this.modelRootType = modelRootType;
     }
 
+    @NotNull
     @Override
     public Class<T> getModelContractType() {
         return modelContractType;
     }
 
+    @NotNull
     @Override
     public Class<M> getModelRootType() {
         return modelRootType;
     }
 
+    @Nullable
     @Override
-    public abstract LSMParser createParser(LSMSource source, ANTLRErrorListener errorListener);
+    public abstract LSMParser createParser(@NotNull LSMSource source, @Nullable ANTLRErrorListener errorListener);
 }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/impl/LSMDialectImpl.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/impl/LSMDialectImpl.java
@@ -16,6 +16,8 @@
  */
 package org.jkiss.dbeaver.model.lsm.impl;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.lsm.*;
 import org.jkiss.dbeaver.model.lsm.mapping.AbstractSyntaxNode;
 import org.jkiss.dbeaver.model.lsm.mapping.SyntaxModel;
@@ -44,12 +46,15 @@ public class LSMDialectImpl implements LSMDialect {
         return casesByContractType.values();
     }
 
+    @Nullable
     @Override
-    public <T extends LSMElement> LSMAnalysisCase<T, ? extends AbstractSyntaxNode> findAnalysisCase(Class<T> expectedContractType) throws LSMException {
+    public <T extends LSMElement> LSMAnalysisCase<T, ? extends AbstractSyntaxNode> findAnalysisCase(
+        @NotNull Class<T> expectedContractType
+    ) throws LSMException {
         @SuppressWarnings("unchecked")
-        LSMAnalysisCase<T, ? extends AbstractSyntaxNode> result = (LSMAnalysisCase<T, ? extends AbstractSyntaxNode>) casesByContractType.get(expectedContractType);
+        var result = (LSMAnalysisCase<T, ? extends AbstractSyntaxNode>) casesByContractType.get(expectedContractType);
         if (result == null) {
-            for (Map.Entry<Class<? extends LSMElement>, LSMAnalysisCase<? extends LSMElement, ? extends AbstractSyntaxNode>> entry : casesByContractType.entrySet()) {
+            for (var entry : casesByContractType.entrySet()) {
                 if (expectedContractType.isAssignableFrom(entry.getKey())) {
                     return (LSMAnalysisCase<T, ? extends AbstractSyntaxNode>) entry.getValue();
                 }
@@ -59,8 +64,12 @@ public class LSMDialectImpl implements LSMDialect {
         return result;
     }
 
+    @NotNull
     @Override
-    public <T extends LSMElement> Future<LSMAnalysis<T>> prepareAnalysis(LSMSource source, LSMAnalysisCase<T, ? extends AbstractSyntaxNode> analysisCase) {
+    public <T extends LSMElement> Future<LSMAnalysis<T>> prepareAnalysis(
+        @NotNull LSMSource source,
+        @NotNull LSMAnalysisCase<T, ? extends AbstractSyntaxNode> analysisCase
+    ) {
         LSMSourceImpl source2 = source.coerce(LSMSourceImpl.class);
         @SuppressWarnings("unchecked")
         LSMAnalysisCaseImpl<T, ? extends AbstractSyntaxNode> analysisCase2 = analysisCase.coerce(LSMAnalysisCaseImpl.class);

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/impl/LSMSourceImpl.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/impl/LSMSourceImpl.java
@@ -18,6 +18,7 @@ package org.jkiss.dbeaver.model.lsm.impl;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.lsm.LSMSource;
 
 import java.io.IOException;
@@ -28,10 +29,11 @@ public class LSMSourceImpl implements LSMSource {
     
     private final CharStream stream;
     
-    public LSMSourceImpl(Reader reader) throws IOException {
+    public LSMSourceImpl(@NotNull Reader reader) throws IOException {
         this.stream = CharStreams.fromReader(reader);
     }
 
+    @NotNull
     @Override
     public CharStream getStream() {
         return this.stream;

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/AbstractSyntaxNode.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/AbstractSyntaxNode.java
@@ -17,6 +17,8 @@
 package org.jkiss.dbeaver.model.lsm.mapping;
 
 import org.antlr.v4.runtime.misc.Interval;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.lsm.LSMElement;
 import org.jkiss.dbeaver.model.lsm.mapping.internal.NodeFieldInfo;
 import org.jkiss.dbeaver.model.lsm.mapping.internal.XTreeNodeBase;
@@ -29,11 +31,12 @@ public abstract class AbstractSyntaxNode implements LSMElement {
     private static final Map<Class<? extends AbstractSyntaxNode>, String> syntaxNodeNameByType = new HashMap<>(
         Map.of(ConcreteSyntaxNode.class, "")
     );
-    
-    private static String getNodeName(Class<? extends AbstractSyntaxNode> type) {
+
+    @NotNull
+    private static String getNodeName(@NotNull Class<? extends AbstractSyntaxNode> type) {
         return syntaxNodeNameByType.computeIfAbsent(
             type,
-            t -> Optional.ofNullable(t.getAnnotation(SyntaxNode.class).name()).orElse(t.getName())
+            t -> Optional.of(t.getAnnotation(SyntaxNode.class).name()).orElse(t.getName())
         );
     }
 
@@ -42,7 +45,7 @@ public abstract class AbstractSyntaxNode implements LSMElement {
         public final Object value;
         public final XTreeNodeBase astNode;
         
-        public BindingInfo(NodeFieldInfo field, Object value, XTreeNodeBase astNode) {
+        public BindingInfo(@NotNull NodeFieldInfo field, @Nullable Object value, @NotNull XTreeNodeBase astNode) {
             this.field = field;
             this.value = value;
             this.astNode = astNode;
@@ -61,10 +64,11 @@ public abstract class AbstractSyntaxNode implements LSMElement {
         this.name = getNodeName(this.getClass());
     }
     
-    protected AbstractSyntaxNode(String name) {
+    protected AbstractSyntaxNode(@Nullable String name) {
         this.name = name;
     }
-    
+
+    @Nullable
     public String getName() {
         return this.name;
     }
@@ -77,16 +81,17 @@ public abstract class AbstractSyntaxNode implements LSMElement {
         return this.astNode != null ? this.astNode.getRealInterval().b : UNDEFINED_POSITION;
     }
     
-    void setAstNode(XTreeNodeBase astNode) {
+    void setAstNode(@NotNull XTreeNodeBase astNode) {
         this.astNode = astNode;
         this.subnodeBindings = null;
     }
 
+    @NotNull
     XTreeNodeBase getAstNode() {
         return this.astNode;
     }
 
-    void appendBinding(BindingInfo binding) {
+    void appendBinding(@NotNull BindingInfo binding) {
         if (subnodeBindings == null) {
             this.subnodeBindings = new LinkedList<>();
         }
@@ -102,7 +107,8 @@ public abstract class AbstractSyntaxNode implements LSMElement {
         }
         return rc;
     };
-    
+
+    @NotNull
     List<BindingInfo> getBindings() {
         if (this.subnodeBindings == null) {
             return Collections.emptyList();
@@ -119,28 +125,33 @@ public abstract class AbstractSyntaxNode implements LSMElement {
         final BindingInfo binding;
         final XTreeNodeBase astNode;
         
-        public SyntaxModelLookupResult(AbstractSyntaxNode node, BindingInfo binding) {
+        public SyntaxModelLookupResult(@NotNull AbstractSyntaxNode node, @Nullable BindingInfo binding) {
             this.node = node;
             this.binding = binding;
             this.astNode = binding == null ? node.astNode : binding.astNode;
         }
-        
+
+        @NotNull
         public Interval getInterval() {
             return astNode.getRealInterval();
         }
-        
+
+        @Nullable
         public String getEntityName() {
             return node.getName();
         }
-        
+
+        @Nullable
         public String getEntityFieldName() {
             return binding == null ? null : binding.field.getFieldName();
         }
-        
+
+        @NotNull
         public String getAstNodeFullName() {
             return astNode.getFullPathName();
         }
-        
+
+        @NotNull
         @Override
         public String toString() {
             String element = binding == null ? this.getEntityName() : (this.getEntityFieldName() + " of " + this.getEntityName());
@@ -148,6 +159,7 @@ public abstract class AbstractSyntaxNode implements LSMElement {
         }
     }
 
+    @Nullable
     public SyntaxModelLookupResult findBoundSyntaxAt(int position) {
         Interval location = new Interval(position, position);
         AbstractSyntaxNode node = this;
@@ -162,8 +174,9 @@ public abstract class AbstractSyntaxNode implements LSMElement {
             return null;
         }
     }
-    
-    private static BindingInfo findBindingOfLocation(AbstractSyntaxNode node, Interval location) {
+
+    @Nullable
+    private static BindingInfo findBindingOfLocation(@NotNull AbstractSyntaxNode node, @NotNull Interval location) {
         List<BindingInfo> bindings = node.getBindings();
         int index = binarySearchByKey(bindings, b -> b.astNode.getRealInterval(), location, (x, y) ->  {
             if (x.b < y.a) {
@@ -210,8 +223,13 @@ public abstract class AbstractSyntaxNode implements LSMElement {
         
         return result;
     }
-    
-    private static <T, K> int binarySearchByKey(List<T> list, Function<T, K> keyGetter, K key, Comparator<K> comparator) {
+
+    private static <T, K> int binarySearchByKey(
+        @NotNull List<T> list,
+        @NotNull Function<T, K> keyGetter,
+        @NotNull K key,
+        @NotNull Comparator<K> comparator
+    ) {
         int low = 0;
         int high = list.size() - 1;
 

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/ConcreteSyntaxNode.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/ConcreteSyntaxNode.java
@@ -16,6 +16,9 @@
  */
 package org.jkiss.dbeaver.model.lsm.mapping;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,10 +31,11 @@ public class ConcreteSyntaxNode extends AbstractSyntaxNode {
         super();
     }
 
-    public ConcreteSyntaxNode(String name) {
+    public ConcreteSyntaxNode(@NotNull String name) {
         super(name);
     }
 
+    @NotNull
     public List<AbstractSyntaxNode> getChildren() {
         if (children == null) {
             return Collections.emptyList();
@@ -43,7 +47,8 @@ public class ConcreteSyntaxNode extends AbstractSyntaxNode {
         }
     }
 
-    public List<AbstractSyntaxNode> getChildren(String name) {
+    @NotNull
+    public List<AbstractSyntaxNode> getChildren(@Nullable String name) {
         List<AbstractSyntaxNode> result;
         if (this.children == null) {
             result = Collections.emptyList();
@@ -58,7 +63,8 @@ public class ConcreteSyntaxNode extends AbstractSyntaxNode {
         return result;
     }
 
-    public <T extends AbstractSyntaxNode> List<T> getChildren(Class<T> subnodeType) {
+    @NotNull
+    public <T extends AbstractSyntaxNode> List<T> getChildren(@NotNull Class<T> subnodeType) {
         List<T> result;
         if (this.children == null) {
             result = Collections.emptyList();
@@ -75,7 +81,7 @@ public class ConcreteSyntaxNode extends AbstractSyntaxNode {
         return result;
     }
 
-    void addChild(AbstractSyntaxNode node) {
+    void addChild(@NotNull AbstractSyntaxNode node) {
         if (this.children == null) {
             this.children = new ArrayList<>();
         }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/ModelErrorsCollection.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/ModelErrorsCollection.java
@@ -16,6 +16,9 @@
  */
 package org.jkiss.dbeaver.model.lsm.mapping;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+
 import java.util.LinkedList;
 import java.util.List;
 
@@ -25,7 +28,7 @@ public class ModelErrorsCollection {
         public final Throwable exception;
         public final String message;
 
-        public ErrorInfo(Throwable exception, String message) {
+        public ErrorInfo(@Nullable Throwable exception, @NotNull String message) {
             this.exception = exception;
             this.message = message;
         }
@@ -33,11 +36,11 @@ public class ModelErrorsCollection {
     
     private final List<ErrorInfo> errors = new LinkedList<>();
 
-    public void add(String message) {
+    public void add(@NotNull String message) {
         this.errors.add(new ErrorInfo(null, message));
     }
 
-    public void add(Throwable ex, String message) {
+    public void add(@Nullable Throwable ex, @NotNull String message) {
         this.errors.add(new ErrorInfo(ex, message));
     }
 

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/SyntaxModelMappingResult.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/SyntaxModelMappingResult.java
@@ -17,25 +17,28 @@
 package org.jkiss.dbeaver.model.lsm.mapping;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 
 public class SyntaxModelMappingResult<T> {
     
     private final ModelErrorsCollection errors;
     private final T model;
     
-    public SyntaxModelMappingResult(ModelErrorsCollection errors, @NotNull T model) {
+    public SyntaxModelMappingResult(@NotNull ModelErrorsCollection errors, @Nullable T model) {
         this.errors = errors;
         this.model = model;
-    }   
-    
+    }
+
     public boolean isNoErrors() {
         return model != null && errors.isEmpty();
     }
-    
+
+    @Nullable
     public T getModel() {
         return model;
     }
-    
+
+    @NotNull
     public ModelErrorsCollection getErrors() {
         return errors;
     }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/SyntaxModelMappingSession.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/SyntaxModelMappingSession.java
@@ -22,14 +22,14 @@ import org.jkiss.dbeaver.model.lsm.mapping.AbstractSyntaxNode.BindingInfo;
 import org.jkiss.dbeaver.model.lsm.mapping.internal.*;
 import org.w3c.dom.Node;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import java.util.stream.Collectors;
 import javax.xml.xpath.XPathEvaluationResult;
 import javax.xml.xpath.XPathEvaluationResult.XPathResultType;
 import javax.xml.xpath.XPathException;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathNodes;
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class SyntaxModelMappingSession {
     
@@ -50,7 +50,7 @@ public class SyntaxModelMappingSession {
             case NUMBER:
             case STRING:
                 if (value instanceof String) {
-                    return ((String)value).length() < 1;
+                    return ((String) value).length() < 1;
                 }
                 break;
             case ANY:
@@ -91,7 +91,7 @@ public class SyntaxModelMappingSession {
             return null;
         }
 
-        Set<XTreeNodeBase> subnodes = new HashSet<XTreeNodeBase>(5);
+        Set<XTreeNodeBase> subnodes = new HashSet<>(5);
         for (var field : typeInfo.fields.values()) {
             subnodes.clear();
             for (var expr : field.termExprs) {
@@ -123,7 +123,7 @@ public class SyntaxModelMappingSession {
                                     }
                                 }
                             } else if (scopeOrSubnode.type() == XPathResultType.NODE && scopeOrSubnode.value() instanceof XTreeNodeBase) {
-                            	var subnodeTypeInfo = subnodeInfo.getNodeTypeInfo();
+                                var subnodeTypeInfo = subnodeInfo.getNodeTypeInfo();
                                 mapSubtrees((XTreeNodeBase) scopeOrSubnode.value(), subnodeTypeInfo, true, tryDescedants, subnodes);
                             }
                         } else {
@@ -156,7 +156,7 @@ public class SyntaxModelMappingSession {
                             if (scopeOrSubnode.type() == XPathResultType.NODESET && scopeOrSubnode.value() instanceof XPathNodes) {
                                 for (var scopeSubnode : (XPathNodes) scopeOrSubnode.value()) {
                                     if (scopeSubnode instanceof XTreeNodeBase) {
-                                    	var subnodeTypeInfo = subnodeInfo.getNodeTypeInfo();
+                                        var subnodeTypeInfo = subnodeInfo.getNodeTypeInfo();
                                         subnode = mapSubtree((XTreeNodeBase) scopeSubnode, subnodeTypeInfo, true, tryDescedants);
                                         if (subnode != null) {
                                             break;
@@ -164,7 +164,7 @@ public class SyntaxModelMappingSession {
                                     }
                                 }
                             } else if (scopeOrSubnode.type() == XPathResultType.NODE && scopeOrSubnode.value() instanceof XTreeNodeBase) {
-                            	var subnodeTypeInfo = subnodeInfo.getNodeTypeInfo();
+                                var subnodeTypeInfo = subnodeInfo.getNodeTypeInfo();
                                 subnode = mapSubtree((XTreeNodeBase) scopeOrSubnode.value(), subnodeTypeInfo, true, tryDescedants);
                             }
                         } else {
@@ -198,7 +198,7 @@ public class SyntaxModelMappingSession {
         if (typeInfo != null) {
             try {
                 String str = typeInfo.stringExpr == null ? nodeInfo.getTextContent()
-            		: typeInfo.stringExpr.evaluateExpression(nodeInfo, String.class);
+                    : typeInfo.stringExpr.evaluateExpression(nodeInfo, String.class);
                 if (str != null && str.length() > 0) {
                     // System.out.println(str + " | " + nodeInfo.getNodeValue());
                     Object value = typeInfo.valuesByName.get(typeInfo.isCaseSensitive ? str : str.toUpperCase());
@@ -216,7 +216,7 @@ public class SyntaxModelMappingSession {
                     }
                 } catch (XPathExpressionException e) {
                     errors.add(e, "Failed to evaluate syntax model literal case condition expression for case " + literalCase.getKey()
-                    	+ " of type " + typeInfo.type.getName());
+                        + " of type " + typeInfo.type.getName());
                 }
             }
         }
@@ -227,58 +227,33 @@ public class SyntaxModelMappingSession {
     private void bindValue(XTreeNodeBase nodeInfo, NodeFieldInfo fieldInfo, List<XTreeNodeBase> subnodes) {
         this.bindValue(nodeInfo, fieldInfo, new XPathEvaluationResult<XPathNodes>() {
             @Override
-            public XPathResultType type() { return XPathResultType.NODESET; }
+            public XPathResultType type() {
+                return XPathResultType.NODESET;
+            }
 
             @Override
             public XPathNodes value() {
                 return new XPathNodes() {
                     @Override
-                    public int size() { return subnodes.size(); }
+                    public int size() {
+                        return subnodes.size();
+                    }
 
-                    @Override @SuppressWarnings("unchecked")
+                    @SuppressWarnings("unchecked")
+                    @Override
                     public Iterator<Node> iterator() {
-                        return (Iterator<Node>)(Iterator<?>)subnodes.iterator();
+                        return (Iterator<Node>) (Iterator<?>) subnodes.iterator();
                     }
 
                     @Override
-                    public Node get(int index) throws XPathException { return subnodes.get(index); }
+                    public Node get(int index) {
+                        return subnodes.get(index);
+                    }
                 };
             }
         });      
     }
 
-    private String getScalarString(NodeFieldInfo fieldInfo,  XPathEvaluationResult<?> xvalue) {
-        try {
-            switch (xvalue.type()) {
-                case NODE:
-                    XTreeNodeBase nodeInfo = (XTreeNodeBase) xvalue.value();
-                    return nodeInfo.getNodeValue();
-                case NODESET:
-                    XPathNodes nodes = (XPathNodes) xvalue.value();
-                    int count = nodes.size();
-                    if (count == 0) {
-                        return null;
-                    } else if (count == 1) {
-                        return nodes.get(0).getNodeValue().toString();
-                    } else {
-                        errors.add("Ambiguous resolution of syntax model value expression for field " + fieldInfo.getFieldName()
-                        	+ " of type " + fieldInfo.getDeclaringClassName());
-                        return nodes.get(0).getNodeValue().toString();
-                    }
-                default:
-                    if (xvalue.value() != null) {
-                        return xvalue.value().toString();
-                    } else {
-                        return null;
-                    }
-            }
-        } catch (XPathException ex) {
-            errors.add(ex, "Failed to evaluate syntax model scalar value expression for field " + fieldInfo.getFieldName()
-                + " of type " + fieldInfo.getDeclaringClassName());
-            return null;
-        }
-    }
-    
     private void bindValue(XTreeNodeBase nodeInfo, NodeFieldInfo fieldInfo, XPathEvaluationResult<?> xvalue) {
         Object value;
         switch (fieldInfo.kind) {
@@ -306,29 +281,46 @@ public class SyntaxModelMappingSession {
                         throw new UnsupportedOperationException("Not supported value type for binding: " + xvalue.type());
                 }
                 break;
-            case String: value = getScalarString(fieldInfo, xvalue); break;
-            case Byte: value = Byte.parseByte(getScalarString(fieldInfo, xvalue)); break;
-            case Short: value = Short.parseShort(getScalarString(fieldInfo, xvalue)); break;
-            case Int: value = Integer.parseInt(getScalarString(fieldInfo, xvalue)); break;
-            case Long: value = Long.parseLong(getScalarString(fieldInfo, xvalue)); break;
-            case Bool: value = Boolean.parseBoolean(getScalarString(fieldInfo, xvalue)); break;
-            case Float: value = Float.parseFloat(getScalarString(fieldInfo, xvalue)); break;
-            case Double: value = Double.parseDouble(getScalarString(fieldInfo, xvalue)); break;
+            case String:
+                value = getScalarString(fieldInfo, xvalue);
+                break;
+            case Byte:
+                value = Byte.parseByte(Objects.requireNonNull(getScalarString(fieldInfo, xvalue)));
+                break;
+            case Short:
+                value = Short.parseShort(Objects.requireNonNull(getScalarString(fieldInfo, xvalue)));
+                break;
+            case Int:
+                value = Integer.parseInt(Objects.requireNonNull(getScalarString(fieldInfo, xvalue)));
+                break;
+            case Long:
+                value = Long.parseLong(Objects.requireNonNull(getScalarString(fieldInfo, xvalue)));
+                break;
+            case Bool:
+                value = Boolean.parseBoolean(getScalarString(fieldInfo, xvalue));
+                break;
+            case Float:
+                value = Float.parseFloat(Objects.requireNonNull(getScalarString(fieldInfo, xvalue)));
+                break;
+            case Double:
+                value = Double.parseDouble(Objects.requireNonNull(getScalarString(fieldInfo, xvalue)));
+                break;
             case Enum:
                 switch (xvalue.type()) {
-                    case NODE: 
+                    case NODE:
                         value = mapLiteralValue((XTreeNodeBase) xvalue.value(), fieldInfo.getLiteralTypeInfo());
                         break;
                     case NODESET:
                         XPathNodes nodes = (XPathNodes) xvalue.value();
                         if (nodes.size() == 1) {
-                            try { value = mapLiteralValue((XTreeNodeBase) nodes.get(0), fieldInfo.getLiteralTypeInfo()); }
-                            catch (XPathException e) { 
+                            try {
+                                value = mapLiteralValue((XTreeNodeBase) nodes.get(0), fieldInfo.getLiteralTypeInfo());
+                            } catch (XPathException e) {
                                 errors.add(e, "Failed to bind raw value to field " + fieldInfo.getFieldName()
-                                	+  " of type " + fieldInfo.getDeclaringClassName());
+                                        +  " of type " + fieldInfo.getDeclaringClassName());
                                 value = null;
                             }
-                        } else { 
+                        } else {
                             value = null;
                         }
                         break;
@@ -338,11 +330,47 @@ public class SyntaxModelMappingSession {
                 break;
             default: throw new UnsupportedOperationException("Unexpected syntax model field kind " + fieldInfo.kind);
         }
-        
-        this.bindRawValue(nodeInfo, fieldInfo, value);
+
+        if (value != null) {
+            this.bindRawValue(nodeInfo, fieldInfo, value);
+        }
     }
+
+    @Nullable
+    private String getScalarString(@NotNull NodeFieldInfo fieldInfo,  @NotNull XPathEvaluationResult<?> xvalue) {
+        try {
+            switch (xvalue.type()) {
+                case NODE:
+                    XTreeNodeBase nodeInfo = (XTreeNodeBase) xvalue.value();
+                    return nodeInfo.getNodeValue();
+                case NODESET:
+                    XPathNodes nodes = (XPathNodes) xvalue.value();
+                    int count = nodes.size();
+                    if (count == 0) {
+                        return null;
+                    } else if (count == 1) {
+                        return nodes.get(0).getNodeValue();
+                    } else {
+                        errors.add("Ambiguous resolution of syntax model value expression for field " + fieldInfo.getFieldName()
+                            + " of type " + fieldInfo.getDeclaringClassName());
+                        return nodes.get(0).getNodeValue();
+                    }
+                default:
+                    if (xvalue.value() != null) {
+                        return xvalue.value().toString();
+                    } else {
+                        return null;
+                    }
+            }
+        } catch (XPathException ex) {
+            errors.add(ex, "Failed to evaluate syntax model scalar value expression for field " + fieldInfo.getFieldName()
+                + " of type " + fieldInfo.getDeclaringClassName());
+            return null;
+        }
+    }
+
     
-    private void bindRawValue(XTreeNodeBase nodeInfo, NodeFieldInfo fieldInfo, Object value) {
+    private void bindRawValue(@NotNull XTreeNodeBase nodeInfo, @NotNull NodeFieldInfo fieldInfo, @NotNull Object value) {
         try {
             this.bindRawValueImpl(nodeInfo, fieldInfo, value);
         } catch (IllegalArgumentException | IllegalAccessException ex) {
@@ -352,10 +380,10 @@ public class SyntaxModelMappingSession {
     }
     
     private void bindRawValueImpl(
-		@NotNull XTreeNodeBase nodeInfo,
-		@NotNull NodeFieldInfo fieldInfo,
-		@Nullable Object value
-	) throws IllegalArgumentException, IllegalAccessException {
+        @NotNull XTreeNodeBase nodeInfo,
+        @NotNull NodeFieldInfo fieldInfo,
+        @Nullable Object value
+    ) throws IllegalArgumentException, IllegalAccessException {
         switch (fieldInfo.kind) {
             case Object: {
                 if (value instanceof XTreeNodeBase) {
@@ -369,21 +397,21 @@ public class SyntaxModelMappingSession {
                 break;
             }
             case Array: { // TODO
-//                int index;
-//                Object newArr, oldArr = fieldInfo.info.get(nodeInfo.model);
-//                Class<?> itemType = fieldInfo.info.getType().getComponentType();
-//                if (value != null) {
-//                    index = Array.getLength(oldArr);
-//                    newArr = Array.newInstance(itemType, index + 1);
-//                    System.arraycopy(oldArr, 0, newArr, 0, index);
-//                } else {
-//                    index = 0;
-//                    newArr = Array.newInstance(itemType, 1);
-//                }
-//                Array.set(newArr, index, value);
-//                fieldInfo.info.set(nodeInfo.model, newArr);
-//                break;
-                throw new UnsupportedOperationException("TODO");
+                /* int index;
+                Object newArr, oldArr = fieldInfo.info.get(nodeInfo.model);
+                Class<?> itemType = fieldInfo.info.getType().getComponentType();
+                if (value != null) {
+                    index = Array.getLength(oldArr);
+                    newArr = Array.newInstance(itemType, index + 1);
+                    System.arraycopy(oldArr, 0, newArr, 0, index);
+                } else {
+                    index = 0;
+                    newArr = Array.newInstance(itemType, 1);
+                }
+                Array.set(newArr, index, value);
+                fieldInfo.info.set(nodeInfo.model, newArr);
+                break;*/
+                throw new UnsupportedOperationException("Arrays binding for syntax model is not implemented yet");
             }
             case List: {
                 @SuppressWarnings("unchecked")
@@ -398,7 +426,7 @@ public class SyntaxModelMappingSession {
                     if (list instanceof ArrayList<?>) {
                         ((ArrayList<?>) list).ensureCapacity(nodes.size());
                     }
-                    for (var xnode: nodes) {
+                    for (var xnode : nodes) {
                         if (xnode instanceof XTreeNodeBase) {
                             XTreeNodeBase subnodeInfo = (XTreeNodeBase) xnode;
                             if (subnodeInfo.getModel() != null) {
@@ -431,7 +459,7 @@ public class SyntaxModelMappingSession {
                     if (list instanceof ArrayList<?>) {
                         ((ArrayList<?>) list).ensureCapacity(nodes.size());
                     }
-                    for (var xnode: nodes) {
+                    for (var xnode : nodes) {
                         if (xnode instanceof XTreeNodeBase) {
                             XTreeNodeBase subnodeInfo = (XTreeNodeBase) xnode;
                             list.add(subnodeInfo.getNodeValue());
@@ -504,9 +532,9 @@ public class SyntaxModelMappingSession {
         if (modelNode != null) {
             @SuppressWarnings("unchecked")
             T result = (T) modelNode;
-            return new SyntaxModelMappingResult<T>(errors, result);
+            return new SyntaxModelMappingResult<>(errors, result);
         } else {
-            return new SyntaxModelMappingResult<T>(errors, null);
+            return new SyntaxModelMappingResult<>(errors, null);
         }    
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/CustomXPathUtils.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/CustomXPathUtils.java
@@ -19,28 +19,29 @@ package org.jkiss.dbeaver.model.lsm.mapping.internal;
 
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.RuleNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.antlr.v4.runtime.tree.Tree;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.xpath.XPathException;
-import javax.xml.xpath.XPathExpression;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathNodes;
 import java.util.Iterator;
 import java.util.Stack;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import javax.xml.xpath.XPathException;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathNodes;
 
 public class CustomXPathUtils {
 
     public static void flattenExclusiveImpl(
-        Node root,
-        XPathExpression expr,
+        @NotNull Node root,
+        @NotNull XPathExpression expr,
         boolean justLeaves,
-        NodesList<Node> result
+        @NotNull NodesList<Node> result
     ) throws XPathExpressionException {
         Stack<Node> stack = new Stack<>();
         stack.add(root);
@@ -61,79 +62,77 @@ public class CustomXPathUtils {
             }
         }
     }
-    
-    public static Stream<Node> streamOf(final NodeList list) {
+
+    @NotNull
+    public static Stream<Node> streamOf(@NotNull final NodeList list) {
         return StreamSupport.stream(iterableOf(list).spliterator(), false);
     }
-    
-    public static Iterable<Node> iterableOf(final NodeList list) {
-        return new Iterable<Node>() {
-            @Override
-            public Iterator<Node> iterator() {
-                return new Iterator<>() {
-                    private int index = 0;
-                    
-                    @Override
-                    public boolean hasNext() {
-                        return index < list.getLength();
-                    }
 
-                    @Override
-                    public Node next() {
-                        return list.item(index++);
-                    }
-                };
+    @NotNull
+    public static Iterable<Node> iterableOf(@NotNull final NodeList list) {
+        return () -> new Iterator<>() {
+            private int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                return index < list.getLength();
+            }
+
+            @Override
+            public Node next() {
+                return list.item(index++);
             }
         };
     }
-    
-    public static Iterable<Node> reverseIterableOf(final XPathNodes list) {
-        return new Iterable<Node>() {
+
+    @NotNull
+    public static Iterable<Node> reverseIterableOf(@NotNull final XPathNodes list) {
+        return () -> new Iterator<>() {
+            private int index = list.size();
+
             @Override
-            public Iterator<Node> iterator() {
-                return new Iterator<>() {
-                    private int index = list.size();
+            public boolean hasNext() {
+                return index > 0;
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        return index > 0;
-                    }
-
-                    @Override
-                    public Node next() {
-                        try {
-                            return list.get(--index);
-                        } catch (XPathException e) {
-                            return null;
-                        }
-                    }
-                };
+            @Override
+            public Node next() {
+                try {
+                    return list.get(--index);
+                } catch (XPathException e) {
+                    return null;
+                }
             }
         };
     }
-    
-    public static String getText(Tree node) {
-        String result;
+
+    @Nullable
+    public static String getText(@NotNull Tree node) {
+        String result = null;
         if (node instanceof TreeRuleNode) {
             TreeRuleNode ruleNode = ((TreeRuleNode) node);
             Interval textRange = ruleNode.getRealInterval();
             result = ruleNode.getStart().getInputStream().getText(textRange);
-        } else if (node instanceof XTreeTextBase && node instanceof TerminalNode) {
-            Interval textRange = ((XTreeTextBase)node).getRealInterval();
-            result = ((TerminalNode)node).getSymbol().getInputStream().getText(textRange);
+        } else if (node instanceof XTreeTextBase) {
+            Interval textRange = ((XTreeTextBase) node).getRealInterval();
+            result = ((TerminalNode) node).getSymbol().getInputStream().getText(textRange);
         } else if (node instanceof ParseTree) {
             result = ((ParseTree) node).getText(); // consider extracting whitespaces but not comments
         } else {
-            Tree first = node, last = node;
+            Tree first = node;
+            Tree last = node;
             while (!(first instanceof TerminalNode) && first.getChildCount() > 0) {
                 first = first.getChild(0);
             }
             while (!(last instanceof TerminalNode) && last.getChildCount() > 0) {
                 last = last.getChild(last.getChildCount() - 1);
             }
-            TerminalNode a = (TerminalNode) first, b = (TerminalNode) last;
-            Interval textRange = Interval.of(a.getSymbol().getStartIndex(), b.getSymbol().getStopIndex());
-            result = b.getSymbol().getTokenSource().getInputStream().getText(textRange);
+            if (first instanceof TerminalNode && last instanceof TerminalNode) {
+                TerminalNode a = (TerminalNode) first;
+                TerminalNode b = (TerminalNode) last;
+                Interval textRange = Interval.of(a.getSymbol().getStartIndex(), b.getSymbol().getStopIndex());
+                result = b.getSymbol().getTokenSource().getInputStream().getText(textRange);
+            }
         }
         return result;
     }    

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/EmptyNodesList.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/EmptyNodesList.java
@@ -16,6 +16,8 @@
  */
 package org.jkiss.dbeaver.model.lsm.mapping.internal;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.w3c.dom.NodeList;
 
 import java.util.Collections;
@@ -33,11 +35,13 @@ public class EmptyNodesList implements NodeList, TreeRuleNode.SubnodesList {
         return 0;
     }
 
+    @NotNull
     @Override
     public List<XTreeNodeBase> getCollection() {
         return Collections.emptyList();
     }
 
+    @Nullable
     @Override
     public XTreeNodeBase item(int index) {
         return null;

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/FieldTypeKind.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/FieldTypeKind.java
@@ -16,11 +16,13 @@
  */
 package org.jkiss.dbeaver.model.lsm.mapping.internal;
 
+import org.jkiss.code.NotNull;
+
 import java.util.ArrayList;
 import java.util.Map;
 
 public enum FieldTypeKind {
-    String(true), 
+    String(true),
     Byte(true),
     Short(true), 
     Int(true),
@@ -41,7 +43,7 @@ public enum FieldTypeKind {
     }
 
     private static final Map<Class<?>, FieldTypeKind> builtinTypeKinds = Map.ofEntries(
-        java.util.Map.entry(String.class, FieldTypeKind.String), 
+        java.util.Map.entry(String.class, FieldTypeKind.String),
         java.util.Map.entry(Byte.class, FieldTypeKind.Byte),
         java.util.Map.entry(Short.class, FieldTypeKind.Short), 
         java.util.Map.entry(Integer.class, FieldTypeKind.Int), 
@@ -58,8 +60,9 @@ public enum FieldTypeKind {
         java.util.Map.entry(float.class, FieldTypeKind.Float),
         java.util.Map.entry(double.class, FieldTypeKind.Double) 
     );
-    
-    public static FieldTypeKind resolveModelLiteralFieldKind(Class<?> fieldType) {
+
+    @NotNull
+    public static FieldTypeKind resolveModelLiteralFieldKind(@NotNull Class<?> fieldType) {
         FieldTypeKind kind = builtinTypeKinds.get(fieldType);
         if (kind == null) {
             if (fieldType.isEnum()) {
@@ -73,7 +76,8 @@ public enum FieldTypeKind {
         return kind;
     }
 
-    public static FieldTypeKind resolveModelSubnodeFieldKind(Class<?> fieldType) {
+    @NotNull
+    public static FieldTypeKind resolveModelSubnodeFieldKind(@NotNull Class<?> fieldType) {
         FieldTypeKind kind;
         if (fieldType.isArray()) {
             kind = FieldTypeKind.Array;

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/LiteralTypeInfo.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/LiteralTypeInfo.java
@@ -16,6 +16,8 @@
  */
 package org.jkiss.dbeaver.model.lsm.mapping.internal;
 
+import org.jkiss.code.NotNull;
+
 import javax.xml.xpath.XPathExpression;
 import java.util.Map;
 
@@ -28,11 +30,11 @@ public class LiteralTypeInfo {
     public final boolean isCaseSensitive;
     
     public LiteralTypeInfo(
-        String ruleName,
-        Class<?> type,
-        XPathExpression stringExpr,
-        Map<Object, XPathExpression> exprByValue,
-        Map<String, Object> valuesByName,
+        @NotNull String ruleName,
+        @NotNull Class<?> type,
+        @NotNull XPathExpression stringExpr,
+        @NotNull Map<Object, XPathExpression> exprByValue,
+        @NotNull Map<String, Object> valuesByName,
         boolean isCaseSensitive
     ) {
         this.ruleName = ruleName;

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/NodeFieldInfo.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/NodeFieldInfo.java
@@ -16,14 +16,15 @@
  */
 package org.jkiss.dbeaver.model.lsm.mapping.internal;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.lsm.mapping.AbstractSyntaxNode;
 import org.jkiss.dbeaver.model.lsm.mapping.SyntaxModel;
 import org.jkiss.dbeaver.model.lsm.mapping.SyntaxSubnodeLookupMode;
 
-import javax.xml.xpath.XPathExpression;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
+import javax.xml.xpath.XPathExpression;
 
 public class NodeFieldInfo {
 
@@ -34,18 +35,21 @@ public class NodeFieldInfo {
         
         private NodeTypeInfo nodeTypeInfo;
         
-        public SubnodeInfo(XPathExpression scopeExpr, 
-                           Class<? extends AbstractSyntaxNode> subnodeType, 
-                           SyntaxSubnodeLookupMode lookupMode) {
+        public SubnodeInfo(
+            @NotNull XPathExpression scopeExpr,
+            @NotNull Class<? extends AbstractSyntaxNode> subnodeType,
+            @NotNull SyntaxSubnodeLookupMode lookupMode
+        ) {
             this.scopeExpr = scopeExpr;
             this.subnodeType = subnodeType;
             this.lookupMode = lookupMode;
         }
 
-        public void fixup(SyntaxModel syntaxModel) {
+        public void fixup(@NotNull SyntaxModel syntaxModel) {
             nodeTypeInfo = syntaxModel.findNodeTypeInfo(subnodeType);
         }
 
+        @NotNull
         public NodeTypeInfo getNodeTypeInfo() {
             return nodeTypeInfo;
         }
@@ -58,29 +62,36 @@ public class NodeFieldInfo {
     
     private LiteralTypeInfo literalTypeInfo;
     
-    public NodeFieldInfo(FieldTypeKind kind, Field info, List<XPathExpression> termExprs, List<SubnodeInfo> subnodesInfo) {
+    public NodeFieldInfo(
+        @NotNull FieldTypeKind kind,
+        @NotNull Field info,
+        @NotNull List<XPathExpression> termExprs,
+        @NotNull List<SubnodeInfo> subnodesInfo
+    ) {
         this.kind = kind;
         this.info = info;
         this.termExprs = Collections.unmodifiableList(termExprs);
         this.subnodesInfo = Collections.unmodifiableList(subnodesInfo);
     }
-    
+
+    @NotNull
     public String getFieldName() {
         return this.info.getName();
     }
-    
+
+    @NotNull
     public String getDeclaringClassName() {
         return this.info.getDeclaringClass().getName();
     }
 
-    public void fixup(SyntaxModel syntaxModel) {
+    public void fixup(@NotNull SyntaxModel syntaxModel) {
         if (kind == FieldTypeKind.Enum) {
             literalTypeInfo = syntaxModel.findLiteralTypeInfo(info.getType());
         } else {
             literalTypeInfo = null;
         }
         
-        for (SubnodeInfo subnodeInfo: subnodesInfo) {
+        for (SubnodeInfo subnodeInfo : subnodesInfo) {
             subnodeInfo.fixup(syntaxModel);
         }   
     }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/NodeTypeInfo.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/NodeTypeInfo.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.model.lsm.mapping.internal;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.lsm.mapping.AbstractSyntaxNode;
 
 import java.lang.reflect.Constructor;
@@ -31,17 +32,18 @@ public class NodeTypeInfo {
     public final Map<String, NodeFieldInfo> fields;
 
     public NodeTypeInfo(
-        String ruleName,
-        Class<? extends AbstractSyntaxNode> type,
-        Constructor<? extends AbstractSyntaxNode> ctor,
-        Map<String, NodeFieldInfo> fields
+        @NotNull String ruleName,
+        @NotNull Class<? extends AbstractSyntaxNode> type,
+        @NotNull Constructor<? extends AbstractSyntaxNode> ctor,
+        @NotNull Map<String, NodeFieldInfo> fields
     ) {
         this.ruleName = ruleName;
         this.type = type;
         this.ctor = ctor;
         this.fields = Collections.unmodifiableMap(fields);
     }
-    
+
+    @NotNull
     public Collection<NodeFieldInfo> getFields() {
         return this.fields.values();
     }     

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/ParserOverrides.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/ParserOverrides.java
@@ -22,22 +22,25 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.lsm.LSMParser;
 
 public abstract class ParserOverrides extends Parser {
 
-    public ParserOverrides(TokenStream input) {
+    public ParserOverrides(@NotNull TokenStream input) {
         super(input);
         this.setBuildParseTree(true);
     }
 
+    @NotNull
     @Override
-    public ErrorNode createErrorNode(ParserRuleContext parent, Token t) {
+    public ErrorNode createErrorNode(@NotNull ParserRuleContext parent, @NotNull Token t) {
         return new TreeTermErrorNode(t);
     }
-    
+
+    @NotNull
     @Override
-    public TerminalNode createTerminalNode(ParserRuleContext parent, Token t) {
+    public TerminalNode createTerminalNode(@NotNull ParserRuleContext parent, @NotNull Token t) {
         return new TreeTermNode(t);
     }
 

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/TreeRuleNode.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/TreeRuleNode.java
@@ -25,6 +25,8 @@ import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.antlr.v4.runtime.tree.Trees;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.lsm.mapping.AbstractSyntaxNode;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -39,21 +41,27 @@ public class TreeRuleNode extends ParserRuleContext implements Element, XTreeEle
 
     public interface SubnodesList extends NodeList {
 
+        @NotNull
         List<XTreeNodeBase> getCollection();
 
+        @Nullable
         XTreeNodeBase item(int index);
 
+        @Nullable
         XTreeNodeBase getFirst();
 
+        @Nullable
         XTreeNodeBase getLast();
     }
     
     private class SubnodesListImpl implements SubnodesList {
-        
+
+        @NotNull
         public List<XTreeNodeBase> getCollection() {
-            return (List<XTreeNodeBase>)(Object)TreeRuleNode.this.children;
+            return (List<XTreeNodeBase>) (Object) TreeRuleNode.this.children;
         }
-        
+
+        @Nullable
         @Override
         public XTreeNodeBase item(int index) {
             List<XTreeNodeBase> items = getCollection();
@@ -65,11 +73,13 @@ public class TreeRuleNode extends ParserRuleContext implements Element, XTreeEle
             return getCollection().size();
         }
 
+        @Nullable
         public XTreeNodeBase getFirst() {
             List<XTreeNodeBase> items = getCollection();
             return items.size() > 0 ? items.get(0) : null;
         }
 
+        @Nullable
         public XTreeNodeBase getLast() {
             List<XTreeNodeBase> items = getCollection();
             return items.size() > 0 ? items.get(items.size() - 1) : null;
@@ -87,7 +97,7 @@ public class TreeRuleNode extends ParserRuleContext implements Element, XTreeEle
         super();
     }
 
-    public TreeRuleNode(ParserRuleContext parent, int invokingStateNumber) {
+    public TreeRuleNode(@NotNull ParserRuleContext parent, int invokingStateNumber) {
         super(parent, invokingStateNumber);
     }    
     
@@ -96,25 +106,27 @@ public class TreeRuleNode extends ParserRuleContext implements Element, XTreeEle
         return index;
     }
     
-    public void setModel(AbstractSyntaxNode model) {
+    public void setModel(@Nullable AbstractSyntaxNode model) {
         if (this.model != null) {
             throw new IllegalStateException();
         } else {
             this.model = model;
         }
     }
-    
+
+    @Nullable
     public AbstractSyntaxNode getModel() {
         return this.model;
     }
-    
+
+    @NotNull
     @Override
     public Interval getRealInterval() {
         return new Interval(this.getStart().getStartIndex(), this.getStop().getStopIndex());
     }
     
     @Override
-    public void fixup(Parser parserCtx, int index) {
+    public void fixup(@NotNull Parser parserCtx, int index) {
         this.index = index;
         if (this.getChildCount() > 0) {
             nodeName = Trees.getNodeText(this, parserCtx);
@@ -126,46 +138,52 @@ public class TreeRuleNode extends ParserRuleContext implements Element, XTreeEle
             throw new IllegalStateException(); // Should never happen?
         }
     }
-    
+
+    @NotNull
     @Override
-    public RuleContext addChild(RuleContext ruleInvocation) {
+    public RuleContext addChild(@NotNull RuleContext ruleInvocation) {
         if (!(ruleInvocation instanceof XTreeNodeBase)) {
             throw new IllegalStateException();
         } else {
             return super.addChild(ruleInvocation);
         }
     }
-    
+
+    @NotNull
     @Override
-    public TerminalNode addChild(Token matchedToken) {
+    public TerminalNode addChild(@NotNull Token matchedToken) {
         return super.addChild(new TreeTermNode(matchedToken));
     }
-    
+
+    @NotNull
     @Override
-    public TerminalNode addChild(TerminalNode t) {
+    public TerminalNode addChild(@NotNull TerminalNode t) {
         if (!(t instanceof XTreeNodeBase)) {
             throw new IllegalStateException();
         } else {
             return super.addChild(t);
         }
     }
-    
+
+    @NotNull
     @Override
-    public <T extends ParseTree> T addAnyChild(T t) {
+    public <T extends ParseTree> T addAnyChild(@NotNull T t) {
         if (!(t instanceof XTreeNodeBase)) {
             throw new IllegalStateException();
         } else {
             return super.addAnyChild(t);
         }
     }
-    
+
+    @NotNull
     @Override
-    public ErrorNode addErrorNode(Token badToken) {
+    public ErrorNode addErrorNode(@NotNull Token badToken) {
         return super.addAnyChild(new TreeTermErrorNode(badToken));
     }
-    
+
+    @NotNull
     @Override
-    public ErrorNode addErrorNode(ErrorNode errorNode) {
+    public ErrorNode addErrorNode(@NotNull ErrorNode errorNode) {
         if (!(errorNode instanceof XTreeNodeBase)) {
             throw new IllegalStateException();
         } else {

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/TreeTermErrorNode.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/TreeTermErrorNode.java
@@ -20,6 +20,7 @@ import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ErrorNodeImpl;
+import org.jkiss.code.NotNull;
 import org.w3c.dom.NodeList;
 
 import java.util.HashMap;
@@ -31,7 +32,7 @@ public class TreeTermErrorNode extends ErrorNodeImpl implements XTreeTextBase {
     
     private Map<String, Object> userData;
     
-    public TreeTermErrorNode(Token symbol) {
+    public TreeTermErrorNode(@NotNull Token symbol) {
         super(symbol);
     }
     
@@ -39,21 +40,24 @@ public class TreeTermErrorNode extends ErrorNodeImpl implements XTreeTextBase {
         return index;
     }
 
+    @NotNull
     @Override
     public Interval getRealInterval() {
         return new Interval(this.getSymbol().getStartIndex(), this.getSymbol().getStopIndex());
     }
     
     @Override
-    public void fixup(Parser parser, int index) {
+    public void fixup(@NotNull Parser parser, int index) {
         this.index = index;
     }
-    
+
+    @NotNull
     @Override
     public TreeRuleNode.SubnodesList getSubnodes() {
         return EmptyNodesList.INSTANCE;
     }
-    
+
+    @NotNull
     @Override
     public NodeList getChildNodes() {
         return EmptyNodesList.INSTANCE;
@@ -63,12 +67,14 @@ public class TreeTermErrorNode extends ErrorNodeImpl implements XTreeTextBase {
     public short getNodeType() {
         return TEXT_NODE;
     }
-    
+
+    @NotNull
     @Override
     public String getNodeName() {
         return "#text";
     }
-    
+
+    @NotNull
     @Override
     public Map<String, Object> getUserDataMap(boolean createIfMissing) {
         return userData != null ? userData : (userData = new HashMap<>());

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/TreeTermNode.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/mapping/internal/TreeTermNode.java
@@ -20,6 +20,7 @@ import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.TerminalNodeImpl;
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.lsm.mapping.internal.TreeRuleNode.SubnodesList;
 import org.w3c.dom.NodeList;
 
@@ -32,7 +33,7 @@ public class TreeTermNode extends TerminalNodeImpl implements XTreeTextBase {
     
     private Map<String, Object> userData;
     
-    public TreeTermNode(Token symbol) {
+    public TreeTermNode(@NotNull Token symbol) {
         super(symbol);
     }
     
@@ -41,20 +42,23 @@ public class TreeTermNode extends TerminalNodeImpl implements XTreeTextBase {
     }
     
     @Override
-    public void fixup(Parser parser, int index) {
+    public void fixup(@NotNull Parser parser, int index) {
         this.index = index;
     }
-    
+
+    @NotNull
     @Override
     public Interval getRealInterval() {
         return new Interval(this.getSymbol().getStartIndex(), this.getSymbol().getStopIndex());
     }
-    
+
+    @NotNull
     @Override
     public SubnodesList getSubnodes() {
         return EmptyNodesList.INSTANCE;
     }
-    
+
+    @NotNull
     @Override
     public NodeList getChildNodes() {
         return EmptyNodesList.INSTANCE;
@@ -64,12 +68,14 @@ public class TreeTermNode extends TerminalNodeImpl implements XTreeTextBase {
     public short getNodeType() {
         return TEXT_NODE;
     }
-    
+
+    @NotNull
     @Override
     public String getNodeName() {
         return "#text";
     }
-    
+
+    @NotNull
     @Override
     public Map<String, Object> getUserDataMap(boolean createIfMissing) {
         return userData != null ? userData : (userData = new HashMap<>());

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/sql/dialect/Sql92Dialect.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/sql/dialect/Sql92Dialect.java
@@ -16,20 +16,7 @@
  */
 package org.jkiss.dbeaver.model.lsm.sql.dialect;
 
-import java.util.BitSet;
-import java.util.Map;
 
-import org.antlr.v4.runtime.ANTLRErrorListener;
-import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ConsoleErrorListener;
-import org.antlr.v4.runtime.Parser;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.Recognizer;
-import org.antlr.v4.runtime.atn.ATNConfigSet;
-import org.antlr.v4.runtime.atn.PredictionMode;
-import org.antlr.v4.runtime.dfa.DFA;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.lsm.LSMDialect;
@@ -45,11 +32,21 @@ import org.jkiss.dbeaver.model.lsm.sql.impl.syntax.Sql92Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ConsoleErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.atn.PredictionMode;
+
+import java.util.Map;
+
 public class Sql92Dialect {
     private static final Logger log = LoggerFactory.getLogger(Sql92Dialect.class);
     
     private static final LSMDialect dialect = new LSMDialectImpl(
-        Map.of(LSMSelectStatement.class, new LSMAnalysisCaseImpl<LSMSelectStatement, SelectStatement>(LSMSelectStatement.class, SelectStatement.class) {
+        Map.of(LSMSelectStatement.class, new LSMAnalysisCaseImpl<>(LSMSelectStatement.class, SelectStatement.class) {
 
             @Nullable
             @Override

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/sql/dialect/Sql92Dialect.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/lsm/sql/dialect/Sql92Dialect.java
@@ -16,11 +16,22 @@
  */
 package org.jkiss.dbeaver.model.lsm.sql.dialect;
 
+import java.util.BitSet;
 import java.util.Map;
 
+import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ConsoleErrorListener;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.atn.PredictionMode;
+import org.antlr.v4.runtime.dfa.DFA;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.lsm.LSMDialect;
 import org.jkiss.dbeaver.model.lsm.LSMParser;
 import org.jkiss.dbeaver.model.lsm.LSMSource;
@@ -31,27 +42,61 @@ import org.jkiss.dbeaver.model.lsm.sql.LSMSelectStatement;
 import org.jkiss.dbeaver.model.lsm.sql.impl.SelectStatement;
 import org.jkiss.dbeaver.model.lsm.sql.impl.syntax.Sql92Lexer;
 import org.jkiss.dbeaver.model.lsm.sql.impl.syntax.Sql92Parser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Sql92Dialect {
+    private static final Logger log = LoggerFactory.getLogger(Sql92Dialect.class);
+    
     private static final LSMDialect dialect = new LSMDialectImpl(
         Map.of(LSMSelectStatement.class, new LSMAnalysisCaseImpl<LSMSelectStatement, SelectStatement>(LSMSelectStatement.class, SelectStatement.class) {
+
+            @Nullable
+            @Override
             public LSMParser createParser(LSMSource source) {
-                return () -> prepareParser(source.getStream()).sqlQuery();
+                return createParser(source, null);
             }
-        }), 
+
+            @Nullable
+            @Override
+            public LSMParser createParser(@NotNull LSMSource source, @Nullable ANTLRErrorListener errorListener) {
+                return () -> {
+                    try {
+                        return prepareParser(source.getStream(), errorListener).sqlQuery();
+                    } catch (RecognitionException e) {
+                        log.debug("Recognition exception occurred while trying to parse the query", e);
+                        return null;
+                    }
+                };
+            }
+        }),
         prepareModel() 
     );
     
+    @NotNull
     private static SyntaxModel prepareModel() {
-        SyntaxModel model = new SyntaxModel(prepareParser(CharStreams.fromString("")));
+        SyntaxModel model = new SyntaxModel(prepareParser(CharStreams.fromString(""), null));
         model.introduce(SelectStatement.class);
         return model;
     }
-    
-    private static Sql92Parser prepareParser(CharStream input) {
-        return new Sql92Parser(new CommonTokenStream(new Sql92Lexer(input)));
+
+    @NotNull
+    private static Sql92Parser prepareParser(@NotNull CharStream input, @Nullable ANTLRErrorListener errorListener) {
+        Sql92Lexer lexer = new Sql92Lexer(input);
+        if (errorListener != null) {
+            lexer.removeErrorListener(ConsoleErrorListener.INSTANCE);
+            lexer.addErrorListener(errorListener);
+        }
+        Sql92Parser parser =  new Sql92Parser(new CommonTokenStream(lexer));
+        if (errorListener != null) {
+            parser.removeErrorListener(ConsoleErrorListener.INSTANCE);
+            parser.addErrorListener(errorListener);
+        }
+        parser.getInterpreter().setPredictionMode(PredictionMode.LL);
+        return parser;
     }
 
+    @NotNull
     public static LSMDialect getInstance() {
         return dialect;
     }

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/stm/ParserOverrides.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/stm/ParserOverrides.java
@@ -31,13 +31,15 @@ public abstract class ParserOverrides extends Parser {
         this.setBuildParseTree(true);
     }
 
+    @NotNull
     @Override
-    public ErrorNode createErrorNode(ParserRuleContext parent, @NotNull Token t) {
+    public ErrorNode createErrorNode(@NotNull ParserRuleContext parent, @NotNull Token t) {
         return new TreeTermErrorNode(t);
     }
-    
+
+    @NotNull
     @Override
-    public TerminalNode createTerminalNode(ParserRuleContext parent, @NotNull Token t) {
+    public TerminalNode createTerminalNode(@NotNull ParserRuleContext parent, @NotNull Token t) {
         return new TreeTermNode(t);
     }
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
@@ -994,7 +994,7 @@ public class SQLCompletionAnalyzer implements DBRRunnableParametrized<DBRProgres
             return Collections.emptyList();
         }
         // log.debug("Extracted table names: " + tableRefs);
-        if (CommonUtils.isNotEmpty(tableAlias)) {
+        if (CommonUtils.isNotEmpty(tableAlias) && tableRefs != null) {
             tableRefs = tableRefs.stream().filter(r -> allowPartialMatch 
                 ? CommonUtils.startsWithIgnoreCase(r.getSecond(), tableAlias)
                 : r.getSecond().equalsIgnoreCase(tableAlias)


### PR DESCRIPTION
We may need to log error somewhere, but in completion analyzer we don't. So, let's skip errors and do not write them to somewhere. The logging error listener might be useful when we want to write something in our debug log.


**How to test it: logs shouldn't contain any messages like "no viable alternative at".**