### PR TITLE
dbeaver/pro#1634 Keep original driver when replacing the old one

### DIFF
--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceSerializerModern.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceSerializerModern.java
@@ -523,9 +523,14 @@ class DataSourceSerializerModern implements DataSourceSerializer
                 if (substitutedDriver == null || substitutedDriver.isTemporary()) {
                     substitutedDriver = originalDriver;
                 }
-                while (substitutedDriver.getReplacedBy() != null) {
-                    substitutedDriver = substitutedDriver.getReplacedBy();
+
+                if (getReplacementDriver(substitutedDriver) == originalDriver) {
+                    final DriverDescriptor original = originalDriver;
+                    originalDriver = substitutedDriver;
+                    substitutedDriver = original;
                 }
+
+                substitutedDriver = getReplacementDriver(substitutedDriver);
 
                 DataSourceDescriptor dataSource = registry.getDataSource(id);
                 boolean newDataSource = (dataSource == null);
@@ -1260,4 +1265,14 @@ class DataSourceSerializerModern implements DataSourceSerializer
         return creds;
     }
 
+    @NotNull
+    private static DriverDescriptor getReplacementDriver(@NotNull DriverDescriptor driver) {
+        DriverDescriptor replacement = driver;
+
+        while (replacement.getReplacedBy() != null) {
+            replacement = replacement.getReplacedBy();
+        }
+
+        return replacement;
+    }
 }


### PR DESCRIPTION
STR:
1. Boot up CE, edit a connection
2. Boot up EE, edit the connection
3. Boot up CE, observe that the connection uses the original driver, edit the connection
4. Boot up EE, observe that the connection uses the replacement driver