### PR TITLE
dbeaver/dbeaver#19907 transfer bindings to keyboard only scheme & only when ERD editor active

### DIFF
--- a/plugins/org.jkiss.dbeaver.erd.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.erd.ui/OSGI-INF/l10n/bundle.properties
@@ -24,10 +24,10 @@ command.org.jkiss.dbeaver.erd.diagram.saveAs.description = Save diagram in exter
 command.org.jkiss.dbeaver.erd.toggleHand.name = Toggle hand tool
 command.org.jkiss.dbeaver.erd.toggleHand.description = Cycle through hand tool and previously used tool
 
-command.org.jkiss.dbeaver.erd.focus.diagram.name = Focus on diagram
-command.org.jkiss.dbeaver.erd.focus.palette.name = Focus on palette
-command.org.jkiss.dbeaver.erd.focus.outline.name = Focus on outline
-command.org.jkiss.dbeaver.erd.focus.parameters.name = Focus on parameters
+command.org.jkiss.dbeaver.erd.focus.diagram.name = ERD: Focus on diagram
+command.org.jkiss.dbeaver.erd.focus.palette.name = ERD: Focus on palette
+command.org.jkiss.dbeaver.erd.focus.outline.name = ERD: Focus on outline
+command.org.jkiss.dbeaver.erd.focus.parameters.name = ERD: Focus on parameters
 
 command.org.jkiss.dbeaver.erd.focus.diagram.description = Changes focus to diagram
 command.org.jkiss.dbeaver.erd.focus.palette.description = Changes focus to palette

--- a/plugins/org.jkiss.dbeaver.erd.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.erd.ui/plugin.xml
@@ -427,13 +427,19 @@
     </extension>
 
     <extension point="org.eclipse.ui.bindings">
-        <key commandId="org.jkiss.dbeaver.erd.focus.diagram" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+1"/>
-        <key commandId="org.jkiss.dbeaver.erd.focus.palette" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+2"/>
-        <key commandId="org.jkiss.dbeaver.erd.focus.outline" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+3"/>
-        <key commandId="org.jkiss.dbeaver.erd.focus.parameter" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+4"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.diagram" contextId="org.jkiss.dbeaver.ui.erd" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+1"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.palette" contextId="org.jkiss.dbeaver.ui.erd" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+2"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.outline" contextId="org.jkiss.dbeaver.ui.erd" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+3"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.parameter" contextId="org.jkiss.dbeaver.ui.erd" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+4"/>
         <key commandId="org.jkiss.dbeaver.erd.toggleHand" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="TAB"/>
     </extension>
-
+    <extension point="org.eclipse.ui.contexts">
+        <context
+                id="org.jkiss.dbeaver.ui.erd"
+                parentId="org.eclipse.ui.contexts.window"
+                name="ERD"
+                description="DBeaver ERD Context"/>
+    </extension>
     <extension point="org.eclipse.ui.handlers">
         <handler commandId="org.jkiss.dbeaver.erd.diagram.view" class="org.jkiss.dbeaver.erd.ui.navigator.ViewDiagramHandler">
             <enabledWhen>

--- a/plugins/org.jkiss.dbeaver.erd.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.erd.ui/plugin.xml
@@ -427,10 +427,10 @@
     </extension>
 
     <extension point="org.eclipse.ui.bindings">
-        <key commandId="org.jkiss.dbeaver.erd.focus.diagram" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+1"/>
-        <key commandId="org.jkiss.dbeaver.erd.focus.palette" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+2"/>
-        <key commandId="org.jkiss.dbeaver.erd.focus.outline" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+3"/>
-        <key commandId="org.jkiss.dbeaver.erd.focus.parameter" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+4"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.diagram" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+1"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.palette" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+2"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.outline" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+3"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.parameter" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+4"/>
         <key commandId="org.jkiss.dbeaver.erd.toggleHand" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="TAB"/>
     </extension>
 
@@ -460,10 +460,34 @@
                 </with>
             </enabledWhen>
         </handler>
-        <handler commandId="org.jkiss.dbeaver.erd.focus.diagram" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus"/>
-        <handler commandId="org.jkiss.dbeaver.erd.focus.palette" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus"/>
-        <handler commandId="org.jkiss.dbeaver.erd.focus.outline" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus"/>
-        <handler commandId="org.jkiss.dbeaver.erd.focus.parameter" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus"/>
+        <handler commandId="org.jkiss.dbeaver.erd.focus.diagram" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus">
+            <activeWhen>
+                <with variable="activeEditor">
+                    <adapt type="org.jkiss.dbeaver.erd.ui.editor.ERDEditorPart"/>
+                </with>
+            </activeWhen>
+        </handler>
+        <handler commandId="org.jkiss.dbeaver.erd.focus.palette" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus">
+            <activeWhen>
+                <with variable="activeEditor">
+                    <adapt type="org.jkiss.dbeaver.erd.ui.editor.ERDEditorPart"/>
+                </with>
+            </activeWhen>
+        </handler>
+        <handler commandId="org.jkiss.dbeaver.erd.focus.outline" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus">
+            <activeWhen>
+                <with variable="activeEditor">
+                    <adapt type="org.jkiss.dbeaver.erd.ui.editor.ERDEditorPart"/>
+                </with>
+            </activeWhen>
+        </handler>
+        <handler commandId="org.jkiss.dbeaver.erd.focus.parameter" class="org.jkiss.dbeaver.erd.ui.action.ERDHandlerFocus">
+            <activeWhen>
+                <with variable="activeEditor">
+                    <adapt type="org.jkiss.dbeaver.erd.ui.editor.ERDEditorPart"/>
+                </with>
+            </activeWhen>
+        </handler>
     </extension>
 
     <extension point="org.eclipse.ui.menus">

--- a/plugins/org.jkiss.dbeaver.erd.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.erd.ui/plugin.xml
@@ -427,19 +427,13 @@
     </extension>
 
     <extension point="org.eclipse.ui.bindings">
-        <key commandId="org.jkiss.dbeaver.erd.focus.diagram" contextId="org.jkiss.dbeaver.ui.erd" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+1"/>
-        <key commandId="org.jkiss.dbeaver.erd.focus.palette" contextId="org.jkiss.dbeaver.ui.erd" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+2"/>
-        <key commandId="org.jkiss.dbeaver.erd.focus.outline" contextId="org.jkiss.dbeaver.ui.erd" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+3"/>
-        <key commandId="org.jkiss.dbeaver.erd.focus.parameter" contextId="org.jkiss.dbeaver.ui.erd" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+4"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.diagram" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+1"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.palette" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+2"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.outline" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+3"/>
+        <key commandId="org.jkiss.dbeaver.erd.focus.parameter" contextId="org.eclipse.ui.contexts.window" schemeId="org.jkiss.dbeaver.keyboardOnlyKeyScheme" sequence="ALT+4"/>
         <key commandId="org.jkiss.dbeaver.erd.toggleHand" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="TAB"/>
     </extension>
-    <extension point="org.eclipse.ui.contexts">
-        <context
-                id="org.jkiss.dbeaver.ui.erd"
-                parentId="org.eclipse.ui.contexts.window"
-                name="ERD"
-                description="DBeaver ERD Context"/>
-    </extension>
+
     <extension point="org.eclipse.ui.handlers">
         <handler commandId="org.jkiss.dbeaver.erd.diagram.view" class="org.jkiss.dbeaver.erd.ui.navigator.ViewDiagramHandler">
             <enabledWhen>

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
@@ -725,7 +725,7 @@
 
         <key commandId="org.jkiss.dbeaver.ui.editors.sql.toggle.result.panel" contextId="org.jkiss.dbeaver.ui.editors.sql.script" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+6"/>
         <key commandId="org.jkiss.dbeaver.ui.editors.sql.maximize.result.panel" contextId="org.jkiss.dbeaver.ui.editors.sql.script" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+SHIFT+6"/>
-        <key commandId="org.jkiss.dbeaver.ui.editors.sql.switch.panel" contextId="org.jkiss.dbeaver.ui.editors.sql.script" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="ALT+6"/>
+        <key commandId="org.jkiss.dbeaver.ui.editors.sql.switch.panel" contextId="org.jkiss.dbeaver.ui.editors.sql.script" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+ALT+6"/>
         <!--<key commandId="org.jkiss.dbeaver.ui.editors.sql.assist.templates" contextId="org.jkiss.dbeaver.ui.editors.sql" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+ALT+SPACE"/>-->
         <key commandId="org.jkiss.dbeaver.ui.editors.sql.open.file" contextId="org.jkiss.dbeaver.ui.editors.sql" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+ALT+SHIFT+O"/>
 


### PR DESCRIPTION
Closes dbeaver/dbeaver#19907 
Now should only be active for keyboard only scheme. Also makes them active only in ERDEditor 