### PR TITLE
dbeaver/pro#1611 fix coloring on dark theme

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/ProgressPageControl.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/ProgressPageControl.java
@@ -83,6 +83,7 @@ public class ProgressPageControl extends Composite implements ISearchContextProv
     private ToolBarManager searchToolbarManager;
     private ToolBarManager customToolbarManager;
     private Composite customControlsComposite;
+    private Color defaultBackgroundColor;
 
     public ProgressPageControl(
         Composite parent,
@@ -440,7 +441,7 @@ public class ProgressPageControl extends Composite implements ISearchContextProv
                 });
             }
             searchToolbarManager.createControl(searchControlsComposite);
-
+            defaultBackgroundColor = searchText.getBackground();
             searchControlsComposite.getParent().layout();
         } finally {
             searchControlsComposite.getParent().setRedraw(true);
@@ -514,7 +515,7 @@ public class ProgressPageControl extends Composite implements ISearchContextProv
                 options |= ISearchExecutor.SEARCH_NEXT;
             }
             boolean success = getSearchRunner().performSearch(getProgressControl().curSearchText, options);
-            getProgressControl().searchText.setBackground(success ? null : searchNotFoundColor);
+            getProgressControl().searchText.setBackground(success ? getProgressControl().defaultBackgroundColor : searchNotFoundColor);
             return success;
         } else {
             cancelSearch(false);
@@ -537,7 +538,7 @@ public class ProgressPageControl extends Composite implements ISearchContextProv
         if (hide) {
             hideControls(true);
         } else {
-            getProgressControl().searchText.setBackground(null);
+            getProgressControl().searchText.setBackground(getProgressControl().defaultBackgroundColor);
         }
     }
 


### PR DESCRIPTION
Closes dbeaver/pro#1611
Now search should look properly on dark theme
![image](https://github.com/dbeaver/dbeaver/assets/20579256/509cf741-bd68-4718-ba24-3ebe8434e841)
![image](https://github.com/dbeaver/dbeaver/assets/20579256/bf2f377b-843f-4399-b3c8-e8343ca946c7)
