### PR TITLE
dbeaver/pro#1502 new connection wizard deprecation

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreMessages.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreMessages.java
@@ -568,6 +568,9 @@ public class CoreMessages extends NLS {
 	public static String dialog_connection_edit_wizard_error_md5_msg;
 	//Connection edit
 
+	public static String dialog_connection_deprecated_title;
+	public static String dialog_connection_deprecated_description;
+
 	// Driver edit
 
 	// Driver download

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreResources.properties
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/CoreResources.properties
@@ -536,6 +536,9 @@ dialog_connection_edit_wizard_bad_pwd_title = Bad password
 dialog_connection_edit_wizard_bad_pwd_msg = Password does not match
 dialog_connection_edit_wizard_error_md5_title = Error making MD5
 dialog_connection_edit_wizard_error_md5_msg =Cannot generate password hash
+
+dialog_connection_deprecated_title = Deprecated driver
+dialog_connection_deprecated_description = This driver is deprecated and cannot be used
 ## Connection edit ##
 
 ## Resource Handlers

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/ConnectionPageDeprecation.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/ConnectionPageDeprecation.java
@@ -16,27 +16,31 @@
  */
 package org.jkiss.dbeaver.ui.dialogs.connection;
 
+import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.events.IHyperlinkListener;
 import org.eclipse.ui.forms.widgets.FormText;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.core.CoreMessages;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
+import org.jkiss.dbeaver.model.connection.DBPDriver;
 import org.jkiss.dbeaver.ui.ShellUtils;
 
 public class ConnectionPageDeprecation extends ConnectionWizardPage {
-    private final DBPDataSourceContainer dataSource;
+    private final DBPDriver driver;
 
-    public ConnectionPageDeprecation(@NotNull DBPDataSourceContainer dataSource) {
+    public ConnectionPageDeprecation(@NotNull DBPDriver driver) {
         super(ConnectionPageDeprecation.class.getName());
-        this.dataSource = dataSource;
+        this.driver = driver;
 
-        setTitle("Deprecated driver");
-        setDescription("This driver is deprecated and cannot be used");
+        setTitle(CoreMessages.dialog_connection_deprecated_title);
+        setDescription(CoreMessages.dialog_connection_deprecated_description);
+        setPageComplete(false);
     }
 
     @Override
@@ -45,13 +49,14 @@ public class ConnectionPageDeprecation extends ConnectionWizardPage {
 
         final Composite composite = toolkit.createComposite(parent, SWT.BORDER);
         composite.setLayoutData(new GridData(GridData.FILL_BOTH));
-        composite.setLayout(new FillLayout(SWT.HORIZONTAL | SWT.VERTICAL));
+        composite.setLayout(new GridLayout(1, false));
 
         final FormText text = new FormText(composite, SWT.NO_FOCUS);
         text.setFont("header", JFaceResources.getFont("org.eclipse.jface.headerfont"));
-        text.setText(dataSource.getDriver().getDeprecationReason(), true, false);
+        text.setText(driver.getDeprecationReason(), true, false);
         text.setHyperlinkSettings(toolkit.getHyperlinkGroup());
         text.addHyperlinkListener(IHyperlinkListener.linkActivatedAdapter(e -> ShellUtils.launchProgram(e.getHref().toString())));
+        text.setLayoutData(GridDataFactory.fillDefaults().grab(true, true).hint(200, 200).create());
 
         toolkit.adapt(text, false, true);
 

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionWizard.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/EditConnectionWizard.java
@@ -142,7 +142,7 @@ public class EditConnectionWizard extends ConnectionWizard {
     @Override
     public void addPages() {
         if (dataSource.getDriver().isDeprecated()) {
-            addPage(new ConnectionPageDeprecation(dataSource));
+            addPage(new ConnectionPageDeprecation(dataSource.getDriver()));
             return;
         }
 

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/NewConnectionWizard.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/NewConnectionWizard.java
@@ -192,7 +192,13 @@ public class NewConnectionWizard extends ConnectionWizard
     public IWizardPage getNextPage(IWizardPage page)
     {
         if (page == pageDrivers) {
-            ConnectionPageSettings pageSettings = getPageSettings((DriverDescriptor) getSelectedDriver());
+            final DBPDriver driver = getSelectedDriver();
+            if (driver.isDeprecated()) {
+                final ConnectionPageDeprecation nextPage = new ConnectionPageDeprecation(driver);
+                nextPage.setWizard(this);
+                return nextPage;
+            }
+            ConnectionPageSettings pageSettings = getPageSettings(driver);
             if (pageSettings == null) {
                 return pageGeneral;
             } else {
@@ -213,6 +219,9 @@ public class NewConnectionWizard extends ConnectionWizard
     @Override
     public boolean performFinish() {
         DriverDescriptor driver = (DriverDescriptor) getSelectedDriver();
+        if (driver.isDeprecated()) {
+            return true;
+        }
         ConnectionPageSettings pageSettings = getPageSettings();
         DataSourceDescriptor dataSourceTpl = pageSettings == null ? getActiveDataSource() : pageSettings.getActiveDataSource();
         DBPDataSourceRegistry dataSourceRegistry = getDataSourceRegistry();
@@ -239,7 +248,11 @@ public class NewConnectionWizard extends ConnectionWizard
 
     @Override
     protected void saveSettings(DataSourceDescriptor dataSource) {
-        ConnectionPageSettings pageSettings = getPageSettings(dataSource.getDriver());
+        final DBPDriver driver = dataSource.getDriver();
+        if (driver.isDeprecated()) {
+            return;
+        }
+        ConnectionPageSettings pageSettings = getPageSettings(driver);
         if (pageSettings != null) {
             pageSettings.saveSettings(dataSource);
         }

--- a/plugins/org.jkiss.dbeaver.ext.generic/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ext.generic/OSGI-INF/l10n/bundle.properties
@@ -112,4 +112,4 @@ It was removed in the <b>Community Edition 23.1</b>.<br/><br/>\
 <li>It does not work on Linux and macOS, and that cannot be improved.</li><p><br/>\
 <span font="header">Further steps</span><br/><br/>\
 You can use the ODBC driver created by the DBeaver team in PRO version or download the old ODBC driver at your own risk.<br/><br/>\
-<a href="https://dbeaver.com/docs/wiki/ODBC-JDBC-Driver/">Learn more about deprecated legacy ODBC driver</a></p></form>
+<a href="https://dbeaver.com/docs/wiki/Deprecated-legacy-ODBC-driver/">Learn more about deprecated legacy ODBC driver</a></p></form>

--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -341,11 +341,6 @@
                     deprecated="%driver.odbc.deprecation.reason"
                     categories="sql">
                     <os name="win32"/>
-                    <file type="jar" path="https://github.com/dbeaver/jdbc-odbc-bridge-jre7/raw/main/jdbc-odbc-bridge-jre7.jar" bundle="!drivers.odbc"/>
-                    <file type="lib" os="win32" arch="x86_64" path="https://github.com/dbeaver/jdbc-odbc-bridge-jre7/raw/main/x64/JdbcOdbc.dll" bundle="!drivers.odbc"/>
-
-                    <file type="jar" path="drivers/odbc" bundle="drivers.odbc"/>
-                    <file type="lib" os="win32" arch="x86_64" path="drivers/odbc/x64" bundle="drivers.odbc"/>
                 </driver>
                 <driver
                     id="derby"

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverDescriptor.java
@@ -683,7 +683,7 @@ public class DriverDescriptor extends AbstractDescriptor implements DBPDriver {
     }
 
     public boolean isDisabled() {
-        return disabled || isDeprecated();
+        return disabled;
     }
 
     public void setDisabled(boolean disabled) {


### PR DESCRIPTION
Acceptance criteria:
- [x] A deprecated driver is shown in the new connection wizard
- [x] A deprecated driver can't be used to create a new connection
- [x] An existing connection using a deprecated driver can't be edited
- [x] An existing connection using a deprecated driver can't be used