### PR TITLE
#19210 Adding an option to revert the sorting of columns

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/controls/ViewerColumnController.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/controls/ViewerColumnController.java
@@ -192,15 +192,6 @@ public class ViewerColumnController<COLUMN, ELEMENT> {
                 repackColumns(true);
             }
         });
-        menuManager.add(new Action(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting) {
-        	{
-        		setDescription(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting_description);
-        	}
-        	@Override
-        	public void run() {
-        		System.out.println("Revert sorting called");
-        	}
-        });
     }
 
     public void addColumn(

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/controls/ViewerColumnController.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/controls/ViewerColumnController.java
@@ -404,7 +404,7 @@ public class ViewerColumnController<COLUMN, ELEMENT> {
     }
 
     public void sortByColumn(int index, int direction) {
-        final ColumnInfo columnInfo = columns.get(index);
+        final ColumnInfo columnInfo = this.getColumnByIndex(index);
         columnInfo.sortListener.sortViewer(columnInfo.column, direction);
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/controls/ViewerColumnController.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/controls/ViewerColumnController.java
@@ -192,6 +192,15 @@ public class ViewerColumnController<COLUMN, ELEMENT> {
                 repackColumns(true);
             }
         });
+        menuManager.add(new Action(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting) {
+        	{
+        		setDescription(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting_description);
+        	}
+        	@Override
+        	public void run() {
+        		System.out.println("Revert sorting called");
+        	}
+        });
     }
 
     public void addColumn(

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.java
@@ -28,6 +28,9 @@ public class UINavigatorMessages extends NLS {
     public static String obj_editor_properties_control_action_configure_columns_description;
     public static String obj_editor_properties_control_action_columns_fit_width;
     public static String obj_editor_properties_control_action_columns_fit_width_description;
+    public static String obj_editor_properties_control_action_columns_revert_sorting;
+    public static String obj_editor_properties_control_action_columns_revert_sorting_description;
+    
     //object properties editor
 
     public static String toolbar_datasource_selector_empty;

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
@@ -4,6 +4,8 @@ obj_editor_properties_control_action_configure_columns = Configure columns
 obj_editor_properties_control_action_configure_columns_description = Configure column visibility
 obj_editor_properties_control_action_columns_fit_width = Auto-size columns
 obj_editor_properties_control_action_columns_fit_width_description = Auto-size columns to fit cell values
+obj_editor_properties_control_action_columns_revert_sorting = Revert sorting
+obj_editor_properties_control_action_columns_revert_sorting_description = Sort the columns in the original order
 
 ## object properties editor ##
 

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
@@ -1479,6 +1479,30 @@ public abstract class ObjectListControl<OBJECT_TYPE> extends ProgressPageControl
         @Override
         public void fillConfigMenu(IContributionManager menuManager) {
             super.fillConfigMenu(menuManager);
+            // Traverse all columns, if there is a column with name "#", add a menu option "Revert sorting"
+            // which is to sort in the ascending order of the "#" column
+            int columnsCount = this.getColumnsCount();
+            int numberColumnInd = -1;
+            for (int i = 0; i < columnsCount; i++) {
+            	System.out.println(this.getColumnName(i));
+            	if (this.getColumnName(i).equals("#")) {
+            		numberColumnInd = i;
+            		break;
+            	}
+            }
+            if(numberColumnInd != -1) {
+            	final int finalNumberColumnInd = numberColumnInd;
+                menuManager.add(new Action(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting) {
+                	{
+                		setDescription(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting_description);
+                	}
+                	@Override
+                	public void run() {
+                       GroupingViewerColumnController.this.sortByColumn(finalNumberColumnInd, SWT.UP);
+                	}
+                });
+            }
+            
             if (isTree && supportsDataGrouping()) {
                 menuManager.add(new Separator());
                 int selectedColumnNumber = columnController.getSelectedColumnNumber();

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
@@ -1484,7 +1484,6 @@ public abstract class ObjectListControl<OBJECT_TYPE> extends ProgressPageControl
             int columnsCount = this.getColumnsCount();
             int numberColumnInd = -1;
             for (int i = 0; i < columnsCount; i++) {
-            	System.out.println(this.getColumnName(i));
             	if (this.getColumnName(i).equals("#")) {
             		numberColumnInd = i;
             		break;

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
@@ -1479,29 +1479,33 @@ public abstract class ObjectListControl<OBJECT_TYPE> extends ProgressPageControl
         @Override
         public void fillConfigMenu(IContributionManager menuManager) {
             super.fillConfigMenu(menuManager);
-            // Traverse all columns, if there is a column with name "#", add a menu option "Revert sorting"
+            // Traverse all columns, if there is a column with name "#", add a
+            // menu option "Revert sorting"
             // which is to sort in the ascending order of the "#" column
             int columnsCount = this.getColumnsCount();
             int numberColumnInd = -1;
             for (int i = 0; i < columnsCount; i++) {
-            	if (this.getColumnName(i).equals("#")) {
-            		numberColumnInd = i;
-            		break;
-            	}
+                if (this.getColumnName(i).equals("#")) {
+                    numberColumnInd = i;
+                    break;
+                }
             }
-            if(numberColumnInd != -1) {
-            	final int finalNumberColumnInd = numberColumnInd;
-                menuManager.add(new Action(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting) {
-                	{
-                		setDescription(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting_description);
-                	}
-                	@Override
-                	public void run() {
-                       GroupingViewerColumnController.this.sortByColumn(finalNumberColumnInd, SWT.UP);
-                	}
-                });
+            if (numberColumnInd != -1) {
+                final int finalNumberColumnInd = numberColumnInd;
+                menuManager.add(
+                        new Action(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting) {
+                            {
+                                setDescription(
+                                        UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting_description);
+                            }
+
+                            @Override
+                            public void run() {
+                                GroupingViewerColumnController.this.sortByColumn(finalNumberColumnInd, SWT.UP);
+                            }
+                        });
             }
-            
+
             if (isTree && supportsDataGrouping()) {
                 menuManager.add(new Separator());
                 int selectedColumnNumber = columnController.getSelectedColumnNumber();

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
@@ -1486,18 +1486,18 @@ public abstract class ObjectListControl<OBJECT_TYPE> extends ProgressPageControl
             for (int i = 0; i < columnsCount; i++) {
                 if (this.getColumnName(i).equals("#")) {
                     final int numberColumnInd = i;
-                    menuManager.add(
-                            new Action(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting) {
-                                {
-                                    setDescription(
-                                            UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting_description);
-                                }
+                    menuManager.add(new Action(
+                            UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting) {
+                        {
+                            setDescription(
+                                    UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting_description);
+                        }
 
-                                @Override
-                                public void run() {
-                                    GroupingViewerColumnController.this.sortByColumn(numberColumnInd, SWT.UP);
-                                }
-                            });
+                        @Override
+                        public void run() {
+                            GroupingViewerColumnController.this.sortByColumn(numberColumnInd, SWT.UP);
+                        }
+                    });
                     break;
                 }
             }

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/itemlist/ObjectListControl.java
@@ -1483,27 +1483,23 @@ public abstract class ObjectListControl<OBJECT_TYPE> extends ProgressPageControl
             // menu option "Revert sorting"
             // which is to sort in the ascending order of the "#" column
             int columnsCount = this.getColumnsCount();
-            int numberColumnInd = -1;
             for (int i = 0; i < columnsCount; i++) {
                 if (this.getColumnName(i).equals("#")) {
-                    numberColumnInd = i;
+                    final int numberColumnInd = i;
+                    menuManager.add(
+                            new Action(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting) {
+                                {
+                                    setDescription(
+                                            UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting_description);
+                                }
+
+                                @Override
+                                public void run() {
+                                    GroupingViewerColumnController.this.sortByColumn(numberColumnInd, SWT.UP);
+                                }
+                            });
                     break;
                 }
-            }
-            if (numberColumnInd != -1) {
-                final int finalNumberColumnInd = numberColumnInd;
-                menuManager.add(
-                        new Action(UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting) {
-                            {
-                                setDescription(
-                                        UINavigatorMessages.obj_editor_properties_control_action_columns_revert_sorting_description);
-                            }
-
-                            @Override
-                            public void run() {
-                                GroupingViewerColumnController.this.sortByColumn(finalNumberColumnInd, SWT.UP);
-                            }
-                        });
             }
 
             if (isTree && supportsDataGrouping()) {


### PR DESCRIPTION
Fixing #19210 

Adding an option to sort the columns according to the original order.
![Screenshot 2023-06-04 at 12 09 20 PM](https://github.com/dbeaver/dbeaver/assets/113857408/5fb36dc7-b69c-4107-9284-34b6d4c7e4b0)

I assume the feature request is about reverting the sorting of the "columns" table only, excluding the "Keys", "References" etc. Therefore, we just need to sort it according to the ascending order of the "#" column.

My current implementation is just to traverse all columns, and if there is a column with the name "#", add a menu option "Revert sorting".
```java
                	@Override
                	public void run() {
                       GroupingViewerColumnController.this.sortByColumn(finalNumberColumnInd, SWT.UP);
                	}
```

This is kinda ugly but works. But if we do not use this trick, we have to override the whole `SortListener` of `ViewerColumnController`. Please let me know if there is any better implementation.