### PR TITLE
Update Google BigQuery JDBC driver to version 1.3.3

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.bigquery/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.bigquery/plugin.xml
@@ -32,7 +32,7 @@
                         propertiesURL="https://cdn.simba.com/products/BigQuery/doc/JDBC_InstallGuide/"
                         categories="bigdata"
                         singleConnection="true">
-                    <file type="jar" path="https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.2.21.1025.zip" bundle="!drivers.bigquery"/>
+                    <file type="jar" path="https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.3.3.1004.zip" bundle="!drivers.bigquery"/>
                     <file type="license" path="https://www.gnu.org/licenses/lgpl-3.0.txt" bundle="!drivers.bigquery"/>
 
                     <file type="jar" path="drivers/bigquery" bundle="drivers.bigquery"/>


### PR DESCRIPTION
Current code base is at 1.2.21. Since then, the following versions have been made available by Simba:
- 1.2.22
- 1.2.23
- 1.2.25
- 1.3.0
- 1.3.1
- 1.3.2
- 1.3.3

(see https://cloud.google.com/bigquery/docs/reference/odbc-jdbc-drivers)

Let's upgrade to 1.3.3 which is the latest at the time of writing.

Fixes https://github.com/dbeaver/dbeaver/issues/19370 and also https://github.com/dbeaver/dbeaver/issues/18646 (which is why I raised this PR).