### PR TITLE
#19992 add escape parameter for bulk load copy command

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreCopyLoader.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreCopyLoader.java
@@ -204,7 +204,7 @@ public class PostgreCopyLoader implements DBSDataBulkLoader, DBSDataBulkLoader.B
 
         session.getProgressMonitor().subTask("Copy into " + tableFQN);
 
-        String queryText = "COPY " + tableFQN + " FROM STDIN (FORMAT CSV)";
+        String queryText = "COPY " + tableFQN + " FROM STDIN (FORMAT CSV, ESCAPE '\\')";
 
         try {
             Object rowCount;


### PR DESCRIPTION
![2023-06-12 11_39_01-DBeaver Ultimate 23 1 0 - empty newtable2](https://github.com/dbeaver/dbeaver/assets/45152336/79af4b0a-bebf-4ee2-8b5c-cd056b393426)

Please check

- [x] - import from another table
- [x] - import from the file
- [x] - different special characters in a source

https://www.postgresql.org/docs/current/sql-copy.html
