### PR TITLE
dbeaver/dbeaver#19756 add handling for snapshot repos

### DIFF
--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/RegistryConstants.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/RegistryConstants.java
@@ -58,6 +58,7 @@ public class RegistryConstants {
     public static final String ATTR_VALUE = "value"; //$NON-NLS-1$
     public static final String ATTR_ALIAS = "alias"; //$NON-NLS-1$
     public static final String ATTR_CLASS = "class"; //$NON-NLS-1$
+    public static final String ATTR_SNAPSHOT = "snapshot"; //$NON-NLS-1$
     public static final String ATTR_URL = "url"; //$NON-NLS-1$
     public static final String ATTR_LINK = "link"; //$NON-NLS-1$
     public static final String ATTR_SCOPE = "scope"; //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifact.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifact.java
@@ -69,6 +69,7 @@ public class MavenArtifact implements IMavenIdentifier
     private String latestVersion;
     private String releaseVersion;
     private Date lastUpdate;
+    private List<String> snapshotVersions = new ArrayList<>();
     private final List<MavenArtifactVersion> localVersions = new ArrayList<>();
 
     private transient boolean metadataLoaded = false;
@@ -87,13 +88,23 @@ public class MavenArtifact implements IMavenIdentifier
         this.fallbackVersion = CommonUtils.trim(fallbackVersion);
     }
 
+
     public void loadMetadata(DBRProgressMonitor monitor) throws IOException {
+        loadMetadata(monitor, null);
+    }
+
+    public void loadMetadata(DBRProgressMonitor monitor, String version) throws IOException {
         latestVersion = null;
         releaseVersion = null;
         versions.clear();
+        snapshotVersions.clear();
         lastUpdate = null;
-
-        String metadataPath = getBaseArtifactURL() + MAVEN_METADATA_XML;
+        String metadataPath = getBaseArtifactURL();
+        // The repository is a SNAPSHOT repo, artifact metadata is stored inside the version
+        if (version != null) {
+            metadataPath += version + "/";
+        }
+        metadataPath += MAVEN_METADATA_XML;
         monitor.subTask("Load metadata " + this + "");
 
         try (InputStream mdStream = WebUtils.openConnection(metadataPath, getRepository().getAuthInfo(), null).getInputStream()) {
@@ -145,31 +156,58 @@ public class MavenArtifact implements IMavenIdentifier
         SAXReader reader = new SAXReader(mdStream);
         reader.parse(new SAXListener() {
             public String lastTag;
+            public boolean insideSnapshotVersion = false;
+            public String currentSnapshotVersion;
+            boolean invalid = false;
 
             @Override
             public void saxStartElement(SAXReader reader, String namespaceURI, String localName, Attributes atts) throws XMLException {
+                if ("snapshotVersion".equals(localName)) {
+                    insideSnapshotVersion = true;
+                }
                 lastTag = localName;
             }
 
             @Override
             public void saxText(SAXReader reader, String data) throws XMLException {
-                if ("version".equals(lastTag)) {
-                    versions.add(data);
-                } else if ("latest".equals(lastTag)) {
-                    latestVersion = data;
-                } else if ("release".equals(lastTag)) {
-                    releaseVersion = data;
-                } else if ("lastUpdate".equals(lastTag)) {
-                    try {
-                        lastUpdate = new Date(Long.parseLong(data));
-                    } catch (NumberFormatException e) {
-                        log.warn(e);
+                if (insideSnapshotVersion) {
+                    if ("value".equals(lastTag)) {
+                        currentSnapshotVersion = data;
+                    } else if ("classifier".equals(lastTag)
+                        && !data.equals(classifier)) {
+                        invalid = true;
+                    } else if ("extension".equals(lastTag) && !"jar".equals(data)) {
+                        invalid = true;
+                    }
+                } else {
+                    if ("version".equals(lastTag)) {
+                        versions.add(data);
+                    } else if ("snapshotVersion".equals(lastTag)) {
+                        insideSnapshotVersion = true;
+                    } else if ("latest".equals(lastTag)) {
+                        latestVersion = data;
+                    } else if ("release".equals(lastTag)) {
+                        releaseVersion = data;
+                    } else if ("lastUpdate".equals(lastTag)) {
+                        try {
+                            lastUpdate = new Date(Long.parseLong(data));
+                        } catch (NumberFormatException e) {
+                            log.warn(e);
+                        }
                     }
                 }
             }
 
             @Override
             public void saxEndElement(SAXReader reader, String namespaceURI, String localName) throws XMLException {
+                if (localName.equals("snapshotVersion")) {
+                    if (!invalid) {
+                        snapshotVersions.add(currentSnapshotVersion);
+                    }
+                    currentSnapshotVersion = null;
+                    insideSnapshotVersion = false;
+                    invalid = false;
+                }
                 lastTag = null;
             }
         });
@@ -216,7 +254,7 @@ public class MavenArtifact implements IMavenIdentifier
     @Nullable
     public Collection<String> getAvailableVersions(DBRProgressMonitor monitor, String versionSpec) throws IOException {
         if (CommonUtils.isEmpty(versions) && !metadataLoaded) {
-            loadMetadata(monitor);
+            loadMetadata(monitor, null);
         }
         if (!isVersionPattern(versionSpec)) {
             return versions;
@@ -266,6 +304,11 @@ public class MavenArtifact implements IMavenIdentifier
     }
 
     String getFileURL(String version, String fileType) {
+        if (getRepository().isSnapshot()) {
+            return getBaseArtifactURL() + versions.get(0) + "/" + getVersionFileName(VersionUtils.findLatestVersion(snapshotVersions),
+                fileType);
+        }
+
         return getBaseArtifactURL() + version + "/" + getVersionFileName(version, fileType);
     }
 
@@ -312,12 +355,14 @@ public class MavenArtifact implements IMavenIdentifier
         if (CommonUtils.isEmpty(versionRef)) {
             throw new IOException("Empty artifact " + this + " version");
         }
-        boolean predefinedVersion =
-            versionRef.equals(MavenArtifactReference.VERSION_PATTERN_RELEASE) ||
-            versionRef.equals(MavenArtifactReference.VERSION_PATTERN_LATEST) ||
-            versionRef.equals(MavenArtifactReference.VERSION_PATTERN_SNAPSHOT);
-        boolean lookupVersion = predefinedVersion || isVersionPattern(versionRef);
-
+        boolean predefinedVersion = versionRef.equals(MavenArtifactReference.VERSION_PATTERN_RELEASE)
+            || versionRef.equals(MavenArtifactReference.VERSION_PATTERN_LATEST) || (
+            versionRef.equals(MavenArtifactReference.VERSION_PATTERN_SNAPSHOT) && !getRepository().isSnapshot());
+        boolean snapshotVersion = repository.isSnapshot() && versionRef.contains(MavenArtifactReference.VERSION_PATTERN_SNAPSHOT);
+        if (snapshotVersion) {
+            loadMetadata(monitor, versionRef);
+        }
+        boolean lookupVersion = predefinedVersion || isVersionPattern(versionRef) || snapshotVersion;
         if (lookupVersion && !metadataLoaded) {
             loadMetadata(monitor);
         }
@@ -325,6 +370,7 @@ public class MavenArtifact implements IMavenIdentifier
         String versionInfo;
         if (lookupVersion) {
             List<String> allVersions = versions;
+
             switch (versionRef) {
                 case MavenArtifactReference.VERSION_PATTERN_RELEASE:
                     versionInfo = releaseVersion;
@@ -336,10 +382,14 @@ public class MavenArtifact implements IMavenIdentifier
                     versionInfo = latestVersion;
                     break;
                 default:
+                    if (snapshotVersion) {
+                        versionInfo = VersionUtils.findLatestVersion(snapshotVersions);
+                        break;
+                    }
                     if (versionRef.startsWith("{") && versionRef.endsWith("}")) {
                         // Regex - find most recent version matching this pattern
                         String regex = versionRef.substring(1, versionRef.length() - 1);
-                        try {
+                    try {
                             Pattern versionPattern = Pattern.compile(regex);
                             List<String> versions = new ArrayList<>(allVersions);
                             versions.removeIf(s -> !versionPattern.matcher(s).matches());
@@ -347,7 +397,7 @@ public class MavenArtifact implements IMavenIdentifier
                         } catch (Exception e) {
                             throw new IOException("Bad version pattern: " + regex);
                         }
-                    } else {
+                    }     else {
                         versionInfo = getVersionFromSpec(versionRef);
                     }
                     break;

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifact.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifact.java
@@ -397,7 +397,7 @@ public class MavenArtifact implements IMavenIdentifier
                         } catch (Exception e) {
                             throw new IOException("Bad version pattern: " + regex);
                         }
-                    }     else {
+                    } else {
                         versionInfo = getVersionFromSpec(versionRef);
                     }
                     break;

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifactReference.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifactReference.java
@@ -133,7 +133,7 @@ public class MavenArtifactReference implements IMavenIdentifier
     }
 
     public String getPath() {
-        return id + ":" + version;
+        return id;
     }
 
     public boolean isResolveOptionalDependencies() {
@@ -163,6 +163,8 @@ public class MavenArtifactReference implements IMavenIdentifier
         }
         if (identifier.getFallbackVersion() != null) {
             id.append(":").append(identifier.getFallbackVersion());
+        } else {
+            id.append(":").append(identifier.getVersion());
         }
         return id.toString();
     }

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifactReference.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifactReference.java
@@ -162,9 +162,8 @@ public class MavenArtifactReference implements IMavenIdentifier
             id.append(":").append(identifier.getClassifier());
         }
         if (identifier.getFallbackVersion() != null) {
-            id.append(":").append(identifier.getFallbackVersion());
-        } else {
-            id.append(":").append(identifier.getVersion());
+            id.append(":").append(identifier.getFallbackVersion() != null ? identifier.getFallbackVersion() :
+                                  identifier.getVersion());
         }
         return id.toString();
     }

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifactVersion.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifactVersion.java
@@ -20,6 +20,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.registry.VersionUtils;
 import org.jkiss.dbeaver.runtime.IVariableResolver;
 import org.jkiss.dbeaver.runtime.WebUtils;
 import org.jkiss.dbeaver.utils.GeneralUtils;

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenRegistry.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenRegistry.java
@@ -23,6 +23,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.connection.DBPAuthInfo;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.registry.RegistryConstants;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.runtime.encode.PasswordEncrypter;
 import org.jkiss.dbeaver.runtime.encode.SimpleStringEncrypter;
@@ -142,6 +143,8 @@ public class MavenRegistry {
                         repoName,
                         repoURL,
                         MavenRepository.RepositoryType.CUSTOM);
+                    boolean snapshot = CommonUtils.toBoolean(repoElement.getAttribute("snapshot"));
+                    repo.setIsSnapshot(snapshot);
                     List<String> scopes = new ArrayList<>();
                     for (Element scopeElement : XMLUtils.getChildElementList(repoElement, "scope")) {
                         scopes.add(scopeElement.getAttribute("group"));
@@ -283,6 +286,7 @@ public class MavenRegistry {
                                     xml.addAttribute("group", scope);
                                 }
                             }
+                            xml.addAttribute(RegistryConstants.ATTR_SNAPSHOT, repository.isSnapshot());
                             final DBPAuthInfo authInfo = repository.getAuthInfo();
                             if (!CommonUtils.isEmpty(authInfo.getUserName())) {
                                 xml.addAttribute("auth-user", authInfo.getUserName());

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenRepository.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenRepository.java
@@ -108,7 +108,6 @@ public class MavenRepository
         this.isSnapshot = source.isSnapshot;
         this.authInfo.setUserName(source.authInfo.getUserName());
         this.authInfo.setUserPassword(source.authInfo.getUserPassword());
-
     }
 
     public String getId() {

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenRepository.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenRepository.java
@@ -63,6 +63,7 @@ public class MavenRepository
     private int order;
     private boolean enabled = true;
     private String description;
+    private boolean isSnapshot = false;
     private final DBPAuthInfo authInfo = new DBPAuthInfo();
 
     private final transient Map<String, MavenArtifact> cachedArtifacts = new LinkedHashMap<>();
@@ -76,7 +77,7 @@ public class MavenRepository
         if (!urlString.endsWith("/")) urlString += "/";
         this.url = urlString;
         this.type = RepositoryType.GLOBAL;
-
+        this.isSnapshot = CommonUtils.toBoolean(config.getAttribute(RegistryConstants.ATTR_SNAPSHOT));
         for (IConfigurationElement scope : config.getChildren("scope")) {
             final String group = scope.getAttribute("group");
             if (!CommonUtils.isEmpty(group)) {
@@ -104,8 +105,10 @@ public class MavenRepository
         this.order = source.order;
         this.enabled = source.enabled;
         this.description = source.description;
+        this.isSnapshot = source.isSnapshot;
         this.authInfo.setUserName(source.authInfo.getUserName());
         this.authInfo.setUserPassword(source.authInfo.getUserPassword());
+
     }
 
     public String getId() {
@@ -114,6 +117,14 @@ public class MavenRepository
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public boolean isSnapshot() {
+        return isSnapshot;
+    }
+
+    public void setIsSnapshot(boolean snapshot) {
+        isSnapshot = snapshot;
     }
 
     public String getName() {

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.java
@@ -256,6 +256,7 @@ public class UIConnectionMessages extends NLS {
     public static String pref_page_drivers_maven_group_properties;
     public static String pref_page_drivers_maven_label_name;
     public static String pref_page_drivers_maven_label_scope;
+    public static String pref_page_drivers_maven_checkbox_snapshot;
     public static String pref_page_drivers_maven_group_authentication;
     public static String pref_page_drivers_maven_label_user;
     public static String pref_page_drivers_maven_label_password;

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.properties
@@ -242,6 +242,7 @@ pref_page_drivers_maven_button_down = Down
 pref_page_drivers_maven_group_properties = Properties
 pref_page_drivers_maven_label_name = Name
 pref_page_drivers_maven_label_scope = Scope 
+pref_page_drivers_maven_checkbox_snapshot = Snapshot Repository
 pref_page_drivers_maven_group_authentication = Authentication
 pref_page_drivers_maven_label_user = User
 pref_page_drivers_maven_label_password = Password 

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/preferences/PrefPageDriversMaven.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/preferences/PrefPageDriversMaven.java
@@ -61,6 +61,7 @@ public class PrefPageDriversMaven extends AbstractPrefPage implements IWorkbench
     private Button moveUpButton;
     private Button moveDownButton;
     private Color enabledColor, disabledColor;
+    private Button isSnapshotRepository;
 
     @Override
     public void init(IWorkbench workbench)
@@ -191,6 +192,16 @@ public class PrefPageDriversMaven extends AbstractPrefPage implements IWorkbench
                     getSelectedRepository().setScopes(CommonUtils.splitString(scopeText.getText(), ','));
                 }
             });
+            isSnapshotRepository = UIUtils.createCheckbox(propsGroup,
+                UIConnectionMessages.pref_page_drivers_maven_checkbox_snapshot, false);
+            isSnapshotRepository.addSelectionListener(new SelectionAdapter() {
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    if (getSelectedRepository() != null) {
+                        getSelectedRepository().setIsSnapshot(isSnapshotRepository.getSelection());
+                    }
+                }
+            });
         }
 
         {
@@ -263,6 +274,9 @@ public class PrefPageDriversMaven extends AbstractPrefPage implements IWorkbench
             scopeText.setEditable(isEditable);
             scopeText.setText(CommonUtils.makeString(repo.getScopes(), ','));
 
+            isSnapshotRepository.setEnabled(isEditable);
+            isSnapshotRepository.setSelection(repo.isSnapshot());
+
             userNameText.setEnabled(true);
             userNameText.setText(CommonUtils.notEmpty(repo.getAuthInfo().getUserName()));
             userPasswordText.setEnabled(true);
@@ -275,6 +289,7 @@ public class PrefPageDriversMaven extends AbstractPrefPage implements IWorkbench
             urlText.setEnabled(false);
             scopeText.setEnabled(false);
             userNameText.setEnabled(false);
+            isSnapshotRepository.setEnabled(false);
             userPasswordText.setEnabled(false);
         }
         moveUpButton.setEnabled(mavenRepoTable.getSelectionIndex() > 0);

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/preferences/PrefPageDriversMaven.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/preferences/PrefPageDriversMaven.java
@@ -165,28 +165,31 @@ public class PrefPageDriversMaven extends AbstractPrefPage implements IWorkbench
         }
 
         {
-            Group propsGroup = UIUtils.createControlGroup(composite, UIConnectionMessages.pref_page_drivers_maven_group_properties, 2, GridData.FILL_HORIZONTAL, 0);
-            idText = UIUtils.createLabelText(propsGroup, "ID", "", SWT.BORDER | SWT.READ_ONLY);
+            Group propsGroup = UIUtils.createControlGroup(composite,
+                UIConnectionMessages.pref_page_drivers_maven_group_properties, 1, GridData.FILL_HORIZONTAL, 0);
+            Composite fields = UIUtils.createPlaceholder(propsGroup, 2);
+            fields.setLayoutData(new GridData(GridData.FILL_BOTH));
+            idText = UIUtils.createLabelText(fields, "ID", "", SWT.BORDER | SWT.READ_ONLY);
             idText.addModifyListener(e -> {
                 if (getSelectedRepository() != null) {
                     getSelectedRepository().setId(idText.getText());
                     mavenRepoTable.getSelection()[0].setText(0, idText.getText());
                 }
             });
-            nameText = UIUtils.createLabelText(propsGroup, UIConnectionMessages.pref_page_drivers_maven_label_name, "", SWT.BORDER);
+            nameText = UIUtils.createLabelText(fields, UIConnectionMessages.pref_page_drivers_maven_label_name, "", SWT.BORDER);
             nameText.addModifyListener(e -> {
                 if (getSelectedRepository() != null) {
                     getSelectedRepository().setName(nameText.getText());
                 }
             });
-            urlText = UIUtils.createLabelText(propsGroup, "URL", "", SWT.BORDER);
+            urlText = UIUtils.createLabelText(fields, "URL", "", SWT.BORDER);
             urlText.addModifyListener(e -> {
                 if (getSelectedRepository() != null) {
                     getSelectedRepository().setUrl(urlText.getText());
                     mavenRepoTable.getSelection()[0].setText(1, urlText.getText());
                 }
             });
-            scopeText = UIUtils.createLabelText(propsGroup, UIConnectionMessages.pref_page_drivers_maven_label_scope, "", SWT.BORDER);
+            scopeText = UIUtils.createLabelText(fields, UIConnectionMessages.pref_page_drivers_maven_label_scope, "", SWT.BORDER);
             scopeText.addModifyListener(e -> {
                 if (getSelectedRepository() != null) {
                     getSelectedRepository().setScopes(CommonUtils.splitString(scopeText.getText(), ','));


### PR DESCRIPTION
Closes dbeaver/dbeaver#19756 Closes dbeaver/pro#1709
Allows to mark repository as SNAPSHOT repository allowing downloading SNAPSHOT versions from it. Also fixes bug dbeaver/pro#1709. [version]-SNAPSHOT will be counted as snapshot versions and the version with the most recent timestamp will be downloaded

To test dbeaver/pro#1709:
* Check what edited maven artifacts are properly saved, there is no incorrect fallbackVersion or classifier being added in maven artefact

To test dbeaver/dbeaver#19756
*  Add snapshot repository, for example:
https://oss.sonatype.org/content/repositories/snapshots/ 
When try downloading SNAPSHOT version which is present in repository

![java_TGxW6m4Xt1](https://github.com/dbeaver/dbeaver/assets/20579256/3de8f742-5886-4605-ae91-906baa493adb)
