### PR TITLE
#20618 move dependency sequence objects reading from tables to columns

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreAttribute.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreAttribute.java
@@ -204,13 +204,7 @@ public abstract class PostgreAttribute<OWNER extends DBSEntity & PostgreObject> 
 
         setPersisted(true);
 
-        if (getTable() instanceof PostgreTable) {
-            PostgreTable postgreTable = (PostgreTable) getTable();
-            if (postgreTable.getDepObjectAttrNumber() == getOrdinalPosition()) {
-                // ID of object which has dependency with this column
-                this.depObjectId = (postgreTable).getDepObjectId();
-            }
-        }
+        this.depObjectId = JDBCUtils.safeGetLong(dbResult, "objid"); // ID of object which has dependency with this column
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
@@ -747,21 +747,12 @@ public class PostgreSchema implements
         public JDBCStatement prepareLookupStatement(@NotNull JDBCSession session, @NotNull PostgreTableContainer container, @Nullable PostgreTableBase object, @Nullable String objectName) throws SQLException {
             StringBuilder sql = new StringBuilder();
             PostgreDataSource dataSource = getDataSource();
-            boolean supportsSequences = dataSource.getServerType().supportsSequences();
             sql.append("SELECT c.oid,c.*,d.description");
             if (dataSource.isServerVersionAtLeast(10, 0)) {
                 sql.append(",pg_catalog.pg_get_expr(c.relpartbound, c.oid) as partition_expr,  pg_catalog.pg_get_partkeydef(c.oid) as partition_key ");
             }
-            if (supportsSequences) {
-                sql.append(", dep.objid, dep.refobjsubid");
-            }
             sql.append("\nFROM pg_catalog.pg_class c\n")
                 .append("LEFT OUTER JOIN pg_catalog.pg_description d ON d.objoid=c.oid AND d.objsubid=0 AND d.classoid='pg_class'::regclass\n");
-            if (supportsSequences) {
-                // Search connection with sequence object
-                sql.append("LEFT OUTER JOIN pg_depend dep on dep.refobjid = c.\"oid\" " +
-                    "AND dep.deptype = 'i' and dep.refobjsubid <> 0 and dep.classid = dep.refclassid\n");
-            }
             sql.append("WHERE c.relnamespace=? AND c.relkind not in ('i','I','c')")
                 .append(object == null && objectName == null ? "" : " AND relname=?");
             final JDBCPreparedStatement dbStat = session.prepareStatement(sql.toString());
@@ -788,37 +779,29 @@ public class PostgreSchema implements
             return JDBCUtils.safeGetBoolean(dbResult, "relispartition");
         }
 
-        protected JDBCStatement prepareChildrenStatement(@NotNull JDBCSession session, @NotNull PostgreTableContainer container)
-            throws SQLException {
-            String sql = "SELECT c.relname,a.*,pg_catalog.pg_get_expr(ad.adbin, ad.adrelid, true) as def_value,dsc.description" +
-                getTableColumnsQueryExtraParameters(container.getSchema(), null) +
-                "\nFROM pg_catalog.pg_attribute a" +
-                "\nINNER JOIN pg_catalog.pg_class c ON (a.attrelid=c.oid)" +
-                "\nLEFT OUTER JOIN pg_catalog.pg_attrdef ad ON (a.attrelid=ad.adrelid AND a.attnum = ad.adnum)" +
-                "\nLEFT OUTER JOIN pg_catalog.pg_description dsc ON (c.oid=dsc.objoid AND a.attnum = dsc.objsubid)" +
-                "\nWHERE NOT a.attisdropped AND c.relnamespace=? AND c.relkind not in ('i','I','c')  ORDER BY a.attnum";
-
-            JDBCPreparedStatement dbStat = session.prepareStatement(sql);
-            dbStat.setLong(1, PostgreSchema.this.getObjectId());
-            return dbStat;
-        }
-
         @Override
         protected JDBCStatement prepareChildrenStatement(@NotNull JDBCSession session, @NotNull PostgreTableContainer container, @Nullable PostgreTableBase forTable)
             throws SQLException {
-            if (forTable == null) {
-                return prepareChildrenStatement(session, container);
-            }
+            boolean supportsSequences = container.getDataSource().getServerType().supportsSequences();
 
             JDBCPreparedStatement dbStat = session.prepareStatement(
                 "SELECT c.relname,a.*,pg_catalog.pg_get_expr(ad.adbin, ad.adrelid, true) as def_value,dsc.description" +
                     getTableColumnsQueryExtraParameters(container.getSchema(), forTable) +
+                    (supportsSequences ? ",dep.objid" : "") +
                     "\nFROM pg_catalog.pg_attribute a" +
                     "\nINNER JOIN pg_catalog.pg_class c ON (a.attrelid=c.oid)" +
                     "\nLEFT OUTER JOIN pg_catalog.pg_attrdef ad ON (a.attrelid=ad.adrelid AND a.attnum = ad.adnum)" +
                     "\nLEFT OUTER JOIN pg_catalog.pg_description dsc ON (c.oid=dsc.objoid AND a.attnum = dsc.objsubid)" +
-                    "\nWHERE NOT a.attisdropped AND c.oid=? ORDER BY a.attnum");
-            dbStat.setLong(1, forTable.getObjectId());
+                    (supportsSequences ? "\nLEFT OUTER JOIN pg_depend dep on dep.refobjid = a.attrelid AND dep.deptype = 'i' " +
+                        "and dep.refobjsubid = a.attnum and dep.classid = dep.refclassid" : "") +
+                    "\nWHERE NOT a.attisdropped AND c.relkind not in ('i','I','c')" +
+                    (forTable != null ? " AND c.oid=?" : " AND c.relnamespace=?") +
+                    "\nORDER BY a.attnum");
+            if (forTable != null) {
+                dbStat.setLong(1, forTable.getObjectId());
+            } else {
+                dbStat.setLong(1, PostgreSchema.this.getObjectId());
+            }
             return dbStat;
         }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -98,8 +98,6 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
         this.hasPartitions = this.partitionKey != null;
         this.hasRowLevelSecurity = getDataSource().getServerType().supportsRowLevelSecurity()
             && JDBCUtils.safeGetBoolean(dbResult, "relrowsecurity");
-        this.depObjectId = JDBCUtils.safeGetLong(dbResult, "objid");
-        this.depObjectAttrNumber = JDBCUtils.safeGetLong(dbResult, "refobjsubid");
     }
 
     // Copy constructor
@@ -190,14 +188,6 @@ public abstract class PostgreTable extends PostgreTableReal implements PostgreTa
 
     public void setPartitionKey(String partitionKey) {
         this.partitionKey = partitionKey;
-    }
-
-    public long getDepObjectId() {
-        return depObjectId;
-    }
-
-    public long getDepObjectAttrNumber() {
-        return depObjectAttrNumber;
     }
 
     @Override


### PR DESCRIPTION
![2023-07-21 19_46_23-DBeaver Ultimate 23 1 3 - t1_3](https://github.com/dbeaver/dbeaver/assets/45152336/8266861e-b7d1-40ac-8c42-e09b01aab8aa)

Please check:

- [x] tables reading in PG
- [x] tables reading in Redshift
- [x] tables reading in CrateDB or Materialize
- [x] one table DDL refreshing in PG
- [x] one table DDL refreshing in Redshift
- [x] one table DDL refreshing in CrateDB or Materialize
- [x] case from the ticket in PG
- [x] and check original ticket https://github.com/dbeaver/dbeaver/issues/18576
