### PR TITLE
dbeaver/pro#1750 Don't allow to schedule tasks that can't be scheduled in TE

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTScheduler.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/task/DBTScheduler.java
@@ -69,6 +69,10 @@ public interface DBTScheduler {
     @Nullable
     DBTTaskScheduleConfiguration getScheduledTaskConfiguration(@NotNull DBTTask task) throws DBException;
 
+    default boolean canSchedule(@NotNull DBTTask task) throws DBException {
+        return true;
+    }
+
     void setTaskSchedule(@NotNull DBTTask task, @NotNull DBTTaskScheduleConfiguration scheduleConfiguration) throws DBException;
 
     void removeTaskSchedule(@NotNull DBTTask task, DBTTaskScheduleInfo scheduleInfo) throws DBException;


### PR DESCRIPTION
Please, check that nothing changed in UE.
You can test in on tasks like schema compare in TE.