### PR TITLE
#20638 Fix drop target retrieving wrong data flavor on Linux

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/panel/grouping/GroupingResultsDecorator.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/panel/grouping/GroupingResultsDecorator.java
@@ -104,7 +104,7 @@ public class GroupingResultsDecorator extends ResultSetDecoratorBase {
             gridDropListeners = null;
         }
         DropTarget dropTarget = new DropTarget(presentationControl, DND.DROP_MOVE | DND.DROP_COPY);
-        dropTarget.setTransfer(LightGrid.GridColumnTransfer.INSTANCE, TextTransfer.getInstance());
+        dropTarget.setTransfer(LightGrid.GridColumnTransfer.INSTANCE);
         dropTarget.addDropListener(new DropTargetAdapter() {
             @Override
             public void dragEnter(DropTargetEvent event) {


### PR DESCRIPTION
The `TextTransfer` was not used at all. I wonder why it was there in the first place.

Acceptance criteria: 
- [x] Works on Windows
- [x] Works on Linux
- [x] Works on macOS