### PR TITLE
#20202 return partitions folder for tables; change partitioned flag reading

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
@@ -71,7 +71,7 @@
                                         </items>
                                     </items>
                                 </folder>
-                                <folder type="org.jkiss.dbeaver.ext.mysql.model.MySQLPartition" label="%tree.partitions.node.name" icon="#partitions" description="Table partitions" visibleIf="object.dataSource.supportsPartitions() &amp;&amp; object.hasPartitions()">
+                                <folder type="org.jkiss.dbeaver.ext.mysql.model.MySQLPartition" label="%tree.partitions.node.name" icon="#partitions" description="Table partitions" visibleIf="object.dataSource.supportsPartitions()">
                                     <items label="%tree.partition.node.name" path="partition" property="partitions" icon="#partition">
                                         <items label="%tree.subpartitions.node.name" itemLabel="%tree.subpartition.node.name" path="subpartition" property="subPartitions" navigable="false" inline="true">
                                         </items>

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
@@ -446,8 +446,10 @@ public class MySQLTable extends MySQLTableBase implements DBPObjectStatistics, D
         additionalInfo.dataFree = JDBCUtils.safeGetLong(dbResult, "Data_free");
         additionalInfo.indexLength = JDBCUtils.safeGetLong(dbResult, "Index_length");
         additionalInfo.rowFormat = JDBCUtils.safeGetString(dbResult, "Row_format");
-        additionalInfo.partitioned = PARTITIONED_STATUS.equalsIgnoreCase(JDBCUtils.safeGetString(dbResult, "Create_options"));
-
+        String createOptions = JDBCUtils.safeGetString(dbResult, "Create_options");
+        if (CommonUtils.isNotEmpty(createOptions)) {
+            additionalInfo.partitioned = createOptions.contains(PARTITIONED_STATUS);
+        }
         additionalInfo.loaded = true;
     }
 


### PR DESCRIPTION
![2023-08-01 09_48_46-DBeaver Ultimate 23 1 3 - advance](https://github.com/dbeaver/dbeaver/assets/45152336/342dac3a-674d-496c-8be9-0c84d6106575)

Please check:

- [x] MariaDB partitioned table and non-partitioned viewing
- [x] MySQL partitioned table and non-partitioned viewing
- [x] MariaDB/MySQL table creation
- [x] create table button must be absent for partitioned tab
