### PR TITLE
#20616 added USING clause for Greenplum tables DDL; partitions readin…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumMaterializedView.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumMaterializedView.java
@@ -83,7 +83,7 @@ public class GreenplumMaterializedView extends PostgreMaterializedView {
                 distributionColumns = GreenplumUtils.getDistributionTableColumns(monitor, distributionColumns, this);
             }
 
-            GreenplumUtils.addObjectModifiersToDDL(monitor, ddl, this, distributionColumns, supportsReplicatedDistribution);
+            GreenplumUtils.addObjectModifiersToDDL(monitor, ddl, this, distributionColumns, supportsReplicatedDistribution, false);
         } catch (DBException e) {
             log.error("Error reading Greenplum table properties", e);
         }

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchema.java
@@ -69,7 +69,7 @@ public class GreenplumSchema extends PostgreSchema {
 
     public class GreenplumTableCache extends TableCache {
 
-        private boolean hasAccessToPartitionsView;
+        private boolean before7version;
 
         GreenplumTableCache() {
             super();
@@ -86,9 +86,9 @@ public class GreenplumSchema extends PostgreSchema {
             String uriLocationColumn = greenplumVersionAtLeast5 ? "urilocation" : "location";
             String execLocationColumn = greenplumVersionAtLeast5 ? "execlocation" : "location";
             boolean hasAccessToExttable = dataSource.isHasAccessToExttable(session);
-            hasAccessToPartitionsView = !dataSource.isGreenplumVersionAtLeast(7, 0);
+            before7version = !dataSource.isGreenplumVersionAtLeast(7, 0);
             String sqlQuery = "SELECT c.oid,c.*,d.description,\n" +
-                (hasAccessToPartitionsView ? "p.partitiontablename,p.partitionboundary as partition_expr," :
+                (before7version ? "p.partitiontablename,p.partitionboundary as partition_expr," :
                     "pg_catalog.pg_get_expr(c.relpartbound, c.oid) as partition_expr, pg_catalog.pg_get_partkeydef(c.oid) as partition_key,") +
                 (hasAccessToExttable ? "CASE WHEN x." + uriLocationColumn + " IS NOT NULL THEN array_to_string(x." + uriLocationColumn +
                     ", ',') ELSE '' END AS urilocation,\n" +
@@ -104,13 +104,15 @@ public class GreenplumSchema extends PostgreSchema {
                 (dataSource.isServerSupportRelstorageColumn(session) ?
                     "case when c.relstorage = 'x' then true else false end as \"is_ext_table\",\n" : "false as \"is_ext_table\",\n") +
                 "case when (ns.nspname !~ '^pg_toast' and ns.nspname like 'pg_temp%') then true else false end as \"is_temp_table\"\n" +
-                "FROM pg_catalog.pg_class c\n" +
+                (before7version ? "" : ", pa.amname\n") +
+                "\nFROM pg_catalog.pg_class c\n" +
                 "INNER JOIN pg_catalog.pg_namespace ns\n\ton ns.oid = c.relnamespace\n" +
                 "LEFT OUTER JOIN pg_catalog.pg_description d\n\tON d.objoid=c.oid AND d.objsubid=0\n" +
                 (hasAccessToExttable ? "LEFT OUTER JOIN pg_catalog.pg_exttable x\n\ton x.reloid = c.oid\n" : "") +
-                (hasAccessToPartitionsView ? "LEFT OUTER JOIN pg_catalog.pg_partitions p\n\ton c.relname = p.partitiontablename " +
+                (before7version ? "LEFT OUTER JOIN pg_catalog.pg_partitions p\n\ton c.relname = p.partitiontablename " +
                     "and ns.nspname = p.schemaname\n" : "") +
-                "WHERE c.relnamespace= ? AND c.relkind not in ('i','c') " +
+                (before7version ? "" : "\nLEFT JOIN pg_catalog.pg_am pa ON pa.oid = c.relam") +
+                "\nWHERE c.relnamespace= ? AND c.relkind not in ('i','c') " +
                 (object == null && objectName == null ? "" : " AND relname=?");
             final JDBCPreparedStatement dbStat = session.prepareStatement(sqlQuery);
             dbStat.setLong(1, getObjectId());
@@ -121,7 +123,7 @@ public class GreenplumSchema extends PostgreSchema {
 
         @Override
         protected boolean isPartitionTableRow(@NotNull JDBCResultSet dbResult) {
-            return hasAccessToPartitionsView ? CommonUtils.isNotEmpty(JDBCUtils.safeGetString(dbResult, "partitiontablename")) :
+            return before7version ? CommonUtils.isNotEmpty(JDBCUtils.safeGetString(dbResult, "partitiontablename")) :
                super.isPartitionTableRow(dbResult);
         }
     }

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTable.java
@@ -20,11 +20,14 @@
  */
 package org.jkiss.dbeaver.ext.greenplum.model;
 
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableColumn;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableRegular;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.utils.CommonUtils;
 
@@ -42,6 +45,7 @@ public class GreenplumTable extends PostgreTableRegular {
     private int[] distributionColumns;
 
     private boolean supportsReplicatedDistribution = false;
+    private String accessMethod;
 
     public GreenplumTable(PostgreSchema catalog) {
         super(catalog);
@@ -53,6 +57,18 @@ public class GreenplumTable extends PostgreTableRegular {
         if (catalog.getDataSource().isServerVersionAtLeast(9, 1)) {
             supportsReplicatedDistribution = true;
         }
+
+        PostgreDataSource dataSource = getDataSource();
+        if (dataSource instanceof GreenplumDataSource) {
+            if (((GreenplumDataSource) dataSource).isGreenplumVersionAtLeast(7, 0)) {
+                accessMethod = JDBCUtils.safeGetString(dbResult, "amname");
+            }
+        }
+    }
+
+    @Nullable
+    public String getAccessMethod() {
+        return accessMethod;
     }
 
     private List<PostgreTableColumn> getDistributionPolicy(DBRProgressMonitor monitor) throws DBException {
@@ -90,7 +106,19 @@ public class GreenplumTable extends PostgreTableRegular {
                 distributionColumns = GreenplumUtils.getDistributionTableColumns(monitor, distributionColumns, this);
             }
 
-            GreenplumUtils.addObjectModifiersToDDL(monitor, ddl, this, distributionColumns, supportsReplicatedDistribution);
+            boolean readPartitionInfo = true;
+            PostgreDataSource dataSource = getDataSource();
+            if (dataSource instanceof GreenplumDataSource) {
+                // Read partitions DDLs separately starting Greenplum 7
+                readPartitionInfo = !((GreenplumDataSource) dataSource).isGreenplumVersionAtLeast(7, 0);
+            }
+            GreenplumUtils.addObjectModifiersToDDL(
+                monitor,
+                ddl,
+                this,
+                distributionColumns,
+                supportsReplicatedDistribution,
+                readPartitionInfo);
         } catch (DBException e) {
             log.error("Error reading Greenplum table properties", e);
         }

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumUtils.java
@@ -132,7 +132,14 @@ public class GreenplumUtils {
         }
     }
 
-    static void addObjectModifiersToDDL(@NotNull DBRProgressMonitor monitor, @NotNull StringBuilder ddl, @NotNull PostgreTableReal table, List<PostgreTableColumn> distributionColumns, boolean supportsReplicatedDistribution) throws DBCException {
+    static void addObjectModifiersToDDL(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull StringBuilder ddl,
+        @NotNull PostgreTableReal table,
+        List<PostgreTableColumn> distributionColumns,
+        boolean supportsReplicatedDistribution,
+        boolean addPartitionInfo
+    ) throws DBCException {
         ddl.append("\nDISTRIBUTED ");
         if (supportsReplicatedDistribution && table.isPersisted() && GreenplumUtils.isDistributedByReplicated(monitor, table)) {
             ddl.append("REPLICATED");
@@ -147,10 +154,12 @@ public class GreenplumUtils {
             ddl.append("RANDOMLY");
         }
 
-        String partitionData = table.isPersisted() ? GreenplumUtils.getPartitionData(monitor, table) : null;
-        if (partitionData != null) {
-            ddl.append("\n");
-            ddl.append(partitionData);
+        if (addPartitionInfo) {
+            String partitionData = table.isPersisted() ? GreenplumUtils.getPartitionData(monitor, table) : null;
+            if (partitionData != null) {
+                ddl.append("\n");
+                ddl.append(partitionData);
+            }
         }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
@@ -20,12 +20,14 @@
  */
 package org.jkiss.dbeaver.ext.greenplum.model;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.postgresql.model.*;
 import org.jkiss.dbeaver.ext.postgresql.model.impls.PostgreServerExtensionBase;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.utils.CommonUtils;
 
 /**
  * PostgreServerGreenplum
@@ -107,6 +109,16 @@ public class PostgreServerGreenplum extends PostgreServerExtensionBase {
     @Override
     public String createWithClause(PostgreTableRegular table, PostgreTableBase tableBase) {
         return GreenplumWithClauseBuilder.generateWithClause(table, tableBase);
+    }
+
+    @Override
+    public void createUsingClause(@NotNull PostgreTableRegular table, @NotNull StringBuilder ddl) {
+        if (table instanceof GreenplumTable) {
+            String accessMethod = ((GreenplumTable) table).getAccessMethod();
+            if (CommonUtils.isNotEmpty(accessMethod)) {
+                ddl.append("\nUSING ").append(accessMethod);
+            }
+        }
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreTableManagerBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreTableManagerBase.java
@@ -82,7 +82,7 @@ public abstract class PostgreTableManagerBase extends SQLTableManager<PostgreTab
                     }
                 }
 
-                if (showComments) {
+                if (showComments && !table.isPartition() && !monitor.isCanceled()) {
                     // Constraint comments
                     boolean hasComments = false;
                     for (PostgreTableConstraintBase constr : CommonUtils.safeCollection(table.getConstraints(monitor))) {
@@ -106,7 +106,7 @@ public abstract class PostgreTableManagerBase extends SQLTableManager<PostgreTab
                 }
 
                 // Triggers
-                if (table instanceof PostgreTableReal) {
+                if (table instanceof PostgreTableReal && !table.isPartition() && !monitor.isCanceled()) {
                     Collection<PostgreTrigger> triggers = ((PostgreTableReal) table).getTriggers(monitor);
                     if (!CommonUtils.isEmpty(triggers)) {
                         actions.add(new SQLDatabasePersistActionComment(dataSource, "Table Triggers"));
@@ -118,7 +118,7 @@ public abstract class PostgreTableManagerBase extends SQLTableManager<PostgreTab
                 }
 
                 // Rules
-                if (table instanceof PostgreTableReal) {
+                if (table instanceof PostgreTableReal && !table.isPartition() && !monitor.isCanceled()) {
                     Collection<PostgreRule> rules = ((PostgreTableReal) table).getRules(monitor);
                     if (!CommonUtils.isEmpty(rules)) {
                         actions.add(new SQLDatabasePersistActionComment(dataSource, "Table Rules"));
@@ -130,7 +130,10 @@ public abstract class PostgreTableManagerBase extends SQLTableManager<PostgreTab
                 }
 
                 // Partitions
-                if (CommonUtils.getOption(options, DBPScriptObject.OPTION_INCLUDE_PARTITIONS) && table instanceof PostgreTable) {
+                if (CommonUtils.getOption(options, DBPScriptObject.OPTION_INCLUDE_PARTITIONS)
+                    && table instanceof PostgreTable
+                    && !monitor.isCanceled()
+                ) {
                     PostgreTable postgreTable = (PostgreTable) table;
                     List<PostgreTableBase> partitions = postgreTable.getPartitions(monitor);
                     if (postgreTable.hasPartitions() && !CommonUtils.isEmpty(partitions)) {
@@ -142,7 +145,7 @@ public abstract class PostgreTableManagerBase extends SQLTableManager<PostgreTab
                     }
                 }
 
-                if (isDDL && !table.isPartition()) {
+                if (isDDL && !table.isPartition() && !monitor.isCanceled()) {
                     PostgreUtils.getObjectGrantPermissionActions(monitor, table, actions, options);
                 }
             } catch (DBException e) {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTablePartition.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTablePartition.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.postgresql.model;
 
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
@@ -62,6 +63,12 @@ public class PostgreTablePartition extends PostgreTable implements DBSTableParti
 
     @Override
     public String getObjectDefinitionText(DBRProgressMonitor monitor, Map<String, Object> options) throws DBException {
+        options.put(DBPScriptObject.OPTION_DDL_SKIP_FOREIGN_KEYS, true);
+        options.put(OPTION_DDL_SEPARATE_FOREIGN_KEYS_STATEMENTS, false);
+        options.put(OPTION_INCLUDE_NESTED_OBJECTS, false);
+        options.put(OPTION_INCLUDE_PERMISSIONS, false);
+        options.put(OPTION_SKIP_INDEXES, true);
+        options.put(DBPScriptObject.OPTION_SKIP_UNIQUE_KEYS, true);
         return DBStructUtils.generateTableDDL(monitor, this, options, false);
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
@@ -279,6 +279,12 @@ public abstract class PostgreServerExtensionBase implements PostgreServerExtensi
         }
 
         if (tableBase instanceof PostgreTableRegular) {
+            if (!alter) {
+                createUsingClause((PostgreTableRegular) tableBase, ddl);
+            }
+        }
+
+        if (tableBase instanceof PostgreTableRegular) {
             PostgreTableRegular table = (PostgreTableRegular) tableBase;
             try {
                 if (!alter) {
@@ -447,6 +453,10 @@ public abstract class PostgreServerExtensionBase implements PostgreServerExtensi
         }
 
         return withClauseBuilder.toString();
+    }
+
+    public void createUsingClause(@NotNull PostgreTableRegular table, @NotNull StringBuilder ddl) {
+        // Do nothing
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPScriptObject.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPScriptObject.java
@@ -57,6 +57,8 @@ public interface DBPScriptObject extends DBPObject {
 
     String OPTION_DDL_SKIP_FOREIGN_KEYS = "ddl.skipForeignKeys"; //$NON-NLS-1$
     String OPTION_DDL_ONLY_FOREIGN_KEYS = "ddl.onlyForeignKeys"; //$NON-NLS-1$
+    String OPTION_SKIP_UNIQUE_KEYS = "ddl.skipUniqueKeys"; //$NON-NLS-1$
+    String OPTION_SKIP_INDEXES = "ddl.skipIndexes"; //$NON-NLS-1$
 
     String OPTION_DDL_SEPARATE_FOREIGN_KEYS_STATEMENTS = "ddl.separateForeignKeys"; //$NON-NLS-1$
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLTableManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLTableManager.java
@@ -246,7 +246,7 @@ public abstract class SQLTableManager<OBJECT_TYPE extends DBSEntity, CONTAINER_T
                 command.aggregateCommand(tcm.makeCreateCommand(column, options));
             }
         }
-        if (pkm != null) {
+        if (pkm != null && !CommonUtils.getOption(options, DBPScriptObject.OPTION_SKIP_UNIQUE_KEYS)) {
             try {
                 for (DBSEntityConstraint constraint : CommonUtils.safeCollection(table.getConstraints(monitor))) {
                     if (skipObject(constraint)) {
@@ -287,7 +287,7 @@ public abstract class SQLTableManager<OBJECT_TYPE extends DBSEntity, CONTAINER_T
                 log.debug(e);
             }
         }
-        if (im != null && table instanceof DBSTable) {
+        if (im != null && table instanceof DBSTable && !CommonUtils.getOption(options, DBPScriptObject.OPTION_SKIP_INDEXES)) {
             try {
                 for (DBSTableIndex index : CommonUtils.safeCollection(((DBSTable)table).getIndexes(monitor))) {
                     if (!isIncludeIndexInDDL(monitor, index)) {


### PR DESCRIPTION
added USING clause for Greenplum tables DDL ([starting Greenplum 7](https://docs.vmware.com/en/VMware-Greenplum/7/greenplum-database/ref_guide-sql_commands-CREATE_TABLE.html)); 
partitions reading and DDL creating enhanced - performance increasing (do not read keys and indexes for partition tables)

You can read the discussion here:
https://github.com/greenplum-db/gpdb/issues/16093#issuecomment-1662973007
Starting Greenplum 7 - we will create table DDL + separate partitions tables DDLs (with the help of the extra button "show partitions")
Before Greenplum 7 - we will use the old way of partitioning info showing - right into DDL (the modern way)

- [x] DDL creating for Greenplum Materialized view
- [x] tables reading in Greenplum 7 and Greenplum 6
- [x] "USING" clause for Greenplum 7 tables (absent in Greenplum 6)
- [x] Partition reading in Greenplum 7 and DDL creation
- [x] Partition reading in Greenplum 6 and DDL creation
- [ ] Partition reading and DDL creation in PostgreSQL

![2023-08-03 13_14_06-DBeaver Ultimate 23 1 4 - t_ao](https://github.com/dbeaver/dbeaver/assets/45152336/57d5eee1-0ba0-4525-9160-72f04b9b79d2)
