### PR TITLE
dbeaver/pro#1792 Make class and label attributes to be not required in driver tag

### DIFF
--- a/plugins/org.jkiss.dbeaver.registry/schema/org.jkiss.dbeaver.dataSourceProvider.exsd
+++ b/plugins/org.jkiss.dbeaver.registry/schema/org.jkiss.dbeaver.dataSourceProvider.exsd
@@ -366,7 +366,7 @@
             <element ref="os" minOccurs="0" maxOccurs="unbounded"/>
             <element ref="replace" minOccurs="0" maxOccurs="unbounded"/>
          </sequence>
-         <attribute name="label" type="string" use="required">
+         <attribute name="label" type="string">
             <annotation>
                <documentation>
                   Driver name
@@ -393,7 +393,7 @@
                </documentation>
             </annotation>
          </attribute>
-         <attribute name="class" type="string" use="required">
+         <attribute name="class" type="string">
             <annotation>
                <documentation>
                   Driver implementation class


### PR DESCRIPTION
This PR fixes errors on build for Vertica due to missing attributes in driver tag:
https://github.com/dbeaver/dbeaver/blob/devel/plugins/org.jkiss.dbeaver.ext.vertica/plugin.xml#L117