### PR TITLE
Dbeaver/pro#1875 use newest functions reading

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
@@ -45,7 +45,7 @@ public class PostgreServerGreenplum extends PostgreServerExtensionBase {
 
     @Override
     public boolean supportsFunctionDefRead() {
-        return false;
+        return dataSource.isServerVersionAtLeast(12, 0);
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
@@ -98,12 +98,12 @@ public class PostgreServerGreenplum extends PostgreServerExtensionBase {
 
     @Override
     public boolean supportsExplainPlanXML() {
-        return false;
+        return dataSource.isServerVersionAtLeast(12, 0);
     }
 
     @Override
     public boolean supportsExplainPlanVerbose() {
-        return false;
+        return dataSource.isServerVersionAtLeast(12, 0);
     }
 
     @Override
@@ -157,7 +157,7 @@ public class PostgreServerGreenplum extends PostgreServerExtensionBase {
 
     @Override
     public boolean supportsRoleBypassRLS() {
-        return false;
+        return dataSource.isServerVersionAtLeast(12, 0);
     }
 
     @Override
@@ -172,7 +172,7 @@ public class PostgreServerGreenplum extends PostgreServerExtensionBase {
 
     @Override
     public boolean supportsDistinctForStatementsWithAcl() {
-        return false;
+        return dataSource.isServerVersionAtLeast(12, 0);
     }
 
     @Override


### PR DESCRIPTION
Greenplum 7 supports PostgreSQL 12,
so we can't change some parameters regarding this info.

https://docs.vmware.com/en/VMware-Greenplum/7/greenplum-database/ref_guide-sql_commands-CREATE_ROLE.html

Please check two Greenplum versions:

Parameters showing in the DDL (from the ticket)

- [x] Execution plan creation (will use FORMAT XML for version 7)
- [x] Execution plan creation (will not use FORMAT XML for version < 7)
- [x] Execution plan creation with VERBOSE parameter (will use VERBOSE keyword in the statement for version 7)
- [x] Execution plan creation with VERBOSE parameter (will NOT use VERBOSE keyword in the statement for version < 7)
- [x] Role Permissions reading for version 7 (accepted criteria - will not fall)
- [x] Role Permissions reading for version < 7 (accepted criteria - will not fall)
- [x] Role creating for Greenplum < 7 - BYPASSRLS | NOBYPASSRLS not in the creation statement
- [x] Role creating for Greenplum 7 - BYPASSRLS | NOBYPASSRLS is in the creation statement
