### PR TITLE
#20935 use data source provider created URL in case of the old URL pa…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.bigquery/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.bigquery/plugin.xml
@@ -24,7 +24,7 @@
                         icon="icons/bigquery_icon.png"
                         iconBig="icons/bigquery_icon_big.png"
                         class="com.simba.googlebigquery.jdbc42.Driver"
-                        sampleURL="jdbc:bigquery://{host}:{port};ProjectId={database};OAuthType=0;OAuthServiceAcctEmail={user};"
+                        sampleURL="jdbc:bigquery://{host}:{port}"
                         defaultHost="https://www.googleapis.com/bigquery/v2"
                         defaultPort="443"
                         description="Google BigQuery driver"

--- a/plugins/org.jkiss.dbeaver.ext.bigquery/src/org/jkiss/dbeaver/ext/bigquery/model/BigQueryDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.bigquery/src/org/jkiss/dbeaver/ext/bigquery/model/BigQueryDataSource.java
@@ -24,6 +24,7 @@ import org.jkiss.dbeaver.model.connection.DBPDriver;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCExecutionContext;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.utils.CommonUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,6 +35,17 @@ public class BigQueryDataSource extends GenericDataSource {
         throws DBException
     {
         super(monitor, container, metaModel, new BigQuerySQLDialect());
+    }
+
+    @Override
+    protected String getConnectionURL(DBPConnectionConfiguration connectionInfo) {
+        String connectionURL = super.getConnectionURL(connectionInfo);
+        if (CommonUtils.isNotEmpty(connectionURL) && connectionURL.contains("OAuthPvtKeyPath={server};")) {
+            // Backward compatibility. We do not want to use this incorrect pattern as a URL. Better to create a new URL.
+            DBPDriver driver = getContainer().getDriver();
+            return driver.getDataSourceProvider().getConnectionURL(driver, connectionInfo);
+        }
+        return connectionURL;
     }
 
     @Override


### PR DESCRIPTION
use data source provider created URL in case of the old URL pattern; 
do BigQuery sampleURL easier

Depends on your drivers.xml file.

You can add there something like:

```xml
<provider id="bigquery">
	<driver id="google_bigquery_jdbc_simba" categories="bigdata" name="Google BigQuery" class="com.simba.googlebigquery.jdbc42.Driver" url="jdbc:bigquery://{host}:{port};ProjectId={database};OAuthType=0;OAuthServiceAcctEmail={user};OAuthPvtKeyPath={server};" port="443" description="Google BigQuery driver" custom="false">
		<library type="jar" path="https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.3.3.1004.zip" custom="false">
			<file id="https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.3.3.1004.zip" path="${drivers_home}\remote\simba-bq-release\jdbc\SimbaJDBCDriverforGoogleBigQuery42_1.3.3.1004.zip"/>
		</library>
		<library type="license" path="https://www.gnu.org/licenses/lgpl-3.0.txt" custom="false">
			<file id="https://www.gnu.org/licenses/lgpl-3.0.txt" path="${drivers_home}\remote\licenses\lgpl-3.0.txt"/>
		</library>
	</driver>
</provider>
```

To reproduce the original issue.