### PR TITLE
Expose external tables for the newest Greenplum server 7

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/plugin.xml
@@ -26,7 +26,7 @@
             <treeInjection path="postgresql/database/schema" after="table">
                 <folder type="org.jkiss.dbeaver.ext.greenplum.model.GreenplumExternalTable"
                         label="%tree.externaltables.node.name"
-                        icon="#folder_table" visibleIf="object.dataSource.supportsExternalTables()">
+                        icon="#folder_table">
                     <items label="%tree.externaltable.node.name" path="externalTable" property="externalTables"
                            icon="#table_external">
                         <folder type="org.jkiss.dbeaver.ext.postgresql.model.PostgreTableColumn"

--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumDataSource.java
@@ -29,7 +29,6 @@ import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
-import org.jkiss.dbeaver.model.meta.Association;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.osgi.framework.Version;
 
@@ -103,11 +102,5 @@ public class GreenplumDataSource extends PostgreDataSource {
             supportsRelstorageColumn = PostgreUtils.isMetaObjectExists(session, "pg_class", "relstorage");
         }
         return supportsRelstorageColumn;
-    }
-
-    @Association
-    public boolean supportsExternalTables() {
-        // External tables turned into foreign tables from version 7
-        return !isGreenplumVersionAtLeast(7, 0);
     }
 }


### PR DESCRIPTION
This partially reverts commit cb7548c45c883a8a077e790d49fea4de9698a814 (https://github.com/dbeaver/dbeaver/pull/20540).

Greenplum 7 turned external tables into foreign tables, but that is only
a low level implementation change, it still provides the legacy external
tables syntax and the `pg_exttable` catalog (via a view instead).

References:
https://github.com/greenplum-db/gpdb/pull/10015
https://github.com/greenplum-db/gpdb/commit/3aad307cb575c6a11a159f599071391b36b21a82