### PR TITLE
#18892 Use select if the function is not a procedure for debugging

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.debug.core/src/org/jkiss/dbeaver/ext/postgresql/debug/internal/impl/PostgreDebugSession.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.debug.core/src/org/jkiss/dbeaver/ext/postgresql/debug/internal/impl/PostgreDebugSession.java
@@ -35,6 +35,7 @@ import org.jkiss.dbeaver.ext.postgresql.debug.core.PostgreSqlDebugCore;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedure;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedureKind;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedureParameter;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.exec.DBCExecutionPurpose;
@@ -337,13 +338,21 @@ public class PostgreDebugSession extends DBGJDBCSession {
                     JDBCCallableStatement statement = null;
                     try {
                         StringBuilder query = new StringBuilder();
-                        query.append("{ CALL ").append(function.getFullyQualifiedName(DBPEvaluationContext.DML)).append("(");
+                        if (function.getKind().equals(PostgreProcedureKind.p)) {
+                            query.append("{ CALL ");
+                        } else {
+                            query.append("SELECT ");
+                        }
+                        query.append(function.getFullyQualifiedName(DBPEvaluationContext.DML)).append("(");
                         for (int i = 0; i < parameters.size(); i++) {
                             if (i > 0) query.append(",");
                             String paramValue = paramValues.get(i);
                             query.append(paramValue);
                         }
-                        query.append(") }");
+                        query.append(")");
+                        if (function.getKind().equals(PostgreProcedureKind.p)) {
+                            query.append(" }");
+                        }
                         log.debug(String.format("Prepared local call %s", query));
                         statement = session.prepareCall(query.toString());
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql.debug.core/src/org/jkiss/dbeaver/ext/postgresql/debug/internal/impl/PostgreDebugSession.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.debug.core/src/org/jkiss/dbeaver/ext/postgresql/debug/internal/impl/PostgreDebugSession.java
@@ -35,7 +35,6 @@ import org.jkiss.dbeaver.ext.postgresql.debug.core.PostgreSqlDebugCore;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedure;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedureKind;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedureParameter;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.exec.DBCExecutionPurpose;
@@ -48,6 +47,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.AbstractJob;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
+import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.IOUtils;
 
@@ -338,7 +338,7 @@ public class PostgreDebugSession extends DBGJDBCSession {
                     JDBCCallableStatement statement = null;
                     try {
                         StringBuilder query = new StringBuilder();
-                        if (function.getKind().equals(PostgreProcedureKind.p)) {
+                        if (function.getProcedureType() == DBSProcedureType.PROCEDURE) {
                             query.append("{ CALL ");
                         } else {
                             query.append("SELECT ");
@@ -350,7 +350,7 @@ public class PostgreDebugSession extends DBGJDBCSession {
                             query.append(paramValue);
                         }
                         query.append(")");
-                        if (function.getKind().equals(PostgreProcedureKind.p)) {
+                        if (function.getProcedureType() == DBSProcedureType.PROCEDURE) {
                             query.append(" }");
                         }
                         log.debug(String.format("Prepared local call %s", query));


### PR DESCRIPTION
You might check PostgreSQL 12` dvdrental.public.film_in_stock` fucntion and `dvdrental.public.display_message` procedure. Both should work now (`film_in_stock` didn't work as we tried to use `CALL `with function instead of `SELECT`).