### PR TITLE
#20730 hide the "target" column in case of no target specified tables…

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/stream/StreamProducerPageSettings.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/stream/StreamProducerPageSettings.java
@@ -91,7 +91,23 @@ public class StreamProducerPageSettings extends DataTransferPageNodeSettings {
             filesTable.setLinesVisible(true);
 
             UIUtils.createTableColumn(filesTable, SWT.LEFT, DTUIMessages.data_transfer_wizard_final_column_source);
-            UIUtils.createTableColumn(filesTable, SWT.LEFT, DTUIMessages.data_transfer_wizard_final_column_target);
+            List<DBSObject> sourceObjects = getWizard().getSettings().getSourceObjects();
+            boolean skipTargetColumn;
+            if (CommonUtils.isEmpty(sourceObjects)) {
+                skipTargetColumn = true;
+            } else {
+                boolean allSourceObjectsNotTables = true;
+                for (DBSObject sourceObject : sourceObjects) {
+                    if (sourceObject instanceof DBSDataManipulator) {
+                        allSourceObjectsNotTables = false;
+                        break;
+                    }
+                }
+                skipTargetColumn = allSourceObjectsNotTables;
+            }
+            if (!skipTargetColumn) {
+                UIUtils.createTableColumn(filesTable, SWT.LEFT, DTUIMessages.data_transfer_wizard_final_column_target);
+            }
 
             filesTable.addSelectionListener(new SelectionAdapter() {
                 @Override


### PR DESCRIPTION
hide the "target" column in case of no target specified tables to avoid "?" text

![2023-08-28 11_08_39-Data Transfer](https://github.com/dbeaver/dbeaver/assets/45152336/7c0684fb-23b8-4fb8-bfe9-6c2cd3cc4170)

![2023-08-28 11_09_37-Data Transfer](https://github.com/dbeaver/dbeaver/assets/45152336/f5fae7b4-6ada-4252-a34f-87d8700d74c4)

- [x] Please check the following:
- [x] import in a table
- [x] import in a catalog
- [x] import in "tables" source
- [x] import from another table
- [x] import to a few tables
- [x] import to a few schemas

(You can do datatransfer process to the end just in one ant case. in other cases - just observe the "Input files" page)
