### PR TITLE
dbeaver/pro#1889 CTE support by grammar

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
@@ -156,6 +156,7 @@ PARTITION: P A R T I T I O N ;
 PRESERVE: P R E S E R V E ;
 PRIMARY: P R I M A R Y ;
 READ: R E A D ;
+RECURSIVE: R E C U R S I V E;
 REFERENCES: R E F E R E N C E S ;
 REPEATABLE: R E P E A T A B L E ;
 RESTRICT: R E S T R I C T ;
@@ -256,7 +257,7 @@ LineComment
    ;
 
 // special characters and character sequences
-fragment NonquoteCharacter: ~'~';
+fragment NonquoteCharacter: ~'\'';
 QuoteSymbol: SingleQuote SingleQuote;
 Introducer: Underscore;
 fragment NewLine: ([\r][\n])|[\n]|[\r];
@@ -279,10 +280,10 @@ fragment IdentifierPart: (IdentifierStart|Digit);
 
 
 // string literals
-NationalCharacterStringLiteral: 'N' SingleQuote ((CharacterRepresentation)+)? SingleQuote (((Separator)+ SingleQuote ((CharacterRepresentation)+)? SingleQuote)+)?;
+NationalCharacterStringLiteral: 'N' SingleQuote CharacterRepresentation* SingleQuote ((Separator)+ SingleQuote CharacterRepresentation* SingleQuote)*;
 CharacterRepresentation: (NonquoteCharacter|QuoteSymbol);
-BitStringLiteral: 'B' SingleQuote ((Bit)+)? SingleQuote (((Separator)+ SingleQuote ((Bit)+)? SingleQuote)+)?;
-HexStringLiteral: 'X' SingleQuote ((Hexit)+)? SingleQuote (((Separator)+ SingleQuote ((Hexit)+)? SingleQuote)+)?;
-StringLiteralContent: SingleQuote ((CharacterRepresentation)+)? SingleQuote (((Separator)+ SingleQuote ((CharacterRepresentation)+)? SingleQuote)+)?;
+BitStringLiteral: 'B' SingleQuote Bit* SingleQuote ((Separator)+ SingleQuote Bit* SingleQuote)*;
+HexStringLiteral: 'X' SingleQuote Hexit* SingleQuote ((Separator)+ SingleQuote Hexit* SingleQuote)*;
+StringLiteralContent: SingleQuote CharacterRepresentation* SingleQuote ((Separator)+ SingleQuote CharacterRepresentation* SingleQuote)*;
 
 WS: Separator;

--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
@@ -53,7 +53,7 @@ sqlQueries: (sqlQuery Semicolon?)* EOF; // EOF - don't stop early. must match al
 sqlQuery: directSqlDataStatement|sqlSchemaStatement|sqlTransactionStatement|sqlSessionStatement|sqlDataStatement;
 
 directSqlDataStatement: (deleteStatement|selectStatement|insertStatement|updateStatement);
-selectStatement: queryExpression (orderByClause)?;
+selectStatement: withClause? queryExpression orderByClause?;
 
 // data type literals
 literal: (signedNumericLiteral|generalLiteral);
@@ -145,6 +145,12 @@ qualifier: (tableName|correlationName);
 correlationName: identifier;
 setFunctionSpecification: (COUNT LeftParen Asterisk RightParen|anyWordsWithProperty);
 
+withClause: WITH RECURSIVE? cteList;
+cteList: with_list_element (Comma with_list_element)*;
+with_list_element: queryName (LeftParen withColumnList RightParen)? AS anyWordsWithProperty? subquery;
+withColumnList: columnName (Comma columnName )*;
+queryName: Identifier;
+
 // select, subquery
 scalarSubquery: subquery;
 subquery: LeftParen queryExpression RightParen;
@@ -158,10 +164,10 @@ simpleTable: (querySpecification|tableValueConstructor|explicitTable);
 querySpecification: SELECT (setQuantifier)? selectList tableExpression?;
 setQuantifier: (DISTINCT|ALL);
 selectList: (Asterisk|selectSublist) (Comma selectSublist)*; // (Comma selectSublist)* contains any quantifier for error recovery;
-selectSublist: (qualifier Period Asterisk | derivedColumn)*; // * for whole rule to handle select fields autocompletion when from immediately after select
+selectSublist: (qualifier Period Asterisk | derivedColumn | (.*?)); // (.*?) for whole rule to handle select fields autocompletion when from immediately after select
 derivedColumn: valueExpression (asClause)?;
 asClause: (AS)? columnName;
-tableExpression: (.*?) fromClause (whereClause)? (groupByClause)? (havingClause)?; // (.*?) - for error recovery
+tableExpression: fromClause (whereClause)? (groupByClause)? (havingClause)?;
 queryPrimary: (nonJoinQueryPrimary|joinedTable);
 queryTerm: (nonJoinQueryTerm|joinedTable);
 queryExpression: (joinedTable|nonJoinQueryTerm) (unionTerm|exceptTerm)*;
@@ -190,8 +196,8 @@ joinColumnList: columnNameList;
 // conditions
 whereClause: WHERE searchCondition;
 groupByClause: GROUP BY groupingColumnReferenceList;
-groupingColumnReferenceList: groupingColumnReference ((Comma groupingColumnReference)+)?;
-groupingColumnReference: columnReference;
+groupingColumnReferenceList: groupingColumnReference (Comma groupingColumnReference)*;
+groupingColumnReference: columnReference | anyWordsWithProperty;
 havingClause: HAVING searchCondition;
 tableValueConstructor: VALUES tableValueConstructorList;
 tableValueConstructorList: rowValueConstructor ((Comma rowValueConstructor)+)?;
@@ -349,7 +355,7 @@ setLocalTimeZoneStatement: SET TIME ZONE setTimeZoneValue;
 setTimeZoneValue: (intervalValueExpression|LOCAL);
 
 // unknown keyword, data type or function name
-anyWord: Identifier;
+anyWord: actualIdentifier;
 anyValue: qualifiedName|literal|valueExpression|Comma;
 anyWordWithAnyValue: anyWord anyValue;
 anyProperty: LeftParen anyValue+ RightParen;


### PR DESCRIPTION
- CTE support
- function calls in group by
- fix bug with `FORMAT (col,'C','en-us') AS col` handling

Query illustrating current possibilities and including all newly added features and fixes
```
WITH Sales_CTE (SalesPersonID, TotalSales, SalesYear)
AS
-- Define the first CTE query.
(
    SELECT SalesPersonID, SUM(TotalDue) AS TotalSales, YEAR(OrderDate) AS SalesYear
    FROM Sales.SalesOrderHeader
    WHERE SalesPersonID IS NOT NULL
       GROUP BY SalesPersonID, YEAR(OrderDate)

)
, -- Use a comma to separate multiple CTE definitions.

-- Define the second CTE query, which returns sales quota data by year for each sales person.
Sales_Quota_CTE (BusinessEntityID, SalesQuota, SalesQuotaYear)
AS
(
       SELECT BusinessEntityID, SUM(SalesQuota)AS SalesQuota, YEAR(QuotaDate) AS SalesQuotaYear
       FROM Sales.SalesPersonQuotaHistory
       GROUP BY BusinessEntityID, YEAR(QuotaDate)
)

-- Define the outer query by referencing columns from both CTEs.
SELECT SalesPersonID
  , SalesYear
  , FORMAT(TotalSales,'C','en-us') AS TotalSales
  , SalesQuotaYear
  , FORMAT (SalesQuota,'C','en-us') AS SalesQuota
  , FORMAT (TotalSales -SalesQuota, 'C','en-us') AS Amt_Above_or_Below_Quota
FROM Sales_CTE
JOIN Sales_Quota_CTE ON Sales_Quota_CTE.BusinessEntityID = Sales_CTE.SalesPersonID
                    AND Sales_CTE.SalesYear = Sales_Quota_CTE.SalesQuotaYear
ORDER BY SalesPersonID, SalesYear;
```
_(taken from here https://learn.microsoft.com/en-us/sql/t-sql/queries/with-common-table-expression-transact-sql?view=sql-server-ver16)_

**How to test it:**
- autocompletion for columns and aliases should work if query contains the mentioned clauses