### PR TITLE
dbeaver/pro#1888 Remove password template replacing for jdbc url

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DatabaseURL.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DatabaseURL.java
@@ -80,7 +80,8 @@ public class DatabaseURL {
                     newComponent = newComponent.replace(makePropPattern(DBConstants.PROP_FILE), connectionInfo.getDatabaseName());
                 }
                 newComponent = newComponent.replace(makePropPattern(DBConstants.PROP_USER), CommonUtils.notEmpty(connectionInfo.getUserName()));
-                newComponent = newComponent.replace(makePropPattern(DBConstants.PROP_PASSWORD), CommonUtils.notEmpty(connectionInfo.getUserPassword()));
+                // support of {password} pattern was removed for security reasons (see dbeaver/pro#1888)
+                //newComponent = newComponent.replace(makePropPattern(DBConstants.PROP_PASSWORD), CommonUtils.notEmpty(connectionInfo.getUserPassword()));
 
                 if (newComponent.startsWith("[")) { //$NON-NLS-1$
                     if (!newComponent.equals(component)) {


### PR DESCRIPTION
- [x] The bug from the issue should be fixed.
- [x] URL parsing for new connection creating should work with such cases: `jdbc:postgresql://usr:pwd@192.168.42.6:5432/e1izabethdb`
![image](https://github.com/dbeaver/dbeaver/assets/28875055/875cb9de-6c8b-4fb7-b4b5-a97ebb29f0c5)
