### PR TITLE
#21077 Grammar improvements and fixes

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
@@ -142,6 +142,7 @@ NAMES: N A M E S ;
 NATURAL: N A T U R A L ;
 NO: N O ;
 NOT: N O T ;
+NOTNULL: N O T N U L L;
 NULL: N U L L ;
 NULLIF: N U L L I F ;
 ON: O N ;
@@ -204,7 +205,7 @@ ZONE: Z O N E ;
 
 // symbols
 EqualsOperator: '=';
-NotEqualsOperator: '<>';
+NotEqualsOperator: '<>' | '!=';
 RightParen: ')';
 LeftParen: '(';
 SingleQuote: '\'';

--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
@@ -49,7 +49,7 @@ public void setIsSupportSquareBracketQuotation(boolean value) { isSupportSquareB
 }
 
 // root rule for script
-sqlQueries: (sqlQuery Semicolon?)* EOF; // EOF - don't stop early. must match all input
+sqlQueries: sqlQuery (Semicolon sqlQuery)* Semicolon? EOF; // EOF - don't stop early. must match all input
 sqlQuery: directSqlDataStatement|sqlSchemaStatement|sqlTransactionStatement|sqlSessionStatement|sqlDataStatement;
 
 directSqlDataStatement: (deleteStatement|selectStatement|insertStatement|updateStatement);
@@ -173,9 +173,9 @@ queryTerm: (nonJoinQueryTerm|joinedTable);
 queryExpression: (joinedTable|nonJoinQueryTerm) (unionTerm|exceptTerm)*;
 
 // from
-fromClause: FROM tableReference ((Comma tableReference)+)?;
+fromClause: FROM tableReference (Comma tableReference)*;
 nonjoinedTableReference: (tableName (PARTITION anyProperty)? (correlationSpecification)?)|(derivedTable correlationSpecification);
-tableReference: (nonjoinedTableReference|joinedTable|tableReferenceHints)*; // * to handle incomplete queries
+tableReference: nonjoinedTableReference|joinedTable|tableReferenceHints|(.*?); // '.*' to handle incomplete queries
 tableReferenceHints: (tableHintKeywords|anyWord)+ anyProperty; // dialect-specific options, should be described and moved to dialects in future
 joinedTable: (nonjoinedTableReference|(LeftParen joinedTable RightParen)) (naturalJoinTerm|crossJoinTerm)+;
 correlationSpecification: (AS)? correlationName (LeftParen derivedColumnList RightParen)?;
@@ -252,7 +252,7 @@ likePredicate: matchValue (NOT)? LIKE pattern (ESCAPE escapeCharacter)?;
 matchValue: characterValueExpression;
 pattern: characterValueExpression;
 escapeCharacter: characterValueExpression;
-nullPredicate: rowValueConstructor IS (NOT)? NULL;
+nullPredicate: rowValueConstructor IS (NOT? NULL | NOTNULL);
 quantifiedComparisonPredicate: rowValueConstructor compOp quantifier tableSubquery;
 quantifier: (all|some);
 all: ALL;
@@ -278,7 +278,7 @@ referencingColumns: referenceColumnList;
 orderByClause: ORDER BY sortSpecificationList;
 sortSpecificationList: sortSpecification ((Comma sortSpecification)+)?;
 sortSpecification: sortKey (orderingSpecification)?;
-sortKey: (columnReference|UnsignedInteger);
+sortKey: columnReference | UnsignedInteger | anyWordsWithProperty;
 orderingSpecification: (ASC|DESC);
 
 // schema definition

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
@@ -708,7 +708,7 @@ public class SQLCompletionAnalyzer implements DBRRunnableParametrized<DBRProgres
             for (Pair<String, String> name : names) {
                 final String tableName = name.getFirst();
                 final String tableAlias = name.getSecond();
-                if (!hasProposal(proposals, tableName)) {
+                if (!CommonUtils.isEmpty(tableName) && !hasProposal(proposals, tableName)) {
                     proposals.add(
                         0,
                         SQLCompletionAnalyzer.createCompletionProposal(

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLIdentifierDetector.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLIdentifierDetector.java
@@ -102,7 +102,7 @@ public class SQLIdentifierDetector extends TPWordDetector {
 
     public boolean isQuoted(String token) {
         for (String[] quoteString : quoteStrings) {
-            if (token.startsWith(quoteString[0])) {
+            if (quoteString[0] != null && token.startsWith(quoteString[0])) {
                 return true;
             }
         }


### PR DESCRIPTION
- [x] fix aliases autocompletion bug for queries like in the issue
- [x] add notnull keyword -- queries with this keyword should not broke autocompletion now
- [x] add support of != -- queries with this operator should not broke autocompletion now
- [x] add support of function calls in order by clause -- queries with things like ```ORDER BY DATE_FORMAT(sc.data_lan,'%Y-%m-%d'),TRIM(mc.descri_can),sc.codcli,sc.codsercli``` should not broke autocompletion now