### PR TITLE
dbeaver/dbeaver#18965 use old timezone during connect

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
@@ -730,11 +730,6 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
         }
     }
 
-    @Override
-    public void shutdown(DBRProgressMonitor monitor) {
-        super.shutdown(monitor);
-    }
-
     public PostgreServerExtension getServerType() {
         if (serverExtension == null) {
             PostgreServerType serverType = PostgreUtils.getServerType(getContainer().getDriver());

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
@@ -98,8 +98,8 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
     private String serverVersion;
     private volatile boolean hasStatistics;
 
-    private static final String LEGACY_TIMEZONE = "Europe/Kiev";
-    private static final String NEW_TIMEZONE = "Europe/Kyiv";
+    private static final String LEGACY_UA_TIMEZONE = "Europe/Kiev";
+    private static final String NEW_UA_TIMEZONE = "Europe/Kyiv";
 
     public PostgreDataSource(DBRProgressMonitor monitor, DBPDataSourceContainer container)
         throws DBException
@@ -507,9 +507,9 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
             // Old versions of postgres and some linux distributions, on which docker images are made, may not contain
             // new timezone, which will lead to the error while connecting, there is no way to know before connecting
             // so to be sure we will use the old name
-            if (NEW_TIMEZONE.equals(TimeZone.getDefault().getID())) { //$NON-NLS-1$
+            if (NEW_UA_TIMEZONE.equals(TimeZone.getDefault().getID())) { //$NON-NLS-1$
                 timezoneOverridden = true;
-                TimezoneRegistry.setDefaultZone(ZoneId.of(LEGACY_TIMEZONE)); //$NON-NLS-1$
+                TimezoneRegistry.setDefaultZone(ZoneId.of(LEGACY_UA_TIMEZONE)); //$NON-NLS-1$
             }
             if (conConfig.getConfigurationType() != DBPDriverConfigurationType.URL &&
                 instance instanceof PostgreDatabase &&
@@ -571,8 +571,8 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
 
             throw e;
         } finally {
-            if (timezoneOverridden && LEGACY_TIMEZONE.equals(TimeZone.getDefault().getID())) { //$NON-NLS-1$
-                TimezoneRegistry.setDefaultZone(ZoneId.of(NEW_TIMEZONE)); //$NON-NLS-1$
+            if (timezoneOverridden && LEGACY_UA_TIMEZONE.equals(TimeZone.getDefault().getID())) { //$NON-NLS-1$
+                TimezoneRegistry.setDefaultZone(ZoneId.of(NEW_UA_TIMEZONE)); //$NON-NLS-1$
             }
         }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
@@ -96,8 +96,10 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
     private String activeDatabaseName;
     private PostgreServerExtension serverExtension;
     private String serverVersion;
-
     private volatile boolean hasStatistics;
+
+    private static final String LEGACY_TIMEZONE = "Europe/Kiev";
+    private static final String NEW_TIMEZONE = "Europe/Kyiv";
 
     public PostgreDataSource(DBRProgressMonitor monitor, DBPDataSourceContainer container)
         throws DBException
@@ -500,13 +502,14 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
             log.debug("Initiate connection to " + getServerType().getServerTypeName() + " database [" + instance.getName() + "@" + conConfig.getHostName() + "] for " + purpose);
         }
         boolean timezoneOverridden = false;
+
         try {
             // Old versions of postgres and some linux distributions, on which docker images are made, may not contain
             // new timezone, which will lead to the error while connecting, there is no way to know before connecting
             // so to be sure we will use the old name
-            if ("Europe/Kyiv".equals(TimeZone.getDefault().getID())) { //$NON-NLS-1$
+            if (NEW_TIMEZONE.equals(TimeZone.getDefault().getID())) { //$NON-NLS-1$
                 timezoneOverridden = true;
-                TimezoneRegistry.setDefaultZone(ZoneId.of("Europe/Kiev")); //$NON-NLS-1$
+                TimezoneRegistry.setDefaultZone(ZoneId.of(LEGACY_TIMEZONE)); //$NON-NLS-1$
             }
             if (conConfig.getConfigurationType() != DBPDriverConfigurationType.URL &&
                 instance instanceof PostgreDatabase &&
@@ -568,8 +571,8 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
 
             throw e;
         } finally {
-            if (timezoneOverridden && "Europe/Kiev".equals(TimeZone.getDefault().getID())) { //$NON-NLS-1$
-                TimezoneRegistry.setDefaultZone(ZoneId.of("Europe/Kyiv")); //$NON-NLS-1$
+            if (timezoneOverridden && LEGACY_TIMEZONE.equals(TimeZone.getDefault().getID())) { //$NON-NLS-1$
+                TimezoneRegistry.setDefaultZone(ZoneId.of(NEW_TIMEZONE)); //$NON-NLS-1$
             }
         }
 


### PR DESCRIPTION
Closes dbeaver/dbeaver#18965
Uses old timezone during connection, after connection succeded returns to the new one.