### PR TITLE
#19849 correctly read IPv4 data for modern Clickhouse driver

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/plugin.xml
@@ -126,6 +126,7 @@
             <type kind="NUMERIC"/>
             <type name="BOOL"/>
             <type name="UUID"/>
+            <type name="IPV4"/>
         </provider>
     </extension>
 

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseConstants.java
@@ -24,4 +24,6 @@ public class ClickhouseConstants {
     public static final String SSL_MODE = "sslmode"; //$NON-NLS-1$
 
     public static final String SSL_ROOT_CERTIFICATE = "sslrootcert"; //$NON-NLS-1$
+
+    public static final String DATA_TYPE_IPV4 = "ipv4";
 }

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseSQLDialect.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.ext.clickhouse.model;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.ext.clickhouse.ClickhouseConstants;
 import org.jkiss.dbeaver.ext.generic.model.GenericSQLDialect;
 import org.jkiss.dbeaver.model.DBPDataKind;
 import org.jkiss.dbeaver.model.DBPDataSource;
@@ -24,6 +25,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCDatabaseMetaData;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCDataSource;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
+import org.jkiss.utils.CommonUtils;
 
 import java.util.Arrays;
 
@@ -268,5 +270,16 @@ public class ClickhouseSQLDialect extends GenericSQLDialect {
     @Override
     public char getStringEscapeCharacter() {
         return '\\';
+    }
+
+    @NotNull
+    @Override
+    public String getTypeCastClause(@NotNull DBSTypedObject attribute, String expression, boolean isInCondition) {
+        String typeName = attribute.getTypeName();
+        if (isInCondition && CommonUtils.isNotEmpty(typeName) && ClickhouseConstants.DATA_TYPE_IPV4.equals(typeName.toLowerCase())) {
+            return "IPv4StringToNum(" + expression + ")";
+        } else {
+            return super.getTypeCastClause(attribute, expression, isInCondition);
+        }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClickhouseValueHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClickhouseValueHandlerProvider.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.ext.clickhouse.model.data;
 
+import org.jkiss.dbeaver.ext.clickhouse.ClickhouseConstants;
 import org.jkiss.dbeaver.model.DBPDataKind;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.data.DBDFormatSettings;
@@ -49,7 +50,7 @@ public class ClickhouseValueHandlerProvider implements DBDValueHandlerProvider {
             } else {
                 return new JDBCNumberValueHandler(type, preferences);
             }
-        } else if (dataKind == DBPDataKind.STRING && "ipv4".equals(lowerTypeName)) {
+        } else if (dataKind == DBPDataKind.STRING && ClickhouseConstants.DATA_TYPE_IPV4.equals(lowerTypeName)) {
             return ClikhouseInetTypeValueHandler.INSTANCE;
         }
         return null;

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClickhouseValueHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClickhouseValueHandlerProvider.java
@@ -50,7 +50,7 @@ public class ClickhouseValueHandlerProvider implements DBDValueHandlerProvider {
             } else {
                 return new JDBCNumberValueHandler(type, preferences);
             }
-        } else if (dataKind == DBPDataKind.STRING && ClickhouseConstants.DATA_TYPE_IPV4.equals(lowerTypeName)) {
+        } else if (ClickhouseConstants.DATA_TYPE_IPV4.equals(lowerTypeName)) {
             return ClikhouseInetTypeValueHandler.INSTANCE;
         }
         return null;

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClickhouseValueHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClickhouseValueHandlerProvider.java
@@ -49,8 +49,9 @@ public class ClickhouseValueHandlerProvider implements DBDValueHandlerProvider {
             } else {
                 return new JDBCNumberValueHandler(type, preferences);
             }
-        } else {
-            return null;
+        } else if (dataKind == DBPDataKind.STRING && "ipv4".equals(lowerTypeName)) {
+            return ClikhouseInetTypeValueHandler.INSTANCE;
         }
+        return null;
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClikhouseInetTypeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClikhouseInetTypeValueHandler.java
@@ -1,0 +1,35 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.clickhouse.model.data;
+
+import org.jkiss.dbeaver.model.exec.DBCSession;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.impl.jdbc.data.handlers.JDBCStringValueHandler;
+import org.jkiss.dbeaver.model.struct.DBSTypedObject;
+
+import java.sql.SQLException;
+
+public class ClikhouseInetTypeValueHandler extends JDBCStringValueHandler {
+
+    static final ClikhouseInetTypeValueHandler INSTANCE = new ClikhouseInetTypeValueHandler();
+
+    @Override
+    protected Object fetchColumnValue(DBCSession session, JDBCResultSet resultSet, DBSTypedObject type, int index) throws SQLException {
+        // Use getString instead of getObject to avoid incorrect result of toString method
+        return resultSet.getString(index);
+    }
+}


### PR DESCRIPTION
Please check the modern and legacy drivers.

Expected value - without a slash at the start of the data string.

![2023-09-08 14_51_30-AnyDesk](https://github.com/dbeaver/dbeaver/assets/45152336/60b4e28c-8fd0-4e27-89ad-d357ba592741)
