### PR TITLE
#20923 hide Restore/Backup buttons in the Navigator tree for provider…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/plugin.xml
@@ -195,9 +195,9 @@
                     label="%tools.backup.db.name"
                     icon="#export"
                     singleton="false">
-                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreObject"/>
-                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema"/>
-                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreTableBase"/>
+                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreObject" if="object.dataSource.serverType.supportsNativeClient()"/>
+                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema" if="object.dataSource.serverType.supportsNativeClient()"/>
+                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreTableBase" if="object.dataSource.serverType.supportsNativeClient()"/>
             </tool>
             <tool
                     class="org.jkiss.dbeaver.ext.postgresql.tools.PostgreToolBackupAll"
@@ -206,7 +206,7 @@
                     label="%tools.backup.all.db.name"
                     icon="#export"
                     singleton="false">
-                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase"/>
+                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase" if="object.dataSource.serverType.supportsNativeClient()"/>
             </tool>
             <tool
                     class="org.jkiss.dbeaver.ext.postgresql.tools.PostgreToolRestore"
@@ -215,8 +215,8 @@
                     label="%tools.restore.db.name"
                     icon="#import"
                     singleton="true">
-                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase"/>
-                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema"/>
+                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase" if="object.dataSource.serverType.supportsNativeClient()"/>
+                <objectType name="org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema" if="object.dataSource.serverType.supportsNativeClient()"/>
             </tool>
             <tool
                     class="org.jkiss.dbeaver.ext.postgresql.tools.PostgreToolScript"

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
@@ -217,4 +217,9 @@ public interface PostgreServerExtension {
      * or use standard {@code ALTER VIEW schema.view RENAME TO schema.view_new}.
      */
     boolean supportsAlterTableForViewRename();
+
+    /**
+     * True if database can use pg_dump and pg_restore clients without errors.
+     */
+    boolean supportsNativeClient();
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
@@ -583,4 +583,9 @@ public abstract class PostgreServerExtensionBase implements PostgreServerExtensi
     public boolean supportsAlterTableForViewRename() {
         return false;
     }
+
+    @Override
+    public boolean supportsNativeClient() {
+        return true;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/redshift/PostgreServerRedshift.java
@@ -484,4 +484,9 @@ public class PostgreServerRedshift extends PostgreServerExtensionBase implements
     public boolean supportsAlterTableForViewRename() {
         return true;
     }
+
+    @Override
+    public boolean supportsNativeClient() {
+        return false;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/connection/DBPNativeClientLocationManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/connection/DBPNativeClientLocationManager.java
@@ -31,4 +31,11 @@ public interface DBPNativeClientLocationManager {
     String getProductName(DBPNativeClientLocation location);
 
     String getProductVersion(DBPNativeClientLocation location);
+
+    /**
+     * @return false if provider child doesn't support native clients
+     */
+    default boolean supportsNativeClients() {
+        return true;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.tasks.native.ui/src/org/jkiss/dbeaver/tasks/ui/nativetool/NativeToolConfigPanel.java
+++ b/plugins/org.jkiss.dbeaver.tasks.native.ui/src/org/jkiss/dbeaver/tasks/ui/nativetool/NativeToolConfigPanel.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.Group;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBPDataSourceProvider;
+import org.jkiss.dbeaver.model.connection.DBPDriver;
 import org.jkiss.dbeaver.model.navigator.*;
 import org.jkiss.dbeaver.model.runtime.DBRRunnableContext;
 import org.jkiss.dbeaver.model.struct.DBSObject;
@@ -120,7 +121,9 @@ public abstract class NativeToolConfigPanel<OBJECT_TYPE extends DBSObject> imple
                 @Override
                 protected boolean isDataSourceVisible(DBNDataSource dataSource) {
                     try {
-                        return providerClass.isInstance(dataSource.getDataSourceContainer().getDriver().getDataSourceProvider());
+                        DBPDriver driver = dataSource.getDataSourceContainer().getDriver();
+                        return providerClass.isInstance(driver.getDataSourceProvider()) &&
+                            (driver.getNativeClientManager() != null && driver.getNativeClientManager().supportsNativeClients());
                     } catch (Exception e) {
                         log.debug(e);
                         return false;


### PR DESCRIPTION
hide Restore/Backup buttons in the Navigator tree for providers that do not support them (like Redshift)

Please check the following:

- [x] in the Navigator Tree, there are no "Restore/Backup" options for Redshift on the database level
- [x] in the Navigator Tree, there are no "Restore/Backup" options for Redshift on the schema level
- [x] in the Navigator Tree, there are no "Restore/Backup" options for Redshift on the table level
- [x] in the Navigator Tree, there are "Restore/Backup" options for PostgreSQL and any fork (check any one - Greenplum, or Cockroach, or Yugabyte) on the database level
- [x] in the Navigator Tree, there are "Restore/Backup" options for PostgreSQL and any fork on the schema level
- [x] in the Navigator Tree, there are "Restore/Backup" options for PostgreSQL and any fork on the table level
- [x] in the Create New task menu, you can not choose Redshift connections in the PRO version for dump/restore tasks
- [x] in the Create New task menu, you can choose Postgres and forks connections in the PRO version for dump/restore tasks

![2023-09-11 11_51_48-Window](https://github.com/dbeaver/dbeaver/assets/45152336/8a1ad856-1bd0-4ba6-a45d-9a5a32fb0767)

![2023-09-11 11_53_22-Window](https://github.com/dbeaver/dbeaver/assets/45152336/f344ea53-c22f-4edb-8917-158332fcd9a2)
