### PR TITLE
#17913 Fix json formatting in a separate editor

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/content/ContentPagePart.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/content/ContentPagePart.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.ui.editors.content;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
@@ -35,7 +36,7 @@ import org.jkiss.dbeaver.ui.UIUtils;
  * <p>
  * This can cause severe performance issues when opening several heavyweight parts at once (text editors, etc.).
  */
-public class ContentPagePart extends EditorPart implements IPropertyListener, IActiveWorkbenchPart, IRefreshablePart {
+public class ContentPagePart extends EditorPart implements IPropertyListener, IActiveWorkbenchPart, IRefreshablePart, IAdaptable {
     private final IEditorPart editorPart;
 
     private Composite composite;
@@ -148,5 +149,10 @@ public class ContentPagePart extends EditorPart implements IPropertyListener, IA
         editorPart.init((IEditorSite) getSite(), getEditorInput());
         editorPart.createPartControl(composite);
         composite.layout(true, true);
+    }
+
+    @Override
+    public <T> T getAdapter(Class<T> adapter) {
+        return this.editorPart.getAdapter(adapter);
     }
 }


### PR DESCRIPTION
1. Open some table with json column (for example, 
2. Click on a cell with json data
3. Press Shift + Enter to open separate editor
4. Press Ctrl+Shift+F to format json <- should work