### PR TITLE
#17675 read enum values as database cache; fix data types renaming

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/config/PostgreEnumValueManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/ui/config/PostgreEnumValueManager.java
@@ -16,15 +16,18 @@
  */
 package org.jkiss.dbeaver.ext.postgresql.ui.config;
 
+import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataType;
 import org.jkiss.dbeaver.model.DBValueFormatting;
 import org.jkiss.dbeaver.model.data.DBDDisplayFormat;
 import org.jkiss.dbeaver.model.struct.DBSDataType;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 import org.jkiss.dbeaver.model.struct.DBSTypedObjectEx;
+import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.data.IValueController;
 import org.jkiss.dbeaver.ui.data.managers.EnumValueManager;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +35,9 @@ import java.util.List;
  * PostgreSQL ENUM value manager
  */
 public class PostgreEnumValueManager extends EnumValueManager {
+
+    private static final Log log = Log.getLog(PostgreEnumValueManager.class);
+
     @Override
     protected boolean isMultiValue(IValueController valueController) {
         return false;
@@ -49,12 +55,18 @@ public class PostgreEnumValueManager extends EnumValueManager {
         if (dataType == null) {
             return null;
         }
-        final Object[] values = dataType.getEnumValues();
-        if (values == null) {
+        PostgreDataType finalDataType = dataType;
+        final Object[][] values = new Object[1][1];
+        try {
+            UIUtils.runInProgressService(monitor -> values[0] = finalDataType.getEnumValues(monitor));
+        } catch (InvocationTargetException | InterruptedException e) {
+            log.debug("Can't read enum values from " + dataType.getFullTypeName());
+        }
+        if (values[0] == null) {
             return null;
         }
-        List<String> strValues = new ArrayList<>(values.length);
-        for (Object value : values) {
+        List<String> strValues = new ArrayList<>(values[0].length);
+        for (Object value : values[0]) {
             strValues.add(DBValueFormatting.getDefaultValueDisplayString(value, DBDDisplayFormat.UI));
         }
         return strValues;

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataType.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataType.java
@@ -33,6 +33,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCObjectCache;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCDataType;
 import org.jkiss.dbeaver.model.meta.ForTest;
+import org.jkiss.dbeaver.model.meta.IPropertyValueValidator;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.meta.PropertyLength;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
@@ -49,7 +50,7 @@ import java.util.*;
  * PostgreTypeType
  */
 public class PostgreDataType extends JDBCDataType<PostgreSchema> 
-    implements PostgreClass, PostgreScriptObject, DBPQualifiedObject, DBPImageProvider, DBSBindableDataType {
+    implements PostgreClass, PostgreScriptObject, DBPQualifiedObject, DBPImageProvider, DBSBindableDataType, DBPNamedObject2 {
 
     private static final Log log = Log.getLog(PostgreDataType.class);
 
@@ -205,7 +206,7 @@ public class PostgreDataType extends JDBCDataType<PostgreSchema>
         this.attributeCache = hasAttributes() ? new AttributeCache() : null;
 
         if (typeCategory == PostgreTypeCategory.E) {
-            readEnumValues(session);
+            readEnumValues(session.getProgressMonitor());
         }
         description = JDBCUtils.safeGetString(dbResult, "description"); //$NON-NLS-1$
     }
@@ -303,23 +304,14 @@ public class PostgreDataType extends JDBCDataType<PostgreSchema>
         this.extraDataType = extraDataType;
     }
 
-    private void readEnumValues(JDBCSession session) throws DBException {
-        try (JDBCPreparedStatement dbStat = session.prepareStatement(
-            "SELECT e.enumlabel \n" +
-                "FROM pg_catalog.pg_enum e\n" +
-                "WHERE e.enumtypid=?\n" +
-                "ORDER BY e.enumsortorder")) {
-            dbStat.setLong(1, getObjectId());
-            try (JDBCResultSet rs = dbStat.executeQuery()) {
-                List<String> values = new ArrayList<>();
-                while (rs.nextRow()) {
-                    values.add(JDBCUtils.safeGetString(rs, 1));
-                }
-                enumValues = values.toArray();
-            }
-        } catch (SQLException e) {
-            throw new DBException("Error reading enum values", e, getDataSource());
-        }
+    private void readEnumValues(@NotNull DBRProgressMonitor monitor) throws DBException {
+        List<PostgreEnumValue> cachedObjects = getDatabase().getEnumValueCache()
+            .getAllObjects(monitor, getDatabase());
+        enumValues = cachedObjects.stream()
+            .filter(e -> e.getEnumTypId() == getObjectId())
+            .sorted(Comparator.comparing(PostgreEnumValue::getEnumSortOrder))
+            .map(PostgreEnumValue::getEnumLabel)
+            .toArray();
     }
 
     public static String[] getOidTypes() {
@@ -327,7 +319,7 @@ public class PostgreDataType extends JDBCDataType<PostgreSchema>
     }
 
     @Override
-    @Property(viewable = true, order = 1)
+    @Property(viewable = true, editable = true, order = 1)
     public String getName() {
         return super.getName();
     }
@@ -626,16 +618,23 @@ public class PostgreDataType extends JDBCDataType<PostgreSchema>
         if (attributeCache != null) {
             attributeCache.clearCache();
         }
-        if (typeCategory == PostgreTypeCategory.E) {
-            try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Refresh enum values")) {
-                readEnumValues(session);
-            }
+        if (enumValues != null) {
+            getDatabase().getEnumValueCache().clearCache();
+            enumValues = null;
         }
         return this;
     }
 
-    @Property(viewable = true, optional = true, order = 16)
-    public Object[] getEnumValues() {
+    @Property(viewable = true, order = 16, visibleIf = EnumTypeValidator.class)
+    public Object[] getEnumValues(DBRProgressMonitor monitor) {
+        if (typeCategory == PostgreTypeCategory.E && enumValues == null) {
+            try {
+                readEnumValues(monitor);
+            } catch (DBException e) {
+                log.error("Can't read enum values of type " + getFullTypeName());
+                enumValues = new Object[]{0};
+            }
+        }
         return enumValues;
     }
 
@@ -1078,6 +1077,13 @@ public class PostgreDataType extends JDBCDataType<PostgreSchema>
             name,
             typeLength,
             dbResult);
+    }
+
+    public static class EnumTypeValidator implements IPropertyValueValidator<PostgreDataType, Object> {
+        @Override
+        public boolean isValidValue(PostgreDataType object, Object value) throws IllegalArgumentException {
+            return object.getTypeCategory() == PostgreTypeCategory.E;
+        }
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreEnumValue.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreEnumValue.java
@@ -1,0 +1,100 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.utils.CommonUtils;
+
+public class PostgreEnumValue implements PostgreObject {
+
+    private PostgreDataSource dataSource;
+    private PostgreDatabase database;
+
+    private long oid;
+    private long enumTypId;
+    private long enumSortOrder;
+    private String enumLabel;
+
+    public PostgreEnumValue(@NotNull PostgreDataSource dataSource, @NotNull PostgreDatabase database, @NotNull JDBCResultSet dbResult) {
+        this.dataSource = dataSource;
+        this.database = database;
+        this.oid = JDBCUtils.safeGetLong(dbResult, "oid");
+        this.enumTypId = JDBCUtils.safeGetLong(dbResult, "enumtypid");
+        this.enumSortOrder = JDBCUtils.safeGetLong(dbResult, "enumsortorder");
+        this.enumLabel = JDBCUtils.safeGetString(dbResult, "enumlabel");
+    }
+
+    @Nullable
+    @Override
+    public DBSObject getParentObject() {
+        return database;
+    }
+
+    @NotNull
+    @Override
+    public PostgreDataSource getDataSource() {
+        return dataSource;
+    }
+
+    @NotNull
+    @Override
+    public PostgreDatabase getDatabase() {
+        return database;
+    }
+
+    @NotNull
+    @Override
+    public String getName() {
+        return CommonUtils.toString(enumTypId);
+    }
+
+    public long getOid() {
+        return oid;
+    }
+
+    public long getEnumTypId() {
+        return enumTypId;
+    }
+
+    public long getEnumSortOrder() {
+        return enumSortOrder;
+    }
+
+    public String getEnumLabel() {
+        return enumLabel;
+    }
+
+    @Nullable
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public long getObjectId() {
+        return oid;
+    }
+
+    @Override
+    public boolean isPersisted() {
+        return true;
+    }
+}


### PR DESCRIPTION
Now, we read the enum's list with all data types together. One query instead of many.

Was

![2023-09-13 22_32_59-DBeaver Enterprise 21 3 4 - _none_ Script-83](https://github.com/dbeaver/dbeaver/assets/45152336/5c91ff52-e30c-4bcf-916c-615feadd40ac)

Now

![2023-09-13 23_47_29-DBeaver Ultimate 23 2 0 - enum_type_7](https://github.com/dbeaver/dbeaver/assets/45152336/724112b7-5287-4ccf-8745-78feddbba166)

So, please check:

- [x] Enum data values are still viewable for enum data types
- [x] Enum data values are still not viewable for not enum data types
- [x] Enum data types refreshing
- [x] Data types renaming via UI
- [x] Connection and data types reading (just check your Qqery manager) - for forks (Redshift, Cockroach, etc.)

