### PR TITLE
#19054 use global store for native tasks; do not fix file names patte…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreDatabaseRestoreSettings.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreDatabaseRestoreSettings.java
@@ -26,7 +26,6 @@ import org.jkiss.dbeaver.model.preferences.DBPPreferenceMap;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
 import org.jkiss.dbeaver.model.runtime.DBRRunnableContext;
 import org.jkiss.dbeaver.model.struct.DBSObject;
-
 import org.jkiss.utils.CommonUtils;
 
 import java.lang.reflect.InvocationTargetException;
@@ -90,36 +89,37 @@ public class PostgreDatabaseRestoreSettings extends PostgreBackupRestoreSettings
         noOwner = store.getBoolean("pg.restore.noOwner");
         createDatabase = store.getBoolean("pg.restore.createDatabase");
 
+        String catalogId = null;
         if (store instanceof DBPPreferenceMap) {
-            String catalogId = store.getString("pg.restore.database");
-
-            if (!CommonUtils.isEmpty(catalogId)) {
-                try {
-                    runnableContext.run(true, true, monitor -> {
-                        try {
-                            PostgreDatabase database = (PostgreDatabase) DBUtils.findObjectById(monitor, getProject(), catalogId);
-                            if (database == null) {
-                                throw new DBException("Database " + catalogId + " not found");
-                            }
-                            restoreInfo = new PostgreDatabaseRestoreInfo(database);
-                        } catch (Throwable e) {
-                            throw new InvocationTargetException(e);
+            catalogId = store.getString("pg.restore.database");
+        }
+        if (!CommonUtils.isEmpty(catalogId)) {
+            try {
+                String finalCatalogId = catalogId;
+                runnableContext.run(true, true, monitor -> {
+                    try {
+                        PostgreDatabase database = (PostgreDatabase) DBUtils.findObjectById(monitor, getProject(), finalCatalogId);
+                        if (database == null) {
+                            throw new DBException("Database " + finalCatalogId + " not found");
                         }
-                    });
-                } catch (InvocationTargetException e) {
-                    log.error("Error loading objects configuration", e);
-                } catch (InterruptedException e) {
-                    // Ignore
-                }
-            } else {
-                for (DBSObject object : getDatabaseObjects()) {
-                    if (object instanceof PostgreSchema) {
-                        object = ((PostgreSchema) object).getDatabase();
-                    } 
-                    if (object instanceof PostgreDatabase) {
-                        restoreInfo = new PostgreDatabaseRestoreInfo((PostgreDatabase) object);
-                        break;
+                        restoreInfo = new PostgreDatabaseRestoreInfo(database);
+                    } catch (Throwable e) {
+                        throw new InvocationTargetException(e);
                     }
+                });
+            } catch (InvocationTargetException e) {
+                log.error("Error loading objects configuration", e);
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+        } else {
+            for (DBSObject object : getDatabaseObjects()) {
+                if (object instanceof PostgreSchema) {
+                    object = ((PostgreSchema) object).getDatabase();
+                }
+                if (object instanceof PostgreDatabase) {
+                    restoreInfo = new PostgreDatabaseRestoreInfo((PostgreDatabase) object);
+                    break;
                 }
             }
         }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreScriptExecuteSettings.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreScriptExecuteSettings.java
@@ -47,32 +47,33 @@ public class PostgreScriptExecuteSettings extends AbstractScriptExecuteSettings<
     @Override
     public void loadSettings(DBRRunnableContext runnableContext, DBPPreferenceStore store) throws DBException {
         super.loadSettings(runnableContext, store);
+        String databaseId = null;
         if (store instanceof DBPPreferenceMap) {
-            String databaseId = store.getString("pg.script.database");
-
-            if (!CommonUtils.isEmpty(databaseId)) {
-                try {
-                    runnableContext.run(true, true, monitor -> {
-                        try {
-                            database = (PostgreDatabase) DBUtils.findObjectById(monitor, getProject(), databaseId);
-                            if (database == null) {
-                                throw new DBException("Database " + databaseId + " not found");
-                            }
-                        } catch (Throwable e) {
-                            throw new InvocationTargetException(e);
+            databaseId = store.getString("pg.script.database");
+        }
+        if (!CommonUtils.isEmpty(databaseId)) {
+            try {
+                String finalDatabaseId = databaseId;
+                runnableContext.run(true, true, monitor -> {
+                    try {
+                        database = (PostgreDatabase) DBUtils.findObjectById(monitor, getProject(), finalDatabaseId);
+                        if (database == null) {
+                            throw new DBException("Database " + finalDatabaseId + " not found");
                         }
-                    });
-                } catch (InvocationTargetException e) {
-                    log.error("Error loading objects configuration", e);
-                } catch (InterruptedException e) {
-                    // Ignore
-                }
-            } else {
-                for (DBSObject object : getDatabaseObjects()) {
-                    if (object instanceof PostgreDatabase) {
-                        database = (PostgreDatabase) object;
-                        break;
+                    } catch (Throwable e) {
+                        throw new InvocationTargetException(e);
                     }
+                });
+            } catch (InvocationTargetException e) {
+                log.error("Error loading objects configuration", e);
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+        } else {
+            for (DBSObject object : getDatabaseObjects()) {
+                if (object instanceof PostgreDatabase) {
+                    database = (PostgreDatabase) object;
+                    break;
                 }
             }
         }

--- a/plugins/org.jkiss.dbeaver.tasks.native.ui/src/org/jkiss/dbeaver/tasks/ui/nativetool/AbstractNativeToolWizard.java
+++ b/plugins/org.jkiss.dbeaver.tasks.native.ui/src/org/jkiss/dbeaver/tasks/ui/nativetool/AbstractNativeToolWizard.java
@@ -74,7 +74,12 @@ public abstract class AbstractNativeToolWizard<SETTINGS extends AbstractNativeTo
 
     public AbstractNativeToolWizard(@NotNull DBTTask task) {
         super(task);
-        this.preferenceStore = new TaskPreferenceStore(task);
+        if (isToolTask()) {
+            // Use global store for tool tasks
+            this.preferenceStore = DBWorkbench.getPlatform().getPreferenceStore();
+        } else {
+            this.preferenceStore = new TaskPreferenceStore(task);
+        }
         this.settings = createSettings();
         this.taskTitle = task.getType().getName();
         this.logPage = new NativeToolWizardPageLog(taskTitle);

--- a/plugins/org.jkiss.dbeaver.tasks.native.ui/src/org/jkiss/dbeaver/tasks/ui/nativetool/AbstractNativeToolWizardPage.java
+++ b/plugins/org.jkiss.dbeaver.tasks.native.ui/src/org/jkiss/dbeaver/tasks/ui/nativetool/AbstractNativeToolWizardPage.java
@@ -108,7 +108,6 @@ public abstract class AbstractNativeToolWizardPage<WIZARD extends AbstractNative
             new StringContentProposalProvider(Arrays.stream(NativeToolUtils.LIMITED_VARIABLES)
                 .map(GeneralUtils::variablePattern)
                 .toArray(String[]::new)));
-        fixOutputFileExtension();
     }
 
     protected void createExtraArgsInput(Composite outputGroup) {


### PR DESCRIPTION
use the global store for native tasks; 
do not fix file name patterns after loading

Please check the following:

- [x] settings saving between native clients wizards using (restore, backup, MySQL, Postgres) 
- [x] case from the ticket
- [x] again https://github.com/dbeaver/dbeaver/issues/21283
- [x] like https://github.com/dbeaver/dbeaver/issues/21283 but for "Execute script" for PostgreSQL