### PR TITLE
dbeaver/pro#1438 fix quoted schemas/tables DDL reading

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumUtils.java
@@ -23,6 +23,7 @@ import org.jkiss.dbeaver.ext.postgresql.PostgreUtils;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableColumn;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableConstraint;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableReal;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
@@ -115,8 +116,10 @@ public class GreenplumUtils {
     private static String getPartitionData(@NotNull DBRProgressMonitor monitor, @NotNull PostgreTableReal table) throws DBCException {
         try (JDBCSession session = DBUtils.openMetaSession(monitor, table, "Read Greenplum table partition data")) {
             try (JDBCStatement dbStat = session.createStatement()) {
-                try (JDBCResultSet dbResult = dbStat.executeQuery("SELECT pg_get_partition_def('" + table.getSchema().getName() + "." + table.getName() + "'::regclass, true, false);")) {
-                    if (dbResult.next()) {
+                try (JDBCResultSet dbResult = dbStat.executeQuery("SELECT pg_get_partition_def('" +
+                    table.getFullyQualifiedName(DBPEvaluationContext.DDL) + "'::regclass, true, false);")
+                ) {
+                    if (dbResult != null && dbResult.next()) {
                         String result = dbResult.getString(1);
                         if (result != null && result.startsWith("PARTITION ")) {
                             return result;

--- a/test/org.jkiss.dbeaver.ext.greenplum.test/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTableTest.java
+++ b/test/org.jkiss.dbeaver.ext.greenplum.test/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumTableTest.java
@@ -79,6 +79,7 @@ public class GreenplumTableTest {
         Mockito.when(mockSchema.getName()).thenReturn(exampleSchemaName);
         Mockito.when(mockSchema.getTableCache()).thenReturn(mockTableCache);
         Mockito.when(mockSchema.getConstraintCache()).thenReturn(mockConstraintCache);
+        Mockito.when(mockSchema.getDatabase()).thenReturn(mockDatabase);
 
         Mockito.when(mockDataSource.getSQLDialect()).thenReturn(new PostgreDialect());
         Mockito.when(mockDataSource.isServerVersionAtLeast(Mockito.anyInt(), Mockito.anyInt())).thenReturn(false);


### PR DESCRIPTION
![2023-10-10 12_09_29-DBeaver Ultimate 23 2 2 - rptHist_ProductionDMRLine](https://github.com/dbeaver/dbeaver/assets/45152336/d67f631c-54ea-4896-8bcb-505eba856eb1)

Please check the DDL reading for quoted/unquoted schemas and for quoted/unquoted tables.

```sql
CREATE TABLE "BlaB#"."rptHist_ProductionDMRLine" (
	city_id int4 NULL,
	date_num date NULL,
	amount_num int4 NULL
)
DISTRIBUTED BY (city_id)
PARTITION BY RANGE(date_num) 
          (
          START ('2008-01-01'::date) END ('2009-01-01'::date) EVERY ('1 day'::interval)
          );
```
