### PR TITLE
#21488 fix incorrect keywords order for generated SQL for foreign keys

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreForeignKeyManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreForeignKeyManager.java
@@ -90,12 +90,6 @@ public class PostgreForeignKeyManager extends SQLForeignKeyManager<PostgreTableF
             }
         }*/
         StringBuilder sql = super.getNestedDeclaration(monitor, owner, command, options);
-
-        if (fk.getMatchType().equals(PostgreTableForeignKey.MatchType.f)) {
-            //Foreign key match types: f = full, p = partial (not implemented yet), s = simple (u == s in old PG versions - default value)
-            sql.append(" MATCH FULL");
-        }
-
         if (fk.isDeferrable()) {
             sql.append(" DEFERRABLE");
         }
@@ -104,6 +98,15 @@ public class PostgreForeignKeyManager extends SQLForeignKeyManager<PostgreTableF
         }
 
         return sql;
+    }
+
+    @Override
+    protected void appendUpdateDeleteRule(PostgreTableForeignKey foreignKey, StringBuilder decl) {
+        if (foreignKey.getMatchType().equals(PostgreTableForeignKey.MatchType.f)) {
+            //Foreign key match types: f = full, p = partial (not implemented yet), s = simple (u == s in old PG versions - default value)
+            decl.append(" MATCH FULL");
+        }
+        super.appendUpdateDeleteRule(foreignKey, decl);
     }
 
     @Override


### PR DESCRIPTION
![2023-10-10 16_59_20-DBeaver Ultimate 23 2 2 - tbl_example](https://github.com/dbeaver/dbeaver/assets/45152336/61c7fa71-63b8-4d28-a5bb-a543fb6e217f)
