### PR TITLE
Update error msg for windows download failed due to cert error

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.properties
@@ -202,9 +202,9 @@ dialog_driver_download_auto_page_driver_security_warning = Security warning
 dialog_driver_download_auto_page_driver_security_warning_msg = Library "{0}" was not found in any secure repositories.\nOnly a non-secure version is available: {1}.\n\nNon-secure repositories are not recommended because of the risk of a malware infection.\n\nAre you sure you want to proceed?
 dialog_driver_download_auto_page_download_rate = Download {0}/{1}
 dialog_driver_download_auto_page_download_failed_msg = Driver file download failed.\nDo you want to retry?
-dialog_driver_download_auto_page_download_failed_cert_msg = Driver file download failed due to certificate issue.\nTry changing the setting `Use Windows trust store` in Preferences->Connections and restart DBeaver. It might help if you haven't overridden trust store.\nDo you want to retry?
+dialog_driver_download_auto_page_download_failed_cert_msg = Driver file download failed due to certificate issue.
 dialog_driver_download_network_unavailable_msg = Network unavailable
-dialog_driver_download_network_unavailable_cert_msg = Network unavailable due to certificate issue.\nTry changing the setting `Use Windows trust store` in Preferences->Connections and restart DBeaver. It might help if you haven't overridden trust store.
+dialog_driver_download_network_unavailable_cert_msg = Network unavailable due to certificate issue.
 ## Driver download ##
 viewer_selector_control_text_classic=Classic
 viewer_selector_control_text_gallery=Gallery


### PR DESCRIPTION
On commnunity version, dbeaver Custom Truststore feature is not avaliable. Removing the relative message to prevent misleading the users.

Reference: https://github.com/dbeaver/dbeaver/wiki/Managing-Truststore-Settings