### PR TITLE
dbeaver/pro#1971 skip parameter numbers used instead names in old PG versions

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreProcedure.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreProcedure.java
@@ -788,7 +788,12 @@ public class PostgreProcedure extends AbstractProcedure<PostgreDataSource, Postg
                 parameter.add(param.getArgumentMode().getKeyword());
             }
             if (showParamNames) {
-                parameter.add(param.getName());
+                String paramName = param.getName();
+                if (forDDL && paramName.startsWith("$")) {
+                    // Old PG versions. Skip this specific case, because it is not name, but param order number
+                } else {
+                    parameter.add(paramName);
+                }
             }
             final PostgreDataType dataType = param.getParameterType();
             final PostgreSchema typeContainer = dataType.getParentObject();


### PR DESCRIPTION
Please check procedures DDLs with parameter names and without (just data types) in PG and in our Greenplum. You can check Redshift just to avoid many problems again.