### PR TITLE
#21151 do not update attribute names for quoted attributes

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseConsumerPageMapping.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseConsumerPageMapping.java
@@ -923,7 +923,7 @@ public class DatabaseConsumerPageMapping extends DataTransferPageNodeSettings {
                 } else {
                     DatabaseMappingAttribute attrMapping = (DatabaseMappingAttribute) mapping;
                     DBPDataSource targetDataSource = settings.getTargetDataSource(mapping);
-                    if (targetDataSource != null) {
+                    if (targetDataSource != null && updateAttributesNames) {
                         name = DBUtils.getUnQuotedIdentifier(targetDataSource, name);
                     }
                     if (attrMapping.getParent().getTarget() instanceof DBSEntity) {

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseMappingAttribute.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseMappingAttribute.java
@@ -149,7 +149,7 @@ public class DatabaseMappingAttribute implements DatabaseMappingObject {
         this.mappingType = mappingType;
         switch (mappingType) {
             case create:
-                targetName = getSourceLabelOrName(getSource(), true);
+                targetName = getSourceLabelOrName(getSource(), true, false);
                 break;
         }
     }
@@ -167,7 +167,7 @@ public class DatabaseMappingAttribute implements DatabaseMappingObject {
         mappingType = DatabaseMappingType.unspecified;
         if (parent.getTarget() instanceof DBSEntity) {
             if (forceRefresh || CommonUtils.isEmpty(targetName)) {
-                targetName = getSourceLabelOrName(source, false);
+                targetName = getSourceLabelOrName(source, false, updateAttributesNames);
             }
             DBSEntity targetEntity = (DBSEntity) parent.getTarget();
             List<? extends DBSEntityAttribute> targetAttributes = targetEntity.getAttributes(monitor);
@@ -233,9 +233,9 @@ public class DatabaseMappingAttribute implements DatabaseMappingObject {
             if (forceRefresh || CommonUtils.isEmpty(targetName)) {
                 if (!updateAttributesNames && CommonUtils.isNotEmpty(targetName)) {
                     // We want to keep targetName in this case. It can be the targetName from a task as example
-                    targetName = getSourceLabelOrName(targetName, false);
+                    targetName = getSourceLabelOrName(targetName, false, false);
                 } else {
-                    targetName = getSourceLabelOrName(source, true);
+                    targetName = getSourceLabelOrName(source, true, updateAttributesNames);
                 }
             }
         }
@@ -251,7 +251,7 @@ public class DatabaseMappingAttribute implements DatabaseMappingObject {
                     DBUtils.isQuotedIdentifier(targetDataSource, targetName) || isSkipNameTransformation());
             }
         } else if (mappingType == DatabaseMappingType.unspecified && source != null && targetName != null) {
-            String sourceLabelOrName = getSourceLabelOrName(source, false);
+            String sourceLabelOrName = getSourceLabelOrName(source, false, updateAttributesNames);
             if (sourceLabelOrName != null && sourceLabelOrName.equalsIgnoreCase(targetName) && !sourceLabelOrName.equals(targetName)) {
                 // Here we change the target name if we switched from target container with identifier case X to container with identifier case Y
                 // See https://github.com/dbeaver/dbeaver/issues/13236
@@ -260,11 +260,11 @@ public class DatabaseMappingAttribute implements DatabaseMappingObject {
         }
     }
 
-    String getSourceLabelOrName(DBSAttributeBase source, boolean addSpecialTransformation) {
-        return getSourceLabelOrName(getSourceAttributeName(source), addSpecialTransformation);
+    String getSourceLabelOrName(DBSAttributeBase source, boolean addSpecialTransformation, boolean updateAttributesNames) {
+        return getSourceLabelOrName(getSourceAttributeName(source), addSpecialTransformation, updateAttributesNames);
     }
 
-    private String getSourceLabelOrName(String name, boolean addSpecialTransformation) {
+    private String getSourceLabelOrName(String name, boolean addSpecialTransformation, boolean updateAttributesNames) {
         DBSObjectContainer container = parent.getSettings().getContainer();
 
         if (container != null && container.getDataSource() != null) {
@@ -272,7 +272,7 @@ public class DatabaseMappingAttribute implements DatabaseMappingObject {
                 name = DatabaseTransferUtils.getTransformedName(
                     container.getDataSource(),
                     name,
-                    DBUtils.isQuotedIdentifier(container.getDataSource(), name) || isSkipNameTransformation());
+                    DBUtils.isQuotedIdentifier(container.getDataSource(), name) || isSkipNameTransformation() || !updateAttributesNames);
             } else if (!DBUtils.isQuotedIdentifier(container.getDataSource(), name) && !isSkipNameTransformation()) {
                 name = DBObjectNameCaseTransformer.transformName(container.getDataSource(), name);
             }

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseMappingContainer.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseMappingContainer.java
@@ -227,7 +227,8 @@ public class DatabaseMappingContainer implements DatabaseMappingObject {
     DatabaseMappingAttribute getAttributeMapping(@NotNull DBDAttributeBinding sourceAttr) {
         return CommonUtils.findBestCaseAwareMatch(
             attributeMappings,
-            CommonUtils.notNull(sourceAttr.getLabel(), sourceAttr.getName()), attr -> attr.getSourceLabelOrName(attr.getSource(), false));
+            CommonUtils.notNull(sourceAttr.getLabel(), sourceAttr.getName()),
+            attr -> attr.getSourceLabelOrName(attr.getSource(), false, false));
     }
 
     /**
@@ -286,7 +287,7 @@ public class DatabaseMappingContainer implements DatabaseMappingObject {
                 DBSAttributeBase sourceAttr = attrMapping.getSource();
                 if (sourceAttr != null) {
                     Map<String, Object> attrSettings = new LinkedHashMap<>();
-                    attrsSection.put(attrMapping.getSourceLabelOrName(sourceAttr, false), attrSettings);
+                    attrsSection.put(attrMapping.getSourceLabelOrName(sourceAttr, false, false), attrSettings);
                     attrMapping.saveSettings(attrSettings);
                 }
             }
@@ -339,7 +340,7 @@ public class DatabaseMappingContainer implements DatabaseMappingObject {
                     if (sourceAttr != null) {
                         Map<String, Object> attrSettings = JSONUtils.getObject(
                             attrsSection,
-                            attrMapping.getSourceLabelOrName(sourceAttr, false));
+                            attrMapping.getSourceLabelOrName(sourceAttr, false, false));
                         if (!attrSettings.isEmpty()) {
                             attrMapping.loadSettings(attrSettings);
                         }

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferUtils.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferUtils.java
@@ -267,7 +267,7 @@ public class DatabaseTransferUtils {
      *
      * @param dataSource for preferences and dialect info
      * @param targetName name for transformation
-     * @param skipCaseChanging true if we do not want to change name case
+     * @param skipCaseChanging true if we do not want to change name case of the original name
      * @return transformed target name (container or attribute)
      */
     @NotNull


### PR DESCRIPTION
![2023-10-31 13_14_36-Data Transfer](https://github.com/dbeaver/dbeaver/assets/45152336/41e6d318-93eb-43ac-8617-e407ba3da1f7)

![2023-10-31 14_16_45-Data Transfer](https://github.com/dbeaver/dbeaver/assets/45152336/75c8ef23-5af2-4c8f-a5a8-495281cdf419)

You need to test many cases. With different upper/camel/lower case attribute names. Names like keywords or with special symbols inside. From lower case databases to upper case. And back. From CSV files.
