### PR TITLE
#4478 add indexes for materialized views with ability to create/drop …

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/plugin.xml
@@ -134,6 +134,12 @@
                                         </items>
                                     </items>
                                 </folder>
+                                <folder type="org.jkiss.dbeaver.ext.oracle.model.OracleTableIndex" label="%tree.indexes.node.name" icon="#indexes" description="Materialized View indexes">
+                                    <items label="%tree.index.node.name" path="index" property="indexes" icon="#index">
+                                        <items label="%tree.index_columns.node.name" itemLabel="%tree.column.node.name" path="column" property="attributeReferences" navigable="false" inline="true">
+                                        </items>
+                                    </items>
+                                </folder>
                             </items>
                         </folder>
                         <folder type="org.jkiss.dbeaver.ext.oracle.model.OracleTableIndex" label="%tree.indexes.node.name" icon="#indexes" description="%tree.indexes.node.tip" virtual="true">

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleIndexManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleIndexManager.java
@@ -18,8 +18,8 @@
 package org.jkiss.dbeaver.ext.oracle.edit;
 
 import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.ext.oracle.model.OracleTableBase;
 import org.jkiss.dbeaver.ext.oracle.model.OracleTableIndex;
-import org.jkiss.dbeaver.ext.oracle.model.OracleTablePhysical;
 import org.jkiss.dbeaver.model.edit.DBECommandContext;
 import org.jkiss.dbeaver.model.impl.sql.edit.struct.SQLIndexManager;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
@@ -32,21 +32,23 @@ import java.util.Map;
 /**
  * Oracle index manager
  */
-public class OracleIndexManager extends SQLIndexManager<OracleTableIndex, OracleTablePhysical> {
+public class OracleIndexManager extends SQLIndexManager<OracleTableIndex, OracleTableBase> {
 
     @Nullable
     @Override
-    public DBSObjectCache<? extends DBSObject, OracleTableIndex> getObjectsCache(OracleTableIndex object)
-    {
+    public DBSObjectCache<? extends DBSObject, OracleTableIndex> getObjectsCache(OracleTableIndex object) {
         return object.getParentObject().getSchema().indexCache;
     }
 
     @Override
     protected OracleTableIndex createDatabaseObject(
-        DBRProgressMonitor monitor, DBECommandContext context, final Object container,
-        Object from, Map<String, Object> options)
-    {
-        OracleTablePhysical table = (OracleTablePhysical) container;
+        DBRProgressMonitor monitor,
+        DBECommandContext context,
+        final Object container,
+        Object from,
+        Map<String, Object> options
+    ) {
+        OracleTableBase table = (OracleTableBase) container;
 
         return new OracleTableIndex(
             table.getSchema(),
@@ -57,8 +59,7 @@ public class OracleIndexManager extends SQLIndexManager<OracleTableIndex, Oracle
     }
 
     @Override
-    protected String getDropIndexPattern(OracleTableIndex index)
-    {
+    protected String getDropIndexPattern(OracleTableIndex index) {
         return "DROP INDEX " + PATTERN_ITEM_INDEX; //$NON-NLS-1$ //$NON-NLS-2$
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleMaterializedView.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleMaterializedView.java
@@ -28,6 +28,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.meta.Association;
 import org.jkiss.dbeaver.model.meta.LazyProperty;
 import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.meta.PropertyGroup;
@@ -39,6 +40,7 @@ import org.jkiss.utils.CommonUtils;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 
@@ -293,6 +295,17 @@ public class OracleMaterializedView extends OracleTableBase implements OracleSou
     }
 
     @Override
+    @Association
+    public Collection<OracleTableIndex> getIndexes(DBRProgressMonitor monitor) throws DBException {
+        return this.getContainer().indexCache.getObjects(monitor, getContainer(), this);
+    }
+
+    @Association
+    public OracleTableIndex getIndex(DBRProgressMonitor monitor, String name) throws DBException {
+        return this.getContainer().indexCache.getObject(monitor, getContainer(), this, name);
+    }
+
+    @Override
     protected String getTableTypeName() {
         return "MATERIALIZED_VIEW";
     }
@@ -309,6 +322,7 @@ public class OracleMaterializedView extends OracleTableBase implements OracleSou
     public DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException
     {
         getContainer().constraintCache.clearObjectCache(this);
+        getContainer().indexCache.clearObjectCache(this);
 
         return getContainer().tableCache.refreshObject(monitor, getContainer(), this);
     }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSchema.java
@@ -1171,15 +1171,15 @@ public class OracleSchema extends OracleGlobalObject implements
     /**
      * Index cache implementation
      */
-    class IndexCache extends JDBCCompositeCache<OracleSchema, OracleTablePhysical, OracleTableIndex, OracleTableIndexColumn> {
+    class IndexCache extends JDBCCompositeCache<OracleSchema, OracleTableBase, OracleTableIndex, OracleTableIndexColumn> {
         IndexCache()
         {
-            super(tableCache, OracleTablePhysical.class, "TABLE_NAME", "INDEX_NAME");
+            super(tableCache, OracleTableBase.class, "TABLE_NAME", "INDEX_NAME");
         }
 
         @NotNull
         @Override
-        protected JDBCStatement prepareObjectsStatement(JDBCSession session, OracleSchema owner, OracleTablePhysical forTable)
+        protected JDBCStatement prepareObjectsStatement(JDBCSession session, OracleSchema owner, OracleTableBase forTable)
             throws SQLException
         {
             StringBuilder sql = new StringBuilder();
@@ -1211,9 +1211,13 @@ public class OracleSchema extends OracleGlobalObject implements
 
         @Nullable
         @Override
-        protected OracleTableIndex fetchObject(JDBCSession session, OracleSchema owner, OracleTablePhysical parent, String indexName, JDBCResultSet dbResult)
-            throws SQLException, DBException
-        {
+        protected OracleTableIndex fetchObject(
+            JDBCSession session,
+            OracleSchema owner,
+            OracleTableBase parent,
+            String indexName,
+            JDBCResultSet dbResult
+        ) throws SQLException, DBException {
             return new OracleTableIndex(owner, parent, indexName, dbResult);
         }
 
@@ -1221,9 +1225,10 @@ public class OracleSchema extends OracleGlobalObject implements
         @Override
         protected OracleTableIndexColumn[] fetchObjectRow(
             JDBCSession session,
-            OracleTablePhysical parent, OracleTableIndex object, JDBCResultSet dbResult)
-            throws SQLException, DBException
-        {
+            OracleTableBase parent,
+            OracleTableIndex object,
+            JDBCResultSet dbResult
+        ) throws DBException {
             String columnName = JDBCUtils.safeGetStringTrimmed(dbResult, "COLUMN_NAME");
             int ordinalPosition = JDBCUtils.safeGetInt(dbResult, "COLUMN_POSITION");
             boolean isAscending = "ASC".equals(JDBCUtils.safeGetStringTrimmed(dbResult, "DESCEND"));

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleTableIndex.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleTableIndex.java
@@ -20,6 +20,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBPNamedObject2;
 import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
@@ -41,8 +42,8 @@ import java.util.Map;
 /**
  * OracleTableIndex
  */
-public class OracleTableIndex extends JDBCTableIndex<OracleSchema, OracleTablePhysical> implements DBSObjectLazy, DBPScriptObject
-{
+public class OracleTableIndex extends JDBCTableIndex<OracleSchema, OracleTableBase>
+    implements DBSObjectLazy, DBPScriptObject, DBPNamedObject2 {
 
     private Object tablespace;
     private boolean nonUnique;
@@ -51,7 +52,7 @@ public class OracleTableIndex extends JDBCTableIndex<OracleSchema, OracleTablePh
 
     public OracleTableIndex(
         OracleSchema schema,
-        OracleTablePhysical table,
+        OracleTableBase table,
         String indexName,
         ResultSet dbResult)
     {
@@ -74,8 +75,7 @@ public class OracleTableIndex extends JDBCTableIndex<OracleSchema, OracleTablePh
         this.tablespace = JDBCUtils.safeGetString(dbResult, "TABLESPACE_NAME");
     }
 
-    public OracleTableIndex(OracleSchema schema, OracleTablePhysical parent, String name, boolean unique, DBSIndexType indexType)
-    {
+    public OracleTableIndex(OracleSchema schema, OracleTableBase parent, String name, boolean unique, DBSIndexType indexType) {
         super(schema, parent, name, indexType, false);
         this.nonUnique = !unique;
 


### PR DESCRIPTION
add indexes for materialized views with the ability to create/drop them

Please check indexes showing/creation/deleting for tables and materialized views

![2023-11-02 13_53_26-DBeaver Ultimate 23 2 4 - TEST_MV_WITH_INDEX](https://github.com/dbeaver/dbeaver/assets/45152336/18104dbe-65d7-4c4a-83c1-ed584e56f62b)

(I'm unsure about the "unique" button for indexes for materialized views, but Oracle has so many versions... may be it supports unique part)
