### PR TITLE
#21757 support conditional NULL/NOT NULL modifiers

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleTableColumnManager.java
@@ -81,9 +81,8 @@ public class OracleTableColumnManager extends SQLTableColumnManager<OracleTableC
         return object.getParentObject().getContainer().tableCache.getChildrenCache(object.getParentObject());
     }
 
-    protected ColumnModifier[] getSupportedModifiers(OracleTableColumn column, Map<String, Object> options)
-    {
-        return new ColumnModifier[] {OracleDataTypeModifier, DefaultModifier, NullNotNullModifier};
+    protected ColumnModifier[] getSupportedModifiers(OracleTableColumn column, Map<String, Object> options) {
+        return new ColumnModifier[]{OracleDataTypeModifier, DefaultModifier, NullNotNullModifierConditional};
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLTableColumnManager.java
@@ -81,7 +81,7 @@ public abstract class SQLTableColumnManager<OBJECT_TYPE extends DBSEntityAttribu
         sql.append(column.isRequired() ? " NOT NULL" : " NULL");
 
     protected final ColumnModifier<OBJECT_TYPE> NullNotNullModifierConditional = (monitor, column, sql, command) -> {
-        if (command instanceof DBECommandComposite) {
+        if (column.isPersisted() && command instanceof DBECommandComposite) {
             if (((DBECommandComposite) command).getProperty("required") == null) {
                 // Do not set NULL/NOT NULL if it wasn't changed
                 return;

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/OracleAlterTableColumnTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/OracleAlterTableColumnTest.java
@@ -82,10 +82,13 @@ public class OracleAlterTableColumnTest {
         oracleTableBase = new OracleTable(testSchema, "TEST_TABLE");
         testColumnVarchar = OracleTestUtils.addColumn(oracleTableBase, "COLUMN1", "VARCHAR", 1);
         testColumnVarchar.setMaxLength(100);
+        testColumnVarchar.setPersisted(true);
         testColumnNumber = OracleTestUtils.addColumn(oracleTableBase, "COLUMN2", "NUMBER", 2);
         testColumnNumber.setPrecision(38);
         testColumnNumber.setScale(0);
+        testColumnNumber.setPersisted(true);
         testColumnChar = OracleTestUtils.addColumn(oracleTableBase, "COLUMN3", "CHAR", 3);
+        testColumnChar.setPersisted(true);
     }
 
     @Test
@@ -146,7 +149,7 @@ public class OracleAlterTableColumnTest {
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
         String expectedDDL =
-            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN1 VARCHAR(100) DEFAULT 'Test value' NULL;" + lineBreak;
+            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN1 VARCHAR(100) DEFAULT 'Test value';" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -163,7 +166,7 @@ public class OracleAlterTableColumnTest {
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
         String expectedDDL =
-            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(38,0) DEFAULT 42 NULL;" + lineBreak;
+            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(38,0) DEFAULT 42;" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -181,7 +184,7 @@ public class OracleAlterTableColumnTest {
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
         String expectedDDL =
-            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN1 VARCHAR(50) DEFAULT 'Test value' NULL;" + lineBreak;
+            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN1 VARCHAR(50) DEFAULT 'Test value';" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -197,7 +200,7 @@ public class OracleAlterTableColumnTest {
 
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
-        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN3 CHAR(33) NULL;" + lineBreak;
+        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN3 CHAR(33);" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -213,7 +216,7 @@ public class OracleAlterTableColumnTest {
 
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
-        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(22,0) NULL;" + lineBreak;
+        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(22,0);" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 
@@ -231,7 +234,29 @@ public class OracleAlterTableColumnTest {
         String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
 
         String expectedDDL =
-            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(38,17) DEFAULT 42 NULL;" + lineBreak;
+            "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN2 NUMBER(38,17) DEFAULT 42;" + lineBreak;
+        Assert.assertEquals(script, expectedDDL);
+    }
+
+    @Test
+    public void generateAlterTableSetNullConditionStatement() throws Exception {
+        TestCommandContext commandContext = new TestCommandContext(executionContext, false);
+
+        PropertySourceEditable pse = new PropertySourceEditable(commandContext, testColumnVarchar, testColumnVarchar);
+        pse.collectProperties();
+        testColumnVarchar.setRequired(true);
+        pse.setPropertyValue(monitor, "required", false);
+
+        List<DBEPersistAction> actions = DBExecUtils.getActionsListFromCommandContext(
+            monitor,
+            commandContext,
+            executionContext,
+            Collections.emptyMap(),
+            null);
+
+        String script = SQLUtils.generateScript(testDataSource, actions.toArray(new DBEPersistAction[0]), false);
+
+        String expectedDDL = "ALTER TABLE TEST_SCHEMA.TEST_TABLE MODIFY COLUMN1 VARCHAR(100) NULL;" + lineBreak;
         Assert.assertEquals(script, expectedDDL);
     }
 


### PR DESCRIPTION
![2023-11-06 10_09_17-NUMBER_ONE - Persist Changes](https://github.com/dbeaver/dbeaver/assets/45152336/be61c240-95eb-4aec-a5e9-c21b647194c9)

Now, the NULL/NOT NULL modifier will be added only if it is changed.

Please check for existing and new columns. 