### PR TITLE
#7760 Handle commit and rollback statements execution in manual commit mode

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQuery.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQuery.java
@@ -21,6 +21,8 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Database;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.Commit;
+import net.sf.jsqlparser.statement.RollbackStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
@@ -205,6 +207,10 @@ public class SQLQuery implements SQLScriptElement {
                 type = SQLQueryType.DDL;
             } else if (statement instanceof Merge) {
                 type = SQLQueryType.MERGE;
+            } else if (statement instanceof Commit) {
+                type = SQLQueryType.COMMIT;
+            } else if (statement instanceof RollbackStatement) {
+                type = SQLQueryType.ROLLBACK;
             } else {
                 type = SQLQueryType.UNKNOWN;
             }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQueryType.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQueryType.java
@@ -28,5 +28,7 @@ public enum SQLQueryType {
     UPDATE,
     MERGE,
     DDL,
-    USE
+    USE,
+    COMMIT,
+    ROLLBACK
 }


### PR DESCRIPTION
Now execution commit and rollback statements should affect transaction manager on the top toolbar in manual commit mode.