### PR TITLE
#21796 use full data types names for user-defined types and keep modi…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreTableColumnManager.java
@@ -207,8 +207,7 @@ public class PostgreTableColumnManager extends SQLTableColumnManager<PostgreTabl
 //        ALTER [ COLUMN ] column SET STORAGE { PLAIN | EXTERNAL | EXTENDED | MAIN }
         String prefix = "ALTER " + table.getTableTypeName() + " " + DBUtils.getObjectFullName(table, DBPEvaluationContext.DDL) +
             " ALTER COLUMN " + DBUtils.getQuotedIdentifier(column) + " ";
-        final PostgreDataType type = column.getDataType();
-        final String fullTypeName = type != null ? DBUtils.getObjectFullName(type, DBPEvaluationContext.DDL) : column.getFullTypeName();
+        final String fullTypeName = column.getFullTypeName();
         String typeClause = fullTypeName;
         if (column.getDataSource().getServerType().supportsAlterTableColumnWithUSING()) {
             typeClause += " USING ";

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreAttribute.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreAttribute.java
@@ -416,10 +416,11 @@ public abstract class PostgreAttribute<OWNER extends DBSEntity & PostgreObject> 
             return getTypeName();
         }
         final PostgreTypeHandler handler = PostgreTypeHandlerProvider.getTypeHandler(dataType);
+        String typeName = dataType.getFullyQualifiedName(DBPEvaluationContext.DDL);
         if (handler != null) {
-            return dataType.getTypeName() + handler.getTypeModifiersString(dataType, typeMod);
+            return typeName + handler.getTypeModifiersString(dataType, typeMod);
         }
-        return dataType.getTypeName();
+        return typeName;
     }
 
     @Override


### PR DESCRIPTION
use full data type names for user-defined types and keep modifiers for standard types

![2023-11-10 12_48_35-album - Persist Changes](https://github.com/dbeaver/dbeaver/assets/45152336/0da47e2e-4a99-4bdb-ad10-f4ae656cd837)

![2023-11-10 12_54_58-DBeaver Ultimate 23 2 4 - album](https://github.com/dbeaver/dbeaver/assets/45152336/c74cbdf0-8200-4458-ba76-2c10a016f141)

![2023-11-10 12_50_35-DBeaver Ultimate 23 2 4 - album](https://github.com/dbeaver/dbeaver/assets/45152336/f5629239-09a4-4dfe-8d6d-be7dfdc59d96)

Data type showing is also changed for the Navigator tree or the tables properties page. 

So, please check

- [x] original request. for different types - standard and user-defined
- [x] this case https://github.com/dbeaver/dbeaver/issues/18409
- [x] and different types modifying
