### PR TITLE
#21898 Don't separate selected region into several queries

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -2504,9 +2504,10 @@ public class SQLEditor extends SQLEditorBase implements
 
         List<SQLScriptElement> elements;
         ITextSelection selection = (ITextSelection) getSelectionProvider().getSelection();
-        if (script ||
-            selection.getLength() > 1 // if we selected several queries - they should not be inside one SQLQuery instance
-        ) {
+        // if we selected several queries and press Run, they're intentionally goes into one SQLQuery
+        // it's a workaround for cases where we can't correctly parse whole query
+        // like in package declarations with multiple statements in body
+        if (script) {
             if (executeFromPosition) {
                 // Get all queries from the current position
                 elements = extractScriptQueries(selection.getOffset(), document.getLength(), true, false, true);

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -2504,7 +2504,7 @@ public class SQLEditor extends SQLEditorBase implements
 
         List<SQLScriptElement> elements;
         ITextSelection selection = (ITextSelection) getSelectionProvider().getSelection();
-        // if we selected several queries and press Run, they're intentionally goes into one SQLQuery
+        // if we select several queries and press Run, they're intentionally goes into one SQLQuery
         // it's a workaround for cases where we can't correctly parse whole query
         // like in package declarations with multiple statements in body
         if (script) {


### PR DESCRIPTION
 I returned back the previous behavior.
In the past sprint I tried to implement the behavior, when we select several queries in single-tab mode and press Run to get multiple results one behind another. However if we start parsing selected region, we broke a workaround for executing queries that we can't parse correctly or that are intentionally should be executed in one batch.