### PR TITLE
#21902 show output panel for statistics tab

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -4836,6 +4836,7 @@ public class SQLEditor extends SQLEditorBase implements
                             // see #16605
                             // But we need to avoid the result tab with the select statement
                             // because the statistics window can not be in focus in this case
+                            results.handleExecuteResult(result);
                             if (getActivePreferenceStore().getBoolean(SQLPreferenceConstants.SET_SELECTION_TO_STATISTICS_TAB) &&
                                 query.getType() != SQLQueryType.SELECT
                             ) {


### PR DESCRIPTION
![2023-11-22 14_51_39-Window](https://github.com/dbeaver/dbeaver/assets/45152336/c3de9d96-abc3-4014-818b-2ee197b943bb)

Important:
SQL Output button must be in the toolbar

Our case is - we have only one result panel, and it is statistic. DBeaver should read and show output in this case as well as for result + output, like for this procedure call:

```sql
CREATE OR REPLACE PROCEDURE pr_test(
    INOUT p_rows INTEGER DEFAULT NULL 
)
AS
$body$
BEGIN
    RAISE NOTICE 'Inside SP, p_rows before modify = %', p_rows;
    p_rows := 100;
    RAISE NOTICE 'Inside SP, p_rows after modify = %', p_rows;
    RETURN;
END
$body$
LANGUAGE 'plpgsql'
;
```

result for: `CALL pr_test();`