### PR TITLE
#21615 Don't show execution results when extracting data

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
@@ -975,8 +975,6 @@ public class SQLQueryJob extends DataSourceJob
             } else {
                 throw new DBCException(lastError, getExecutionContext());
             }
-        } else if (result && statistics.getStatementsCount() > 0) {
-            showExecutionResult(session);
         }
     }
 


### PR DESCRIPTION
It only affects data extraction from the editor, meaning loading data in the editor should work as before.