### PR TITLE
Fix duplicate confirmation of closing when update

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/DBeaverPreferences.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/DBeaverPreferences.java
@@ -33,6 +33,7 @@ public final class DBeaverPreferences
     public static final String TEXT_EDIT_UNDO_LEVEL = "text.edit.undo.level"; //$NON-NLS-1$
 
     public static final String CONFIRM_EXIT = "exit"; //$NON-NLS-1$
+    public static final String CONFIRM_EXIT_TEMPORARY = "temporary_exit"; //$NON-NLS-1$
     public static final String CONFIRM_TXN_DISCONNECT = "disconnect_txn"; //$NON-NLS-1$
     public static final String CONFIRM_TXN_RECONNECT = "reconnect_txn"; //$NON-NLS-1$
     public static final String CONFIRM_DRIVER_DOWNLOAD = "driver_download"; //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchAdvisor.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchAdvisor.java
@@ -339,13 +339,8 @@ public class ApplicationWorkbenchAdvisor extends IDEWorkbenchAdvisor {
         try {
             IWorkbenchWindow window = getWorkbenchConfigurer().getWorkbench().getActiveWorkbenchWindow();
             if (window != null) {
-                if (!MessageDialogWithToggle.NEVER.equals(ConfirmationDialog.getSavedPreference(DBeaverPreferences.CONFIRM_EXIT))) {
-                    // Workaround of #703 bug. NEVER doesn't make sense for Exit confirmation. It is the same as ALWAYS.
-                    if (ConfirmationDialog.confirmAction(window.getShell(), DBeaverPreferences.CONFIRM_EXIT, ConfirmationDialog.QUESTION)
-                        != IDialogConstants.YES_ID)
-                    {
-                        return false;
-                    }
+                if (!closeConfirmed(window)) {
+                    return false;
                 }
                 // Close al content editors
                 // They are locks resources which are shared between other editors
@@ -387,6 +382,18 @@ public class ApplicationWorkbenchAdvisor extends IDEWorkbenchAdvisor {
             e.printStackTrace();
             return true;
         }
+    }
+    
+    private boolean closeConfirmed(IWorkbenchWindow window) {
+        if (DBWorkbench.getPlatform().getPreferenceStore().getBoolean(DBeaverPreferences.CONFIRM_EXIT_TEMPORARY)) {
+            return true;
+        }
+        if (MessageDialogWithToggle.NEVER.equals(ConfirmationDialog.getSavedPreference(DBeaverPreferences.CONFIRM_EXIT))) {
+            // Workaround of #703 bug. NEVER doesn't make sense for Exit confirmation. It is the same as ALWAYS.
+            return true;
+        }
+        int confirmCode = ConfirmationDialog.confirmAction(window.getShell(), DBeaverPreferences.CONFIRM_EXIT, ConfirmationDialog.QUESTION);
+        return confirmCode == IDialogConstants.YES_ID;
     }
 
     private boolean closeActiveTransactions() {

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
@@ -31,6 +31,7 @@ import org.eclipse.ui.*;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.DBeaverPreferences;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.core.CoreMessages;
 import org.jkiss.dbeaver.model.impl.app.ApplicationDescriptor;
@@ -38,8 +39,8 @@ import org.jkiss.dbeaver.model.impl.app.ApplicationRegistry;
 import org.jkiss.dbeaver.model.runtime.AbstractJob;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.registry.updater.VersionDescriptor;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.runtime.WebUtils;
-import org.jkiss.dbeaver.ui.ActionUtils;
 import org.jkiss.dbeaver.ui.ShellUtils;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.app.standalone.internal.CoreApplicationActivator;
@@ -330,8 +331,10 @@ public class VersionUpdateDialog extends Dialog {
                 };
 
                 UIUtils.asyncExec(() -> {
+                    DBWorkbench.getPlatform().getPreferenceStore().setValue(DBeaverPreferences.CONFIRM_EXIT_TEMPORARY, true);
                     workbench.close();
-
+                    DBWorkbench.getPlatform().getPreferenceStore().setValue(DBeaverPreferences.CONFIRM_EXIT_TEMPORARY, false);
+                    
                     if (!workbench.isClosing()) {
                         workbench.removeWorkbenchListener(listener);
                         ShellUtils.launchProgram(folder.toString());

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
@@ -298,8 +298,8 @@ public class VersionUpdateDialog extends Dialog {
                 }
 
                 final boolean confirmed = UIUtils.confirmAction(
-                        CoreMessages.dialog_version_update_downloader_title,
-                        NLS.bind(CoreMessages.dialog_version_update_downloader_confirm_install, app.getName())
+                    CoreMessages.dialog_version_update_downloader_title,
+                    NLS.bind(CoreMessages.dialog_version_update_downloader_confirm_install, app.getName())
                 );
                 if (!confirmed) {
                     ShellUtils.showInSystemExplorer(file.toAbsolutePath().toString());

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
@@ -307,7 +307,6 @@ public class VersionUpdateDialog extends Dialog {
                 }
 
                 final IWorkbench workbench = PlatformUI.getWorkbench();
-                final IWorkbenchWindow workbenchWindow = UIUtils.getActiveWorkbenchWindow();
 
                 // Arm shutdown listener now because later will be too late
                 final IWorkbenchListener listener = new IWorkbenchListener() {
@@ -331,7 +330,7 @@ public class VersionUpdateDialog extends Dialog {
                 };
 
                 UIUtils.asyncExec(() -> {
-                    ActionUtils.runCommand(IWorkbenchCommandConstants.FILE_EXIT, workbenchWindow);
+                    workbench.close();
 
                     if (!workbench.isClosing()) {
                         workbench.removeWorkbenchListener(listener);

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
@@ -329,14 +329,6 @@ public class VersionUpdateDialog extends Dialog {
             if (!CommonUtils.isEmpty(earlyAccessURL)) {
                 ShellUtils.launchProgram(earlyAccessURL);
             }
-        } else if (buttonId == IDialogConstants.PROCEED_ID) {
-            final IWorkbenchWindow window = UIUtils.getActiveWorkbenchWindow();
-            CheckForUpdateAction.activateStandardHandler(window);
-            try {
-                ActionUtils.runCommand(CheckForUpdateAction.P2_UPDATE_COMMAND, PlatformUI.getWorkbench().getActiveWorkbenchWindow());
-            } finally {
-                CheckForUpdateAction.deactivateStandardHandler(window);
-            }
         }
         close();
     }


### PR DESCRIPTION
Summary:
Fixed duplicate confirmation of closing when update via update dialog coupled with code clean up.

Details:
When a user attempts to upgrade via Check for Updates, a pop-up will be displayed asking if they want to quit. And a pop-up with the same content is displayed once more.
Since there is no reason to do so, I reduced it to a one-time process.
About code clean up,  I refactored a bit to clean up the code and removed the deprecated PROCEED_ID button behavior. (See https://github.com/dbeaver/dbeaver/commit/473d7954e53bc24bfb293c6ade5218ba0dd6bf1d)