### PR TITLE
#21944 Fix Oracle timestamp display error

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/sql/task/SQLScriptDataReceiver.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/sql/task/SQLScriptDataReceiver.java
@@ -16,9 +16,10 @@
  */
 package org.jkiss.dbeaver.tools.sql.task;
 
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.data.DBDDataReceiver;
+import org.jkiss.dbeaver.model.data.DBDValueHandler;
 import org.jkiss.dbeaver.model.exec.*;
-import org.jkiss.utils.CommonUtils;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -31,6 +32,7 @@ public class SQLScriptDataReceiver implements DBDDataReceiver {
 
     private Integer rowSize;
     private Writer dumpWriter;
+    private List<DBCAttributeMetaData> attributes;
 
     @Override
     public void fetchStart(DBCSession session, DBCResultSet resultSet, long offset, long maxRows) throws DBCException {
@@ -39,7 +41,7 @@ public class SQLScriptDataReceiver implements DBDDataReceiver {
         }
         if (dumpWriter != null) {
             DBCResultSetMetaData rsMeta = resultSet.getMeta();
-            List<DBCAttributeMetaData> attributes = rsMeta.getAttributes();
+            attributes = rsMeta.getAttributes();
             rowSize = attributes.size();
             try {
                 dumpWriter.append("Columns:\t");
@@ -63,7 +65,10 @@ public class SQLScriptDataReceiver implements DBDDataReceiver {
             try {
                 for (int i = 0; i < rowSize; i++) {
                     if (resultSet.getAttributeValue(i) != null) {
-                        dumpWriter.append(CommonUtils.toString(resultSet.getAttributeValue(i))).append("\t");
+                    	DBCAttributeMetaData type = attributes.get(i);
+                    	DBDValueHandler valueHandler = DBUtils.findValueHandler(session, type);
+                    	Object object = valueHandler.fetchValueObject(session, resultSet, type, i);
+                        dumpWriter.append(object.toString()).append("\t");
                     } else {
                         dumpWriter.append("NULL\t");
                     }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleTemporalAccessorValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleTemporalAccessorValueHandler.java
@@ -28,11 +28,8 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.data.handlers.JDBCTemporalAccessorValueHandler;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 
-import java.lang.reflect.Method;
-import java.sql.Connection;
 import java.sql.Types;
 import java.time.format.DateTimeFormatter;
-import java.util.Calendar;
 
 /**
  * Object type support
@@ -44,27 +41,6 @@ public class OracleTemporalAccessorValueHandler extends JDBCTemporalAccessorValu
     private static final DateTimeFormatter DEFAULT_DATE_FORMAT = DateTimeFormatter.ofPattern("'DATE '''yyyy-MM-dd''");
     private static final DateTimeFormatter DEFAULT_TIME_FORMAT = DateTimeFormatter.ofPattern("'TIME '''HH:mm:ss.SSS''");
 
-    private static Object getTimestampReadMethod(Class<?> aClass, Connection connection, Object object) throws Exception {
-        switch (aClass.getName()) {
-            case OracleConstants.TIMESTAMP_CLASS_NAME:
-                return getNativeMethod(aClass, "timestampValue")
-                        .invoke(object);
-            case OracleConstants.TIMESTAMPTZ_CLASS_NAME:
-                return getNativeMethod(aClass, "timestampValue", Connection.class)
-                        .invoke(object, connection);
-            case OracleConstants.TIMESTAMPLTZ_CLASS_NAME:
-                return getNativeMethod(aClass, "timestampValue", Connection.class, Calendar.class)
-                        .invoke(object, connection, Calendar.getInstance());
-        }
-        throw new org.jkiss.dbeaver.DBException("Unsupported Oracle TIMESTAMP type: " + aClass.getName());
-    }
-
-    private static Method getNativeMethod(Class<?> aClass, String name, Class<?> ... args) throws NoSuchMethodException {
-        Method method = aClass.getMethod(name, args);
-        method.setAccessible(true);
-        return method;
-    }
-
     public OracleTemporalAccessorValueHandler(DBDFormatSettings formatSettings)
     {
         super(formatSettings);
@@ -72,14 +48,11 @@ public class OracleTemporalAccessorValueHandler extends JDBCTemporalAccessorValu
 
     @Override
     public Object getValueFromObject(@NotNull DBCSession session, @NotNull DBSTypedObject type, Object object, boolean copy, boolean validateValue) throws DBCException {
-        if (object != null) {
-            String className = object.getClass().getName();
-            if (className.startsWith(OracleConstants.TIMESTAMP_CLASS_NAME)) {
-                try {
-                    return getTimestampReadMethod(object.getClass(), ((JDBCSession)session).getOriginal(), object);
-                } catch (Exception e) {
-                    throw new org.jkiss.dbeaver.model.exec.DBCException("Error extracting Oracle TIMESTAMP value", e);
-                }
+        if (object != null && object.getClass().getName().startsWith(OracleConstants.TIMESTAMP_CLASS_NAME)) {
+            try {
+                return OracleTimestampConverter.toTimestamp(object, ((JDBCSession) session).getOriginal());
+            } catch (Exception e) {
+                throw new DBCException("Error extracting Oracle TIMESTAMP value", e);
             }
         }
         return super.getValueFromObject(session, type, object, copy, validateValue);

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleTimestampConverter.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleTimestampConverter.java
@@ -1,0 +1,56 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2023 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.oracle.data;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.oracle.model.OracleConstants;
+import org.jkiss.utils.BeanUtils;
+
+import java.sql.Connection;
+import java.sql.Timestamp;
+import java.util.Calendar;
+
+public class OracleTimestampConverter {
+    // See  https://docs.oracle.com/en/database/oracle/oracle-database/12.2/jajdb/oracle/sql/TIMESTAMP.html#timestampValue--
+    private static final String TO_TIMESTAMP_METHOD_NAME = "timestampValue";
+
+    private OracleTimestampConverter() {
+    }
+
+    public static Timestamp toTimestamp(@NotNull Object object, @NotNull Connection connection) throws Exception {
+        Class<?> aClass = object.getClass();
+        return switch (aClass.getName()) {
+        case OracleConstants.TIMESTAMP_CLASS_NAME ->
+            (Timestamp) invokeNativeMethod(object, TO_TIMESTAMP_METHOD_NAME, null, null);
+        case OracleConstants.TIMESTAMPTZ_CLASS_NAME -> (Timestamp) invokeNativeMethod(object, TO_TIMESTAMP_METHOD_NAME,
+                new Class<?>[] { Connection.class }, new Object[] { connection });
+        case OracleConstants.TIMESTAMPLTZ_CLASS_NAME -> (Timestamp) invokeNativeMethod(object, TO_TIMESTAMP_METHOD_NAME,
+                new Class<?>[] { Connection.class, Calendar.class },
+                new Object[] { connection, Calendar.getInstance() });
+        default -> throw new DBException("Unsupported Oracle TIMESTAMP type: " + aClass.getName());
+        };
+    }
+
+    private static Object invokeNativeMethod(Object object, String name, Class<?>[] classes, Object[] args) throws Exception {
+        try {
+            return BeanUtils.invokeObjectMethod(object, name, classes, args);
+        } catch (Throwable e) {
+            throw new DBException("Cannot invoke method " + name + " on " + object.getClass(), e);
+        }
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleTimestampValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/data/OracleTimestampValueHandler.java
@@ -18,7 +18,6 @@ package org.jkiss.dbeaver.ext.oracle.data;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.oracle.model.OracleConstants;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.data.DBDDataFormatter;
@@ -37,13 +36,10 @@ import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.time.ExtendedDateFormat;
 
-import java.lang.reflect.Method;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.text.Format;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 
 /**
  * Object type support
@@ -53,8 +49,6 @@ public class OracleTimestampValueHandler extends JDBCDateTimeValueHandler {
     private static final SimpleDateFormat DEFAULT_DATETIME_FORMAT = new ExtendedDateFormat("'TIMESTAMP '''yyyy-MM-dd HH:mm:ss.ffffff''");
     private static final SimpleDateFormat DEFAULT_DATE_FORMAT = new SimpleDateFormat("'DATE '''yyyy-MM-dd''");
     private static final SimpleDateFormat DEFAULT_TIME_FORMAT = new SimpleDateFormat("'TIME '''HH:mm:ss.SSS''");
-
-    //private static Method TIMESTAMP_READ_METHOD = null, TIMESTAMPTZ_READ_METHOD = null, TIMESTAMPLTZ_READ_METHOD = null;
 
     @NotNull
     private DBPDataSource dataSource;
@@ -90,14 +84,11 @@ public class OracleTimestampValueHandler extends JDBCDateTimeValueHandler {
 
     @Override
     public Object getValueFromObject(@NotNull DBCSession session, @NotNull DBSTypedObject type, Object object, boolean copy, boolean validateValue) throws DBCException {
-        if (object != null) {
-            String className = object.getClass().getName();
-            if (className.startsWith(OracleConstants.TIMESTAMP_CLASS_NAME)) {
-                try {
-                    return getTimestampReadMethod(object.getClass(), ((JDBCSession)session).getOriginal(), object);
-                } catch (Exception e) {
-                    throw new DBCException("Error extracting Oracle TIMESTAMP value", e);
-                }
+        if (object != null && object.getClass().getName().startsWith(OracleConstants.TIMESTAMP_CLASS_NAME)) {
+            try {
+                return OracleTimestampConverter.toTimestamp(object, ((JDBCSession) session).getOriginal());
+            } catch (Exception e) {
+                throw new DBCException("Error extracting Oracle TIMESTAMP value", e);
             }
         }
         return super.getValueFromObject(session, type, object, copy, validateValue);
@@ -114,27 +105,6 @@ public class OracleTimestampValueHandler extends JDBCDateTimeValueHandler {
             }
         }
         return super.getValueDisplayString(column, value, format);
-    }
-
-    private static Object getTimestampReadMethod(Class<?> aClass, Connection connection, Object object) throws Exception {
-        switch (aClass.getName()) {
-            case OracleConstants.TIMESTAMP_CLASS_NAME:
-                return getNativeMethod(aClass, "timestampValue")
-                    .invoke(object);
-            case OracleConstants.TIMESTAMPTZ_CLASS_NAME:
-                return getNativeMethod(aClass, "timestampValue", Connection.class)
-                    .invoke(object, connection);
-            case OracleConstants.TIMESTAMPLTZ_CLASS_NAME:
-                return getNativeMethod(aClass, "timestampValue", Connection.class, Calendar.class)
-                    .invoke(object, connection, Calendar.getInstance());
-        }
-        throw new DBException("Unsupported Oracle TIMESTAMP type: " + aClass.getName());
-    }
-
-    private static Method getNativeMethod(Class<?> aClass, String name, Class<?> ... args) throws NoSuchMethodException {
-        Method method = aClass.getMethod(name, args);
-        method.setAccessible(true);
-        return method;
     }
 
     @Nullable


### PR DESCRIPTION
OracleTemporalAccessorValueHandler used if driver version is higher than 12.2(in cese of issuer's) has no getValueFromObject for process raw Oracle types.
So, I added it same as OracleTimestampValueHandler's and then extracted method to avoid duplicated code.