### PR TITLE
#21615 Revert "Don't show results when extracting data (#21953)"

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
@@ -975,6 +975,8 @@ public class SQLQueryJob extends DataSourceJob
             } else {
                 throw new DBCException(lastError, getExecutionContext());
             }
+        } else if (result && statistics.getStatementsCount() > 0) {
+            showExecutionResult(session);
         }
     }
 


### PR DESCRIPTION
It broke result tabs for queries with no results.