### PR TITLE
#21991 show default procedure parameters

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdProcedure.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdProcedure.java
@@ -111,7 +111,7 @@ public class FireBirdProcedure extends GenericProcedure implements DBSObjectWith
                         "F.RDB$CHARACTER_LENGTH AS CHAR_LEN,\n" +
                         "PP.RDB$PARAMETER_NUMBER + 1 AS ORDINAL_POSITION,\n" +
                         "F.RDB$CHARACTER_SET_ID,\n" +
-                        "F.RDB$DEFAULT_SOURCE AS DEFAULT_VALUE\n" +
+                        "COALESCE(PP.RDB$DEFAULT_SOURCE, F.RDB$DEFAULT_SOURCE) AS DEFAULT_VALUE\n" +
                         "FROM\n" +
                         "   RDB$PROCEDURE_PARAMETERS PP,\n" +
                         "   RDB$FIELDS F\n" +


### PR DESCRIPTION
![2023-11-28 12_36_11-DBeaver Ultimate 23 3 0 - SP_PARAMS_WITH_DEFAULT_VALUES](https://github.com/dbeaver/dbeaver/assets/45152336/4dc8fb6d-a875-40e2-a572-9fd7c821be48)

Impact only on the **procedure** parameters reading. You can check it in different Firebird versions.
