### PR TITLE
#21495 set query limits flag for MySQL/MariaDB

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLDataSource.java
@@ -110,6 +110,8 @@ public class MySQLDataSource extends JDBCDataSource implements DBPObjectStatisti
                 } else {
                     return 255;
                 }
+            case DBPDataSource.FEATURE_LIMIT_AFFECTS_DML:
+                return true;
         }
         return super.getDataSourceFeature(featureId);
     }


### PR DESCRIPTION
Please check the case from the ticket and some different SELECT queries with a result set fetch size and without it (set to 0). 
(Expected result: `LIMIT 0, 200` will be added to your query. Depends on your settings in Preferences -> Editors -> Data Editor)

Also, you can ask me about how work with the original query from the ticket