### PR TITLE
#22165 add row level security policies support for Greenplum 7

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/PostgreServerGreenplum.java
@@ -184,4 +184,9 @@ public class PostgreServerGreenplum extends PostgreServerExtensionBase {
     public boolean supportsEventTriggers() {
         return dataSource.isServerVersionAtLeast(9, 3);
     }
+
+    @Override
+    public boolean supportsRowLevelSecurity() {
+        return dataSource.isServerVersionAtLeast(12, 0);
+    }
 }


### PR DESCRIPTION
![2023-12-13 16_02_30-DBeaver Ultimate 23 3 0 - account_managers](https://github.com/dbeaver/dbeaver/assets/45152336/7ab98a2f-9790-4283-abb4-fc615352effd)

Please check in Greenplum 7 (partner db) (visible)
and in old Greenplum (our db) (absent)