### PR TITLE
dbeaver/pro#2293 Fix small bugs

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
@@ -183,11 +183,17 @@ colorDefinition.org.jkiss.dbeaver.sql.editor.color.text.background.description =
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.disabled.background.label = SQL disabled background
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.disabled.background.description = SQL text background
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.table.foreground.label = SQL table name foreground
+colorDefinition.org.jkiss.dbeaver.sql.editor.color.table.foreground.description = SQL table name foreground
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.table.alias.foreground.label = SQL table alias foreground
+colorDefinition.org.jkiss.dbeaver.sql.editor.color.table.alias.foreground.description = SQL table alias foreground
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.column.foreground.label = SQL column name foreground
+colorDefinition.org.jkiss.dbeaver.sql.editor.color.column.foreground.description = SQL column name foreground
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.column.derived.foreground.label = SQL derived column foreground
+colorDefinition.org.jkiss.dbeaver.sql.editor.color.column.derived.foreground.description = SQL column alias foreground
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.schema.foreground.label = SQL schema name foreground
+colorDefinition.org.jkiss.dbeaver.sql.editor.color.schema.foreground.description = SQL schema name foreground
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.semanticError.foreground.label = SQL semantic error foreground
+colorDefinition.org.jkiss.dbeaver.sql.editor.color.semanticError.foreground.description = SQL semantic error foreground
 
 
 keyword.org.jkiss.dbeaver.pref.keyword.sql.format.label = formatter query keyword case tab space indent substatement comma delimiter workbench upper lower mixed line

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLBackgroundParsingJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLBackgroundParsingJob.java
@@ -362,10 +362,16 @@ public class SQLBackgroundParsingJob {
                 }
                 return;
             } else {
-                elements.set(0, SQLScriptParser.extractQueryAtPos(parserContext, elements.get(0).getOffset()));
+                SQLScriptElement element = SQLScriptParser.extractQueryAtPos(parserContext, elements.get(0).getOffset());
+                if (element != null) {
+                    elements.set(0, element);
+                }
                 if (elements.size() > 1) {
                     int index = elements.size() - 1;
-                    elements.set(index, SQLScriptParser.extractQueryAtPos(parserContext, elements.get(index).getOffset()));
+                    element = SQLScriptParser.extractQueryAtPos(parserContext, elements.get(index).getOffset());
+                    if (element != null) {
+                        elements.set(index, element);
+                    }
                 }
             }
             

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLTokenAdapter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLTokenAdapter.java
@@ -100,7 +100,7 @@ public class SQLTokenAdapter extends Token {
                     style = SWT.NORMAL;
                     break;
                 case T_TABLE_ALIAS:
-                    colorKey = SQLConstants.CONFIG_COLOR_TABLE;
+                    colorKey = SQLConstants.CONFIG_COLOR_TABLE_ALIAS;
                     style = SWT.ITALIC;
                     break;
                 case T_COLUMN:
@@ -108,7 +108,7 @@ public class SQLTokenAdapter extends Token {
                     style = SWT.NORMAL;
                     break;
                 case T_COLUMN_DERIVED:
-                    colorKey = SQLConstants.CONFIG_COLOR_COLUMN;
+                    colorKey = SQLConstants.CONFIG_COLOR_COLUMN_DERIVED;
                     style = SWT.ITALIC;
                     break;
                 case T_SCHEMA:


### PR DESCRIPTION
- Fix NPE - you should not catch it while writing some query and jumping from aliases to tables with Ctrl+Click
- Color descriptions are added. You should find descriptions for all SQL Editor colors on a human natural language
![image](https://github.com/dbeaver/dbeaver/assets/28875055/0f46c898-5c78-4abf-b883-156f46ee6612)
- If you change SQL table alias foreground and SQL derived column foreground, new color should be applied. 