### PR TITLE
#22169 Add multiline comment rule to lexer

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
@@ -372,9 +372,10 @@ UnsignedInteger: (Digit)+;
 ApproximateNumericLiteral: (UnsignedInteger|DecimalLiteral) 'E' SignedInteger;
 fragment SignedInteger: (PlusSign|MinusSign)? UnsignedInteger;
 
-LineComment
-   : ('--'|'#') ~ [\r\n]* -> channel (HIDDEN)
-   ;
+
+Comment: (LineComment | MultilineComment) -> channel (HIDDEN);
+LineComment : ('--'|'#') ~ [\r\n]*;
+MultilineComment: ('/*' .*? '*/');
 
 // special characters and character sequences
 fragment NonquoteCharacter: ~'\'';


### PR DESCRIPTION
I believe we don't want to handle nested comments for simplicity. It makes comments parsing not easy and I'm not sure we really need it. Maybe let's wait for requests?
https://groups.google.com/g/antlr-discussion/c/OEk5ug3GNNM