### PR TITLE
#22335 Don't allow dot character in the parameter name

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/rules/ScriptParameterRule.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/rules/ScriptParameterRule.java
@@ -120,7 +120,7 @@ public class ScriptParameterRule implements TPRule {
     }
 
     private static boolean isValidParameterChar(char c) {
-        return Character.isJavaIdentifierPart(c) || c == '.';
+        return Character.isJavaIdentifierPart(c); // if we allow '.', it broke some use cases, see #22335
     }
 
     /**


### PR DESCRIPTION
The `Bind variables` dialog doesn't appear anymore as :schema.* is correctly parsed to identify "schema" parameter.