### PR TITLE
#22471 fix schemas permissions query reading for newest PostgreSQL ve…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreRole.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreRole.java
@@ -506,7 +506,7 @@ public class PostgreRole implements
                     "\n\tn.oid AS relnamespace,\n" +
                     "\tnspacl AS relacl,\n" +
                     "\tn.nspname AS relname,\n" +
-                    "\t'C' AS relkind,\n" +
+                    "\tcast('C' as \"char\") AS relkind,\n" +
                     "(aclexplode(nspacl)).grantee as granteeI\n" +
                     "FROM\n" +
                     "\tpg_catalog.pg_namespace n\n" +


### PR DESCRIPTION
Fix schemas permissions query reading for the newest PostgreSQL versions

Please check PostgreSQL 16 and any other old PostgreSQL version < 14
Reading schemas permissions in the Role tab.
Also, you can check Cockroach. (not necessary)