### PR TITLE
#22490 Add double-dash single-line comments for Snowflake dialect

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.core/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeSQLDialect.java
@@ -180,4 +180,9 @@ public class SnowflakeSQLDialect extends GenericSQLDialect implements TPRuleProv
         }
         return super.mustBeQuoted(str, forceCaseSensitive);
     }
+    
+    @Override
+    public String[] getSingleLineComments() {
+        return new String[]{SQLConstants.SL_COMMENT, "//"};
+    }
 }


### PR DESCRIPTION
Double-dash comments should be colored with grey for Snowflake