### PR TITLE
#22641 Fix keywords highlighting and schema name in conditions highlighting

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryModelRecognizer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryModelRecognizer.java
@@ -734,7 +734,7 @@ public class SQLQueryModelRecognizer {
             this.symbolEntries.add(entry);
             entry.getSymbol().setSymbolClass(SQLQuerySymbolClass.QUOTED);
             return entry;
-        } else if (this.reservedWords.contains(rawIdentifierString)) {
+        } else if (this.reservedWords.contains(rawIdentifierString.toUpperCase())) { // keywords are uppercased in dialect
             SQLQuerySymbolEntry entry = new SQLQuerySymbolEntry(actualBody.getRealInterval(), rawIdentifierString, rawIdentifierString);
             this.symbolEntries.add(entry);
             entry.getSymbol().setSymbolClass(SQLQuerySymbolClass.RESERVED);

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryQualifiedName.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryQualifiedName.java
@@ -88,12 +88,16 @@ public class SQLQueryQualifiedName { // qualifier
             this.entityName.merge(rr.aliasOrNull);
         } else if (rr.source instanceof SQLQueryRowsTableDataModel tableModel) {
             if (this.entityName != null) {
-                this.entityName.setDefinition(tableModel);
+                SQLQueryQualifiedName tableName = tableModel.getName();
+                this.entityName.setDefinition(tableName.entityName);
                 if (this.schemaName != null) {
-                    this.schemaName.setDefinition(tableModel);
-                }
-                if (this.catalogName != null) {
-                    this.catalogName.setDefinition(tableModel);
+                    SQLQuerySymbolEntry schemaDef = tableName.schemaName != null ? tableName.schemaName : tableName.entityName;
+                    this.schemaName.setDefinition(schemaDef);
+                    
+                    if (this.catalogName != null) {
+                        SQLQuerySymbolEntry catalogDef = tableName.catalogName != null ? tableName.catalogName : schemaDef;
+                        this.catalogName.setDefinition(catalogDef);
+                    }
                 }
             }
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryRowsTableDataModel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryRowsTableDataModel.java
@@ -58,7 +58,7 @@ public class SQLQueryRowsTableDataModel extends SQLQueryRowsSourceModel implemen
     @NotNull
     @Override
     public SQLQuerySymbolClass getSymbolClass() {
-        return this.table != null ? SQLQuerySymbolClass.TABLE : SQLQuerySymbolClass.ERROR; // TODO depends on connection availability
+        return this.table != null ? SQLQuerySymbolClass.TABLE : SQLQuerySymbolClass.ERROR;
     }
 
     @NotNull


### PR DESCRIPTION
- [x] Keywords should be highlighted with dark red no matter which case is used
- [x] Schema name should be highlighted with different column in where and select list, when it's valid. For example:
![image](https://github.com/dbeaver/dbeaver/assets/28875055/c3fbe5c7-97e0-4a09-8b50-7e92b2a72a65)
(To be highlighted, schema name should be in from clause too - otherwise the query is most probably invalid)

