### PR TITLE
#22686 check replace/insert methods existing before data transfer

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseConsumerPageLoadSettings.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseConsumerPageLoadSettings.java
@@ -501,6 +501,7 @@ public class DatabaseConsumerPageLoadSettings extends DataTransferPageNodeSettin
         } else {
             onDuplicateKeyInsertMethods.setText(DBSDataManipulator.INSERT_NONE_METHOD);
             onDuplicateKeyInsertMethods.setEnabled(false);
+            settings.setOnDuplicateKeyInsertMethodId(null);
         }
 
         availableInsertMethodsDescriptors = insertMethodsDescriptors;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/registry/SQLDialectDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/registry/SQLDialectDescriptor.java
@@ -259,7 +259,7 @@ public class SQLDialectDescriptor extends AbstractContextDescriptor implements S
             }
         }
 
-        return new ArrayList<>(insertMethodDescriptors);
+        return insertMethodDescriptors != null ? new ArrayList<>(insertMethodDescriptors) : new ArrayList<>();
     }
 
     @Override


### PR DESCRIPTION
Please check the following:

- [x] the case from the ticket
- [x] point 2 - using the replace or insert method during the DT in any supported database (expected result - it is still working)
- [x] using data transfer right after point 2 in any not supported database (like Sybase) - expected result - data transfer works ok