### PR TITLE
#22731 update varchar max length syntax for non-sql server databases

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDialect.java
@@ -222,10 +222,15 @@ public class SQLServerDialect extends JDBCSQLDialect implements TPRuleProvider, 
                 case SQLServerConstants.TYPE_SQL_VARIANT:
                 case SQLServerConstants.TYPE_VARBINARY: {
                     long maxLength = column.getMaxLength();
+                    int maxStringLength = CommonUtils.toInt(dataSource.getDataSourceFeature(DBPDataSource.FEATURE_MAX_STRING_LENGTH));
                     if (maxLength == 0) {
                         return null;
-                    } else if (maxLength == -1 || maxLength > 8000) {
-                        return "(MAX)";
+                    } else if (maxLength == -1 || maxLength >= maxStringLength) {
+                        if (dataSource instanceof SQLServerDataSource) {
+                            return "(MAX)";
+                        } else {
+                            return "(" + maxStringLength + ")";
+                        }
                     } else {
                         return "(" + maxLength + ")";
                     }


### PR DESCRIPTION
I checked Synapse and Babelfish documentation. Looks like the support varchar(max). So, I've added this type of condition (because Sybase has an SQLServerGenericDatasource class).

![2024-02-08 11_06_59-Configure metadata structure](https://github.com/dbeaver/dbeaver/assets/45152336/c12e255b-6504-4756-a106-470bcd913a8a)

So, please check:

- [x] Case from the ticket (with string ~ 8000 symbols)
- [x] Import in SQL Server (still varchar(max)) 