### PR TITLE
#22356 Fix scrolling in single tab result sets mode

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -3901,7 +3901,7 @@ public class SQLEditor extends SQLEditorBase implements
 
             Listener scrollListener = event -> {
                 Control underScroll = (Control) event.widget;
-                if (underScroll.getShell() == tabContentScroller.getShell() && tabContentScroller.isVisible()) {
+                if (underScroll.getShell() == tabContentScroller.getShell() && tabContentScroller.isVisible() && ((event.stateMask & SWT.CTRL) == SWT.CTRL)) {
                     Point clickedPoint = underScroll.toDisplay(event.x, event.y);
                     if (tabContentScroller.getClientArea().contains(tabContentScroller.toControl(clickedPoint))) {
                         for (Control c = underScroll; c != null; c = c.getParent()) {


### PR DESCRIPTION
If the cursor on the results grid, then we scroll data grid.
If the cursor is outside data grid or other scrollable control, then we scroll outside.
If `ctrl` is pressed and we're trying to scroll, then we always scroll outside the data grid.