### PR TITLE
dbeaver/pro#2472 set subpartition type by default to the RANGE

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleTablePartition.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleTablePartition.java
@@ -121,7 +121,7 @@ public class OracleTablePartition extends OracleTablePhysical implements DBSTabl
         // Creation constructor
         public PartitionInfoBase() {
             this.partitionType = PartitionType.RANGE;
-            this.subpartitionType = PartitionType.NONE;
+            this.subpartitionType = PartitionType.RANGE;
         }
 
         public void setPartitionTablespace(Object partitionTablespace) {


### PR DESCRIPTION
1. Open a new create table dialog
2. create columns (at least 2)
3. specify these column names in the fields: Partition key, Subpartition key
4. Create at least one partition and one subpartition
5. Check result syntax

![2024-02-12 11_22_20-NEWTABLE_4 - Persist Changes](https://github.com/dbeaver/dbeaver/assets/45152336/d1e97d81-dd79-4f86-8464-e0bb7b819d83)
