### PR TITLE
dbeaver/pro#2491 Improve support of CASE statements

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
@@ -139,7 +139,7 @@ escapeCharacter: characterValueExpression;
 inPredicateValue: (tableSubquery|(LeftParen (valueExpression (Comma valueExpression)*) RightParen));
 
 rowValueConstructor: (rowValueConstructorElement|LeftParen rowValueConstructorList anyUnexpected?? RightParen|rowSubquery);
-rowValueConstructorElement: (valueExpression|nullSpecification|defaultSpecification);
+rowValueConstructorElement: (valueExpression|defaultSpecification);
 nullSpecification: NULL;
 defaultSpecification: DEFAULT;
 rowValueConstructorList: rowValueConstructorElement (Comma rowValueConstructorElement)*;
@@ -219,14 +219,14 @@ correspondingSpec: CORRESPONDING (BY LeftParen correspondingColumnList RightPare
 correspondingColumnList: columnNameList;
 caseExpression: (caseAbbreviation|simpleCase|searchedCase);
 caseAbbreviation: (NULLIF LeftParen valueExpression Comma valueExpression RightParen|COALESCE LeftParen valueExpression (Comma valueExpression)+ RightParen);
-simpleCase: CASE valueExpression (simpleWhenClause)+ (elseClause)? END;
-simpleWhenClause: WHEN valueExpression THEN result;
-result: valueExpression|NULL;
+simpleCase: CASE (valueExpression|searchCondition) (simpleWhenClause)+ (elseClause)? END;
+simpleWhenClause: WHEN (valueExpression|searchCondition) THEN result;
+result: valueExpression;
 elseClause: ELSE result;
 searchedCase: CASE (searchedWhenClause)+ (elseClause)? END;
 searchedWhenClause: WHEN searchCondition THEN result;
 castSpecification: CAST LeftParen castOperand AS dataType RightParen;
-castOperand: (valueExpression|NULL);
+castOperand: valueExpression;
 
 overClause: OVER LeftParen (PARTITION BY valueExpression (Comma valueExpression)*)? orderByClause? ((ROWS|RANGE) anyUnexpected)? RightParen;
 
@@ -253,7 +253,7 @@ intervalOperation2: Asterisk intervalFactor((((Asterisk|Solidus) factor)+ (sign 
 
 valueExpressionPrimary: unsignedNumericLiteral|generalLiteral|generalValueSpecification|countAllExpression
     |scalarSubquery|caseExpression|LeftParen valueExpression anyUnexpected?? RightParen|castSpecification
-    |aggregateExpression|anyWordsWithProperty2|valueReference|anyWordsWithProperty;
+    |aggregateExpression|nullSpecification|truthValue|anyWordsWithProperty2|valueReference|anyWordsWithProperty;
 
 numericPrimary: (valueExpressionPrimary|extractExpression);
 factor: sign? numericPrimary;
@@ -348,7 +348,7 @@ setClause: ((setTarget | setTargetList) (EqualsOperator updateSource)?)|anyUnexp
 setTarget: valueReference;
 setTargetList: LeftParen valueReference? (Comma valueReference)* RightParen?;
 updateSource: updateValue | (LeftParen updateValue (Comma updateValue)* RightParen?);
-updateValue: valueExpression|nullSpecification|DEFAULT;
+updateValue: valueExpression|DEFAULT;
 
 // transactions
 sqlTransactionStatement: (setTransactionStatement|setConstraintsModeStatement|commitStatement|rollbackStatement);


### PR DESCRIPTION
The query from the issue should be highlighted and you should be able perform jumping from aliases references to declarations inside query.