### PR TITLE
dbeaver/pro#2494 Improve support for type casts

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
@@ -328,6 +328,7 @@ ZONE: Z O N E ;
 
 
 // symbols
+TypeCast: '::';
 EqualsOperator: '=';
 NotEqualsOperator: '<>' | '!=';
 RightParen: ')';

--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
@@ -251,7 +251,9 @@ numericOperation:                           (((Asterisk|Solidus) factor)+ (sign 
 intervalOperation:       intervalQualifier?((((Asterisk|Solidus) factor)+ (sign intervalTerm)*)|((sign intervalTerm)+));
 intervalOperation2: Asterisk intervalFactor((((Asterisk|Solidus) factor)+ (sign intervalTerm)*)|((sign intervalTerm)+));
 
-valueExpressionPrimary: unsignedNumericLiteral|generalLiteral|generalValueSpecification|countAllExpression
+valueExpressionPrimary: valueExpressionCast|valueExpressionAtom;
+valueExpressionCast: valueExpressionAtom TypeCast dataType;
+valueExpressionAtom: unsignedNumericLiteral|generalLiteral|generalValueSpecification|countAllExpression
     |scalarSubquery|caseExpression|LeftParen valueExpression anyUnexpected?? RightParen|castSpecification
     |aggregateExpression|anyWordsWithProperty2|valueReference|anyWordsWithProperty;
 

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/stm/STMKnownRuleNames.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/stm/STMKnownRuleNames.java
@@ -127,6 +127,7 @@ public class STMKnownRuleNames {
     public static final String dynamicParameterSpecification = SQLStandardParser.ruleNames[SQLStandardParser.RULE_dynamicParameterSpecification];
     public static final String columnReference = SQLStandardParser.ruleNames[SQLStandardParser.RULE_columnReference];
     public static final String valueReference = SQLStandardParser.ruleNames[SQLStandardParser.RULE_valueReference];
+    public static final String valueExpressionCast = SQLStandardParser.ruleNames[SQLStandardParser.RULE_valueExpressionCast];
 
     public static final String qualifier = SQLStandardParser.ruleNames[SQLStandardParser.RULE_qualifier];
     public static final String correlationName = SQLStandardParser.ruleNames[SQLStandardParser.RULE_correlationName];
@@ -203,6 +204,7 @@ public class STMKnownRuleNames {
     //valueExpression: (numericValueExpression|characterValueExpression|datetimeValueExpression|intervalValueExpression);
 
     public static final String valueExpression = SQLStandardParser.ruleNames[SQLStandardParser.RULE_valueExpression];
+    public static final String valueExpressionAtom = SQLStandardParser.ruleNames[SQLStandardParser.RULE_valueExpressionAtom];
 
     public static final String valueExpressionPrimarySignedBased = SQLStandardParser.ruleNames[SQLStandardParser.RULE_valueExpressionPrimarySignedBased];
     public static final String valueExpressionPrimaryBased = SQLStandardParser.ruleNames[SQLStandardParser.RULE_valueExpressionPrimaryBased];

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorOutlinePage.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorOutlinePage.java
@@ -744,6 +744,12 @@ public class SQLEditorOutlinePage extends ContentOutlinePage implements IContent
             this.makeNode(node, indexingExpr, text, extraText, icon);
             return null;
         }
+        
+        @Override
+        public Object visitValueTypeCastExpr(SQLQueryValueTypeCastExpression typeCastExpr, OutlineQueryNode node) {
+            typeCastExpr.getValueExpr().apply(this, node);
+            return null;
+        }
 
         @Nullable
         private String obtainExprTypeNameString(@NotNull SQLQueryValueExpression expr) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryModelRecognizer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryModelRecognizer.java
@@ -854,6 +854,7 @@ public class SQLQueryModelRecognizer {
     
     private static final Set<String> knownValueExpressionRootNames = Set.of(
         STMKnownRuleNames.valueExpression,
+        STMKnownRuleNames.valueExpressionAtom,
         STMKnownRuleNames.searchCondition,
         STMKnownRuleNames.havingClause,
         STMKnownRuleNames.whereClause,
@@ -864,7 +865,8 @@ public class SQLQueryModelRecognizer {
     private static final Set<String> knownRecognizableValueExpressionNames = Set.of(
         STMKnownRuleNames.subquery,
         STMKnownRuleNames.columnReference,
-        STMKnownRuleNames.valueReference
+        STMKnownRuleNames.valueReference,
+        STMKnownRuleNames.valueExpressionCast
     );
 
     @NotNull
@@ -926,6 +928,7 @@ public class SQLQueryModelRecognizer {
         return switch (node.getNodeKindId()) {
             case SQLStandardParser.RULE_subquery -> new SQLQueryValueSubqueryExpression(range, this.collectQueryExpression(node));
             case SQLStandardParser.RULE_valueReference -> this.collectValueReferenceExpression(node);
+            case SQLStandardParser.RULE_valueExpressionCast -> new SQLQueryValueTypeCastExpression(range, this.collectValueExpression(node.getStmChild(0)), node.getStmChild(2).getTextContent());
             default -> throw new UnsupportedOperationException(
                 "Subquery of columnReference expected while facing with " + node.getNodeName()
             );

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryModelRecognizer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryModelRecognizer.java
@@ -928,7 +928,11 @@ public class SQLQueryModelRecognizer {
         return switch (node.getNodeKindId()) {
             case SQLStandardParser.RULE_subquery -> new SQLQueryValueSubqueryExpression(range, this.collectQueryExpression(node));
             case SQLStandardParser.RULE_valueReference -> this.collectValueReferenceExpression(node);
-            case SQLStandardParser.RULE_valueExpressionCast -> new SQLQueryValueTypeCastExpression(range, this.collectValueExpression(node.getStmChild(0)), node.getStmChild(2).getTextContent());
+            case SQLStandardParser.RULE_valueExpressionCast -> new SQLQueryValueTypeCastExpression(
+                range,
+                this.collectValueExpression(node.getStmChild(0)),
+                node.getStmChild(2).getTextContent()
+            );
             default -> throw new UnsupportedOperationException(
                 "Subquery of columnReference expected while facing with " + node.getNodeName()
             );

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/context/SQLQueryExprType.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/context/SQLQueryExprType.java
@@ -101,6 +101,11 @@ public abstract class SQLQueryExprType {
         SQLQueryExprType type = columns.isEmpty() ? SQLQueryExprType.UNKNOWN : columns.get(0).type; 
         return type;
     }
+    
+    @NotNull
+    public static SQLQueryExprType forExplicitTypeRef(@NotNull String typeRefString) {
+        return new SQLQueryExprPredefinedType(typeRefString, DBPDataKind.UNKNOWN);
+    }
 
     @NotNull
     public static SQLQueryExprType forTypedObject(

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryNodeModelVisitor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryNodeModelVisitor.java
@@ -43,6 +43,9 @@ public interface SQLQueryNodeModelVisitor<T, R> {
     
     @Nullable
     R visitValueIndexingExpr(@NotNull SQLQueryValueIndexingExpression indexingExpr, T arg);
+    
+    @Nullable
+    R visitValueTypeCastExpr(@NotNull SQLQueryValueTypeCastExpression typeCastExpr, T arg);
 
     @Nullable
     R visitSelectionResult(SQLQuerySelectionResultModel selectionResult, T arg);

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryValueTypeCastExpression.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryValueTypeCastExpression.java
@@ -1,0 +1,79 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.editors.sql.semantics.model;
+
+
+import org.antlr.v4.runtime.misc.Interval;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLQueryRecognitionContext;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLQuerySymbol;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLQuerySymbolClass;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLQuerySymbolEntry;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.context.SQLQueryDataContext;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.context.SQLQueryExprType;
+
+public class SQLQueryValueTypeCastExpression extends SQLQueryValueExpression {
+
+    @NotNull
+    private final SQLQueryValueExpression value;
+    @NotNull
+    private final String typeRefString;
+
+    public SQLQueryValueTypeCastExpression(
+        @NotNull Interval range,
+        @NotNull SQLQueryValueExpression value,
+        @NotNull String typeRefString
+    ) {
+        super(range);
+        this.value = value;
+        this.typeRefString = typeRefString;
+    }
+
+    @NotNull
+    public String getTypeRefString() {
+        return this.typeRefString;
+    }
+
+    @NotNull
+    public SQLQueryValueExpression getValueExpr() {
+        return this.value;
+    }
+
+    @NotNull
+    @Override
+    public SQLQuerySymbol getColumnNameIfTrivialExpression() {
+        return null;
+    }
+    
+    @Override
+    void propagateContext(@NotNull SQLQueryDataContext context, @NotNull SQLQueryRecognitionContext statistics) {
+        this.value.propagateContext(context, statistics);
+        this.type = SQLQueryExprType.forExplicitTypeRef(this.typeRefString);
+    }
+    
+    @Override
+    protected <R, T> R applyImpl(@NotNull SQLQueryNodeModelVisitor<T, R> visitor, @NotNull T arg) {
+        return visitor.visitValueTypeCastExpr(this, arg);
+    }
+
+    @Override
+    public String toString() {
+        return "TypeCast[" + this.value.toString() + ", " + this.typeRefString + "]";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryValueTypeCastExpression.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryValueTypeCastExpression.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ui.editors.sql.semantics.model;
 
 import org.antlr.v4.runtime.misc.Interval;
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLQueryRecognitionContext;
@@ -55,7 +56,7 @@ public class SQLQueryValueTypeCastExpression extends SQLQueryValueExpression {
         return this.value;
     }
 
-    @NotNull
+    @Nullable
     @Override
     public SQLQuerySymbol getColumnNameIfTrivialExpression() {
         return null;


### PR DESCRIPTION
- [x] It typecast `::` is used, then highlighting and Ctrl+Click should work.
- [x] Outline should reflect data type from typecast
![image](https://github.com/dbeaver/dbeaver/assets/28875055/bb4afb17-37b4-4ef9-8b55-2c8998c1b44c)


Please check when connection is active and not.
