### PR TITLE
dbeaver/dbeaver#22259 avoid using snapshot url for non snapshot versions

### DIFF
--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifact.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifact.java
@@ -341,7 +341,13 @@ public class MavenArtifact implements IMavenIdentifier
         return null;
     }
 
-    private MavenArtifactVersion makeLocalVersion(DBRProgressMonitor monitor, String versionStr, boolean setActive, boolean resolveOptionalDependencies, boolean snapshotVersion) throws IllegalArgumentException, IOException {
+    private MavenArtifactVersion makeLocalVersion(
+        DBRProgressMonitor monitor,
+        String versionStr,
+        boolean setActive,
+        boolean resolveOptionalDependencies,
+        boolean snapshotVersion
+    ) throws IllegalArgumentException, IOException {
         MavenArtifactVersion version = getVersion(versionStr);
         if (version == null) {
             version = new MavenArtifactVersion(monitor, this, versionStr, resolveOptionalDependencies, snapshotVersion);

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifact.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifact.java
@@ -70,7 +70,7 @@ public class MavenArtifact implements IMavenIdentifier
     private String latestVersion;
     private String releaseVersion;
     private Date lastUpdate;
-    private List<String> snapshotVersions = new ArrayList<>();
+    private final List<String> snapshotVersions = new ArrayList<>();
     private final List<MavenArtifactVersion> localVersions = new ArrayList<>();
 
     private transient boolean metadataLoaded = false;
@@ -106,7 +106,7 @@ public class MavenArtifact implements IMavenIdentifier
             metadataPath += version + "/";
         }
         metadataPath += MAVEN_METADATA_XML;
-        monitor.subTask("Load metadata " + this + "");
+        monitor.subTask("Load metadata " + this);
 
         try (InputStream mdStream = WebUtils.openConnection(metadataPath, getRepository().getAuthInfo(), null).getInputStream()) {
             parseMetadata(mdStream);
@@ -304,10 +304,12 @@ public class MavenArtifact implements IMavenIdentifier
         return repository.getUrl() + dir + "/";
     }
 
-    String getFileURL(String version, String fileType) {
-        if (getRepository().isSnapshot()) {
-            return getBaseArtifactURL() + versions.get(0) + "/" + getVersionFileName(VersionUtils.findLatestVersion(snapshotVersions),
-                fileType);
+    String getFileURL(String version, String fileType, boolean snapshotVersion) {
+        if (snapshotVersion) {
+            return getBaseArtifactURL() + versions.get(0) + "/" + getVersionFileName(
+                VersionUtils.findLatestVersion(snapshotVersions),
+                fileType
+            );
         }
 
         return getBaseArtifactURL() + version + "/" + getVersionFileName(version, fileType);
@@ -339,10 +341,10 @@ public class MavenArtifact implements IMavenIdentifier
         return null;
     }
 
-    private MavenArtifactVersion makeLocalVersion(DBRProgressMonitor monitor, String versionStr, boolean setActive, boolean resolveOptionalDependencies) throws IllegalArgumentException, IOException {
+    private MavenArtifactVersion makeLocalVersion(DBRProgressMonitor monitor, String versionStr, boolean setActive, boolean resolveOptionalDependencies, boolean snapshotVersion) throws IllegalArgumentException, IOException {
         MavenArtifactVersion version = getVersion(versionStr);
         if (version == null) {
-            version = new MavenArtifactVersion(monitor, this, versionStr, resolveOptionalDependencies);
+            version = new MavenArtifactVersion(monitor, this, versionStr, resolveOptionalDependencies, snapshotVersion);
             localVersions.add(version);
         }
         return version;
@@ -384,6 +386,9 @@ public class MavenArtifact implements IMavenIdentifier
                     break;
                 default:
                     if (snapshotVersion) {
+                        if (snapshotVersions.isEmpty()) {
+                            throw new IOException("Artifact '" + this + "' has empty snapshot version list");
+                        }
                         versionInfo = VersionUtils.findLatestVersion(snapshotVersions);
                         break;
                     }
@@ -421,7 +426,7 @@ public class MavenArtifact implements IMavenIdentifier
         MavenArtifactVersion localVersion = getVersion(versionInfo);
         if (localVersion == null) {
             try {
-                localVersion = makeLocalVersion(monitor, versionInfo, lookupVersion, resolveOptionalDependencies);
+                localVersion = makeLocalVersion(monitor, versionInfo, lookupVersion, resolveOptionalDependencies, snapshotVersion);
             } catch (IOException e) {
                 // Some IO error - not fatal
                 log.debug("Error loading version info: " + e.getMessage());

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifactVersion.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/maven/MavenArtifactVersion.java
@@ -50,6 +50,7 @@ public class MavenArtifactVersion implements IMavenIdentifier {
     private static final String DEFAULT_PROFILE_ID = "#root";
 
     private final MavenArtifact artifact;
+    private final boolean snapshotVersion;
     private String name;
     private String version;
     private String packaging;
@@ -93,11 +94,12 @@ public class MavenArtifactVersion implements IMavenIdentifier {
         @NotNull DBRProgressMonitor monitor,
         @NotNull MavenArtifact artifact,
         @NotNull String version,
-        boolean resolveOptionalDependencies
+        boolean resolveOptionalDependencies,
+        boolean snapshotVersion
     ) throws IOException {
         this.artifact = artifact;
         this.version = CommonUtils.trim(version);
-
+        this.snapshotVersion = snapshotVersion;
         loadPOM(monitor, resolveOptionalDependencies);
         this.version = evaluateString(this.version);
 
@@ -206,7 +208,7 @@ public class MavenArtifactVersion implements IMavenIdentifier {
     }
 
     public String getExternalURL() {
-        return artifact.getFileURL(version, getPackagingFileExtension());
+        return artifact.getFileURL(version, getPackagingFileExtension(), snapshotVersion);
     }
 
     @NotNull
@@ -224,7 +226,7 @@ public class MavenArtifactVersion implements IMavenIdentifier {
     }
 
     public String getExternalURL(String fileType) {
-        return artifact.getFileURL(version, fileType);
+        return artifact.getFileURL(version, fileType, snapshotVersion);
     }
 
     public String getPath() {
@@ -249,7 +251,7 @@ public class MavenArtifactVersion implements IMavenIdentifier {
     }
 
     private String getRemotePOMLocation() {
-        return artifact.getFileURL(version, MavenArtifact.FILE_POM);
+        return artifact.getFileURL(version, MavenArtifact.FILE_POM, snapshotVersion);
     }
 
     private void cachePOM(File localPOM) throws IOException {


### PR DESCRIPTION
Closes dbeaver/dbeaver#22259
Please check that snapshot download done in #19756 is working.
How to test: 
put Sonatype snapshot repository as a first repository in maven configuration and see if it still works