### PR TITLE
dbeaver/pro#2370 Add support for script variables to query model and outline

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/css/e4-dark_dbeaver_prefstyle.css
+++ b/plugins/org.jkiss.dbeaver.core/css/e4-dark_dbeaver_prefstyle.css
@@ -39,6 +39,7 @@
             'org.jkiss.dbeaver.sql.editor.color.comment.foreground=102,151,104'
             'org.jkiss.dbeaver.sql.editor.color.delimiter.foreground=238,204,100'
             'org.jkiss.dbeaver.sql.editor.color.parameter.foreground=126,186,211'
+            'org.jkiss.dbeaver.sql.editor.color.sqlVariable.foreground=126,186,211'
             'org.jkiss.dbeaver.sql.editor.color.command.foreground=211,186,211'
 
             'org.jkiss.dbeaver.erd.diagram.background=47,47,47'

--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
@@ -152,6 +152,10 @@ lexer grammar SQLStandardLexer;
 
 DelimitedIdentifier: { tryConsumeQuottedIdentifier(_input) }? ({isIdentifierEndReached(_input)}? .)+;
 
+BatchVariableName: At Identifier;
+ClientVariableName: Dollar LeftBrace Identifier RightBrace;
+ClientParameterName: Colon Identifier;
+
 // letters to support case-insensitivity for keywords
 fragment A:[aA];
 fragment B:[bB];
@@ -328,7 +332,9 @@ ZONE: Z O N E ;
 
 
 // symbols
-TypeCast: '::';
+At: '@';
+DoubleDollar: '$$';
+Dollar: '$';
 EqualsOperator: '=';
 NotEqualsOperator: '<>' | '!=';
 RightParen: ')';
@@ -336,6 +342,7 @@ LeftParen: '(';
 SingleQuote: '\'';
 BackQuote: '`';
 Comma: ',';
+TypeCast: '::';
 Colon: ':';
 Semicolon: ';';
 Ampersand: '&';
@@ -352,6 +359,8 @@ LessThanOperator: '<';
 LessThanOrEqualsOperator: '<=';
 LeftBracket: '[';
 RightBracket: ']';
+LeftBrace: '{';
+RightBrace: '}';
 MinusSign: '-';
 PlusSign: '+';
 QuestionMark: '?';

--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
@@ -255,7 +255,9 @@ valueExpressionPrimary: valueExpressionCast|valueExpressionAtom;
 valueExpressionCast: valueExpressionAtom TypeCast dataType;
 valueExpressionAtom: unsignedNumericLiteral|generalLiteral|generalValueSpecification|countAllExpression
     |scalarSubquery|caseExpression|LeftParen valueExpression anyUnexpected?? RightParen|castSpecification
-    |aggregateExpression|nullSpecification|truthValue|anyWordsWithProperty2|valueReference|anyWordsWithProperty;
+    |aggregateExpression|nullSpecification|truthValue|variableExpression|anyWordsWithProperty2|valueReference|anyWordsWithProperty;
+
+variableExpression: BatchVariableName|ClientVariableName|ClientParameterName;
 
 numericPrimary: (valueExpressionPrimary|extractExpression);
 factor: sign? numericPrimary;

--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/stm/STMKnownRuleNames.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/stm/STMKnownRuleNames.java
@@ -128,6 +128,7 @@ public class STMKnownRuleNames {
     public static final String columnReference = SQLStandardParser.ruleNames[SQLStandardParser.RULE_columnReference];
     public static final String valueReference = SQLStandardParser.ruleNames[SQLStandardParser.RULE_valueReference];
     public static final String valueExpressionCast = SQLStandardParser.ruleNames[SQLStandardParser.RULE_valueExpressionCast];
+    public static final String variableExpression = SQLStandardParser.ruleNames[SQLStandardParser.RULE_variableExpression];
 
     public static final String qualifier = SQLStandardParser.ruleNames[SQLStandardParser.RULE_qualifier];
     public static final String correlationName = SQLStandardParser.ruleNames[SQLStandardParser.RULE_correlationName];

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/SQLTokenType.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/tokens/SQLTokenType.java
@@ -35,6 +35,7 @@ public enum SQLTokenType implements TPTokenType {
     T_COLUMN_DERIVED(508),
     T_SCHEMA(509),
     T_COMPOSITE_FIELD(510),
+    T_SQL_VARIABLE(511),
     T_SEMANTIC_ERROR(900),
     
     T_UNKNOWN(1000),

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLConstants.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLConstants.java
@@ -667,6 +667,7 @@ public class SQLConstants {
     public static final String CONFIG_COLOR_COLUMN_DERIVED = "org.jkiss.dbeaver.sql.editor.color.column.derived.foreground";
     public static final String CONFIG_COLOR_SCHEMA = "org.jkiss.dbeaver.sql.editor.color.schema.foreground";
     public static final String CONFIG_COLOR_COMPOSITE_FIELD = "org.jkiss.dbeaver.sql.editor.color.composite.field.foreground";
+    public static final String CONFIG_COLOR_SQL_VARIABLE = "org.jkiss.dbeaver.sql.editor.color.sqlVariable.foreground";
     public static final String CONFIG_COLOR_SEMANTIC_ERROR = "org.jkiss.dbeaver.sql.editor.color.semanticError.foreground";
     public static final String CONFIG_COLOR_NUMBER = "org.jkiss.dbeaver.sql.editor.color.number.foreground";
     public static final String CONFIG_COLOR_COMMENT = "org.jkiss.dbeaver.sql.editor.color.comment.foreground";

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
@@ -196,6 +196,8 @@ colorDefinition.org.jkiss.dbeaver.sql.editor.color.schema.foreground.label = SQL
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.schema.foreground.description = SQL schema name foreground
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.semanticError.foreground.label = SQL semantic error foreground
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.semanticError.foreground.description = SQL semantic error foreground
+colorDefinition.org.jkiss.dbeaver.sql.editor.color.sqlVariable.foreground.label = SQL variable name foreground
+colorDefinition.org.jkiss.dbeaver.sql.editor.color.sqlVariable.foreground.description = SQL variable name foreground
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.composite.field.foreground.label = Composite type field foreground
 colorDefinition.org.jkiss.dbeaver.sql.editor.color.composite.field.foreground.description = Composite type field foreground
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
@@ -1295,6 +1295,13 @@
             <description>%colorDefinition.org.jkiss.dbeaver.sql.editor.color.composite.field.foreground.description</description>
         </colorDefinition>
         <colorDefinition
+            label="%colorDefinition.org.jkiss.dbeaver.sql.editor.color.sqlVariable.foreground.label"
+            categoryId="org.jkiss.dbeaver.ui.presentation.sql"
+            id="org.jkiss.dbeaver.sql.editor.color.sqlVariable.foreground"
+            value="COLOR_DARK_BLUE">
+            <description>%colorDefinition.org.jkiss.dbeaver.sql.editor.color.sqlVariable.foreground.description</description>
+        </colorDefinition>
+        <colorDefinition
             label="%colorDefinition.org.jkiss.dbeaver.sql.editor.color.semanticError.foreground.label"
             categoryId="org.jkiss.dbeaver.ui.presentation.sql"
             id="org.jkiss.dbeaver.sql.editor.color.semanticError.foreground"

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorOutlinePage.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorOutlinePage.java
@@ -693,6 +693,19 @@ public class SQLEditorOutlinePage extends ContentOutlinePage implements IContent
 
         @Nullable
         @Override
+        public Object visitValueVariableExpr(@NotNull SQLQueryValueVariableExpression varExpr, @NotNull OutlineQueryNode node) {
+            DBPImage icon = switch (varExpr.getKind()) {
+                case BATCH_VARIABLE -> UIIcon.SQL_VARIABLE2;
+                case CLIENT_PARAMETER -> UIIcon.SQL_PARAMETER;
+                case CLIENT_VARIABLE -> UIIcon.SQL_PARAMETER;
+                default -> throw new IllegalStateException("Unexpected variable expression kind " + varExpr);
+            };
+            this.makeNode(node, varExpr, prepareQueryPreview(varExpr.getRawName()), icon);
+            return null;
+        }
+        
+        @Nullable
+        @Override
         public Object visitValueColumnRefExpr(
             @NotNull SQLQueryValueColumnReferenceExpression columnRefExpr,
             @NotNull OutlineQueryNode node

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryModelRecognizer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryModelRecognizer.java
@@ -38,6 +38,7 @@ import org.jkiss.dbeaver.ui.editors.sql.semantics.context.SQLQueryDataContext;
 import org.jkiss.dbeaver.ui.editors.sql.semantics.context.SQLQueryDataSourceContext;
 import org.jkiss.dbeaver.ui.editors.sql.semantics.context.SQLQueryDummyDataSourceContext;
 import org.jkiss.dbeaver.ui.editors.sql.semantics.model.*;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.model.SQLQueryValueVariableExpression;
 import org.jkiss.utils.Pair;
 
 import java.lang.reflect.Field;
@@ -756,22 +757,29 @@ public class SQLQueryModelRecognizer {
         STMTreeNode actualBody = actual.findChildOfName(STMKnownRuleNames.actualIdentifier).getStmChild(0);
         String rawIdentifierString = actualBody.getTextContent();
         if (actualBody.getPayload() instanceof Token t && t.getType() == SQLStandardLexer.Quotted) {
-            SQLQuerySymbolEntry entry = new SQLQuerySymbolEntry(actualBody.getRealInterval(), rawIdentifierString, rawIdentifierString);
-            this.symbolEntries.add(entry);
+            SQLQuerySymbolEntry entry = this.registerSymbolEntry(actualBody.getRealInterval(), rawIdentifierString, rawIdentifierString);
             entry.getSymbol().setSymbolClass(SQLQuerySymbolClass.QUOTED);
             return entry;
         } else if (this.reservedWords.contains(rawIdentifierString.toUpperCase())) { // keywords are uppercased in dialect
-            SQLQuerySymbolEntry entry = new SQLQuerySymbolEntry(actualBody.getRealInterval(), rawIdentifierString, rawIdentifierString);
-            this.symbolEntries.add(entry);
+            SQLQuerySymbolEntry entry = this.registerSymbolEntry(actualBody.getRealInterval(), rawIdentifierString, rawIdentifierString);
             entry.getSymbol().setSymbolClass(SQLQuerySymbolClass.RESERVED);
             return entry;
         } else {
             SQLDialect dialect = this.obtainSqlDialect();
             String actualIdentifierString = SQLUtils.identifierToCanonicalForm(dialect, rawIdentifierString, forceUnquotted, false);
-            SQLQuerySymbolEntry entry = new SQLQuerySymbolEntry(actualBody.getRealInterval(), actualIdentifierString, rawIdentifierString);
-            this.symbolEntries.add(entry);
-            return entry;
+            return this.registerSymbolEntry(actualBody.getRealInterval(), actualIdentifierString, rawIdentifierString);
         }
+    }
+
+    @NotNull
+    private SQLQuerySymbolEntry registerSymbolEntry(
+        @NotNull Interval region,
+        @NotNull String name,
+        @NotNull String rawName
+    ) {
+        SQLQuerySymbolEntry entry = new SQLQuerySymbolEntry(region, name, rawName);
+        this.symbolEntries.add(entry);
+        return entry;
     }
     
     private static final Set<String> tableNameContainers = Set.of(
@@ -866,7 +874,8 @@ public class SQLQueryModelRecognizer {
         STMKnownRuleNames.subquery,
         STMKnownRuleNames.columnReference,
         STMKnownRuleNames.valueReference,
-        STMKnownRuleNames.valueExpressionCast
+        STMKnownRuleNames.valueExpressionCast,
+        STMKnownRuleNames.variableExpression
     );
 
     @NotNull
@@ -933,9 +942,31 @@ public class SQLQueryModelRecognizer {
                 this.collectValueExpression(node.getStmChild(0)),
                 node.getStmChild(2).getTextContent()
             );
-            default -> throw new UnsupportedOperationException(
-                "Subquery of columnReference expected while facing with " + node.getNodeName()
-            );
+            case SQLStandardParser.RULE_variableExpression -> {
+                String rawName = node.getStmChild(0).getTextContent();
+                yield switch (rawName.charAt(0)) {
+                    case '@' -> new SQLQueryValueVariableExpression(
+                        range,
+                        this.registerSymbolEntry(range, rawName.substring(1), rawName),
+                        SQLQueryValueVariableExpression.VariableExpressionKind.BATCH_VARIABLE,
+                        rawName
+                    );
+                    case '$' -> new SQLQueryValueVariableExpression(
+                        range,
+                        this.registerSymbolEntry(range, rawName.substring(2, rawName.length() - 1), rawName),
+                        SQLQueryValueVariableExpression.VariableExpressionKind.CLIENT_VARIABLE,
+                        rawName
+                    );
+                    case ':' -> new SQLQueryValueVariableExpression(
+                        range,
+                        this.registerSymbolEntry(range, rawName.substring(1), rawName),
+                        SQLQueryValueVariableExpression.VariableExpressionKind.CLIENT_PARAMETER,
+                        rawName
+                    );
+                    default -> throw new UnsupportedOperationException("Unsupported variable expression: " + node.getTextContent());
+                };
+            }
+            default -> throw new UnsupportedOperationException("Unknown expression kind " + node.getNodeName());
         };
     }
 
@@ -995,7 +1026,7 @@ public class SQLQueryModelRecognizer {
     }
     
     @Nullable
-    public static SQLQuerySymbolClass tryFallbackSymbolForStringLiteral (
+    public static SQLQuerySymbolClass tryFallbackSymbolForStringLiteral(
         @NotNull SQLDialect dialect,
         @NotNull SQLQuerySymbolEntry symbolEntry,
         boolean isColumnResolved

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQuerySymbolClass.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQuerySymbolClass.java
@@ -31,6 +31,9 @@ public enum SQLQuerySymbolClass {
     COLUMN(SQLTokenType.T_COLUMN),
     COLUMN_DERIVED(SQLTokenType.T_COLUMN_DERIVED),
     COMPOSITE_FIELD(SQLTokenType.T_COMPOSITE_FIELD),
+    SQL_BATCH_VARIABLE(SQLTokenType.T_SQL_VARIABLE),
+    DBEAVER_VARIABLE(SQLTokenType.T_VARIABLE),
+    DBEAVER_PARAMETER(SQLTokenType.T_PARAMETER),
     ERROR(SQLTokenType.T_SEMANTIC_ERROR);
     
     private final SQLTokenType tokenType;

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryNodeModelVisitor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryNodeModelVisitor.java
@@ -33,6 +33,9 @@ public interface SQLQueryNodeModelVisitor<T, R> {
     R visitValueFlatExpr(SQLQueryValueFlattenedExpression flattenedExpr, T arg);
 
     @Nullable
+    R visitValueVariableExpr(@NotNull SQLQueryValueVariableExpression varExpr, T arg);
+
+    @Nullable
     R visitValueColumnRefExpr(SQLQueryValueColumnReferenceExpression columnRefExpr, T arg);
     
     @Nullable

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryValueVariableExpression.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryValueVariableExpression.java
@@ -1,0 +1,106 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.editors.sql.semantics.model;
+
+import org.antlr.v4.runtime.misc.Interval;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.*;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.context.SQLQueryDataContext;
+
+/**
+ * Script variable. One of :var, ${var} or @var depending on the VariableExpressionKind
+ */
+public class SQLQueryValueVariableExpression extends SQLQueryValueExpression {
+    /**
+     * Kind of the script variable
+     */
+    public enum VariableExpressionKind {
+        /**
+         * The variable of kind @var
+         */
+        BATCH_VARIABLE(SQLQuerySymbolClass.SQL_BATCH_VARIABLE),
+        /**
+         * The variable of kind ${var}
+         */
+        CLIENT_VARIABLE(SQLQuerySymbolClass.DBEAVER_VARIABLE),
+        /**
+         * The variable of kind :var
+         */
+        CLIENT_PARAMETER(SQLQuerySymbolClass.DBEAVER_PARAMETER);
+        
+        public final SQLQuerySymbolClass symbolClass;
+
+        VariableExpressionKind(@NotNull SQLQuerySymbolClass symbolClass) {
+            this.symbolClass = symbolClass;
+        }
+    }
+
+    @NotNull
+    private final SQLQuerySymbolEntry name;
+    @NotNull
+    private final VariableExpressionKind kind;
+    @NotNull
+    private final String rawName;
+    
+    public SQLQueryValueVariableExpression(
+        @NotNull Interval range,
+        @NotNull SQLQuerySymbolEntry name,
+        @NotNull VariableExpressionKind kind,
+        @NotNull String rawName
+    ) {
+        super(range);
+        this.name = name;
+        this.kind = kind;
+        this.rawName = rawName;
+    }
+    
+    @Nullable
+    @Override
+    public SQLQuerySymbol getColumnNameIfTrivialExpression() {
+        return this.kind == VariableExpressionKind.BATCH_VARIABLE ? this.name.getSymbol() : null;
+    }
+
+    @NotNull
+    public VariableExpressionKind getKind() {
+        return this.kind;
+    }
+
+    @NotNull
+    public String getRawName() {
+        return this.rawName;
+    }
+    
+    @Override
+    void propagateContext(@NotNull SQLQueryDataContext context, @NotNull SQLQueryRecognitionContext statistics) {
+        if (this.name.isNotClassified()) {
+            this.name.getSymbol().setSymbolClass(this.kind.symbolClass);
+        }
+    }
+
+    @Nullable
+    @Override
+    protected <R, T> R applyImpl(@NotNull SQLQueryNodeModelVisitor<T, R> visitor, @NotNull T arg) {
+        return visitor.visitValueVariableExpr(this, arg);
+    }
+
+    @NotNull
+    @Override
+    public String toString() {
+        return "Variable[" + this.kind + ":" + this.name + "]";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLTokenAdapter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLTokenAdapter.java
@@ -119,6 +119,10 @@ public class SQLTokenAdapter extends Token {
                     colorKey = SQLConstants.CONFIG_COLOR_COMPOSITE_FIELD;
                     style = SWT.NORMAL;
                     break;
+                case T_SQL_VARIABLE:
+                    colorKey = SQLConstants.CONFIG_COLOR_SQL_VARIABLE;
+                    style = SWT.NORMAL;
+                    break;
                 case T_SEMANTIC_ERROR:
                     colorKey = SQLConstants.CONFIG_COLOR_SEMANTIC_ERROR;
                     style = SWT.BOLD | SWT.ITALIC | TextAttribute.UNDERLINE;


### PR DESCRIPTION
![image](https://github.com/dbeaver/dbeaver/assets/28875055/ea968110-2d89-4caa-bec6-d4ea92df88d0)

![image](https://github.com/dbeaver/dbeaver/assets/28875055/dea313b8-e197-4953-9244-a8a6ba34062e)
![image](https://github.com/dbeaver/dbeaver/assets/28875055/0bbc13f7-9fc4-45d4-8786-980560bfea30)

# For QA
- Please check that these parameters and variables are correctly parsed, highlighted and appeared in outline for more complex queries than on the screenshot.
- Try changing color of the `@var` variable