### PR TITLE
#22934 fix task id in config

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/plugin.xml
@@ -312,7 +312,7 @@
                     group="org.jkiss.dbeaver.ext.oracle.ui.tools.maintenance"
                     label="%tool.org.jkiss.dbeaver.ext.oracle.ui.tools.maintenance.OracleToolTriggerDisable.label"
                     singleton="false">
-                <task id="OracleToolTriggerDisable"/>
+                <task id="oracleToolTriggerDisable"/>
             </tool>
             <tool
                     description="%tool.org.jkiss.dbeaver.ext.oracle.ui.tools.maintenance.OracleToolTriggerEnable.description"


### PR DESCRIPTION
```
<task id="oracleToolTriggerDisable" name="%task.oracleToolTriggerDisable.name" description="%task.oracleToolTriggerDisable.name" icon="platform:/plugin/org.jkiss.dbeaver.model/icons/tree/admin.png" type="oracleTool" handler="org.jkiss.dbeaver.ext.oracle.tasks.OracleToolTableTriggerDisable">
            <datasource id="oracle"/>
            <objectType name="org.jkiss.dbeaver.ext.oracle.model.OracleTableTrigger" if="object.status == 'ENABLED'"/>
</task>
```

Because initially, it is lower-cased.

![2024-02-23 18_14_02-Window](https://github.com/dbeaver/dbeaver/assets/45152336/4948ade7-f590-411f-911a-a964773e238e)
