### PR TITLE
dbeaver/dbeaver#21920 handle unique key type changing in the dialog window

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.base/src/org/jkiss/dbeaver/ui/editors/object/struct/ConstraintNameGenerator.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.base/src/org/jkiss/dbeaver/ui/editors/object/struct/ConstraintNameGenerator.java
@@ -71,7 +71,7 @@ public class ConstraintNameGenerator {
 
         this.constraintType = constraintType;
         if (CommonUtils.isEmpty(constraintName)) {
-            generateConstraintName();
+            generateConstraintName(false);
         }
     }
 
@@ -113,14 +113,14 @@ public class ConstraintNameGenerator {
         this.constraintType = newType;
 
         if (!nameUpdated) {
-            this.generateConstraintName();
+            this.generateConstraintName(true);
         } else {
             this.makeNameUnique();
         }
     }
 
-    private void generateConstraintName() {
-        if (CommonUtils.isEmpty(this.constraintName)) {
+    private void generateConstraintName(boolean forceRefresh) {
+        if (CommonUtils.isEmpty(this.constraintName) || forceRefresh) {
             String namePrefix = TYPE_PREFIX.get(constraintType);
             if (namePrefix == null) {
                 namePrefix = "_KEY";


### PR DESCRIPTION
I can't reproduce the case from the ticket anymore, but I think we need to change the key name in case of the constraint type changing (and generate a new one name with a correct prefix)


![2024-02-26 14_36_21-NewTable_1 - Persist Changes](https://github.com/dbeaver/dbeaver/assets/45152336/c5e787a6-a9c1-4093-8a26-09c395169935)
