### PR TITLE
#21748 Fix SRID being ignored when editing geometry data in MySQL

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.gis/src/org/jkiss/dbeaver/model/gis/GisAttribute.java
+++ b/plugins/org.jkiss.dbeaver.data.gis/src/org/jkiss/dbeaver/model/gis/GisAttribute.java
@@ -16,7 +16,6 @@
  */
 package org.jkiss.dbeaver.model.gis;
 
-import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
@@ -26,9 +25,6 @@ import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 */
 public interface GisAttribute {
     int getAttributeGeometrySRID(DBRProgressMonitor monitor) throws DBCException;
-
-    @NotNull
-    DBGeometryDimension getAttributeGeometryDimension(DBRProgressMonitor monitor) throws DBCException;
 
     @Nullable
     String getAttributeGeometryType(DBRProgressMonitor monitor) throws DBCException;

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLConstants.java
@@ -146,6 +146,7 @@ public class MySQLConstants {
     public static final String COL_ROUTINE_COMMENT = "ROUTINE_COMMENT";
     public static final String COL_DEFINER = "DEFINER";
     public static final String COL_CHARACTER_SET_CLIENT = "CHARACTER_SET_CLIENT";
+    public static final String COL_SRS_ID = "SRS_ID";
 
     public static final String COL_TRIGGER_SCHEMA = "TRIGGER_SCHEMA";
     public static final String COL_TRIGGER_NAME = "TRIGGER_NAME";

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/MySQLUtils.java
@@ -17,6 +17,7 @@
 
 package org.jkiss.dbeaver.ext.mysql;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.mysql.model.MySQLDataSource;
 import org.jkiss.dbeaver.model.connection.DBPDriver;
@@ -151,5 +152,33 @@ public class MySQLUtils {
 
     public static boolean isAlterUSerSupported(MySQLDataSource dataSource) {
         return dataSource.isMariaDB() ? dataSource.isServerVersionAtLeast(10, 2) : dataSource.isServerVersionAtLeast(5, 7);
+    }
+
+    /**
+     * Check if column SRID ({@code SRID <srid>} attribute) is supported
+     */
+    public static boolean isColumnSridSupported(@NotNull MySQLDataSource dataSource) {
+        // There's no any documentation in which version this feature was added
+        return !dataSource.isMariaDB() && dataSource.isServerVersionAtLeast(8, 0);
+    }
+
+    /**
+     * Check if given type name is a spatial data type
+     */
+    public static boolean isSpatialDataType(@NotNull String name) {
+        // Switch expression looks ugly here, sorry
+        switch (name.toLowerCase(Locale.ROOT)) {
+            case MySQLConstants.TYPE_GEOMETRY:
+            case MySQLConstants.TYPE_POINT:
+            case MySQLConstants.TYPE_LINESTRING:
+            case MySQLConstants.TYPE_POLYGON:
+            case MySQLConstants.TYPE_MULTIPOINT:
+            case MySQLConstants.TYPE_MULTILINESTRING:
+            case MySQLConstants.TYPE_MULTIPOLYGON:
+            case MySQLConstants.TYPE_GEOMETRYCOLLECTION:
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTableColumn.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTableColumn.java
@@ -25,6 +25,7 @@ import org.jkiss.dbeaver.ext.mysql.MySQLUtils;
 import org.jkiss.dbeaver.model.DBPNamedObject2;
 import org.jkiss.dbeaver.model.DBPOrderedObject;
 import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.gis.GisAttribute;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCColumnKeyType;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTableColumn;
@@ -48,7 +49,9 @@ import java.util.List;
 /**
  * MySQLTableColumn
  */
-public class MySQLTableColumn extends JDBCTableColumn<MySQLTableBase> implements DBSTableColumn, DBSTypedObjectExt3, DBPNamedObject2, DBPOrderedObject
+public class MySQLTableColumn
+    extends JDBCTableColumn<MySQLTableBase>
+    implements DBSTableColumn, DBSTypedObjectExt3, DBPNamedObject2, DBPOrderedObject, GisAttribute
 {
     private static final Log log = Log.getLog(MySQLTableColumn.class);
 
@@ -78,6 +81,7 @@ public class MySQLTableColumn extends JDBCTableColumn<MySQLTableBase> implements
     private String extraInfo;
     private String genExpression;
     private long modifiers;
+    private Integer srid;
 
     private String fullTypeName;
     private List<String> enumValues;
@@ -193,6 +197,10 @@ public class MySQLTableColumn extends JDBCTableColumn<MySQLTableBase> implements
                     modifiers |= DBSTypedObject.TYPE_MOD_NUMBER_UNSIGNED;
                     break;
             }
+        }
+
+        if (MySQLUtils.isColumnSridSupported(getDataSource())) {
+            srid = JDBCUtils.safeGetInteger(dbResult, MySQLConstants.COL_SRS_ID);
         }
     }
 
@@ -389,6 +397,22 @@ public class MySQLTableColumn extends JDBCTableColumn<MySQLTableBase> implements
     @Override
     public String getDescription() {
         return getComment();
+    }
+
+    @Override
+    public int getAttributeGeometrySRID(DBRProgressMonitor monitor) {
+        return srid != null ? srid : -1;
+    }
+
+    @Nullable
+    @Override
+    public String getAttributeGeometryType(DBRProgressMonitor monitor) {
+        return MySQLUtils.isSpatialDataType(typeName) ? typeName : null;
+    }
+
+    @Nullable
+    public Integer getSrid() {
+        return srid;
     }
 
     public static class CharsetListProvider implements IPropertyValueListProvider<MySQLTableColumn> {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableColumn.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTableColumn.java
@@ -22,9 +22,7 @@ import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.postgresql.PostgreUtils;
 import org.jkiss.dbeaver.ext.postgresql.model.data.type.PostgreGeometryTypeHandler;
-import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
-import org.jkiss.dbeaver.model.gis.DBGeometryDimension;
 import org.jkiss.dbeaver.model.gis.GisAttribute;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCColumnKeyType;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
@@ -77,19 +75,13 @@ public class PostgreTableColumn extends PostgreAttribute<PostgreTableBase>
     }
 
     @Override
-    public int getAttributeGeometrySRID(DBRProgressMonitor monitor) throws DBCException {
+    public int getAttributeGeometrySRID(DBRProgressMonitor monitor) {
         return PostgreGeometryTypeHandler.getGeometrySRID(getTypeMod());
-    }
-
-    @NotNull
-    @Override
-    public DBGeometryDimension getAttributeGeometryDimension(DBRProgressMonitor monitor) throws DBCException {
-        return PostgreGeometryTypeHandler.getGeometryDimension(getTypeMod());
     }
 
     @Nullable
     @Override
-    public String getAttributeGeometryType(DBRProgressMonitor monitor) throws DBCException {
+    public String getAttributeGeometryType(DBRProgressMonitor monitor) {
         return PostgreGeometryTypeHandler.getGeometryType(getTypeMod());
     }
 


### PR DESCRIPTION
Reproducible against MySQL 8.0+

```sql
CREATE TABLE `place` (
  `id` bigint UNSIGNED NOT NULL AUTO_INCREMENT,
  `location` POINT SRID 25831 NOT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `id` (`id`)
);

INSERT INTO `place` (`location`) VALUES (ST_GeomFromText('point(3.210907 41.972898)', 25831));
```