### PR TITLE
scripts to build DBeaver for all platforms

### DIFF
--- a/build_all_platforms.cmd
+++ b/build_all_platforms.cmd
@@ -1,0 +1,5 @@
+set MAVEN_OPTS=-Xmx2048m
+IF NOT EXIST ..\dbeaver-common git clone https://github.com/dbeaver/dbeaver-common.git ..\dbeaver-common
+cd product/aggregate
+call mvn clean install -T 1C -Pall-platforms
+cd ../..

--- a/build_all_platforms.sh
+++ b/build_all_platforms.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+[ ! -d ../dbeaver-common ] && git clone https://github.com/dbeaver/dbeaver-common.git ../dbeaver-common
+
+cd product/aggregate
+mvn clean install -T 1C -Pall-platforms
+cd ../..
+


### PR DESCRIPTION
These build scripts make use of the `all-platforms` Maven profile to produce DBeaver build artifacts for all supported platforms, including the `aarch64` (i.e. `Arm64`) platforms for Linux and MacOS.