### PR TITLE
dbeaver/pro#2511 hide dependencies metadata for RisingWave

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/plugin.xml
@@ -120,7 +120,7 @@
                                                 </items>
                                             </items>
                                         </folder>
-                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip" virtual="true">
+                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip" virtual="true" visibleIf="connected &amp;&amp; dataSource.serverType.supportsDependencies()">
                                             <items label="%tree.dependency.node.name" path="dependency" property="dependencies" icon="#reference" virtual="true"/>
                                         </folder>
                                         <folder label="%tree.references.node.name" icon="#references" description="%tree.references.node.tip" virtual="true" visibleIf="connected &amp;&amp; dataSource.serverType.supportsForeignKeys()">
@@ -161,7 +161,7 @@
                                                 </items>
                                             </items>
                                         </folder>
-                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip" virtual="true">
+                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip" virtual="true" visibleIf="connected &amp;&amp; dataSource.serverType.supportsDependencies()">
                                             <items label="%tree.dependency.node.name" path="dependency" property="dependencies" icon="#reference" virtual="true"/>
                                         </folder>
                                     </items>
@@ -172,7 +172,7 @@
                                             <items label="%tree.column.node.name" path="attribute" property="attributes" icon="#column">
                                             </items>
                                         </folder>
-                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip" virtual="true">
+                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip" virtual="true" visibleIf="connected &amp;&amp; dataSource.serverType.supportsDependencies()">
                                             <items label="%tree.dependency.node.name" path="dependency" property="dependencies" icon="#reference" virtual="true"/>
                                         </folder>
                                         <folder type="org.jkiss.dbeaver.ext.postgresql.model.PostgreTrigger" label="%tree.triggers.node.name" icon="#triggers" description="View triggers" visibleIf="connected &amp;&amp; dataSource.serverType.supportsTriggers()">
@@ -195,7 +195,7 @@
                                                 </items>
                                             </items>
                                         </folder>
-                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip" virtual="true">
+                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip" virtual="true" visibleIf="connected &amp;&amp; dataSource.serverType.supportsDependencies()">
                                             <items label="%tree.dependency.node.name" path="dependency" property="dependencies" icon="#reference" virtual="true"/>
                                         </folder>
                                     </items>
@@ -211,7 +211,7 @@
                                         <folder label="%tree.procedure_columns.node.name" icon="#columns" description="%tree.procedure_columns.node.name">
                                             <items label="%tree.procedure_columns.node.name" itemLabel="%tree.column.node.name" path="column" property="parameters" navigable="false"/>
                                         </folder>
-                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip">
+                                        <folder label="%tree.dependencies.node.name" icon="#references" description="%tree.dependencies.node.tip" visibleIf="connected &amp;&amp; dataSource.serverType.supportsDependencies()">
                                             <items label="%tree.dependency.node.name" path="dependency" property="dependencies" icon="#reference" virtual="true"/>
                                         </folder>
                                     </items>

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
@@ -56,6 +56,9 @@ public interface PostgreServerExtension {
 
     boolean supportsEventTriggers();
 
+    /** True if supports objects dependencies metadata reading */
+    boolean supportsDependencies();
+
     boolean supportsFunctionDefRead();
 
     boolean supportsFunctionCreate();

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
@@ -100,6 +100,11 @@ public abstract class PostgreServerExtensionBase implements PostgreServerExtensi
     }
 
     @Override
+    public boolean supportsDependencies() {
+        return true;
+    }
+
+    @Override
     public boolean supportsFunctionCreate() {
         return true;
     }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerRisingWave.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerRisingWave.java
@@ -67,17 +67,17 @@ public class PostgreServerRisingWave extends PostgreServerExtensionBase {
     }
 
     @Override
+    public boolean supportsDependencies() {
+        return false;
+    }
+
+    @Override
     public boolean supportsFunctionCreate() {
         return false;
     }
 
     @Override
     public boolean supportsRules() {
-        return false;
-    }
-
-    @Override
-    public boolean supportsRowLevelSecurity() {
         return false;
     }
 


### PR DESCRIPTION
For 

- [ ] Tables
- [ ] Views
- [ ] Materialized Views

And please check it also for any PostgreSQL - that dependencies folder is still in its place.

![2024-03-06 13_44_38-Window](https://github.com/dbeaver/dbeaver/assets/45152336/d0de7e63-ad84-4083-ac2b-f59d553d07cc)
