### PR TITLE
Avoid NPEs during text controls checking

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.hana.ui/src/org/jkiss/dbeaver/ext/hana/ui/views/HANAConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.hana.ui/src/org/jkiss/dbeaver/ext/hana/ui/views/HANAConnectionPage.java
@@ -138,7 +138,7 @@ public class HANAConnectionPage extends ConnectionPageWithAuth implements IDialo
         if (CommonUtils.isEmpty(portText.getText().trim()))
             return false;
         if (edition != HANAEdition.GENERIC) {
-            if (instanceText.getEditable()) {
+            if (instanceText.getEditable() && !CommonUtils.isEmpty(instanceText.getText())) {
                 int instance = CommonUtils.toInt(instanceText.getText().trim(), -1);
                 if(instance < 0 || instance > 99) return false;
             }


### PR DESCRIPTION
To avoid 

```
java.lang.NumberFormatException: empty String
	at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1842)
	at java.base/jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
	at java.base/java.lang.Double.parseDouble(Double.java:651)
	at org.jkiss.utils.CommonUtils.toInt(CommonUtils.java:378)
	at org.jkiss.dbeaver.ext.hana.ui.views.HANAConnectionPage.isComplete(HANAConnectionPage.java:142)
	at org.jkiss.dbeaver.ui.dialogs.connection.ConnectionPageSettings.isPageComplete(ConnectionPageSettings.java:468)
	at org.eclipse.jface.wizard.Wizard.canFinish(Wizard.java:161)
	at org.jkiss.dbeaver.ui.dialogs.MultiPageWizardDialog.updateButtons(MultiPageWizardDialog.java:515)
	at org.jkiss.dbeaver.ui.dialogs.connection.EditConnectionDialog.updateButtons(EditConnectionDialog.java:164)
	at org.jkiss.dbeaver.ui.dialogs.connection.ConnectionPageSettings.updateButtons(ConnectionPageSettings.java:502)
```