### PR TITLE
dbeaver/pro#2493 Change query to read Sybase procedures

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/generic/SQLServerMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/generic/SQLServerMetaModel.java
@@ -150,7 +150,9 @@ public class SQLServerMetaModel extends GenericMetaModel implements DBCQueryTran
 
     @Override
     public String getProcedureDDL(DBRProgressMonitor monitor, GenericProcedure sourceObject) throws DBException {
-        if (isSqlServer() && sourceObject.getDataSource().isServerVersionAtLeast(SQLServerConstants.SQL_SERVER_2005_VERSION_MAJOR,0)) {
+        String objectName = sourceObject.getName();
+        GenericDataSource dataSource = sourceObject.getDataSource();
+        if (isSqlServer() && dataSource.isServerVersionAtLeast(SQLServerConstants.SQL_SERVER_2005_VERSION_MAJOR,0)) {
             try (JDBCSession session = DBUtils.openMetaSession(monitor, sourceObject, "Read routine definition")) {
                 try (JDBCPreparedStatement dbStat = session.prepareStatement(
                     "SELECT definition FROM " + DBUtils.getQuotedIdentifier(sourceObject.getCatalog()) + ".sys.sql_modules WHERE object_id=OBJECT_ID(?)"
@@ -160,14 +162,34 @@ public class SQLServerMetaModel extends GenericMetaModel implements DBCQueryTran
                         if (dbResult.nextRow()) {
                             return dbResult.getString(1);
                         }
-                        return "-- Routine '" + sourceObject.getName() + "' definition not found in ";
+                        return "-- Routine '" + objectName + "' definition not found";
                     }
                 }
             } catch (SQLException e) {
-                throw new DBException(e, sourceObject.getDataSource());
+                throw new DBException(e, dataSource);
             }
         }
-        return extractSource(monitor, sourceObject.getDataSource(), sourceObject, sourceObject.getCatalog(), sourceObject.getSchema().getName(), sourceObject.getName());
+        if (getServerType() == ServerType.SYBASE) {
+            try (JDBCSession session = DBUtils.openMetaSession(monitor, sourceObject, "Read routine definition")) {
+                try (JDBCPreparedStatement dbStat = session.prepareStatement(
+                    "select proc_defn from SYS.SYSPROCEDURE s\n" +
+                        "LEFT JOIN " + DBUtils.getQuotedIdentifier(sourceObject.getCatalog()) + ".dbo.sysobjects so " +
+                        "ON so.id = s.object_id\n" +
+                        "WHERE s.proc_name=?"
+                )) {
+                    dbStat.setString(1, objectName);
+                    try (JDBCResultSet dbResult = dbStat.executeQuery()) {
+                        if (dbResult.nextRow()) {
+                            return dbResult.getString(1);
+                        }
+                        return "-- Routine '" + objectName + "' definition not found";
+                    }
+                }
+            } catch (SQLException e) {
+                throw new DBException(e, dataSource);
+            }
+        }
+        return extractSource(monitor, dataSource, sourceObject, sourceObject.getCatalog(), sourceObject.getSchema().getName(), objectName);
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/generic/SQLServerMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/generic/SQLServerMetaModel.java
@@ -152,7 +152,7 @@ public class SQLServerMetaModel extends GenericMetaModel implements DBCQueryTran
     public String getProcedureDDL(DBRProgressMonitor monitor, GenericProcedure sourceObject) throws DBException {
         String objectName = sourceObject.getName();
         GenericDataSource dataSource = sourceObject.getDataSource();
-        if (isSqlServer() && dataSource.isServerVersionAtLeast(SQLServerConstants.SQL_SERVER_2005_VERSION_MAJOR,0)) {
+        if (isSqlServer() && dataSource.isServerVersionAtLeast(SQLServerConstants.SQL_SERVER_2005_VERSION_MAJOR, 0)) {
             try (JDBCSession session = DBUtils.openMetaSession(monitor, sourceObject, "Read routine definition")) {
                 try (JDBCPreparedStatement dbStat = session.prepareStatement(
                     "SELECT definition FROM " + DBUtils.getQuotedIdentifier(sourceObject.getCatalog()) + ".sys.sql_modules WHERE object_id=OBJECT_ID(?)"
@@ -172,7 +172,7 @@ public class SQLServerMetaModel extends GenericMetaModel implements DBCQueryTran
         if (getServerType() == ServerType.SYBASE) {
             try (JDBCSession session = DBUtils.openMetaSession(monitor, sourceObject, "Read routine definition")) {
                 try (JDBCPreparedStatement dbStat = session.prepareStatement(
-                    "select proc_defn from SYS.SYSPROCEDURE s\n" +
+                    "SELECT proc_defn from SYS.SYSPROCEDURE s\n" +
                         "LEFT JOIN " + DBUtils.getQuotedIdentifier(sourceObject.getCatalog()) + ".dbo.sysobjects so " +
                         "ON so.id = s.object_id\n" +
                         "WHERE s.proc_name=?"


### PR DESCRIPTION
Please check both Sybase instances (12 and 16) with the big script
And check separately Sybase EE and Sybase CE
And any Azure database (that procedures DDLs are still readable)