### PR TITLE
#23126 hide aggregate functions for RisingWave

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerRisingWave.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerRisingWave.java
@@ -128,7 +128,7 @@ public class PostgreServerRisingWave extends PostgreServerExtensionBase {
 
     @Override
     public boolean supportsAggregates() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Just check our RisingWave instance - the navigator tree (for QA)