### PR TITLE
dbeaver/pro#2689 Don't rollback/disconnect during query execution

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
@@ -42,6 +42,9 @@ import org.jkiss.dbeaver.model.net.DBWHandlerConfiguration;
 import org.jkiss.dbeaver.model.net.DBWHandlerType;
 import org.jkiss.dbeaver.model.net.DBWNetworkHandler;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
+import org.jkiss.dbeaver.model.qm.QMUtils;
+import org.jkiss.dbeaver.model.qm.meta.QMMConnectionInfo;
+import org.jkiss.dbeaver.model.qm.meta.QMMStatementExecuteInfo;
 import org.jkiss.dbeaver.model.runtime.AbstractJob;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.DBRRunnableParametrized;
@@ -996,5 +999,24 @@ public class DBExecUtils {
             }
         }
         return sourceTable;
+    }
+
+    /**
+     * Checks if the data source has pending statements that are still executing.
+     */
+    public static boolean isExecutionInProgress(@NotNull DBPDataSource dataSource) {
+        for (DBSInstance instance : dataSource.getAvailableInstances()) {
+            for (DBCExecutionContext context : instance.getAllContexts()) {
+                QMMConnectionInfo qmConnection = QMUtils.getCurrentConnection(context);
+                if (qmConnection != null) {
+                    QMMStatementExecuteInfo lastExec = qmConnection.getExecutionStack();
+                    if (lastExec != null && !lastExec.isClosed()) {
+                        // It is in progress
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/runtime/jobs/DataSourceMonitorJob.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/runtime/jobs/DataSourceMonitorJob.java
@@ -28,17 +28,15 @@ import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBPMessageType;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.app.*;
-import org.jkiss.dbeaver.model.auth.SMSession;
 import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
 import org.jkiss.dbeaver.model.connection.DBPConnectionType;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
 import org.jkiss.dbeaver.model.exec.DBCTransactionManager;
+import org.jkiss.dbeaver.model.exec.DBExecUtils;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
 import org.jkiss.dbeaver.model.qm.QMTransactionState;
 import org.jkiss.dbeaver.model.qm.QMUtils;
-import org.jkiss.dbeaver.model.qm.meta.QMMConnectionInfo;
-import org.jkiss.dbeaver.model.qm.meta.QMMStatementExecuteInfo;
 import org.jkiss.dbeaver.model.runtime.AbstractJob;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSInstance;
@@ -46,7 +44,6 @@ import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.runtime.DBeaverNotifications;
 
 import java.util.*;
-import java.util.function.LongSupplier;
 
 /**
  * DataSourceMonitorJob.
@@ -196,14 +193,14 @@ public class DataSourceMonitorJob extends AbstractJob {
 
         DBPDataSource dataSource = dsDescriptor.getDataSource();
 
+        if (dataSource != null && DBExecUtils.isExecutionInProgress(dataSource)) {
+            return false;
+        }
+
         if (dataSource != null && disconnectTimeoutSeconds > 0 && idleInterval > disconnectTimeoutSeconds) {
             if (DisconnectJob.isInProcess(dsDescriptor)) {
                 return false;
             }
-            if (isExecutionInProgress(dataSource)) {
-                return false;
-            }
-
             // Kill idle connection
             DisconnectJob disconnectJob = new DisconnectJob(dsDescriptor);
             disconnectJob.schedule();
@@ -245,22 +242,6 @@ public class DataSourceMonitorJob extends AbstractJob {
             return true;
         }
 
-        return false;
-    }
-
-    private static boolean isExecutionInProgress(DBPDataSource dataSource) {
-        for (DBSInstance instance : dataSource.getAvailableInstances()) {
-            for (DBCExecutionContext context : instance.getAllContexts()) {
-                QMMConnectionInfo qmConnection = QMUtils.getCurrentConnection(context);
-                if (qmConnection != null) {
-                    QMMStatementExecuteInfo lastExec = qmConnection.getExecutionStack();
-                    if (lastExec != null && !lastExec.isClosed()) {
-                        // It is in progress
-                        return true;
-                    }
-                }
-            }
-        }
         return false;
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/runtime/jobs/DataSourceMonitorJob.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/runtime/jobs/DataSourceMonitorJob.java
@@ -193,12 +193,8 @@ public class DataSourceMonitorJob extends AbstractJob {
 
         DBPDataSource dataSource = dsDescriptor.getDataSource();
 
-        if (dataSource != null && DBExecUtils.isExecutionInProgress(dataSource)) {
-            return false;
-        }
-
         if (dataSource != null && disconnectTimeoutSeconds > 0 && idleInterval > disconnectTimeoutSeconds) {
-            if (DisconnectJob.isInProcess(dsDescriptor)) {
+            if (DisconnectJob.isInProcess(dsDescriptor) || DBExecUtils.isExecutionInProgress(dataSource)) {
                 return false;
             }
             // Kill idle connection

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -5513,11 +5513,6 @@ public class SQLEditor extends SQLEditorBase implements
             return null;
         }
 
-        final DBPDataSource dataSource = dataSourceContainer.getDataSource();
-        if (dataSource != null && DBExecUtils.isExecutionInProgress(dataSource)) {
-            return null;
-        }
-
         final long lastUserActivityTime = DataSourceMonitorJob.getLastUserActivityTime();
         if (lastUserActivityTime < 0) {
             return null;
@@ -5543,7 +5538,8 @@ public class SQLEditor extends SQLEditorBase implements
 
         if ((isTransactionInProgress && rollbackTimeoutSeconds > 0) &&
             (rollbackTimeoutSeconds > elapsedSeconds) &&
-            (disconnectTimeoutSeconds <= 0 || rollbackTimeoutSeconds < disconnectTimeoutSeconds)
+            (disconnectTimeoutSeconds <= 0 || rollbackTimeoutSeconds < disconnectTimeoutSeconds) &&
+            !DBExecUtils.isExecutionInProgress(dataSourceContainer.getDataSource())
         ) {
             return NLS.bind(
                 SQLEditorMessages.sql_editor_status_bar_rollback_label,

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -5513,6 +5513,11 @@ public class SQLEditor extends SQLEditorBase implements
             return null;
         }
 
+        final DBPDataSource dataSource = dataSourceContainer.getDataSource();
+        if (dataSource != null && DBExecUtils.isExecutionInProgress(dataSource)) {
+            return null;
+        }
+
         final long lastUserActivityTime = DataSourceMonitorJob.getLastUserActivityTime();
         if (lastUserActivityTime < 0) {
             return null;


### PR DESCRIPTION
This change affects just the "rollback idle transactions" option, but please also verify the "close idle connections" option works as before.