### PR TITLE
#23292 Fix errors in log on some query

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryTableInsertModel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/model/SQLQueryTableInsertModel.java
@@ -58,8 +58,10 @@ public class SQLQueryTableInsertModel extends SQLQueryTableStatementModel {
     public void propagateContextImpl(@NotNull SQLQueryDataContext context, @NotNull SQLQueryRecognitionContext statistics) {
         if (this.columnNames != null) {
             for (SQLQuerySymbolEntry columnName : this.columnNames) {
-                SQLQueryResultColumn column = context.resolveColumn(statistics.getMonitor(), columnName.getName());
-                SQLQueryValueColumnReferenceExpression.propagateColumnDefinition(columnName, column, statistics);
+                if (columnName.isNotClassified()) {
+                    SQLQueryResultColumn column = context.resolveColumn(statistics.getMonitor(), columnName.getName());
+                    SQLQueryValueColumnReferenceExpression.propagateColumnDefinition(columnName, column, statistics);
+                }
             }
         }
 


### PR DESCRIPTION
How to check:
1. Get this script
```
create table table_diff_1  (id bigint, uid uuid, name varchar);
create table table_diff_2  (id bigint, uid uuid, name varchar);

INSERT INTO table_diff_1 (id, uid, name)
SELECT num, uuid_in(overlay(overlay(md5(random()::text || ':' || clock_timestamp()::text) placing '4' from 13) placing to_hex(floor(random()*(11-8+1) + 8)::int)::text from 17)::cstring), 'load tests ' || num
FROM generate_series(1, 10000000) num;

INSERT INTO table2 (id, name)
SELECT uuid_in(overlay(overlay(md5(random()::text || ':' || clock_timestamp()::text) placing '4' from 13) placing to_hex(floor(random()*(11-8+1) + 8)::int)::text from 17)::cstring), 'load tests'
FROM generate_series(1, 10000000);


create table table_same_1 (id bigint, name varchar);
create table table_same_2 (id bigint, name varchar);

INSERT INTO table_same_1 (id, '')
SELECT uid
FROM generate_series(1, 1000000) uid;
```
2. Edit it in a different way
3. No errors should be in debug log