### PR TITLE
dbeaver/pro#2729 SSH page settings load fix

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/ConnectionPageNetworkHandler.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/dialogs/connection/ConnectionPageNetworkHandler.java
@@ -163,21 +163,12 @@ public class ConnectionPageNetworkHandler extends ConnectionWizardPage implement
 
         configurator.createControl(handlerComposite, handlerDescriptor, this::updatePageCompletion);
 
-        configurator.loadSettings(handlerConfiguration);
-
         if (useHandlerCheck != null) {
             useHandlerCheck.setSelection(handlerConfiguration.isEnabled());
         }
 
         enableHandlerContent();
         updateProfileList();
-
-        if (activeProfile != null) {
-            DBWHandlerConfiguration profileConfig = activeProfile.getConfiguration(handlerDescriptor);
-            if (profileConfig != null) {
-                configurator.loadSettings(profileConfig);
-            }
-        }
 
         setControl(composite);
     }

--- a/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/JSCHSessionController.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.jsch/src/org/jkiss/dbeaver/model/net/ssh/JSCHSessionController.java
@@ -71,7 +71,7 @@ public class JSCHSessionController extends AbstractSessionController<JSCHSession
         } else if (auth instanceof SSHAuthConfiguration.KeyFile key) {
             log.debug("SSHSessionController: Using public key authentication");
             try {
-                addIdentityKeyFile(monitor, configuration.getDataSource(), key.path(), key.password());
+                addIdentityKeyFile(monitor, configuration.getDataSource(), Path.of(key.path()), key.password());
             } catch (Exception e) {
                 throw new DBException("Error adding identity key", e);
             }

--- a/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/SSHJSessionController.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.sshj/src/org/jkiss/dbeaver/model/net/ssh/SSHJSessionController.java
@@ -79,11 +79,10 @@ public class SSHJSessionController extends AbstractSessionController<SSHJSession
             if (auth instanceof SSHAuthConfiguration.Password password) {
                 client.authPassword(host.username(), password.password());
             } else if (auth instanceof SSHAuthConfiguration.KeyFile key) {
-                final String location = key.path().toAbsolutePath().toString();
                 if (CommonUtils.isEmpty(key.password())) {
-                    client.authPublickey(host.username(), location);
+                    client.authPublickey(host.username(), key.path());
                 } else {
-                    client.authPublickey(host.username(), client.loadKeys(location, key.password().toCharArray()));
+                    client.authPublickey(host.username(), client.loadKeys(key.path(), key.password().toCharArray()));
                 }
             } else if (auth instanceof SSHAuthConfiguration.KeyData key) {
                 final PasswordFinder finder = CommonUtils.isEmpty(key.password())

--- a/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHTunnelConfiguratorUI.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHTunnelConfiguratorUI.java
@@ -65,9 +65,6 @@ import org.jkiss.dbeaver.utils.SystemVariablesResolver;
 import org.jkiss.utils.CommonUtils;
 
 import java.lang.reflect.InvocationTargetException;
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -760,23 +757,10 @@ public class SSHTunnelConfiguratorUI implements IObjectPropertyConfigurator<Obje
                 case PASSWORD -> new SSHAuthConfiguration.Password(password, savePassword);
                 case PUBLIC_KEY -> {
                     final String privateKey = privateKeyText.getText().trim();
-                    if (privateKey.isEmpty()) {
-                        throw new DBException("Private key must not be empty");
-                    }
                     if (DBWorkbench.isDistributed()) {
                         yield new SSHAuthConfiguration.KeyData(privateKey, password, savePassword);
                     } else {
-                        final Path path;
-                        try {
-                            path = Path.of(privateKey);
-                        } catch (InvalidPathException e) {
-                            // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394
-                            throw new DBException("Invalid private key path: %s".formatted(privateKey));
-                        }
-                        if (Files.notExists(path)) {
-                            throw new DBException("Private key file does not exist: " + path);
-                        }
-                        yield new SSHAuthConfiguration.KeyFile(path, password, savePassword);
+                        yield new SSHAuthConfiguration.KeyFile(privateKey, password, savePassword);
                     }
                 }
                 case AGENT -> new SSHAuthConfiguration.Agent();

--- a/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages.java
@@ -55,7 +55,6 @@ public class SSHUIMessages extends NLS {
     public static String model_ssh_configurator_group_timeouts_text;
     public static String model_ssh_configurator_group_port_forwarding_text;
     public static String model_ssh_configurator_group_jump_server_settings_text;
-    public static String model_ssh_configurator_group_jump_server_checkbox_label;
     public static String model_ssh_configurator_variables_hint_label;
     public static String model_ssh_configurator_ssh_documentation_link;
 

--- a/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages_ru.properties
+++ b/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHUIMessages_ru.properties
@@ -53,8 +53,6 @@ model_ssh_configurator_label_bypass_verification_description = \u041E\u0442\u043
 
 model_ssh_configurator_group_jump_server_settings_text = Jump \u0441\u0435\u0440\u0432\u0435\u0440\u0430
 
-model_ssh_configurator_group_jump_server_checkbox_label = \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C jump \u0441\u0435\u0440\u0432\u0435\u0440
-
 model_ssh_configurator_variables_hint_label = You can use variables in SSH parameters.
 
 model_ssh_configurator_ssh_documentation_link = <a>\u0414\u043E\u043A\u0443\u043C\u0435\u043D\u0442\u0430\u0446\u0438\u044F SSH</a>

--- a/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
@@ -275,13 +275,13 @@ public class SSHUtils {
                 final String path = configuration.getStringProperty(prefix + SSHConstants.PROP_KEY_PATH);
                 if (CommonUtils.isEmpty(path)) {
                     String privKeyValue = configuration.getSecureProperty(prefix + SSHConstants.PROP_KEY_VALUE);
-                    if (privKeyValue == null) {
+                    if (validate && privKeyValue == null) {
                         throw new DBException("Private key not specified");
                     }
-                    yield new SSHAuthConfiguration.KeyData(privKeyValue, password, savePassword);
+                    yield new SSHAuthConfiguration.KeyData(CommonUtils.notEmpty(privKeyValue), password, savePassword);
                 } else {
                     final Path file = Path.of(path);
-                    if (Files.notExists(file)) {
+                    if (validate && Files.notExists(file)) {
                         throw new DBException("Private key file '" + path + "' does not exist");
                     }
                     yield new SSHAuthConfiguration.KeyFile(file, password, savePassword);

--- a/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/SSHUtils.java
@@ -281,16 +281,7 @@ public class SSHUtils {
                     yield new SSHAuthConfiguration.KeyData(CommonUtils.notEmpty(privKeyValue), password, savePassword);
                 } else {
                     if (validate) {
-                        final Path file;
-                        try {
-                            file = Path.of(path);
-                        } catch (InvalidPathException e) {
-                            // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394
-                            throw new DBException(kind.formatErrorMessage("invalid private key path: %s".formatted(path)));
-                        }
-                        if (Files.notExists(file)) {
-                            throw new DBException(kind.formatErrorMessage("private key file does not exist: " + path));
-                        }
+                        validatePathAndEnsureExists(kind, path);
                     }
                     yield new SSHAuthConfiguration.KeyFile(path, password, savePassword);
                 }
@@ -356,6 +347,20 @@ public class SSHUtils {
 
         if (markEnabled) {
             configuration.setProperty(prefix + RegistryConstants.ATTR_ENABLED, true);
+        }
+    }
+
+    // Had to extract this code into a separate method to avoid triggering a JDT compiler bug
+    // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394
+    private static void validatePathAndEnsureExists(@NotNull ConfigurationKind kind, @NotNull String string) throws DBException {
+        final Path path;
+        try {
+            path = Path.of(string);
+        } catch (InvalidPathException e) {
+            throw new DBException(kind.formatErrorMessage("invalid private key path: " + string));
+        }
+        if (Files.notExists(path)) {
+            throw new DBException(kind.formatErrorMessage("private key file does not exist: " + string));
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/config/SSHAuthConfiguration.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh/src/org/jkiss/dbeaver/model/net/ssh/config/SSHAuthConfiguration.java
@@ -19,8 +19,6 @@ package org.jkiss.dbeaver.model.net.ssh.config;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 
-import java.nio.file.Path;
-
 public sealed interface SSHAuthConfiguration {
     sealed interface WithPassword extends SSHAuthConfiguration {
         @Nullable
@@ -32,7 +30,7 @@ public sealed interface SSHAuthConfiguration {
     record Password(@Nullable String password, boolean savePassword) implements WithPassword {
     }
 
-    record KeyFile(@NotNull Path path, @Nullable String password, boolean savePassword) implements WithPassword {
+    record KeyFile(@NotNull String path, @Nullable String password, boolean savePassword) implements WithPassword {
     }
 
     record KeyData(@NotNull String data, @Nullable String password, boolean savePassword) implements WithPassword {


### PR DESCRIPTION
To reproduce:
1. Choose the "public key" authentication method and specify the path to a key
2. Save the connection
3. Delete the specified key
4. Open the connection, open the SSH page

Also, check:
- [ ] Changing the active profile updates the current configuration, including the "Enable XXX" checkbox next to the combo