### PR TITLE
dbeaver/pro#2744 Fix parallel transfer job cancellation

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DataTransferJob.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DataTransferJob.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.exec.DBCStatistics;
 import org.jkiss.dbeaver.model.runtime.AbstractJob;
@@ -46,7 +47,7 @@ public class DataTransferJob extends AbstractJob {
         @NotNull DataTransferSettings settings,
         @NotNull DBTTask task,
         @NotNull Log log,
-        @NotNull DBRProgressMonitor parentMonitor,
+        @Nullable DBRProgressMonitor parentMonitor,
         int index
     ) {
         super("Data transfer job [" + index + "]: " + settings.getConsumer().getName());
@@ -75,7 +76,7 @@ public class DataTransferJob extends AbstractJob {
     @Override
     protected IStatus run(DBRProgressMonitor jobMonitor) {
         final int pipeCount = settings.getDataPipes().size();
-        final DBRProgressMonitor monitor = pipeCount == 1 ? parentMonitor : jobMonitor;
+        final DBRProgressMonitor monitor = parentMonitor != null ? parentMonitor : jobMonitor;
         monitor.beginTask("Perform data transfer", pipeCount);
         hasErrors = false;
         long startTime = System.currentTimeMillis();
@@ -89,7 +90,9 @@ public class DataTransferJob extends AbstractJob {
             }
             try {
                 hasErrors |= !transferData(monitor, transferPipe);
-                parentMonitor.worked(1);
+                if (parentMonitor != null) {
+                    parentMonitor.worked(1);
+                }
                 jobMonitor.worked(1);
             } catch (Exception e) {
                 // Report as an OK status to avoid showing the error in the UI (it's handled by the caller)

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/task/DTTaskHandlerTransfer.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/task/DTTaskHandlerTransfer.java
@@ -17,6 +17,8 @@
 package org.jkiss.dbeaver.tools.transfer.task;
 
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.jobs.JobGroup;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
@@ -24,6 +26,7 @@ import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.exec.DBCStatistics;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.DBRRunnableContext;
+import org.jkiss.dbeaver.model.runtime.ProxyProgressMonitor;
 import org.jkiss.dbeaver.model.task.*;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.tools.transfer.*;
@@ -162,18 +165,39 @@ public class DTTaskHandlerTransfer implements DBTTaskHandler, DBTTaskInfoCollect
         final Throwable[] error = new Throwable[1];
         try {
             runnableContext.run(true, true, monitor -> {
+                final JobGroup group;
+                if (dataPipes.size() > 1) {
+                    group = new JobGroup("Data transfer", totalJobs, totalJobs);
+                } else {
+                    group = null;
+                }
+
                 final DataTransferJob[] jobs = new DataTransferJob[totalJobs];
                 for (int i = 0; i < totalJobs; i++) {
                     DataTransferJob job = new DataTransferJob(settings, task, log, monitor, i);
+                    job.setJobGroup(group);
                     job.schedule();
                     jobs[i] = job;
                 }
+
                 monitor.beginTask("Performing data transfer in parallel", settings.getDataPipes().size());
-                for (DataTransferJob job : jobs) {
+
+                if (group != null) {
                     try {
-                        job.join();
-                    } catch (InterruptedException e) {
-                        break;
+                        group.join(0, new ProxyProgressMonitor(monitor));
+                    } catch (InterruptedException | OperationCanceledException e) {
+                        group.cancel();
+                        return;
+                    }
+                }
+
+                for (DataTransferJob job : jobs) {
+                    if (group == null) {
+                        try {
+                            job.join();
+                        } catch (InterruptedException e) {
+                            break;
+                        }
                     }
                     final IStatus result = job.getResult();
                     if (result.getException() != null) {

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/task/DTTaskHandlerTransfer.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/task/DTTaskHandlerTransfer.java
@@ -166,7 +166,7 @@ public class DTTaskHandlerTransfer implements DBTTaskHandler, DBTTaskInfoCollect
         try {
             runnableContext.run(true, true, monitor -> {
                 final JobGroup group;
-                if (dataPipes.size() > 1) {
+                if (totalJobs > 1) {
                     group = new JobGroup("Data transfer", totalJobs, totalJobs);
                 } else {
                     group = null;
@@ -174,7 +174,7 @@ public class DTTaskHandlerTransfer implements DBTTaskHandler, DBTTaskInfoCollect
 
                 final DataTransferJob[] jobs = new DataTransferJob[totalJobs];
                 for (int i = 0; i < totalJobs; i++) {
-                    DataTransferJob job = new DataTransferJob(settings, task, log, monitor, i);
+                    DataTransferJob job = new DataTransferJob(settings, task, log, totalJobs == 1 ? monitor : null, i);
                     job.setJobGroup(group);
                     job.schedule();
                     jobs[i] = job;


### PR DESCRIPTION
It should now be possible to cancel the topmost job, and all other transfer jobs should be canceled as well.