### PR TITLE
Fix potential github action smells

### DIFF
--- a/.github/workflows/commit-msgs-validator.yml
+++ b/.github/workflows/commit-msgs-validator.yml
@@ -14,4 +14,6 @@ on:
 
 jobs:
   check-commit-message:
+    permissions: 
+      contents: write
     uses: dbeaver/dbeaver/.github/workflows/reused-commit-msgs-validator.yml@devel

--- a/.github/workflows/reused-commit-msgs-validator.yml
+++ b/.github/workflows/reused-commit-msgs-validator.yml
@@ -8,10 +8,12 @@ on:
 jobs:
   validate-commit-message:
     name: Validate Commit Message
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    permissions: 
+      contents: write
     steps:
       - name: Validate Commit Message Content
-        uses: gsactions/commit-message-checker@v1
+        uses: gsactions/commit-message-checker@b88ee88552f16f594ca19cb2c7fcd90df95c9bd4  # v1
         with:
           pattern: '^(#\d{3,6}|((Merge|dbeaver|cloudbeaver).+?#\d{3,6})|((DB-|CB-|web-)\d+)).*$'
           excludeDescription: 'true'


### PR DESCRIPTION
Hey! 🙂
I want to contribute the following changes to your workflow:

- Stop running workflows when there is a newer commit in PR
- Use commit hash instead of tags for action versions
- Use fixed version for runs-on argument
- Define permissions for workflows with external actions

These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html)

closes #29272 