### PR TITLE
#23324 Add loop as begin end block in Vertica

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaSQLDialect.java
@@ -40,6 +40,7 @@ public class VerticaSQLDialect extends GenericSQLDialect implements TPRuleProvid
     private static final String[][] VERTICA_BEGIN_END_BLOCK = new String[][]{
             {SQLConstants.BLOCK_BEGIN, SQLConstants.BLOCK_END},
             {SQLConstants.KEYWORD_CASE, SQLConstants.BLOCK_END},
+            {"LOOP", SQLConstants.BLOCK_END + " LOOP"}
     };
 
     private static String[] EXEC_KEYWORDS = {"CALL"};

--- a/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaSQLDialect.java
@@ -45,6 +45,9 @@ public class VerticaSQLDialect extends GenericSQLDialect implements TPRuleProvid
 
     private static String[] EXEC_KEYWORDS = {"CALL"};
 
+    private static final String[] VERTICA_BLOCK_HEADERS = new String[]{
+        "DECLARE"
+    };
     private static String[] VERTICA_KEYWORDS = new String[]{
         // SELECT * FROM keywords WHERE reserved = 'R'
         "BIT",
@@ -124,6 +127,11 @@ public class VerticaSQLDialect extends GenericSQLDialect implements TPRuleProvid
     @Override
     public String[][] getBlockBoundStrings() {
         return VERTICA_BEGIN_END_BLOCK;
+    }
+
+    @Override
+    public String[] getBlockHeaderStrings() {
+        return VERTICA_BLOCK_HEADERS;
     }
 
     @NotNull


### PR DESCRIPTION
We can't solve this issue, while we don't have a nearly full grammar for CREATE PROCEDURE statement.
I just added LOOP - END LOOP as a block and DECLARE as a block header in dialect.
(Look at the folding)
was:
![image](https://github.com/dbeaver/dbeaver/assets/28875055/77456dcc-7438-4d35-a396-8472a0bf3215)

become:
![image](https://github.com/dbeaver/dbeaver/assets/28875055/6296ec9d-bfa5-4d20-9562-57871055c61c)
