### PR TITLE
dbeaver/dbeaver#22517 Language-independent bookmarks

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/resources/bookmarks/BookmarksHandlerImpl.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/resources/bookmarks/BookmarksHandlerImpl.java
@@ -233,16 +233,16 @@ public class BookmarksHandlerImpl extends AbstractResourceHandler {
         throws DBException
     {
         if (CommonUtils.isEmpty(title)) {
-            title = node.getNodeDisplayName();
+            title = node.getNodeId();
         }
 
         List<String> nodePath = new ArrayList<>();
         for (DBNNode parent = node; !(parent instanceof DBNDataSource); parent = parent.getParentNode()) {
-            nodePath.add(0, parent.getNodeDisplayName());
+            nodePath.add(0, parent.getNodeId());
         }
         BookmarkStorage storage = new BookmarkStorage(
             title,
-            node.getNodeTypeLabel() + " " + node.getNodeDisplayName(), //$NON-NLS-1$
+            node.getNodeTypeLabel() + " " + node.getNodeId(), //$NON-NLS-1$
             node.getNodeIconDefault(),
             node.getDataSourceContainer().getId(),
             nodePath);
@@ -277,7 +277,7 @@ public class BookmarksHandlerImpl extends AbstractResourceHandler {
                     final DBNNode[] children = currentNode.getChildren(monitor);
                     if (!ArrayUtils.isEmpty(children)) {
                         for (DBNNode node : children) {
-                            if (path.equals(node.getNodeDisplayName())) {
+                            if (path.equals(node.getNodeId()) || path.equals(node.getNodeDisplayName())) {
                                 nextChild = node;
                                 break;
                             }


### PR DESCRIPTION
Changes bookmark generation to use node IDs instead of display names.