### PR TITLE
#26708 Hide `.project` and `.settings` folder only in standalone app

### DIFF
--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/LocalProjectImpl.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/LocalProjectImpl.java
@@ -232,7 +232,7 @@ public class LocalProjectImpl extends BaseProjectImpl {
     }
 
     public void hideConfigurationFiles() {
-        if (project.isOpen()) {
+        if (project.isOpen() && DBWorkbench.getPlatform().getApplication().isStandalone()) {
             // To avoid accidental corruption of the workspace configuration by search/replace commands,
             // we need to mark metadata folder as hidden (see dbeaver/dbeaver#20759)
             IFolder metadataFolder = project.getFolder(DBPProject.METADATA_FOLDER);


### PR DESCRIPTION
Please check
- [x] the issue by steps to reproduce
- [ ] this issue on eclipse plugin https://github.com/dbeaver/dbeaver/issues/20759