### PR TITLE
#23039 Fix trailing space insert after completion

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLCompletionProposal.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLCompletionProposal.java
@@ -114,15 +114,14 @@ public class SQLCompletionProposal extends SQLCompletionProposalBase implements 
                     } else {
                         if (docLen <= replacementSum + 2) {
                             insertTrailingSpace = true;
-                        } else if (Character.isWhitespace(document.getChar(replacementSum))) {
-                            insertTrailingSpace = docLen > replacementSum + 1 && (!Character.isSpaceChar(document.getChar(replacementSum + 1)));
                         } else {
-                            insertTrailingSpace = true;
+                            final char ch = document.getChar(replacementSum);
+                            insertTrailingSpace = !Character.isWhitespace(ch) || ch == '\r' || ch == '\n';
                         }
                         if (insertTrailingSpace) {
                             replaceOn += ' ';
+                            cursorPosition++;
                         }
-                        cursorPosition++;
                     }
                 }
             }


### PR DESCRIPTION
This issue CAN be reproduced on Windows. Use the attached script and start auto-completing the column on the second line.

The issue is caused by the line terminator on Linux and macOS.

[script.sql.txt](https://github.com/dbeaver/dbeaver/files/15419711/script.sql.txt)
