### PR TITLE
dbeaver/dbeaver#23314 Hide unrelated folders and files

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/ModelPreferences.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/ModelPreferences.java
@@ -226,6 +226,7 @@ public final class ModelPreferences
     public static final String NAVIGATOR_SHOW_FOLDER_PLACEHOLDERS = "navigator.show.folder.placeholders"; //$NON-NLS-1$
     public static final String NAVIGATOR_SORT_ALPHABETICALLY = "navigator.sort.case.insensitive"; //$NON-NLS-1$
     public static final String NAVIGATOR_SORT_FOLDERS_FIRST = "navigator.sort.forlers.first"; //$NON-NLS-1$
+    public static final String NAVIGATOR_SHOW_HIDDEN_ASSETS = "navigator.show.hidden.assets"; //$NON-NLS-1$
 
     public static final String PLATFORM_LANGUAGE = "platform.language"; //$NON-NLS-1$
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNProject.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNProject.java
@@ -191,6 +191,10 @@ public class DBNProject extends DBNResource implements DBNNodeExtendable {
             children.removeIf(node -> node instanceof DBNResource && !((DBNResource) node).isResourceExists());
         }
 
+        if (!DBWorkbench.getPlatform().getPreferenceStore().getBoolean(ModelPreferences.NAVIGATOR_SHOW_HIDDEN_ASSETS)) {
+        	children.removeIf(node -> node instanceof DBNResource && ((DBNResource) node).getContentLocationResource().getLocation().toFile().isHidden());
+        }
+        
         if (!CommonUtils.isEmpty(extraNodes)) {
             children.addAll(extraNodes);
         }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNUtils.java
@@ -17,7 +17,6 @@
 package org.jkiss.dbeaver.model.navigator;
 
 import org.apache.commons.jexl3.JexlContext;
-
 import org.eclipse.core.resources.IResource;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.java
@@ -168,6 +168,8 @@ public class UINavigatorMessages extends NLS {
     public static String pref_page_projects_settings_label_not_store_resources_in_another_project;
     public static String pref_page_projects_settings_label_restart_require_refresh_global_settings;
     public static String pref_page_projects_settings_description;
+    public static String pref_page_projects_settings_show_hidden_assets;
+    public static String pref_page_projects_settings_show_hidden_assets_tip;
 
     public static String ui_navigator_loading_text_loading;
     public static String ui_properties_category_information;

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
@@ -146,6 +146,8 @@ pref_page_projects_settings_label_not_use_hidden_folders = Cannot use hidden fol
 pref_page_projects_settings_label_not_store_resources_in_another_project = Cannot store resources in another project
 pref_page_projects_settings_label_restart_require_refresh_global_settings = Restart is required to refresh global settings
 pref_page_projects_settings_description = DBeaver project resources/folders settings
+pref_page_projects_settings_show_hidden_assets = Show hidden folders and files
+pref_page_projects_settings_show_hidden_assets_tip = Show hidden files and folders (as determined by the operating system) in project views.
 
 ui_navigator_loading_text_loading=Loading
 ui_properties_category_information = Information

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/preferences/PrefPageDatabaseNavigator.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/preferences/PrefPageDatabaseNavigator.java
@@ -68,6 +68,7 @@ public class PrefPageDatabaseNavigator extends AbstractPrefPage implements IWork
     private Button showObjectTipsCheck;
     private Button showToolTipsCheck;
     private Button showContentsInToolTipsContents;
+    private Button showHiddenAssets;
 
     private Button showResourceFolderPlaceholdersCheck;
     private Button groupByDriverCheck;
@@ -175,6 +176,12 @@ public class PrefPageDatabaseNavigator extends AbstractPrefPage implements IWork
                 UINavigatorMessages.pref_page_database_general_label_show_contents_in_tooltips_tip,
                 store.getBoolean(NavigatorPreferences.NAVIGATOR_SHOW_CONTENTS_IN_TOOLTIP),
                 2);
+            showHiddenAssets = UIUtils.createCheckbox(
+                navigatorGroup,
+                UINavigatorMessages.pref_page_projects_settings_show_hidden_assets,
+                UINavigatorMessages.pref_page_projects_settings_show_hidden_assets_tip,
+                store.getBoolean(ModelPreferences.NAVIGATOR_SHOW_HIDDEN_ASSETS),
+                2);
         }
 
         {
@@ -276,6 +283,7 @@ public class PrefPageDatabaseNavigator extends AbstractPrefPage implements IWork
         colorAllNodesCheck.setSelection(store.getDefaultBoolean(NavigatorPreferences.NAVIGATOR_COLOR_ALL_NODES));
         showResourceFolderPlaceholdersCheck.setSelection(store.getDefaultBoolean(ModelPreferences.NAVIGATOR_SHOW_FOLDER_PLACEHOLDERS));
         groupByDriverCheck.setSelection(store.getDefaultBoolean(NavigatorPreferences.NAVIGATOR_GROUP_BY_DRIVER));
+        showHiddenAssets.setSelection(store.getDefaultBoolean(ModelPreferences.NAVIGATOR_SHOW_HIDDEN_ASSETS));
         longListFetchSizeText.setText(String.valueOf(store.getDefaultInt(NavigatorPreferences.NAVIGATOR_LONG_LIST_FETCH_SIZE)));
         UIUtils.setComboSelection(objDoubleClickBehavior, store.getDefaultString(NavigatorPreferences.NAVIGATOR_OBJECT_DOUBLE_CLICK));
         UIUtils.setComboSelection(dsDoubleClickBehavior, store.getDefaultString(NavigatorPreferences.NAVIGATOR_CONNECTION_DOUBLE_CLICK));
@@ -302,6 +310,7 @@ public class PrefPageDatabaseNavigator extends AbstractPrefPage implements IWork
         store.setValue(NavigatorPreferences.NAVIGATOR_COLOR_ALL_NODES, colorAllNodesCheck.getSelection());
         store.setValue(ModelPreferences.NAVIGATOR_SHOW_FOLDER_PLACEHOLDERS, showResourceFolderPlaceholdersCheck.getSelection());
         store.setValue(NavigatorPreferences.NAVIGATOR_GROUP_BY_DRIVER, groupByDriverCheck.getSelection());
+        store.setValue(ModelPreferences.NAVIGATOR_SHOW_HIDDEN_ASSETS, showHiddenAssets.getSelection());
         store.setValue(NavigatorPreferences.NAVIGATOR_LONG_LIST_FETCH_SIZE, longListFetchSizeText.getText());
         NavigatorPreferences.DoubleClickBehavior objDCB = NavigatorPreferences.DoubleClickBehavior.EXPAND;
         if (objDoubleClickBehavior.getSelectionIndex() == 0) {


### PR DESCRIPTION
Adds a setting that hides folders and files from project views that are considered hidden by the operating system.

The new setting is the final checkbox in the navigator group.
![settings](https://github.com/dbeaver/dbeaver/assets/99054872/afc9c1a3-f44c-462b-b7dd-54b9fe1cfb19)
