### PR TITLE
#22795 Transaction status update fix

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -5531,6 +5531,8 @@ public class SQLEditor extends SQLEditorBase implements
     }
 
     private class TransactionStatusUpdateJob extends AbstractJob {
+        private static final int UPDATE_DELAY_MS = 1000;
+
         public TransactionStatusUpdateJob() {
             super("Update transaction status");
             setUser(false);
@@ -5545,17 +5547,13 @@ public class SQLEditor extends SQLEditorBase implements
 
             UIUtils.syncExec(() -> updateStatusField(STATS_CATEGORY_TRANSACTION_TIMEOUT));
 
-            schedule(1000);
+            schedule(UPDATE_DELAY_MS);
             return Status.OK_STATUS;
         }
     }
 
     @Nullable
     private String getTransactionStatusText() throws DBCException {
-        if (true) {
-            return getTitle() + ": " + String.valueOf(System.currentTimeMillis());
-        }
-
         if (dataSourceContainer == null) {
             return null;
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -205,6 +205,8 @@ public class SQLEditor extends SQLEditorBase implements
         MULTIPLE_RESULTS_PER_TAB_PROPERTY, MULTIPLE_RESULTS_PER_TAB_PROP_NAME,
         SQLPreferenceConstants.MULTIPLE_RESULTS_PER_TAB, CommonUtils.toString(false));
 
+    private static volatile TransactionStatusUpdateJob transactionStatusUpdateJob;
+
     static final String STATS_CATEGORY_TRANSACTION_TIMEOUT = "TransactionTimeout";
     private ResultSetOrientation resultSetOrientation = ResultSetOrientation.HORIZONTAL;
     private CustomSashForm resultsSash;
@@ -302,10 +304,6 @@ public class SQLEditor extends SQLEditorBase implements
             }
         }
     };
-
-    static {
-        new TransactionStatusUpdateJob().schedule();
-    }
 
     public SQLEditor() {
         PlatformUI.getWorkbench().getThemeManager().addPropertyChangeListener(themeChangeListener);
@@ -1044,6 +1042,15 @@ public class SQLEditor extends SQLEditorBase implements
         // Update controls
         UIExecutionQueue.queueExec(this::onDataSourceChange);
         themeChangeListener.propertyChange(null);
+
+        if (transactionStatusUpdateJob == null) {
+            synchronized (this) {
+                if (transactionStatusUpdateJob == null) {
+                    transactionStatusUpdateJob = new TransactionStatusUpdateJob();
+                    transactionStatusUpdateJob.schedule();
+                }
+            }
+        }
     }
 
     protected boolean isHideQueryText() {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -3053,7 +3053,6 @@ public class SQLEditor extends SQLEditorBase implements
         }
 
         PlatformUI.getWorkbench().getThemeManager().removePropertyChangeListener(themeChangeListener);
-
         UIUtils.dispose(editorImage);
         baseEditorImage = null;
         editorImage = null;

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -5552,7 +5552,7 @@ public class SQLEditor extends SQLEditorBase implements
         }
     }
 
-    public static class TransactionStatusUpdateJob extends AbstractJob {
+    public static final class TransactionStatusUpdateJob extends AbstractJob {
         private static final int UPDATE_DELAY_MS = 1000;
 
         public TransactionStatusUpdateJob() {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -303,6 +303,10 @@ public class SQLEditor extends SQLEditorBase implements
         }
     };
 
+    static {
+        new TransactionStatusUpdateJob().schedule();
+    }
+
     public SQLEditor() {
         PlatformUI.getWorkbench().getThemeManager().addPropertyChangeListener(themeChangeListener);
     }
@@ -5552,7 +5556,7 @@ public class SQLEditor extends SQLEditorBase implements
         }
     }
 
-    public static final class TransactionStatusUpdateJob extends AbstractJob {
+    private static final class TransactionStatusUpdateJob extends AbstractJob {
         private static final int UPDATE_DELAY_MS = 1000;
 
         public TransactionStatusUpdateJob() {
@@ -5563,7 +5567,7 @@ public class SQLEditor extends SQLEditorBase implements
 
         @Override
         protected IStatus run(DBRProgressMonitor monitor) {
-            if (monitor.isCanceled()) {
+            if (monitor.isCanceled() || DBWorkbench.getPlatform().isShuttingDown()) {
                 return Status.CANCEL_STATUS;
             }
             IWorkbenchWindow window = UIUtils.findActiveWorkbenchWindow();

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorActivator.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorActivator.java
@@ -33,8 +33,7 @@ public class SQLEditorActivator extends AbstractUIPlugin {
     // The shared instance
     private static SQLEditorActivator plugin;
     private DBPPreferenceStore preferences;
-
-    private static SQLEditor.TransactionStatusUpdateJob transactionStatusUpdateJob;
+    private SQLEditor.TransactionStatusUpdateJob transactionStatusUpdateJob;
 
     public SQLEditorActivator() {
     }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorActivator.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorActivator.java
@@ -21,6 +21,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.jkiss.dbeaver.model.impl.preferences.BundlePreferenceStore;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
 import org.jkiss.dbeaver.model.runtime.features.DBRFeatureRegistry;
+import org.jkiss.dbeaver.ui.editors.sql.SQLEditor;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorFeatures;
 import org.osgi.framework.BundleContext;
 
@@ -33,6 +34,8 @@ public class SQLEditorActivator extends AbstractUIPlugin {
     private static SQLEditorActivator plugin;
     private DBPPreferenceStore preferences;
 
+    private static SQLEditor.TransactionStatusUpdateJob transactionStatusUpdateJob;
+
     public SQLEditorActivator() {
     }
 
@@ -42,11 +45,19 @@ public class SQLEditorActivator extends AbstractUIPlugin {
         plugin = this;
         preferences = new BundlePreferenceStore(getBundle());
 
+        transactionStatusUpdateJob = new SQLEditor.TransactionStatusUpdateJob();
+        transactionStatusUpdateJob.schedule();
+
         DBRFeatureRegistry.getInstance().registerFeatures(SQLEditorFeatures.class);
     }
 
     @Override
     public void stop(BundleContext context) throws Exception {
+        if (transactionStatusUpdateJob != null) {
+            transactionStatusUpdateJob.cancel();
+            transactionStatusUpdateJob = null;
+        }
+
         plugin = null;
         super.stop(context);
     }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorActivator.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/internal/SQLEditorActivator.java
@@ -21,7 +21,6 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.jkiss.dbeaver.model.impl.preferences.BundlePreferenceStore;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
 import org.jkiss.dbeaver.model.runtime.features.DBRFeatureRegistry;
-import org.jkiss.dbeaver.ui.editors.sql.SQLEditor;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorFeatures;
 import org.osgi.framework.BundleContext;
 
@@ -33,7 +32,6 @@ public class SQLEditorActivator extends AbstractUIPlugin {
     // The shared instance
     private static SQLEditorActivator plugin;
     private DBPPreferenceStore preferences;
-    private SQLEditor.TransactionStatusUpdateJob transactionStatusUpdateJob;
 
     public SQLEditorActivator() {
     }
@@ -44,19 +42,11 @@ public class SQLEditorActivator extends AbstractUIPlugin {
         plugin = this;
         preferences = new BundlePreferenceStore(getBundle());
 
-        transactionStatusUpdateJob = new SQLEditor.TransactionStatusUpdateJob();
-        transactionStatusUpdateJob.schedule();
-
         DBRFeatureRegistry.getInstance().registerFeatures(SQLEditorFeatures.class);
     }
 
     @Override
     public void stop(BundleContext context) throws Exception {
-        if (transactionStatusUpdateJob != null) {
-            transactionStatusUpdateJob.cancel();
-            transactionStatusUpdateJob = null;
-        }
-
         plugin = null;
         super.stop(context);
     }


### PR DESCRIPTION
I did not find a better solution except for creating a separate service that will listen for part activation and update the status bar accordingly, but I decided to keep it simple.

If we ever decide to move this indicator from the status bar to the toolbar, we can easily use the approach described above.

STR:
1. You must have two connections: one with a disconnect timeout set and the second without
2. Open SQL editors for both of them
3. Go away for some time so the timer appears