### PR TITLE
#34283 Disable complex type parsing

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/grammar/ClickhouseDataTypes.g4
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/grammar/ClickhouseDataTypes.g4
@@ -36,16 +36,20 @@ grammar ClickhouseDataTypes;
 package org.jkiss.dbeaver.ext.clickhouse;
 }
 
-ENUM_KW: 'Enum' ('8'|'16');
-MAP_KV: 'Map';
-ARRAY_KV: 'Array';
-TUPLE_KV: 'Tuple';
+Enum: 'Enum' ('8'|'16');
+Map: 'Map';
+Array: 'Array';
+Tuple: 'Tuple';
+Int: 'U'? 'Int' ('8'|'16'|'32'|'64'|'128'|'256');
+Float: 'Float' ('32'|'64');
+Decimal: 'Decimal' ('32'|'64'|'128'|'256')?;
 
 RightParen: ')';
 LeftParen: '(';
 
 Space: [ \t]+ -> channel(HIDDEN);
 Number: [-]?[0-9]+;
+Identifier: [a-zA-Z_][a-zA-Z0-9_]*;
 
 Comma: ',';
 Eq: '=';
@@ -80,25 +84,22 @@ simpleType
  | ipv6Type
  ;
 
-enumType: ENUM_KW LeftParen enumEntryList RightParen;
+enumType: Enum LeftParen enumEntryList RightParen;
 enumEntryList: enumEntry (Comma enumEntry)*;
 enumEntry: String Eq Number;
 
-tupleType: TUPLE_KV LeftParen tupleElementList RightParen;
+tupleType: Tuple LeftParen tupleElementList RightParen;
 tupleElementList: tupleElement (Comma tupleElement)*;
-tupleElement: anyType; // TODO support named elements (Name? type)
+tupleElement: (key=Identifier)? value=anyType;
 
-arrayType: ARRAY_KV LeftParen anyType RightParen;
-mapType: MAP_KV LeftParen key=anyType Comma value=anyType RightParen;
+arrayType: Array LeftParen anyType RightParen;
+mapType: Map LeftParen key=anyType Comma value=anyType RightParen;
 
 stringType: 'String';
 uuidType: 'UUID';
 boolType: 'Boolean';
-intType: unsigned='U'? 'Int' bits=('8' | '16' | '32' | '64' | '128' | '256');
-floatType: 'Float' bits=('32' | '64');
+intType: Int;
+floatType: Float;
 ipv4Type: 'IPV4';
 ipv6Type: 'IPV6';
-decimalType
- : 'Decimal' bits=('32' | '64' | '128' | '256') LeftParen Comma scale=Number RightParen
- | 'Decimal' LeftParen precision=Number Comma scale=Number RightParen
- ;
+decimalType: Decimal (LeftParen (precision=Number Comma)? scale=Number RightParen)?;

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseTypeParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseTypeParser.java
@@ -101,17 +101,30 @@ public class ClickhouseTypeParser {
     }
 
     @Nullable
-    public static DBSDataType getType(@NotNull DBRProgressMonitor monitor, @NotNull ClickhouseDataSource dataSource, @NotNull String typeName) throws DBException {
+    public static DBSDataType getType(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull ClickhouseDataSource dataSource,
+        @NotNull String typeName
+    ) throws DBException {
         final var lexer = new ClickhouseDataTypesLexer(CharStreams.fromString(typeName));
         final var parser = new ClickhouseDataTypesParser(new CommonTokenStream(lexer));
         final var type = parser.type().anyType();
-        final DBSDataType resolved;
 
         if (parser.getNumberOfSyntaxErrors() > 0) {
             log.debug("Rejecting invalid or unsupported type: " + typeName);
             return null;
         }
 
+        return getType(monitor, dataSource, type);
+    }
+
+    @Nullable
+    public static DBSDataType getType(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull ClickhouseDataSource dataSource,
+        @NotNull ClickhouseDataTypesParser.AnyTypeContext type
+    ) throws DBException {
+        final DBSDataType resolved;
         if (type.simpleType() != null) {
             resolved = DBUtils.resolveDataType(monitor, dataSource, type.simpleType().getText());
         } else if (type.markerType() != null) {
@@ -127,7 +140,7 @@ public class ClickhouseTypeParser {
         }
 
         if (resolved == null) {
-            log.debug("Can't resolve type for '" + typeName + "'");
+            log.debug("Can't resolve type from '" + type + "'");
         }
 
         return resolved;
@@ -135,7 +148,7 @@ public class ClickhouseTypeParser {
 
     @Nullable
     private static DBSDataType getArrayType(@NotNull DBRProgressMonitor monitor, @NotNull ClickhouseDataSource dataSource, ArrayTypeContext type) throws DBException {
-        final DBSDataType componentType = getType(monitor, dataSource, type.anyType().getText());
+        final DBSDataType componentType = getType(monitor, dataSource, type.anyType());
 
         if (componentType == null) {
             return null;
@@ -146,33 +159,33 @@ public class ClickhouseTypeParser {
 
     @Nullable
     private static DBSDataType getTupleType(@NotNull DBRProgressMonitor monitor, @NotNull ClickhouseDataSource dataSource, @NotNull TupleTypeContext context) throws DBException {
-        final List<String> names = new ArrayList<>();
-        final List<DBSDataType> types = new ArrayList<>();
+        final List<Pair<String, DBSDataType>> elements = new ArrayList<>();
 
         if (context.tupleElementList() != null && context.tupleElementList().tupleElement() != null) {
             for (ClickhouseDataTypesParser.TupleElementContext element : context.tupleElementList().tupleElement()) {
-                final DBSDataType type = getType(monitor, dataSource, element.anyType().getText());
-
+                final DBSDataType type = getType(monitor, dataSource, element.value.getText());
                 if (type == null) {
                     return null;
                 }
 
-                names.add("Attr" + (names.size() + 1)); // TODO: Named tuple elements are not supported
-                types.add(type);
+                String key;
+                if (element.key != null) {
+                    key = element.key.getText();
+                } else {
+                    key = String.valueOf(elements.size() + 1);
+                }
+
+                elements.add(new Pair<>(key, type));
             }
         }
 
-        return new ClickhouseTupleType(
-            dataSource,
-            types.toArray(DBSDataType[]::new),
-            names.toArray(String[]::new)
-        );
+        return new ClickhouseTupleType(dataSource, elements);
     }
 
     @Nullable
     private static DBSDataType getMapType(@NotNull DBRProgressMonitor monitor, @NotNull ClickhouseDataSource dataSource, @NotNull MapTypeContext context) throws DBException {
-        final DBSDataType keyType = getType(monitor, dataSource, context.key.getText());
-        final DBSDataType valueType = getType(monitor, dataSource, context.value.getText());
+        final DBSDataType keyType = getType(monitor, dataSource, context.key);
+        final DBSDataType valueType = getType(monitor, dataSource, context.value);
 
         if (keyType == null || valueType == null) {
             return null;
@@ -186,11 +199,9 @@ public class ClickhouseTypeParser {
         if (!isEnum(type)) {
             return Collections.emptyMap();
         }
-        var input = CharStreams.fromString(type);
-        var ll = new ClickhouseDataTypesLexer(input);
-        var tokens = new CommonTokenStream(ll);
-        var pp = new ClickhouseDataTypesParser(tokens);
-        var tree = pp.enumType();
+        var lexer = new ClickhouseDataTypesLexer(CharStreams.fromString(type));
+        var parser = new ClickhouseDataTypesParser(new CommonTokenStream(lexer));
+        var tree = parser.enumType();
 
         if (tree.enumEntryList() != null && tree.enumEntryList().enumEntry() != null) {
             return tree.enumEntryList().enumEntry().stream()

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseTypeParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseTypeParser.java
@@ -51,12 +51,15 @@ public class ClickhouseTypeParser {
 
     private static final Gson gson = new Gson();
 
+    // FIXME: Disabled as per dbeaver/dbeaver#34283
+    private static final boolean ENABLE_COMPLEX_TYPE_PARSING = false;
+
     private ClickhouseTypeParser() {
         // prevents instantiation
     }
 
     public static boolean isComplexType(@NotNull String typeName) {
-        return typeName.startsWith("Map") || typeName.startsWith("Tuple") || typeName.startsWith("Array");
+        return ENABLE_COMPLEX_TYPE_PARSING && (typeName.startsWith("Map") || typeName.startsWith("Tuple") || typeName.startsWith("Array"));
     }
 
     @Nullable
@@ -76,9 +79,9 @@ public class ClickhouseTypeParser {
             return null;
         }
 
-        if (type instanceof ClickhouseMapType map) {
+        if (type instanceof ClickhouseMapType map && ENABLE_COMPLEX_TYPE_PARSING) {
             return new JDBCCompositeMap(session, map, ((Map<?, ?>) object));
-        } else if (type instanceof ClickhouseTupleType tuple) {
+        } else if (type instanceof ClickhouseTupleType tuple && ENABLE_COMPLEX_TYPE_PARSING) {
             final Object[] values;
             if (object instanceof Map) {
                 values = ((Map<?, ?>) object).entrySet().stream()

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMapType.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMapType.java
@@ -18,9 +18,16 @@ package org.jkiss.dbeaver.ext.clickhouse.model;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.struct.DBSDataType;
+import org.jkiss.utils.Pair;
+
+import java.util.List;
 
 public class ClickhouseMapType extends ClickhouseTupleType {
-    public ClickhouseMapType(@NotNull ClickhouseDataSource dataSource, @NotNull DBSDataType keyType, @NotNull DBSDataType valueType) {
-        super(dataSource, new DBSDataType[]{keyType, valueType}, new String[]{"Key", "Value"});
+    public ClickhouseMapType(
+        @NotNull ClickhouseDataSource dataSource,
+        @NotNull DBSDataType keyType,
+        @NotNull DBSDataType valueType
+    ) {
+        super(dataSource, "Map", List.of(new Pair<>("Key", keyType), new Pair<>("Value", valueType)));
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseTupleType.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseTupleType.java
@@ -22,9 +22,9 @@ import org.jkiss.dbeaver.model.DBPDataKind;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.*;
+import org.jkiss.utils.Pair;
 
 import java.sql.Types;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,16 +34,33 @@ public class ClickhouseTupleType extends ClickhouseAbstractDataType implements D
     private final List<ClickhouseTupleTypeAttribute> attributes;
     private final String name;
 
-    public ClickhouseTupleType(@NotNull ClickhouseDataSource dataSource, @NotNull DBSDataType[] types, @NotNull String[] names) {
+    public ClickhouseTupleType(
+        @NotNull ClickhouseDataSource dataSource,
+        @NotNull List<Pair<String, DBSDataType>> elements
+    ) {
+        this(dataSource, "Tuple", elements);
+    }
+
+    protected ClickhouseTupleType(
+        @NotNull ClickhouseDataSource dataSource,
+        @NotNull String name,
+        @NotNull List<Pair<String, DBSDataType>> elements
+    ) {
         super(dataSource);
 
-        this.attributes = IntStream.range(0, types.length)
-            .mapToObj(index -> new ClickhouseTupleTypeAttribute(this, types[index], names[index], index))
-            .collect(Collectors.toList());
+        this.attributes = IntStream.range(0, elements.size())
+            .mapToObj(index -> new ClickhouseTupleTypeAttribute(
+                this,
+                elements.get(index).getSecond(),
+                elements.get(index).getFirst(),
+                index
+            ))
+            .toList();
 
-        this.name = Arrays.stream(types)
+        this.name = name + elements.stream()
+            .map(Pair::getSecond)
             .map(DBSTypedObject::getFullTypeName)
-            .collect(Collectors.joining(", ", "Tuple(", ")"));
+            .collect(Collectors.joining(", ", "(", ")"));
     }
 
     @NotNull


### PR DESCRIPTION
This PR disables parsing and processing of complex types, such as `Array`, `Map`, and `Tuple` for now.