### PR TITLE
#34613 Fix too long name of simple structure compare report

### DIFF
--- a/plugins/org.jkiss.dbeaver.cmp.simple.ui/src/org/jkiss/dbeaver/tools/compare/simple/ui/CompareObjectsWizard.java
+++ b/plugins/org.jkiss.dbeaver.cmp.simple.ui/src/org/jkiss/dbeaver/tools/compare/simple/ui/CompareObjectsWizard.java
@@ -36,6 +36,7 @@ import org.jkiss.dbeaver.ui.DialogSettingsDelegate;
 import org.jkiss.dbeaver.ui.ShellUtils;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.dialogs.DialogUtils;
+import org.jkiss.dbeaver.utils.RuntimeUtils;
 import org.jkiss.utils.CommonUtils;
 
 import java.io.File;
@@ -142,21 +143,23 @@ public class CompareObjectsWizard extends Wizard implements IExportWizard {
         return report;
     }
 
-    private void renderReport(DBRProgressMonitor monitor, CompareReport report)
-    {
+    private void renderReport(DBRProgressMonitor monitor, CompareReport report) {
         try {
             File reportFile;
             switch (settings.getOutputType()) {
                 case BROWSER:
                     reportFile = File.createTempFile("compare-report", ".html");
                     break;
-                default:
-                {
-                    StringBuilder fileName = new StringBuilder("compare");//"compare-report.html";
-                    for (DBNDatabaseNode node : report.getNodes()) {
-                        fileName.append("-").append(CommonUtils.escapeIdentifier(node.getName()));
+                default: {
+                    StringBuilder fileName = new StringBuilder("compare"); //"compare-report.html";
+                    if (report.getNodes().size() <= 3) {
+                        for (DBNDatabaseNode node : report.getNodes()) {
+                            fileName.append("-").append(CommonUtils.escapeIdentifier(node.getName()));
+                        }
+                        fileName.append("-report.html");
+                    } else {
+                        fileName.append("-report").append("-").append(RuntimeUtils.getCurrentTimeStamp()).append(".html");
                     }
-                    fileName.append("-report.html");
                     File parentFolder = new File(settings.getOutputFolder());
                     if (!parentFolder.exists()) {
                         if (!parentFolder.mkdirs()) {


### PR DESCRIPTION
If more than 3 objects selected, we won't append object name to report

![image](https://github.com/dbeaver/dbeaver/assets/28875055/f5b9be52-1792-4399-830d-8e75628bef1d)
