### PR TITLE
#34563 Don't dump server output for each result of one query

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -4359,7 +4359,11 @@ public class SQLEditor extends SQLEditorBase implements
 
         @Override
         public void handleExecuteResult(DBCExecutionResult result) {
-            dumpQueryServerOutput(result);
+            // dump server output only once on one query execution
+            // even if it return multiple query results (resultSetNumber > 0)
+            if (this.resultSetNumber == 0) {
+                dumpQueryServerOutput(result);
+            }
         }
 
         @Override

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
@@ -667,7 +667,7 @@ public class SQLQueryJob extends DataSourceJob
                                     if (rowsFetched == 0) {
                                         throw e;
                                     } else {
-                                        // Some rows were fetched so we don't want to fail entire query
+                                        // Some rows were fetched, so we don't want to fail entire query
                                         // Ad error as a warning
                                         log.warn("Fetch failed", e);
                                         statistics.setRowsFetched(rowsFetched);
@@ -688,7 +688,7 @@ public class SQLQueryJob extends DataSourceJob
                         }
                     } catch (DBCException e) {
                         // In some cases we can't read update count
-                        // This is bad but we can live with it
+                        // This is bad, but we can live with it
                         // Just print a warning
                         log.warn("Can't obtain update count", e);
                     }


### PR DESCRIPTION
Now, if query returns multiple results, we dump server output only once.