### PR TITLE
dbeaver/pro#2622 Add semantic error problem markers

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLDocumentScriptItemSyntaxContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLDocumentScriptItemSyntaxContext.java
@@ -22,6 +22,8 @@ import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.sql.semantics.OffsetKeyedTreeMap.NodesIterator;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryModel;
 
+import java.util.List;
+
 public class SQLDocumentScriptItemSyntaxContext {
     private static final Log log = Log.getLog(SQLDocumentScriptItemSyntaxContext.class);
     @NotNull
@@ -32,18 +34,27 @@ public class SQLDocumentScriptItemSyntaxContext {
     private final String originalText;
     @NotNull
     private final SQLQueryModel queryModel;
+    private final int initialPosition;
     private int length;
     private boolean hasContextBoundaryAtLength = true;
     private boolean isDirty = false;
+    @Nullable
+    private List<SQLQueryRecognitionProblemInfo> problems = null;
 
     public SQLDocumentScriptItemSyntaxContext(
+        int initialPosition,
         @NotNull String originalText,
         @NotNull SQLQueryModel queryModel,
         int length
     ) {
+        this.initialPosition = initialPosition;
         this.originalText = originalText;
         this.queryModel = queryModel;
         this.length = length;
+    }
+
+    public int getInitialPosition() {
+        return this.initialPosition;
     }
 
     @NotNull
@@ -72,6 +83,15 @@ public class SQLDocumentScriptItemSyntaxContext {
         synchronized (this.lock) {
             return this.isDirty;
         }
+    }
+    
+    public void setProblems(@Nullable List<SQLQueryRecognitionProblemInfo> problems) {
+        this.problems = problems;
+    }
+
+    @Nullable
+    public List<SQLQueryRecognitionProblemInfo> getProblems() {
+        return problems;
     }
 
     @Nullable

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLDocumentSyntaxContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLDocumentSyntaxContext.java
@@ -177,9 +177,17 @@ public class SQLDocumentSyntaxContext {
         int length,
         boolean hasContextBoundaryAtLength
     ) {
-        SQLDocumentScriptItemSyntaxContext scriptItem = new SQLDocumentScriptItemSyntaxContext(elementOriginalText, queryModel, length);
+        SQLDocumentScriptItemSyntaxContext scriptItem = new SQLDocumentScriptItemSyntaxContext(
+            offset,
+            elementOriginalText,
+            queryModel,
+            length
+        );
         scriptItem.setHasContextBoundaryAtLength(hasContextBoundaryAtLength);
-        this.scriptItems.put(offset, scriptItem);
+        SQLDocumentScriptItemSyntaxContext oldScriptItem = this.scriptItems.put(offset, scriptItem);
+        if (oldScriptItem != scriptItem && oldScriptItem != null) {
+            this.forEachListener(l -> l.onScriptItemInvalidated(oldScriptItem));
+        }
         this.forEachListener(l -> l.onScriptItemIntroduced(scriptItem));
         return scriptItem;
     }
@@ -214,7 +222,7 @@ public class SQLDocumentSyntaxContext {
                     SQLDocumentScriptItemSyntaxContext currItem2 = it.getCurrValue();
                     if (currOffset <= offset && currOffset + currItem2.length() > offset) {
                         keyOffsetsToRemove = ListNode.push(keyOffsetsToRemove, currOffset);
-                        this.forEachListener(l -> l.onScriptItemInvalidated(currItem));
+                        this.forEachListener(l -> l.onScriptItemInvalidated(currItem2));
                         lastAffectedOffset = currOffset + currItem2.length();
                     }
                 } else {

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLDocumentSyntaxContextListener.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLDocumentSyntaxContextListener.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.model.sql.semantics;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 
 /**
@@ -25,11 +26,12 @@ public interface SQLDocumentSyntaxContextListener {
     /**
      * Occurs when a new script item is introduced to the document syntax context
      */
-    void onScriptItemIntroduced(@Nullable SQLDocumentScriptItemSyntaxContext item);
+    void onScriptItemIntroduced(@NotNull SQLDocumentScriptItemSyntaxContext item);
+
     /**
      * Occurs when the script item is removed from the document syntax context
      */
-    void onScriptItemInvalidated(@Nullable SQLDocumentScriptItemSyntaxContext item);
+    void onScriptItemInvalidated(@NotNull SQLDocumentScriptItemSyntaxContext item);
 
     /**
      * Occurs when all script item are removed to the document syntax context

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryExpressionMapper.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryExpressionMapper.java
@@ -26,8 +26,8 @@ import org.jkiss.dbeaver.model.stm.STMTreeNode;
 
 import java.util.*;
 
-class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceModel, SQLQueryModelContext> {
-    public SQLQueryExpressionMapper(@Nullable SQLQueryModelContext recognizer) {
+class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceModel, SQLQueryModelRecognizer> {
+    public SQLQueryExpressionMapper(@Nullable SQLQueryModelRecognizer recognizer) {
         super(SQLQueryRowsSourceModel.class, queryExpressionSubtreeNodeNames, translations, recognizer);
     }
 
@@ -65,7 +65,7 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
     );
 
     @NotNull
-    private static final Map<String, TreeMapperCallback<SQLQueryRowsSourceModel, SQLQueryModelContext>> translations = Map.of(
+    private static final Map<String, TreeMapperCallback<SQLQueryRowsSourceModel, SQLQueryModelRecognizer>> translations = Map.of(
         STMKnownRuleNames.directSqlDataStatement, (n, cc, r) -> {
             if (cc.isEmpty()) {
                 return null;
@@ -78,9 +78,8 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
                 STMTreeNode withNode = n.findChildOfName(STMKnownRuleNames.withClause);
                 boolean isRecursive = withNode.getChildCount() > 2; // is RECURSIVE keyword presented
 
-                SQLQueryRowsCteModel cte = new SQLQueryRowsCteModel(r, n, isRecursive, resultQuery);
-
                 STMTreeNode cteListNode = withNode.getStmChild(withNode.getChildCount() - 1);
+                List<SQLQueryRowsCteSubqueryModel> cteSubqueries = new ArrayList<>();
                 for (int i = 0, j = 0; i < cteListNode.getChildCount() && j < subqueries.size(); i += 2, j++) {
                     STMTreeNode cteSubqueryNode = cteListNode.getStmChild(i);
 
@@ -88,12 +87,11 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
 
                     STMTreeNode columnListNode = cteSubqueryNode.findChildOfName(STMKnownRuleNames.columnNameList);
                     List<SQLQuerySymbolEntry> columnList = columnListNode != null ? r.collectColumnNameList(columnListNode) : List.of();
-
                     SQLQueryRowsSourceModel subquerySource = subqueries.get(j);
-                    cte.addSubquery(cteSubqueryNode, subqueryName, columnList, subquerySource);
+                    cteSubqueries.add(new SQLQueryRowsCteSubqueryModel(cteSubqueryNode, subqueryName, columnList, subquerySource));
                 }
 
-                return cte;
+                return new SQLQueryRowsCteModel(n, isRecursive, cteSubqueries, resultQuery);
             }
         },
         STMKnownRuleNames.queryExpression, (n, cc, r) -> {
@@ -112,7 +110,7 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
                         default ->
                             throw new UnsupportedOperationException("Unexpected child node kind at queryExpression");
                     };
-                    source = new SQLQueryRowsSetCorrespondingOperationModel(r, range, childNode, source, nextSource, corresponding, opKind);
+                    source = new SQLQueryRowsSetCorrespondingOperationModel(range, childNode, source, nextSource, corresponding, opKind);
                 }
                 return source;
             }
@@ -133,7 +131,7 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
                         default ->
                             throw new UnsupportedOperationException("Unexpected child node kind at nonJoinQueryTerm");
                     };
-                    source = new SQLQueryRowsSetCorrespondingOperationModel(r, range, childNode, source, nextSource, corresponding, opKind);
+                    source = new SQLQueryRowsSetCorrespondingOperationModel(range, childNode, source, nextSource, corresponding, opKind);
                 }
                 return source;
             }
@@ -155,19 +153,19 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
                             Optional<STMTreeNode> joinConditionNode = Optional.ofNullable(childNode.findChildOfName(STMKnownRuleNames.joinSpecification))
                                     .map(cn -> cn.findChildOfName(STMKnownRuleNames.joinCondition));
                             if (joinConditionNode.isPresent()) {
-                                try (SQLQueryModelContext.LexicalScopeHolder condScope = r.openScope()) {
+                                try (SQLQueryModelRecognizer.LexicalScopeHolder condScope = r.openScope()) {
                                     condScope.lexicalScope.registerSyntaxNode(joinConditionNode.get());
                                     yield joinConditionNode.map(cn -> cn.findChildOfName(STMKnownRuleNames.searchCondition))
                                             .map(r::collectValueExpression)
-                                            .map(e -> new SQLQueryRowsNaturalJoinModel(r, range, childNode, currSource, nextSource, e, condScope.lexicalScope))
-                                            .orElseGet(() -> new SQLQueryRowsNaturalJoinModel(r, range, childNode, currSource, nextSource, Collections.emptyList()));
+                                            .map(e -> new SQLQueryRowsNaturalJoinModel(range, childNode, currSource, nextSource, e, condScope.lexicalScope))
+                                            .orElseGet(() -> new SQLQueryRowsNaturalJoinModel(range, childNode, currSource, nextSource, Collections.emptyList()));
                                 }
                             } else {
-                                yield new SQLQueryRowsNaturalJoinModel(r, range, childNode, currSource, nextSource, r.collectColumnNameList(childNode));
+                                yield new SQLQueryRowsNaturalJoinModel(range, childNode, currSource, nextSource, r.collectColumnNameList(childNode));
                             }
                         }
                         case SQLStandardParser.RULE_crossJoinTerm ->
-                            new SQLQueryRowsCrossJoinModel(r, range, childNode, currSource, nextSource);
+                            new SQLQueryRowsCrossJoinModel(range, childNode, currSource, nextSource);
                         default ->
                             throw new UnsupportedOperationException("Unexpected child node kind at queryExpression");
                     };
@@ -186,7 +184,7 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
                     Interval range = Interval.of(n.getRealInterval().a, childNode.getRealInterval().b);
                     source = switch (childNode.getNodeKindId()) {
                         case SQLStandardParser.RULE_tableReference ->
-                            new SQLQueryRowsCrossJoinModel(r, range, childNode, source, nextSource);
+                            new SQLQueryRowsCrossJoinModel(range, childNode, source, nextSource);
                         default -> throw new UnsupportedOperationException("Unexpected child node kind at fromClause");
                     };
                 }
@@ -201,7 +199,7 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
 
             SQLQueryLexicalScope selectListScope;
             STMTreeNode selectKeywordNode;
-            try (SQLQueryModelContext.LexicalScopeHolder selectListScopeHolder = r.openScope()) {
+            try (SQLQueryModelRecognizer.LexicalScopeHolder selectListScopeHolder = r.openScope()) {
                 selectListScope = selectListScopeHolder.lexicalScope;
                 selectKeywordNode = n.getStmChild(0); // SELECT keyword
 
@@ -268,7 +266,7 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
                         STMTreeNode filterNode = filterNodes[i];
                         int scopeIndex = i + 1;
                         if (filterNode != null) {
-                            try (SQLQueryModelContext.LexicalScopeHolder exprScope = r.openScope()) {
+                            try (SQLQueryModelRecognizer.LexicalScopeHolder exprScope = r.openScope()) {
                                 filterExprs[i] = r.collectValueExpression(filterNode);
                                 nextScopeNodes[prevScopeIndex] = filterNode;
                                 scopes[scopeIndex] = exprScope.lexicalScope;
@@ -288,13 +286,13 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
                 }
 
                 projectionModel = new SQLQueryRowsProjectionModel(
-                    r, n, selectListScope, source, fromScope,
+                    n, selectListScope, source, fromScope,
                     SQLQueryRowsProjectionModel.FiltersData.of(filterExprs[0], filterExprs[1], filterExprs[2], filterExprs[3]),
                     SQLQueryRowsProjectionModel.FiltersData.of(scopes[1], scopes[2], scopes[3], scopes[4]),
                     resultModel
                 );
             } else {
-                projectionModel = new SQLQueryRowsProjectionModel(r, n, selectListScope, source, resultModel);
+                projectionModel = new SQLQueryRowsProjectionModel(n, selectListScope, source, resultModel);
             }
             return projectionModel;
         },
@@ -318,7 +316,7 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
                     SQLQuerySymbolEntry correlationName = r.collectIdentifier(
                         lastSubnode.getStmChild(lastSubnode.getChildCount() == 1 || lastSubnode.getChildCount() == 4 ? 0 : 1)
                     );
-                    source = new SQLQueryRowsCorrelatedSourceModel(r, n, source, correlationName, r.collectColumnNameList(lastSubnode));
+                    source = new SQLQueryRowsCorrelatedSourceModel(n, source, correlationName, r.collectColumnNameList(lastSubnode));
                 }
             }
             return source;
@@ -329,7 +327,7 @@ class SQLQueryExpressionMapper extends SQLQueryTreeMapper<SQLQueryRowsSourceMode
             for (int i = 1; i < n.getChildCount(); i += 2) {
                 values.add(r.collectValueExpression(n.getStmChild(i)));
             }
-            return new SQLQueryRowsTableValueModel(r, n, values);
+            return new SQLQueryRowsTableValueModel(n, values);
         }
     );
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionContext.java
@@ -24,6 +24,7 @@ import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.sql.SQLSyntaxManager;
 import org.jkiss.dbeaver.model.stm.STMTreeNode;
 
+import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -44,7 +45,7 @@ public class SQLQueryRecognitionContext {
     private final SQLSyntaxManager syntaxManager;
 
     @NotNull
-    private final LinkedList<SQLQueryRecognitionProblemInfo> problems = new LinkedList<>();
+    private final Deque<SQLQueryRecognitionProblemInfo> problems = new LinkedList<>();
 
     public SQLQueryRecognitionContext(
         @NotNull DBRProgressMonitor monitor,

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionContext.java
@@ -17,20 +17,83 @@
 package org.jkiss.dbeaver.model.sql.semantics;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.sql.SQLSyntaxManager;
 import org.jkiss.dbeaver.model.stm.STMTreeNode;
+
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Accumulates the statistics about recognition process
  */
-public interface SQLQueryRecognitionContext {
+public class SQLQueryRecognitionContext {
 
-    DBRProgressMonitor getMonitor();
+    @NotNull
+    private final DBRProgressMonitor monitor;
 
-    void appendError(@NotNull STMTreeNode treeNode, @NotNull String error);
+    @Nullable
+    DBCExecutionContext executionContext;
 
-    void appendError(@NotNull SQLQuerySymbolEntry symbol, @NotNull String error);
+    private final boolean useRealMetadata;
 
-    void appendError(@NotNull SQLQuerySymbolEntry symbol, @NotNull String error, @NotNull DBException ex);
+    @NotNull
+    private final SQLSyntaxManager syntaxManager;
+
+    @NotNull
+    private final LinkedList<SQLQueryRecognitionProblemInfo> problems = new LinkedList<>();
+
+    public SQLQueryRecognitionContext(
+        @NotNull DBRProgressMonitor monitor,
+        @Nullable DBCExecutionContext executionContext,
+        boolean useRealMetadata,
+        @NotNull SQLSyntaxManager syntaxManager
+    ) {
+        this.monitor = monitor;
+        this.executionContext = executionContext;
+        this.useRealMetadata = useRealMetadata;
+        this.syntaxManager = syntaxManager;
+    }
+
+    @NotNull
+    public DBRProgressMonitor getMonitor() {
+        return this.monitor;
+    }
+
+    @Nullable
+    DBCExecutionContext getExecutionContext() {
+        return this.executionContext;
+    }
+
+    boolean useRealMetadata() {
+        return this.useRealMetadata;
+    }
+
+    @NotNull
+    SQLSyntaxManager getSyntaxManager() {
+        return this.syntaxManager;
+    }
+
+    public List<SQLQueryRecognitionProblemInfo> getProblems() {
+        return List.copyOf(this.problems);
+    }
+
+    public void appendError(@NotNull SQLQuerySymbolEntry symbol, @NotNull String error, @NotNull DBException ex) {
+        this.problems.addLast(new SQLQueryRecognitionProblemInfo(symbol.getSyntaxNode(), symbol, error, ex));
+    }
+
+    public void appendError(@NotNull SQLQuerySymbolEntry symbol, @NotNull String error) {
+        this.problems.addLast(new SQLQueryRecognitionProblemInfo(symbol.getSyntaxNode(), symbol, error, null));
+    }
+
+    public void appendError(@NotNull STMTreeNode treeNode, @NotNull String error) {
+        this.problems.addLast(new SQLQueryRecognitionProblemInfo(treeNode, null, error, null));
+    }
+
+    public void reset() {
+        this.problems.clear();
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionProblemInfo.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionProblemInfo.java
@@ -1,0 +1,72 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.semantics;
+
+import org.antlr.v4.runtime.misc.Interval;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.stm.STMTreeNode;
+
+public class SQLQueryRecognitionProblemInfo {
+    @NotNull
+    private final STMTreeNode syntaxNode;
+    @Nullable
+    private final SQLQuerySymbolEntry symbol;
+    @NotNull
+    private final String message;
+    @Nullable
+    private final DBException exception;
+
+    public SQLQueryRecognitionProblemInfo(
+        @NotNull STMTreeNode syntaxNode,
+        @Nullable SQLQuerySymbolEntry symbol,
+        @NotNull String message,
+        @Nullable DBException exception
+    ) {
+        this.syntaxNode = syntaxNode;
+        this.symbol = symbol;
+        this.message = message;
+        this.exception = exception;
+    }
+
+    @NotNull
+    public String getMessage() {
+        return this.message;
+    }
+
+    @NotNull
+    public Interval getInterval() {
+        return this.syntaxNode.getRealInterval();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.syntaxNode.getRealInterval().toString()).append(": ");
+        if (this.symbol != null) {
+            sb.append(this.symbol.getName()).append(": ");
+        } else {
+            sb.append(this.syntaxNode.getTextContent()).append(": ");
+        }
+        sb.append(this.message);
+        if (this.exception != null) {
+            sb.append(": ").append(this.exception.toString());
+        }
+        return super.toString() + "[" + sb.toString() + "]";
+    }
+}

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDataSourceContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDataSourceContext.java
@@ -18,11 +18,12 @@ package org.jkiss.dbeaver.model.sql.semantics.context;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.sql.SQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLSearchUtils;
 import org.jkiss.dbeaver.model.sql.parser.SQLIdentifierDetector;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.model.select.SQLQueryRowsSourceModel;
 import org.jkiss.dbeaver.model.sql.semantics.model.select.SQLQueryRowsTableValueModel;
 import org.jkiss.dbeaver.model.stm.STMTreeNode;
@@ -41,13 +42,16 @@ import java.util.List;
  */
 public class SQLQueryDataSourceContext extends SQLQueryDataContext {
     @NotNull
-    private final SQLQueryModelContext context;
+    private final SQLDialect dialect;
+    @NotNull
+    private final DBCExecutionContext executionContext;
     @NotNull
     private final SQLIdentifierDetector identifierDetector;
 
-    public SQLQueryDataSourceContext(@NotNull SQLQueryModelContext context) {
-        this.context = context;
-        this.identifierDetector = new SQLIdentifierDetector(context.getDialect());
+    public SQLQueryDataSourceContext(@NotNull SQLDialect dialect, @NotNull DBCExecutionContext executionContext) {
+        this.dialect = dialect;
+        this.executionContext = executionContext;
+        this.identifierDetector = new SQLIdentifierDetector(dialect);
     }
 
     @NotNull
@@ -59,12 +63,12 @@ public class SQLQueryDataSourceContext extends SQLQueryDataContext {
     @Nullable
     @Override
     public DBSEntity findRealTable(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
-        if (this.context.getExecutionContext().getDataSource() instanceof DBSObjectContainer container) {
+        if (this.executionContext.getDataSource() instanceof DBSObjectContainer container) {
             List<String> tableName2 = new ArrayList<>(tableName);
             DBSObject obj = SQLSearchUtils.findObjectByFQN(
                 monitor,
                 container,
-                this.context.getExecutionContext(),
+                this.executionContext,
                 tableName2,
                 false,
                 identifierDetector
@@ -93,13 +97,13 @@ public class SQLQueryDataSourceContext extends SQLQueryDataContext {
     @NotNull
     @Override
     public SQLDialect getDialect() {
-        return this.context.getDialect();
+        return this.dialect;
     }
 
     @NotNull
     @Override
     public SQLQueryRowsSourceModel getDefaultTable(@NotNull STMTreeNode syntaxNode) {
-        return new SQLQueryRowsTableValueModel(context, syntaxNode, Collections.emptyList());
+        return new SQLQueryRowsTableValueModel(syntaxNode, Collections.emptyList());
     }
     
     @Override

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDummyDataSourceContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDummyDataSourceContext.java
@@ -35,7 +35,7 @@ import java.util.*;
 
 public class SQLQueryDummyDataSourceContext extends SQLQueryDataContext {
 
-    private final SQLQueryModelContext context;
+    private final SQLDialect dialect;
 
     private final DummyDbObject dummyDataSource;
     private final DummyDbObject defaultDummyCatalog;
@@ -309,7 +309,7 @@ public class SQLQueryDummyDataSourceContext extends SQLQueryDataContext {
 
         @Override
         public SQLDialect getSQLDialect() {
-            return context.getDialect();
+            return dialect;
         }
 
         @Override
@@ -338,11 +338,12 @@ public class SQLQueryDummyDataSourceContext extends SQLQueryDataContext {
     }
 
     public SQLQueryDummyDataSourceContext(
-        @NotNull SQLQueryModelContext context,
+        @NotNull SQLDialect dialect,
         @NotNull Set<String> knownColumnNames,
         @NotNull Set<List<String>> knownTableNames
     ) {
-        this.context = context;
+        this.dialect = dialect;
+
         this.knownColumnNames = knownColumnNames;
         this.knownTableNames = new HashSet<>();
         this.knownSchemaNames = new HashSet<>();
@@ -439,7 +440,7 @@ public class SQLQueryDummyDataSourceContext extends SQLQueryDataContext {
     
     @Override
     public DBSEntity findRealTable(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
-        List<String> rawTableName = tableName.stream().map(this.context.getDialect()::getUnquotedIdentifier).toList();
+        List<String> rawTableName = tableName.stream().map(this.dialect::getUnquotedIdentifier).toList();
         DummyDbObject catalog = rawTableName.size() > 2
             ? this.dummyDataSource.getChildrenMapImpl().get(rawTableName.get(rawTableName.size() - 3)) : this.defaultDummyCatalog;
         DummyDbObject schema = rawTableName.size() > 1
@@ -460,13 +461,13 @@ public class SQLQueryDummyDataSourceContext extends SQLQueryDataContext {
     @NotNull
     @Override
     public SQLDialect getDialect() {
-        return this.context.getDialect();
+        return this.dialect;
     }
     
     @NotNull
     @Override
     public SQLQueryRowsSourceModel getDefaultTable(@NotNull STMTreeNode syntaxNode) {
-        return new DummyTableRowsSource(context, syntaxNode);
+        return new DummyTableRowsSource(syntaxNode);
     }
     
     @Override
@@ -476,8 +477,8 @@ public class SQLQueryDummyDataSourceContext extends SQLQueryDataContext {
     
     public class DummyTableRowsSource extends SQLQueryRowsTableDataModel {
         
-        public DummyTableRowsSource(SQLQueryModelContext context, @NotNull STMTreeNode syntaxNode) {
-            super(context, syntaxNode, new SQLQueryQualifiedName(syntaxNode, new SQLQuerySymbolEntry(syntaxNode, "DummyTable", "DummyTable")));
+        public DummyTableRowsSource(@NotNull STMTreeNode syntaxNode) {
+            super(syntaxNode, new SQLQueryQualifiedName(syntaxNode, new SQLQuerySymbolEntry(syntaxNode, "DummyTable", "DummyTable")));
         }
 
         @NotNull

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/SQLQueryModelContent.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/SQLQueryModelContent.java
@@ -19,7 +19,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model;
 import org.antlr.v4.runtime.misc.Interval;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
 import org.jkiss.dbeaver.model.stm.STMTreeNode;
@@ -29,21 +29,13 @@ import org.jkiss.dbeaver.model.stm.STMTreeNode;
  */
 public abstract class SQLQueryModelContent extends SQLQueryNodeModel {
 
-    private final SQLQueryModelContext context;
-
     public SQLQueryModelContent(
-        @NotNull SQLQueryModelContext context,
         @NotNull Interval interval,
         @NotNull STMTreeNode syntaxNode,
         @Nullable SQLQueryNodeModel ... subnodes
     ) {
         super(interval, syntaxNode, subnodes);
-        this.context = context;
     }
 
     protected abstract void applyContext(@NotNull SQLQueryDataContext dataContext, @NotNull SQLQueryRecognitionContext recognitionContext);
-
-    public SQLQueryModelContext getContext() {
-        return context;
-    }
 }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryObjectDataModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryObjectDataModel.java
@@ -45,11 +45,10 @@ public class SQLQueryObjectDataModel extends SQLQueryRowsSourceModel implements 
     private DBSObject object = null;
 
     public SQLQueryObjectDataModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQueryQualifiedName name,
         @NotNull DBSObjectType objectType) {
-        super(context, syntaxNode);
+        super(syntaxNode);
         this.name = name;
         this.objectType = objectType;
     }
@@ -84,6 +83,8 @@ public class SQLQueryObjectDataModel extends SQLQueryRowsSourceModel implements 
 
             if (this.object != null) {
                 this.name.setDefinition(object);
+            } else {
+                statistics.appendError(getSyntaxNode(), "Object " + this.name.toIdentifierString() + " not found in the database");
             }
         }
         return context;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryObjectDropModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryObjectDropModel.java
@@ -18,7 +18,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.ddl;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryQualifiedName;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
@@ -30,35 +30,40 @@ import org.jkiss.dbeaver.model.struct.DBSObjectType;
 
 public class SQLQueryObjectDropModel extends SQLQueryModelContent {
 
+    @Nullable
     private final SQLQueryObjectDataModel object;
     private final boolean ifExists;
 
     @Nullable
     private SQLQueryDataContext dataContext = null;
 
-    public static SQLQueryModelContent createModel(SQLQueryModelContext context, STMTreeNode node, DBSObjectType objectType) {
+    @NotNull
+    public static SQLQueryModelContent recognize(
+        @NotNull SQLQueryModelRecognizer recognizer,
+        @NotNull STMTreeNode node,
+        @NotNull DBSObjectType objectType
+    ) {
         SQLQueryObjectDataModel procedure =
             node.getChildren().stream().filter(n -> n.getNodeName().equals(STMKnownRuleNames.qualifiedName))
             .map(n -> new SQLQueryObjectDataModel(
-                context,
-                n, new SQLQueryQualifiedName(n, context.collectIdentifier(n.getFirstStmChild())),
+                n, new SQLQueryQualifiedName(n, recognizer.collectIdentifier(n.getFirstStmChild())),
                 objectType))
             .findFirst().orElse(null);
         boolean ifExists = node.findChildOfName(STMKnownRuleNames.ifExistsSpec) != null; // "IF EXISTS" presented
-        return new SQLQueryObjectDropModel(context, node, procedure, ifExists);
+        return new SQLQueryObjectDropModel(node, procedure, ifExists);
     }
 
     private SQLQueryObjectDropModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @Nullable SQLQueryObjectDataModel object,
         boolean ifExists
     ) {
-        super(context, syntaxNode.getRealInterval(), syntaxNode);
+        super(syntaxNode.getRealInterval(), syntaxNode);
         this.object = object;
         this.ifExists = ifExists;
     }
 
+    @Nullable
     public SQLQueryObjectDataModel getObject() {
         return object;
     }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryTableDropModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryTableDropModel.java
@@ -18,7 +18,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.ddl;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryModelContent;
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
  */
 public class SQLQueryTableDropModel extends SQLQueryModelContent {
 
+    @Nullable
     private final List<SQLQueryRowsTableDataModel> tables;
     private final boolean isView;
     private final boolean ifExists;
@@ -42,26 +43,31 @@ public class SQLQueryTableDropModel extends SQLQueryModelContent {
     @Nullable
     private SQLQueryDataContext dataContext = null;
 
-    public static SQLQueryModelContent createModel(SQLQueryModelContext context, STMTreeNode node, boolean isView) {
+    @NotNull
+    public static SQLQueryModelContent recognize(
+        @NotNull SQLQueryModelRecognizer recognizer,
+        @NotNull STMTreeNode node,
+        boolean isView
+    ) {
         List<SQLQueryRowsTableDataModel> tables =
             node.getChildren().stream().filter(n -> n.getNodeName().equals(STMKnownRuleNames.tableName))
-                .map(context::collectTableReference).collect(Collectors.toList());
+                .map(recognizer::collectTableReference).collect(Collectors.toList());
         boolean ifExists = node.findChildOfName(STMKnownRuleNames.ifExistsSpec) != null; // "IF EXISTS" presented
-        return new SQLQueryTableDropModel(context, node, tables, ifExists, isView);
+        return new SQLQueryTableDropModel(node, tables, ifExists, isView);
     }
 
     private SQLQueryTableDropModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @Nullable List<SQLQueryRowsTableDataModel> tables,
         boolean ifExists,
         boolean isView) {
-        super(context, syntaxNode.getRealInterval(), syntaxNode);
+        super(syntaxNode.getRealInterval(), syntaxNode);
         this.tables = tables;
         this.ifExists = ifExists;
         this.isView = isView;
     }
 
+    @Nullable
     public List<SQLQueryRowsTableDataModel> getTables() {
         return this.tables;
     }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/dml/SQLQueryDMLStatementModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/dml/SQLQueryDMLStatementModel.java
@@ -18,7 +18,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.dml;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryModelContent;
@@ -37,11 +37,10 @@ public abstract class SQLQueryDMLStatementModel extends SQLQueryModelContent {
     private SQLQueryDataContext resultContext = null;
     
     public SQLQueryDMLStatementModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @Nullable SQLQueryRowsTableDataModel tableModel
     ) {
-        super(context, syntaxNode.getRealInterval(), syntaxNode, tableModel);
+        super(syntaxNode.getRealInterval(), syntaxNode, tableModel);
         this.tableModel = tableModel;
     }
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/dml/SQLQueryDeleteModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/dml/SQLQueryDeleteModel.java
@@ -19,7 +19,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.dml;
 import org.antlr.v4.runtime.misc.Interval;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQuerySymbolEntry;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
@@ -43,32 +43,32 @@ public class SQLQueryDeleteModel extends SQLQueryDMLStatementModel {
     @Nullable 
     private final SQLQueryRowsCorrelatedSourceModel aliasedTableModel;
 
-    public static SQLQueryModelContent createModel(SQLQueryModelContext context, STMTreeNode node) {
+    @NotNull
+    public static SQLQueryModelContent recognize(@NotNull SQLQueryModelRecognizer recognizer, @NotNull STMTreeNode node) {
         STMTreeNode tableNameNode = node.findChildOfName(STMKnownRuleNames.tableName);
-        SQLQueryRowsTableDataModel tableModel = tableNameNode == null ? null : context.collectTableReference(tableNameNode);
+        SQLQueryRowsTableDataModel tableModel = tableNameNode == null ? null : recognizer.collectTableReference(tableNameNode);
 
         STMTreeNode aliasNode = node.findChildOfName(STMKnownRuleNames.correlationName);
-        SQLQuerySymbolEntry alias = aliasNode == null ? null : context.collectIdentifier(aliasNode);
+        SQLQuerySymbolEntry alias = aliasNode == null ? null : recognizer.collectIdentifier(aliasNode);
 
         STMTreeNode whereClauseNode = node.findChildOfName(STMKnownRuleNames.whereClause);
-        SQLQueryValueExpression whereClauseExpr = whereClauseNode == null ? null : context.collectValueExpression(whereClauseNode);
+        SQLQueryValueExpression whereClauseExpr = whereClauseNode == null ? null : recognizer.collectValueExpression(whereClauseNode);
 
-        return new SQLQueryDeleteModel(context, node, tableModel, alias, whereClauseExpr);
+        return new SQLQueryDeleteModel(node, tableModel, alias, whereClauseExpr);
     }
 
     private SQLQueryDeleteModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @Nullable SQLQueryRowsTableDataModel tableModel,
         @Nullable SQLQuerySymbolEntry alias,
         @Nullable SQLQueryValueExpression whereClause
     ) {
-        super(context, syntaxNode, tableModel);
+        super(syntaxNode, tableModel);
         this.whereClause = whereClause;
         
         if (alias != null && tableModel != null) {
             Interval correlatedRegion = Interval.of(tableModel.getInterval().a, alias.getInterval().b);
-            this.aliasedTableModel = new SQLQueryRowsCorrelatedSourceModel(context, syntaxNode, tableModel, alias, Collections.emptyList());
+            this.aliasedTableModel = new SQLQueryRowsCorrelatedSourceModel(syntaxNode, tableModel, alias, Collections.emptyList());
         } else {
             this.aliasedTableModel  = null;
         }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/dml/SQLQueryInsertModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/dml/SQLQueryInsertModel.java
@@ -18,7 +18,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.dml;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQuerySymbolEntry;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
@@ -43,10 +43,10 @@ public class SQLQueryInsertModel extends SQLQueryDMLStatementModel {
     @Nullable
     private final SQLQueryRowsSourceModel valuesRows;
 
-
-    public static SQLQueryModelContent createModel(SQLQueryModelContext context, STMTreeNode node) {
+    @NotNull
+    public static SQLQueryModelContent recognize(@NotNull SQLQueryModelRecognizer recognizer, @NotNull STMTreeNode node) {
         STMTreeNode tableNameNode = node.findChildOfName(STMKnownRuleNames.tableName);
-        SQLQueryRowsTableDataModel tableModel = tableNameNode == null ? null : context.collectTableReference(tableNameNode);
+        SQLQueryRowsTableDataModel tableModel = tableNameNode == null ? null : recognizer.collectTableReference(tableNameNode);
 
         List<SQLQuerySymbolEntry> columnNames;
         SQLQueryRowsSourceModel valuesRows;
@@ -54,26 +54,25 @@ public class SQLQueryInsertModel extends SQLQueryDMLStatementModel {
         STMTreeNode insertColumnsAndSource = node.findChildOfName(STMKnownRuleNames.insertColumnsAndSource);
         if (insertColumnsAndSource != null) {
             STMTreeNode insertColumnList = insertColumnsAndSource.findChildOfName(STMKnownRuleNames.insertColumnList);
-            columnNames = insertColumnList == null ? null : context.collectColumnNameList(insertColumnList);
+            columnNames = insertColumnList == null ? null : recognizer.collectColumnNameList(insertColumnList);
 
             STMTreeNode valuesNode = insertColumnsAndSource.findChildOfName(STMKnownRuleNames.queryExpression);
-            valuesRows = valuesNode == null ? null : context.collectQueryExpression(valuesNode);
+            valuesRows = valuesNode == null ? null : recognizer.collectQueryExpression(valuesNode);
         } else {
             columnNames = Collections.emptyList();
             valuesRows = null; // use default table?
         }
 
-        return new SQLQueryInsertModel(context, node, tableModel, columnNames, valuesRows);
+        return new SQLQueryInsertModel(node, tableModel, columnNames, valuesRows);
     }
 
     private SQLQueryInsertModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @Nullable SQLQueryRowsTableDataModel tableModel,
         @Nullable List<SQLQuerySymbolEntry> columnNames,
         @Nullable SQLQueryRowsSourceModel valuesRows
     ) {
-        super(context, syntaxNode, tableModel);
+        super(syntaxNode, tableModel);
         this.columnNames = columnNames;
         this.valuesRows = valuesRows;
     }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsCorrelatedSourceModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsCorrelatedSourceModel.java
@@ -38,13 +38,12 @@ public class SQLQueryRowsCorrelatedSourceModel extends SQLQueryRowsSourceModel {
     private final List<SQLQuerySymbolEntry> correlationColumNames;
 
     public SQLQueryRowsCorrelatedSourceModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQueryRowsSourceModel source,
         @NotNull SQLQuerySymbolEntry alias,
         @NotNull List<SQLQuerySymbolEntry> correlationColumNames
     ) {
-        super(context, syntaxNode, source);
+        super(syntaxNode, source);
         this.source = source;
         this.alias = alias;
         this.correlationColumNames = correlationColumNames;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsCrossJoinModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsCrossJoinModel.java
@@ -18,7 +18,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.select;
 
 import org.antlr.v4.runtime.misc.Interval;
 import org.jkiss.code.NotNull;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryNodeModelVisitor;
@@ -29,13 +29,12 @@ import org.jkiss.dbeaver.model.stm.STMTreeNode;
  */
 public class SQLQueryRowsCrossJoinModel extends SQLQueryRowsSetOperationModel {
     public SQLQueryRowsCrossJoinModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull Interval range,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQueryRowsSourceModel left,
         @NotNull SQLQueryRowsSourceModel right
     ) {
-        super(context, range, syntaxNode, left, right);
+        super(range, syntaxNode, left, right);
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsCteSubqueryModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsCteSubqueryModel.java
@@ -18,7 +18,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.select;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQuerySymbolClass;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQuerySymbolEntry;
@@ -40,13 +40,12 @@ public class SQLQueryRowsCteSubqueryModel extends SQLQueryRowsSourceModel {
     public final SQLQueryRowsSourceModel source;
 
     public SQLQueryRowsCteSubqueryModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQuerySymbolEntry subqueryName,
         @NotNull List<SQLQuerySymbolEntry> columNames,
         @NotNull SQLQueryRowsSourceModel source
     ) {
-        super(context, syntaxNode);
+        super(syntaxNode);
         this.subqueryName = subqueryName;
         this.columNames = columNames;
         this.source = source;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsNaturalJoinModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsNaturalJoinModel.java
@@ -41,7 +41,6 @@ public class SQLQueryRowsNaturalJoinModel extends SQLQueryRowsSetOperationModel 
     private final SQLQueryLexicalScope conditionScope;
 
     public SQLQueryRowsNaturalJoinModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull Interval range,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQueryRowsSourceModel left,
@@ -49,7 +48,7 @@ public class SQLQueryRowsNaturalJoinModel extends SQLQueryRowsSetOperationModel 
         @NotNull SQLQueryValueExpression condition,
         @NotNull SQLQueryLexicalScope conditionScope
     ) {
-        super(context, range, syntaxNode, left, right);
+        super(range, syntaxNode, left, right);
         super.registerSubnode(condition);
         this.condition = condition;
         this.conditionScope = conditionScope;
@@ -59,14 +58,13 @@ public class SQLQueryRowsNaturalJoinModel extends SQLQueryRowsSetOperationModel 
     }
 
     public SQLQueryRowsNaturalJoinModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull Interval range,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQueryRowsSourceModel left,
         @NotNull SQLQueryRowsSourceModel right,
         @Nullable List<SQLQuerySymbolEntry> columsToJoin
     ) {
-        super(context, range, syntaxNode, left, right);
+        super(range, syntaxNode, left, right);
         this.condition = null;
         this.conditionScope = null;
         this.columsToJoin = columsToJoin;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsProjectionModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsProjectionModel.java
@@ -20,7 +20,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.sql.SQLDialect.ProjectionAliasVisibilityScope;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryLexicalScope;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryResultColumn;
@@ -72,17 +72,15 @@ public class SQLQueryRowsProjectionModel extends SQLQueryRowsSourceModel {
     private final FiltersData<SQLQueryLexicalScope> filterScopes;
 
     public SQLQueryRowsProjectionModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQueryLexicalScope selectListScope,
         @NotNull SQLQueryRowsSourceModel fromSource,
         @NotNull SQLQuerySelectionResultModel result
     ) {
-        this(context, syntaxNode, selectListScope, fromSource, null, FiltersData.EMPTY, FiltersData.EMPTY, result);
+        this(syntaxNode, selectListScope, fromSource, null, FiltersData.EMPTY, FiltersData.EMPTY, result);
     }
 
     public SQLQueryRowsProjectionModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQueryLexicalScope selectListScope,
         @NotNull SQLQueryRowsSourceModel fromSource,
@@ -91,7 +89,7 @@ public class SQLQueryRowsProjectionModel extends SQLQueryRowsSourceModel {
         @NotNull FiltersData<SQLQueryLexicalScope> filterScopes,
         @NotNull SQLQuerySelectionResultModel result
     ) {
-        super(context, syntaxNode, fromSource, result, filterExprs.whereClause, filterExprs.havingClause, filterExprs.groupByClause, filterExprs.orderByClause);
+        super(syntaxNode, fromSource, result, filterExprs.whereClause, filterExprs.havingClause, filterExprs.groupByClause, filterExprs.orderByClause);
         this.result = result;
         this.selectListScope = selectListScope;
         this.fromSource = fromSource;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsSetCorrespondingOperationModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsSetCorrespondingOperationModel.java
@@ -19,7 +19,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.select;
 import org.antlr.v4.runtime.misc.Interval;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQuerySymbol;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQuerySymbolEntry;
@@ -42,7 +42,6 @@ public class SQLQueryRowsSetCorrespondingOperationModel extends SQLQueryRowsSetO
     private final SQLQueryRowsSetCorrespondingOperationKind kind;
 
     public SQLQueryRowsSetCorrespondingOperationModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull Interval range,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQueryRowsSourceModel left,
@@ -50,7 +49,7 @@ public class SQLQueryRowsSetCorrespondingOperationModel extends SQLQueryRowsSetO
         @NotNull List<SQLQuerySymbolEntry> correspondingColumnNames,
         @NotNull SQLQueryRowsSetCorrespondingOperationKind kind
     ) {
-        super(context, range, syntaxNode, left, right);
+        super(range, syntaxNode, left, right);
         this.correspondingColumnNames = correspondingColumnNames;
         this.kind = kind;
     }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsSetOperationModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsSetOperationModel.java
@@ -18,7 +18,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.select;
 
 import org.antlr.v4.runtime.misc.Interval;
 import org.jkiss.code.NotNull;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.stm.STMTreeNode;
 
 /**
@@ -29,13 +29,12 @@ public abstract class SQLQueryRowsSetOperationModel extends SQLQueryRowsSourceMo
     protected final SQLQueryRowsSourceModel right;
 
     public SQLQueryRowsSetOperationModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull Interval range,
         @NotNull STMTreeNode syntaxNode,
         @NotNull SQLQueryRowsSourceModel left,
         @NotNull SQLQueryRowsSourceModel right
     ) {
-        super(context, range, syntaxNode, left, right);
+        super(range, syntaxNode, left, right);
         this.left = left;
         this.right = right;
     }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsSourceModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsSourceModel.java
@@ -19,7 +19,7 @@ package org.jkiss.dbeaver.model.sql.semantics.model.select;
 import org.antlr.v4.runtime.misc.Interval;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryModelContent;
@@ -35,12 +35,12 @@ public abstract class SQLQueryRowsSourceModel extends SQLQueryModelContent {
     @Nullable
     private SQLQueryDataContext resultDataContext = null;
 
-    public SQLQueryRowsSourceModel(@NotNull SQLQueryModelContext context, @NotNull STMTreeNode syntaxNode, @Nullable SQLQueryNodeModel... subnodes) {
-        super(context, syntaxNode.getRealInterval(), syntaxNode, subnodes);
+    public SQLQueryRowsSourceModel(@NotNull STMTreeNode syntaxNode, @Nullable SQLQueryNodeModel... subnodes) {
+        super(syntaxNode.getRealInterval(), syntaxNode, subnodes);
     }
 
-    public SQLQueryRowsSourceModel(SQLQueryModelContext context, @NotNull Interval region, @NotNull STMTreeNode syntaxNode, @Nullable SQLQueryNodeModel ... subnodes) {
-        super(context, region, syntaxNode, subnodes);
+    public SQLQueryRowsSourceModel(@NotNull Interval region, @NotNull STMTreeNode syntaxNode, @Nullable SQLQueryNodeModel ... subnodes) {
+        super(region, syntaxNode, subnodes);
     }
 
     /**

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsTableDataModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsTableDataModel.java
@@ -49,8 +49,8 @@ public class SQLQueryRowsTableDataModel extends SQLQueryRowsSourceModel implemen
     @Nullable
     private DBSEntity table = null;
 
-    public SQLQueryRowsTableDataModel(SQLQueryModelContext context, @NotNull STMTreeNode syntaxNode, @NotNull SQLQueryQualifiedName name) {
-        super(context, syntaxNode);
+    public SQLQueryRowsTableDataModel(@NotNull STMTreeNode syntaxNode, @NotNull SQLQueryQualifiedName name) {
+        super(syntaxNode);
         this.name = name;
     }
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsTableValueModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsTableValueModel.java
@@ -17,7 +17,7 @@
 package org.jkiss.dbeaver.model.sql.semantics.model.select;
 
 import org.jkiss.code.NotNull;
-import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryModelRecognizer;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQuerySymbol;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
@@ -37,10 +37,9 @@ public class SQLQueryRowsTableValueModel extends SQLQueryRowsSourceModel {
     private final List<SQLQueryValueExpression> values;
     
     public SQLQueryRowsTableValueModel(
-        @NotNull SQLQueryModelContext context,
         @NotNull STMTreeNode syntaxNode,
         @NotNull List<SQLQueryValueExpression> values) {
-        super(context, syntaxNode);
+        super(syntaxNode);
         this.values = values;
     }
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryValueColumnReferenceExpression.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryValueColumnReferenceExpression.java
@@ -110,7 +110,7 @@ public class SQLQueryValueColumnReferenceExpression extends SQLQueryValueExpress
                 if (dialect.isQuotedString(rawString)) {
                     forcedClass = SQLQuerySymbolClass.STRING;
                 } else {
-                    forcedClass = SQLQueryModelContext.tryFallbackSymbolForStringLiteral(dialect, this.columnName, resultColumn != null);
+                    forcedClass = SQLQueryModelRecognizer.tryFallbackSymbolForStringLiteral(dialect, this.columnName, resultColumn != null);
                 }
             } else {
                 this.column = resultColumn;

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
@@ -245,7 +245,8 @@ pref.page.name.sql.format             = Formatting
 pref.page.name.sql.resources          = Scripts
 pref.page.name.sql.templates          = Templates
 
-databaseScriptProblem.name=Database Script Problem
+databaseScriptProblem.name=Database script problem
+semanticProblem.name=Semantic error problem
 scriptEditorPropertyPage.name = SQL Editor behavior
 
 confirm.sql.group.name = SQL Editor

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
@@ -1542,6 +1542,11 @@
         <super type="org.eclipse.core.resources.textmarker"/>
     </extension>
 
+    <extension id="semanticProblemMarker" name="%semanticProblem.name" point="org.eclipse.core.resources.markers">
+        <super type="org.eclipse.core.resources.problemmarker"/>
+        <super type="org.eclipse.core.resources.textmarker"/>
+    </extension>
+
     <extension point="org.jkiss.dbeaver.sqlGenerator">
         <generator id="ddlByResultSet" class="org.jkiss.dbeaver.ui.editors.sql.generator.SQLGeneratorDDLFromResultSet" label="CREATE" description="CREATE table" order="6">
             <objectType name="org.jkiss.dbeaver.ui.controls.resultset.IResultSetController"/>

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
@@ -80,6 +80,8 @@ import org.jkiss.dbeaver.ui.editors.sql.internal.SQLEditorMessages;
 import org.jkiss.dbeaver.ui.editors.sql.preferences.*;
 import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLBackgroundParsingJob;
 import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLEditorOutlinePage;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLEditorSemanticMarkersManager;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLSemanticErrorAnnotation;
 import org.jkiss.dbeaver.ui.editors.sql.syntax.*;
 import org.jkiss.dbeaver.ui.editors.sql.templates.SQLTemplatesPage;
 import org.jkiss.dbeaver.ui.editors.sql.util.SQLSymbolInserter;
@@ -128,8 +130,9 @@ public abstract class SQLEditorBase extends BaseTextEditor implements DBPContext
     @Nullable
     private SQLParserContext parserContext;
     private ProjectionSupport projectionSupport;
-    private SQLBackgroundParsingJob backgroundParsingJob;    
+    private SQLBackgroundParsingJob backgroundParsingJob;
     private SQLEditorOutlinePage outlinePage;
+    private SQLEditorSemanticMarkersManager semanticMarkersManager;
 
     //private Map<Annotation, Position> curAnnotations;
 
@@ -183,7 +186,29 @@ public abstract class SQLEditorBase extends BaseTextEditor implements DBPContext
 
         DBWorkbench.getPlatform().getPreferenceStore().addPropertyChangeListener(this);
     }
-    
+
+    @Override
+    public void gotoMarker(IMarker marker) {
+        try {
+            if (marker.getAttribute(SQLSemanticErrorAnnotation.MARKER_ATTRIBUTE_NAME) instanceof SQLSemanticErrorAnnotation annotation) {
+                final IAnnotationModel annotationModel = this.getAnnotationModel();
+                final TextViewer textViewer = this.getTextViewer();
+                if (annotationModel != null && textViewer != null) {
+                    Position position = annotationModel.getPosition(annotation);
+                    if (!position.isDeleted) {
+                        textViewer.setSelectedRange(position.getOffset(), position.getLength());
+                        textViewer.revealRange(position.getOffset(), position.getLength());
+                    }
+                    return;
+                }
+            }
+        } catch (CoreException e) {
+            log.error("Error retrieving marker attribute", e);
+        }
+
+        super.gotoMarker(marker);
+    }
+
     public SQLDocumentSyntaxContext getSyntaxContext() {
         return backgroundParsingJob == null ? null : backgroundParsingJob.getCurrentContext();
     }
@@ -668,7 +693,10 @@ public abstract class SQLEditorBase extends BaseTextEditor implements DBPContext
     @Override
     public void dispose() {
         DBWorkbench.getPlatform().getPreferenceStore().removePropertyChangeListener(this);
-        if (backgroundParsingJob != null) {
+        if (this.semanticMarkersManager != null) {
+            this.semanticMarkersManager.dispose();
+        }
+        if (this.backgroundParsingJob != null) {
             this.backgroundParsingJob.dispose();
         }
         this.occurrencesHighlighter.dispose();
@@ -779,15 +807,25 @@ public abstract class SQLEditorBase extends BaseTextEditor implements DBPContext
     }
 
     public void reloadSyntaxRules() {
-        if (SQLEditorUtils.isSQLSyntaxParserApplied(this.getEditorInput()) && isAdvancedHighlightingEnabled()) {
-            if (backgroundParsingJob == null) {
-                backgroundParsingJob = new SQLBackgroundParsingJob(this);
+        if (SQLEditorUtils.isSQLSyntaxParserApplied(this.getEditorInput()) && this.isAdvancedHighlightingEnabled()) {
+            if (this.backgroundParsingJob == null) {
+                this.backgroundParsingJob = new SQLBackgroundParsingJob(this);
+            }
+            if (getActivePreferenceStore().getBoolean(SQLPreferenceConstants.PROBLEM_MARKERS_ENABLED) && this.semanticMarkersManager == null) {
+                this.semanticMarkersManager = new SQLEditorSemanticMarkersManager(this);
             }
         } else {
-            if (backgroundParsingJob != null) {
-                backgroundParsingJob.dispose();
-                backgroundParsingJob = null;
+            if (this.backgroundParsingJob != null) {
+                this.backgroundParsingJob.dispose();
+                this.backgroundParsingJob = null;
             }
+        }
+        if (this.semanticMarkersManager != null && (
+            this.backgroundParsingJob == null ||
+            !this.getActivePreferenceStore().getBoolean(SQLPreferenceConstants.PROBLEM_MARKERS_ENABLED)
+        )) {
+            this.semanticMarkersManager.dispose();
+            this.semanticMarkersManager = null;
         }
 
         // Refresh syntax
@@ -846,8 +884,11 @@ public abstract class SQLEditorBase extends BaseTextEditor implements DBPContext
             verticalRuler.update();
         }
 
-        if (backgroundParsingJob != null) {
-            backgroundParsingJob.setup();
+        if (this.backgroundParsingJob != null) {
+            this.backgroundParsingJob.setup();
+        }
+        if (this.semanticMarkersManager != null) {
+            this.semanticMarkersManager.refresh();
         }
     }
 
@@ -1224,6 +1265,15 @@ public abstract class SQLEditorBase extends BaseTextEditor implements DBPContext
                     this.outlinePage.refresh();
                 }
                 return;
+        }
+    }
+
+    public void refreshAdvancedServices() {
+        if (this.outlinePage != null) {
+            this.outlinePage.refresh();
+        }
+        if (this.semanticMarkersManager != null) {
+            this.semanticMarkersManager.refresh();
         }
     }
     

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorUtils.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorUtils.java
@@ -517,9 +517,7 @@ public class SQLEditorUtils {
         }
         for (SQLEditor sqlEditor : affectedEditors) {
             sqlEditor.refreshEditorIconAndTitle();
-            if (sqlEditor.getOverviewOutlinePage() instanceof SQLEditorOutlinePage outline) {
-                outline.refresh();
-            }
+            sqlEditor.refreshAdvancedServices();
         }
 
         PlatformUI.getWorkbench().getService(ICommandService.class).refreshElements(DisableSQLSyntaxParserHandler.COMMAND_ID, null);

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLBackgroundParsingJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLBackgroundParsingJob.java
@@ -530,6 +530,7 @@ public class SQLBackgroundParsingJob {
             monitor.worked(1);
 
             SQLSyntaxManager syntaxManager = this.editor.getSyntaxManager();
+            SQLQueryRecognitionContext recognitionContext = new SQLQueryRecognitionContext(monitor, executionContext, useRealMetadata, syntaxManager);
 
             int i = 1;
             for (SQLScriptElement element : elements) {
@@ -537,11 +538,8 @@ public class SQLBackgroundParsingJob {
                     break;
                 }
                 try {
-                    SQLQueryModelContext recognizer = new SQLQueryModelContext(executionContext, useRealMetadata, syntaxManager);
-                    SQLQueryModel queryModel = recognizer.recognizeQuery(
-                        element.getOriginalText(),
-                        monitor
-                    );
+                    recognitionContext.reset();
+                    SQLQueryModel queryModel = SQLQueryModelRecognizer.recognizeQuery(recognitionContext, element.getOriginalText());
 
                     if (queryModel != null) {
                         if (DEBUG) {
@@ -555,6 +553,7 @@ public class SQLBackgroundParsingJob {
                             element instanceof SQLQuery queryElement && Boolean.TRUE.equals(queryElement.isEndsWithDelimiter())
                         );
                         itemContext.clear();
+                        itemContext.setProblems(recognitionContext.getProblems());
                         for (SQLQuerySymbolEntry entry : queryModel.getAllSymbols()) {
                             itemContext.registerToken(entry.getInterval().a, entry);
                         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLEditorSemanticMarkersManager.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLEditorSemanticMarkersManager.java
@@ -36,6 +36,7 @@ import org.jkiss.dbeaver.ui.AbstractUIJob;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -114,7 +115,7 @@ public class SQLEditorSemanticMarkersManager {
             return;
         }
 
-        HashMap.Entry<SQLDocumentScriptItemSyntaxContext, UpdateMarkersOperationInfo>[] entries;
+        Map.Entry<SQLDocumentScriptItemSyntaxContext, UpdateMarkersOperationInfo>[] entries;
         synchronized (syncRoot) {
             if (this.resetAnnotations) {
                 try {
@@ -128,10 +129,10 @@ public class SQLEditorSemanticMarkersManager {
             this.queuedOperations.clear();
         }
 
-        for (HashMap.Entry<SQLDocumentScriptItemSyntaxContext, UpdateMarkersOperationInfo> entry : entries) {
+        for (Map.Entry<SQLDocumentScriptItemSyntaxContext, UpdateMarkersOperationInfo> entry : entries) {
             SQLDocumentScriptItemSyntaxContext scriptItem = entry.getKey();
             if (entry.getValue().introduceMarkers && scriptItem.getProblems() != null) {
-                LinkedList<SQLSemanticErrorAnnotation> itemAnnotations = this.annotations.computeIfAbsent(scriptItem, c -> new LinkedList<>());
+                Deque<SQLSemanticErrorAnnotation> itemAnnotations = this.annotations.computeIfAbsent(scriptItem, c -> new LinkedList<>());
                 int scriptItemPosition = scriptItem.getInitialPosition();
                 for (SQLQueryRecognitionProblemInfo problemInfo : scriptItem.getProblems()) {
                     try {
@@ -151,7 +152,7 @@ public class SQLEditorSemanticMarkersManager {
                     }
                 }
             } else {
-                LinkedList<SQLSemanticErrorAnnotation> itemAnnotations = this.annotations.remove(scriptItem);
+                Deque<SQLSemanticErrorAnnotation> itemAnnotations = this.annotations.remove(scriptItem);
                 if (itemAnnotations != null) {
                     for (SQLSemanticErrorAnnotation annotation : itemAnnotations) {
                         IMarker marker = annotation.getMarker();

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLEditorSemanticMarkersManager.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLEditorSemanticMarkersManager.java
@@ -97,9 +97,9 @@ public class SQLEditorSemanticMarkersManager {
     @NotNull
     private final Object syncRoot = new Object();
     @NotNull
-    private final HashMap<SQLDocumentScriptItemSyntaxContext, UpdateMarkersOperationInfo> queuedOperations = new HashMap<>();
+    private final Map<SQLDocumentScriptItemSyntaxContext, UpdateMarkersOperationInfo> queuedOperations = new HashMap<>();
     @NotNull
-    private final HashMap<SQLDocumentScriptItemSyntaxContext, LinkedList<SQLSemanticErrorAnnotation>> annotations = new HashMap<>();
+    private final Map<SQLDocumentScriptItemSyntaxContext, LinkedList<SQLSemanticErrorAnnotation>> annotations = new HashMap<>();
     private volatile boolean resetAnnotations = false;
 
     public SQLEditorSemanticMarkersManager(@NotNull SQLEditorBase editor) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLEditorSemanticMarkersManager.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLEditorSemanticMarkersManager.java
@@ -1,0 +1,258 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.editors.sql.semantics;
+
+import org.antlr.v4.runtime.misc.Interval;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextInputListener;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.TextViewer;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.sql.semantics.*;
+import org.jkiss.dbeaver.ui.AbstractUIJob;
+import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
+import org.jkiss.dbeaver.utils.GeneralUtils;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+public class SQLEditorSemanticMarkersManager {
+
+    private static final Log log = Log.getLog(SQLEditorSemanticMarkersManager.class);
+
+    @NotNull
+    private final ITextInputListener textInputListener = new ITextInputListener() {
+
+        @Override
+        public void inputDocumentChanged(IDocument oldInput, IDocument newInput) {
+            refresh();
+        }
+
+        @Override
+        public void inputDocumentAboutToBeChanged(IDocument oldInput, IDocument newInput) {
+        }
+    };
+
+    private final SQLDocumentSyntaxContextListener syntaxContextListener = new SQLDocumentSyntaxContextListener() {
+        @Override
+        public void onScriptItemIntroduced(@NotNull SQLDocumentScriptItemSyntaxContext item) {
+            synchronized (syncRoot) {
+                queuedOperations.compute(item, (c, op) -> UpdateMarkersOperationInfo.setIntroduce(op, true));
+                scheduleRefreshJob();
+            }
+        }
+
+        @Override
+        public void onScriptItemInvalidated(@NotNull SQLDocumentScriptItemSyntaxContext item) {
+            synchronized (syncRoot) {
+                queuedOperations.compute(item, (c, op) -> UpdateMarkersOperationInfo.setIntroduce(op, false));
+                scheduleRefreshJob();
+            }
+        }
+
+        @Override
+        public void onAllScriptItemsInvalidated() {
+            scheduleClearAllProblems();
+        }
+    };
+
+    @NotNull
+    private final AbstractUIJob refreshJob = new AbstractUIJob("SQL editor error markers refresh") {
+        @NotNull
+        @Override
+        protected IStatus runInUIThread(@NotNull DBRProgressMonitor monitor) {
+            updateMarkers();
+            return Status.OK_STATUS;
+        }
+    };
+
+    @NotNull
+    private final SQLEditorBase editor;
+    @Nullable
+    private volatile SQLDocumentSyntaxContext syntaxContext;
+    @NotNull
+    private final Object syncRoot = new Object();
+    @NotNull
+    private final HashMap<SQLDocumentScriptItemSyntaxContext, UpdateMarkersOperationInfo> queuedOperations = new HashMap<>();
+    @NotNull
+    private final HashMap<SQLDocumentScriptItemSyntaxContext, LinkedList<SQLSemanticErrorAnnotation>> annotations = new HashMap<>();
+    private volatile boolean resetAnnotations = false;
+
+    public SQLEditorSemanticMarkersManager(@NotNull SQLEditorBase editor) {
+        this.editor = editor;
+        this.setup();
+    }
+
+    private void updateMarkers() {
+        final IResource resource = GeneralUtils.adapt(this.editor.getEditorInput(), IResource.class);
+        final IAnnotationModel annotationModel = this.editor.getAnnotationModel();
+        if (resource == null || annotationModel == null) {
+            return;
+        }
+
+        HashMap.Entry<SQLDocumentScriptItemSyntaxContext, UpdateMarkersOperationInfo>[] entries;
+        synchronized (syncRoot) {
+            if (this.resetAnnotations) {
+                try {
+                    resource.deleteMarkers(SQLSemanticErrorAnnotation.MARKER_TYPE, false, IResource.DEPTH_ONE);
+                } catch (CoreException e) {
+                    log.error("Error deleting problem markers", e);
+                }
+                this.resetAnnotations = false;
+            }
+            entries = this.queuedOperations.entrySet().toArray(new Map.Entry[0]);
+            this.queuedOperations.clear();
+        }
+
+        for (HashMap.Entry<SQLDocumentScriptItemSyntaxContext, UpdateMarkersOperationInfo> entry : entries) {
+            SQLDocumentScriptItemSyntaxContext scriptItem = entry.getKey();
+            if (entry.getValue().introduceMarkers && scriptItem.getProblems() != null) {
+                LinkedList<SQLSemanticErrorAnnotation> itemAnnotations = this.annotations.computeIfAbsent(scriptItem, c -> new LinkedList<>());
+                int scriptItemPosition = scriptItem.getInitialPosition();
+                for (SQLQueryRecognitionProblemInfo problemInfo : scriptItem.getProblems()) {
+                    try {
+                        Interval problemInterval = problemInfo.getInterval();
+                        final IMarker marker = resource.createMarker(SQLSemanticErrorAnnotation.MARKER_TYPE, Map.of(
+                                IMarker.SEVERITY, IMarker.SEVERITY_ERROR,
+                                IMarker.MESSAGE, problemInfo.getMessage(),
+                                IMarker.TRANSIENT, true
+                        ));
+                        SQLSemanticErrorAnnotation annotation = new SQLSemanticErrorAnnotation(marker, problemInfo);
+                        marker.setAttribute(SQLSemanticErrorAnnotation.MARKER_ATTRIBUTE_NAME, annotation);
+                        Position position = new Position(scriptItemPosition + problemInterval.a, problemInterval.length());
+                        annotationModel.addAnnotation(annotation, position);
+                        itemAnnotations.addLast(annotation);
+                    } catch (CoreException e) {
+                        log.error("Error creating problem marker", e);
+                    }
+                }
+            } else {
+                LinkedList<SQLSemanticErrorAnnotation> itemAnnotations = this.annotations.remove(scriptItem);
+                if (itemAnnotations != null) {
+                    for (SQLSemanticErrorAnnotation annotation : itemAnnotations) {
+                        IMarker marker = annotation.getMarker();
+                        try {
+                            marker.setAttribute(SQLSemanticErrorAnnotation.MARKER_ATTRIBUTE_NAME, null);
+                        } catch (CoreException e) {
+                            log.error("Error dissociating problem marker", e);
+                        }
+                        annotationModel.removeAnnotation(annotation);
+                        try {
+                            marker.delete();
+                        } catch (CoreException e) {
+                            log.error("Error deleting problem marker", e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void refresh() {
+        SQLDocumentSyntaxContext actualContext = this.editor.getSyntaxContext();
+        synchronized (this.syncRoot) {
+            SQLDocumentSyntaxContext currentContext = this.syntaxContext;
+            if (actualContext != currentContext) {
+                if (currentContext != null) {
+                    this.cleanup();
+                }
+                if (actualContext != null) {
+                    this.setup();
+                }
+            }
+            {
+                SQLDocumentSyntaxContext context = this.syntaxContext;
+                if (context != null) {
+                    for (SQLScriptItemAtOffset itemAtOffset : context.getScriptItems()) {
+                        queuedOperations.compute(itemAtOffset.item, (c, op) -> UpdateMarkersOperationInfo.setIntroduce(op, true));
+                    }
+                    this.scheduleClearAllProblems();
+                }
+            }
+        }
+    }
+
+    private void scheduleClearAllProblems() {
+        synchronized (syncRoot) {
+            queuedOperations.clear();
+            resetAnnotations = true;
+            scheduleRefreshJob();
+        }
+    }
+
+    private void scheduleRefreshJob() {
+        this.refreshJob.schedule(500);
+    }
+
+    private void setup() {
+        SQLDocumentSyntaxContext context = this.editor.getSyntaxContext();
+        if (context != null) {
+            this.syntaxContext = context;
+            context.addListener(this.syntaxContextListener);
+            this.scheduleRefreshJob();
+        }
+        TextViewer textViewer = this.editor.getTextViewer();
+        if (textViewer != null) {
+            textViewer.addTextInputListener(this.textInputListener);
+        }
+    }
+
+    private void cleanup() {
+        TextViewer textViewer = this.editor.getTextViewer();
+        if (textViewer != null) {
+            textViewer.removeTextInputListener(this.textInputListener);
+        }
+
+        SQLDocumentSyntaxContext context = this.syntaxContext;
+        if (context != null) {
+            context.removeListener(this.syntaxContextListener);
+            this.syntaxContext = null;
+        }
+        this.scheduleClearAllProblems();
+    }
+
+    /**
+     * Release associated resources
+     */
+    public void dispose() {
+        this.cleanup();
+    }
+
+
+    private static class UpdateMarkersOperationInfo {
+        public boolean introduceMarkers;
+
+        @NotNull
+        public static UpdateMarkersOperationInfo setIntroduce(@Nullable UpdateMarkersOperationInfo operationInfo, boolean addMarkers) {
+            if (operationInfo == null) {
+                operationInfo = new UpdateMarkersOperationInfo();
+            }
+            operationInfo.introduceMarkers = addMarkers;
+            return operationInfo;
+        }
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLSemanticErrorAnnotation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLSemanticErrorAnnotation.java
@@ -1,0 +1,51 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.editors.sql.semantics;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.jface.text.source.IAnnotationPresentation;
+import org.eclipse.jface.text.source.ImageUtilities;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Canvas;
+import org.eclipse.ui.texteditor.MarkerAnnotation;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.DBIcon;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionProblemInfo;
+import org.jkiss.dbeaver.ui.DBeaverIcons;
+
+public class SQLSemanticErrorAnnotation extends MarkerAnnotation implements IAnnotationPresentation {
+    public static final String MARKER_TYPE = "org.jkiss.dbeaver.ui.editors.sql.semanticProblemMarker";
+    public static final String TYPE = "org.eclipse.ui.workbench.texteditor.error";
+    public static final String MARKER_ATTRIBUTE_NAME = "org.jkiss.dbeaver.ui.editors.sql.semantics.semanticProblemAnnotation";
+    private final SQLQueryRecognitionProblemInfo problemInfo; // TODO will be needed for quick fix
+
+    public SQLSemanticErrorAnnotation(@NotNull IMarker marker, SQLQueryRecognitionProblemInfo problemInfo) {
+        super(TYPE, marker);
+        this.problemInfo = problemInfo;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void paint(GC gc, Canvas canvas, Rectangle r) {
+        ImageUtilities.drawImage(DBeaverIcons.getImage(DBIcon.TINY_ERROR), gc, canvas, r, SWT.CENTER, SWT.TOP);
+    }
+
+
+}
+

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLSemanticErrorAnnotation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLSemanticErrorAnnotation.java
@@ -28,15 +28,15 @@ import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.DBIcon;
 import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionProblemInfo;
 import org.jkiss.dbeaver.ui.DBeaverIcons;
+import org.jkiss.dbeaver.ui.editors.sql.syntax.SQLProblemAnnotation;
 
 public class SQLSemanticErrorAnnotation extends MarkerAnnotation implements IAnnotationPresentation {
     public static final String MARKER_TYPE = "org.jkiss.dbeaver.ui.editors.sql.semanticProblemMarker";
-    public static final String TYPE = "org.eclipse.ui.workbench.texteditor.error";
     public static final String MARKER_ATTRIBUTE_NAME = "org.jkiss.dbeaver.ui.editors.sql.semantics.semanticProblemAnnotation";
     private final SQLQueryRecognitionProblemInfo problemInfo; // TODO will be needed for quick fix
 
     public SQLSemanticErrorAnnotation(@NotNull IMarker marker, SQLQueryRecognitionProblemInfo problemInfo) {
-        super(TYPE, marker);
+        super(SQLProblemAnnotation.TYPE, marker);
         this.problemInfo = problemInfo;
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLInformationProvider.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLInformationProvider.java
@@ -75,7 +75,7 @@ public class SQLInformationProvider implements IInformationProvider, IInformatio
     {
         this.editor = editor;
         this.contextInformer = contextInformer;
-        implementation = new SQLAnnotationHover(editor);
+        this.implementation = new SQLAnnotationHover(editor);
 
         if (this.editor instanceof SQLEditor) {
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/util/SQLAnnotationHover.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/util/SQLAnnotationHover.java
@@ -271,7 +271,7 @@ public class SQLAnnotationHover extends AbstractSQLEditorTextHover
                     IRegion visualLineRange = editor.getTextViewer().modelRange2WidgetRange(modelLineRange);
                     StyledText widget = editor.getTextViewer().getTextWidget();
                     int offset = visualLineRange.getOffset();
-                    Rectangle localLineBounds =  widget.getTextBounds(offset, offset + visualLineRange.getLength());
+                    Rectangle localLineBounds =  widget.getTextBounds(offset, offset + visualLineRange.getLength() - 1);
                     Rectangle globalLineBounds = Geometry.toDisplay(widget, localLineBounds);
 
                     if (this.getBounds().intersects(globalLineBounds)) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/util/SQLAnnotationHover.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/util/SQLAnnotationHover.java
@@ -16,31 +16,71 @@
  */
 package org.jkiss.dbeaver.ui.editors.sql.util;
 
+import org.antlr.v4.runtime.misc.Interval;
+import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.text.*;
-import org.eclipse.jface.text.source.Annotation;
-import org.eclipse.jface.text.source.IAnnotationHover;
-import org.eclipse.jface.text.source.IAnnotationModel;
-import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+import org.eclipse.jface.text.source.*;
+import org.eclipse.jface.util.Geometry;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.forms.events.HyperlinkEvent;
+import org.eclipse.ui.forms.events.IHyperlinkListener;
+import org.eclipse.ui.forms.widgets.Hyperlink;
 import org.eclipse.ui.texteditor.spelling.SpellingAnnotation;
 import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
+import org.jkiss.dbeaver.ui.editors.sql.semantics.SQLSemanticErrorAnnotation;
 import org.jkiss.dbeaver.ui.editors.sql.syntax.SQLProblemAnnotation;
 
-import java.util.Iterator;
+import java.util.*;
 
 
 /**
  * SQLAnnotationHover
  */
 public class SQLAnnotationHover extends AbstractSQLEditorTextHover
-    implements ITextHover, IAnnotationHover, ITextHoverExtension, ITextHoverExtension2 {
+    implements ITextHover, IAnnotationHover, ITextHoverExtension, ITextHoverExtension2, IAnnotationHoverExtension {
     private static final Log log = Log.getLog(SQLAnnotationHover.class);
 
     private SQLEditorBase editor;
 
     public SQLAnnotationHover(SQLEditorBase editor) {
         setEditor(editor);
+    }
+
+    /**
+     * Show info from annotations on the specified line
+     */
+    @Override
+    public String getHoverInfo(ISourceViewer sourceViewer, int lineNumber) {
+        try {
+            int linePosition = sourceViewer.getDocument().getLineOffset(lineNumber);
+            int lineLength = sourceViewer.getDocument().getLineLength(lineNumber);
+            StringBuilder sb = new StringBuilder();
+            for (Iterator<Annotation> ai = sourceViewer.getAnnotationModel().getAnnotationIterator(); ai.hasNext(); ) {
+                Annotation anno = ai.next();
+                if (isSupportedAnnotation(anno)) {
+                    Position annoPosition = sourceViewer.getAnnotationModel().getPosition(anno);
+                    if (annoPosition != null) {
+                        if (annoPosition.overlapsWith(linePosition, lineLength)) {
+                            sb.append(anno.getText()).append("; ");
+                        }
+                    }
+                }
+            }
+            return sb.isEmpty() ? null : sb.toString();
+        } catch (BadLocationException e) {
+            log.debug(e);
+            return null;
+        }
     }
 
     @Override
@@ -54,22 +94,45 @@ public class SQLAnnotationHover extends AbstractSQLEditorTextHover
         if (!(textViewer instanceof ISourceViewer)) {
             return null;
         }
+        List<IHyperlink> links = new ArrayList<>();
         ISourceViewer sourceViewer = (ISourceViewer) textViewer;
         for (Iterator<Annotation> ai = sourceViewer.getAnnotationModel().getAnnotationIterator(); ai.hasNext(); ) {
             Annotation anno = ai.next();
             if (isSupportedAnnotation(anno)) {
                 Position annoPosition = sourceViewer.getAnnotationModel().getPosition(anno);
-                if (annoPosition != null && annoPosition.overlapsWith(hoverRegion.getOffset(), 1)) {
-                    return anno.getText();
+                if (annoPosition != null) {
+                    if (annoPosition.overlapsWith(hoverRegion.getOffset(), hoverRegion.getLength())) {
+                        links.add(new IHyperlink() {
+                            @Override
+                            public IRegion getHyperlinkRegion() {
+                                return new Region(annoPosition.getOffset(), annoPosition.getLength());
+                            }
+
+                            @Override
+                            public String getTypeLabel() {
+                                return null;
+                            }
+
+                            @Override
+                            public String getHyperlinkText() {
+                                return anno.getText();
+                            }
+
+                            @Override
+                            public void open() {
+                                TextViewer textViewer = editor.getTextViewer();
+                                if (textViewer != null) {
+                                    textViewer.setSelectedRange(annoPosition.getOffset(), annoPosition.getLength());
+                                    textViewer.revealRange(annoPosition.getOffset(), annoPosition.getLength());
+                                }
+                            }
+                        });
+                    }
                 }
             }
         }
-
-        return null;
-    }
-
-    private boolean isSupportedAnnotation(Annotation anno) {
-        return anno instanceof SpellingAnnotation || anno instanceof SQLProblemAnnotation;
+        links.sort(Comparator.comparingInt(l -> l.getHyperlinkRegion().getOffset()));
+        return links.isEmpty() ? null : links.toArray(IHyperlink[]::new);
     }
 
     @Override
@@ -77,42 +140,45 @@ public class SQLAnnotationHover extends AbstractSQLEditorTextHover
         if (!(textViewer instanceof ISourceViewer)) {
             return null;
         }
+        Interval hoverInterval = new Interval(offset, offset);
+        Interval resultInterval = null;
         IAnnotationModel annotationModel = ((ISourceViewer) textViewer).getAnnotationModel();
         if (annotationModel != null) {
             for (Iterator<Annotation> ai = annotationModel.getAnnotationIterator(); ai.hasNext(); ) {
                 Annotation anno = ai.next();
                 if (isSupportedAnnotation(anno)) {
                     Position annoPosition = annotationModel.getPosition(anno);
-                    if (annoPosition != null && annoPosition.overlapsWith(offset, 1)) {
-                        return new Region(annoPosition.getOffset(), annoPosition.getLength());
+                    if (annoPosition != null) {
+                        Interval annoInterval = new Interval(annoPosition.getOffset(), annoPosition.getOffset() + annoPosition.getLength());
+                        if (annoInterval.properlyContains(hoverInterval)) {
+                            resultInterval = resultInterval == null ? annoInterval : resultInterval.union(annoInterval);
+                        }
                     }
                 }
             }
         }
-        return null;
+        return resultInterval == null ? null : new Region(resultInterval.a, resultInterval.length());
     }
 
-    /**
-     * Show info from annotations on the specified line
-     */
     @Override
-    public String getHoverInfo(ISourceViewer sourceViewer, int lineNumber) {
+    public Object getHoverInfo(ISourceViewer sourceViewer, ILineRange lineRange, int visibleNumberOfLines) {
         try {
-            int linePosition = sourceViewer.getDocument().getLineOffset(lineNumber);
-            int lineLength = sourceViewer.getDocument().getLineLength(lineNumber);
-            for (Iterator<Annotation> ai = sourceViewer.getAnnotationModel().getAnnotationIterator(); ai.hasNext(); ) {
-                Annotation anno = ai.next();
-                if (isSupportedAnnotation(anno)) {
-                    Position annoPosition = sourceViewer.getAnnotationModel().getPosition(anno);
-                    if (annoPosition != null && annoPosition.overlapsWith(linePosition, lineLength)) {
-                        return anno.getText();
-                    }
-                }
-            }
+            IRegion lineRegion = sourceViewer.getDocument().getLineInformation(lineRange.getStartLine());
+            return this.getHoverInfo2(sourceViewer, lineRegion);
         } catch (BadLocationException e) {
             log.debug(e);
+            return null;
         }
-        return null;
+    }
+
+    @Override
+    public ILineRange getHoverLineRange(ISourceViewer viewer, int lineNumber) {
+        return new LineRange(lineNumber, 1);
+    }
+
+    @Override
+    public boolean canHandleMouseCursor() {
+        return true;
     }
 
     @Override
@@ -121,11 +187,103 @@ public class SQLAnnotationHover extends AbstractSQLEditorTextHover
     }
 
     public IInformationControlCreator getHoverControlCreator() {
-        return parent -> {
-            DefaultInformationControl control = new DefaultInformationControl(parent, false);
-            control.setSizeConstraints(60, 10);
-            return control;
-        };
+        return LinkListInformationControl::new;
+    }
+
+    private boolean isSupportedAnnotation(Annotation anno) {
+        return anno instanceof SpellingAnnotation || anno instanceof SQLProblemAnnotation || anno instanceof SQLSemanticErrorAnnotation;
+    }
+
+    private class LinkListInformationControl extends AbstractInformationControl implements IInformationControlExtension2 {
+
+        private Composite linksContainer;
+        private int firstLinkOffset = -1;
+
+        public LinkListInformationControl(Shell parentShell) {
+            super(parentShell, false);
+            this.setBackgroundColor(new Color(255, 128, 128));
+            create();
+        }
+
+        @Override
+        public void setInformation(String information) {
+            //replaced by IInformationControlExtension2#setInput(java.lang.Object)
+        }
+
+        @Override
+        public void setInput(Object input) {
+            for (IHyperlink hyperlink : (IHyperlink[]) input) {
+                if (this.firstLinkOffset < 0) {
+                    firstLinkOffset = hyperlink.getHyperlinkRegion().getOffset();
+                }
+                Hyperlink link = new Hyperlink(this.linksContainer, SWT.NONE);
+                link.setText(hyperlink.getHyperlinkText());
+                link.setUnderlined(true);
+                link.addHyperlinkListener(new IHyperlinkListener() {
+                    private Point oldSelection = null;
+
+                    @Override
+                    public void linkEntered(HyperlinkEvent e) {
+                        oldSelection = editor.getTextViewer() != null ? editor.getTextViewer().getSelectedRange() : null;
+                        IRegion hyperlinkRegion = hyperlink.getHyperlinkRegion();
+                        editor.getTextViewer().setSelectedRange(hyperlinkRegion.getOffset(), hyperlinkRegion.getLength());
+                    }
+
+                    @Override
+                    public void linkExited(HyperlinkEvent e) {
+                        if (oldSelection != null && editor.getTextViewer() != null) {
+                            editor.getTextViewer().setSelectedRange(oldSelection.x, oldSelection.y);
+                        }
+                    }
+
+                    @Override
+                    public void linkActivated(HyperlinkEvent e) {
+                        hyperlink.open();
+                    }
+                });
+            }
+            super.getShell().pack(true);
+        }
+
+        @Override
+        protected void createContent(Composite parent) {
+            this.linksContainer = UIUtils.createComposite(parent, 1);
+            this.linksContainer.setLayout(GridLayoutFactory.swtDefaults().create());
+        }
+
+        @Override
+        public boolean hasContents() {
+            return true;
+        }
+
+        @Override
+        public Point computeSizeHint() {
+            Rectangle bounds = this.getBounds();
+            return new Point(bounds.width, bounds.height);
+        }
+
+        @Override
+        public void setVisible(boolean visible) {
+            if (visible && this.firstLinkOffset >= 0 && editor.getDocument() != null && editor.getTextViewer() != null) {
+                IRegion modelLineRange;
+                try {
+                    modelLineRange = editor.getDocument().getLineInformationOfOffset(this.firstLinkOffset);
+                    IRegion visualLineRange = editor.getTextViewer().modelRange2WidgetRange(modelLineRange);
+                    StyledText widget = editor.getTextViewer().getTextWidget();
+                    int offset = visualLineRange.getOffset();
+                    Rectangle localLineBounds =  widget.getTextBounds(offset, offset + visualLineRange.getLength());
+                    Rectangle globalLineBounds = Geometry.toDisplay(widget, localLineBounds);
+
+                    if (this.getBounds().intersects(globalLineBounds)) {
+                        this.setLocation(new Point(this.getBounds().x, globalLineBounds.y + globalLineBounds.height));
+                    }
+                    super.getShell().pack(true);
+                } catch (BadLocationException e) {
+                    // nah, no way to adjust position
+                }
+            }
+            super.setVisible(visible);
+        }
     }
 
 }


### PR DESCRIPTION
Now we show problem markers for semantic errors
![image](https://github.com/user-attachments/assets/f2a5cf1c-96a4-4179-b98e-cc157b88fa1a)

We have multiple messages in one tooltip and can jumpby to the issue source from marker tooltip or from Problems view by clicking
![image](https://github.com/user-attachments/assets/8aad2630-3413-4ce4-9fce-853bec836623)
