### PR TITLE
dbeaver/pro#2712 Added a shortcut for advance copy with last settings

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.core/plugin.xml
@@ -963,6 +963,7 @@
         <key commandId="org.jkiss.dbeaver.ui.tools.menu" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" platform="cocoa" sequence="CTRL+V"/>
 
         <key commandId="org.jkiss.dbeaver.core.edit.copy.special" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+SHIFT+C"/>
+        <key commandId="org.jkiss.dbeaver.core.edit.copy.special.with.last.settings" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+SHIFT+ALT+C"/>
         <key commandId="org.jkiss.dbeaver.core.edit.paste.special" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+SHIFT+V"/>
         <key commandId="org.jkiss.dbeaver.core.navigator.bookmark.add" contextId="org.jkiss.dbeaver.ui.context.navigator.view" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" sequence="CTRL+ALT+SHIFT+D"/>
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/plugin.xml
@@ -470,6 +470,14 @@
                 </with>
             </enabledWhen>
         </handler>
+        <handler commandId="org.jkiss.dbeaver.core.edit.copy.special.with.last.settings" class="org.jkiss.dbeaver.ui.controls.resultset.handler.ResultSetHandlerCopySpecial">
+            <activeWhen><reference definitionId="org.jkiss.dbeaver.core.ui.resultset.presentation.control"/></activeWhen>
+            <enabledWhen>
+                <with variable="activePart">
+                    <test property="org.jkiss.dbeaver.core.resultset.canCopy"/>
+                </with>
+            </enabledWhen>
+        </handler>
         <handler commandId="org.jkiss.dbeaver.core.edit.paste.special" class="org.jkiss.dbeaver.ui.controls.resultset.handler.ResultSetHandlerPasteSpecial">
             <activeWhen><reference definitionId="org.jkiss.dbeaver.core.ui.resultset.presentation.control"/></activeWhen>
             <enabledWhen>

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerCopySpecial.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerCopySpecial.java
@@ -55,7 +55,6 @@ public class ResultSetHandlerCopySpecial extends ResultSetHandlerMain implements
     public static final Log log = Log.getLog(ResultSetHandlerCopySpecial.class);
     public static final String CMD_COPY_SPECIAL = IActionConstants.CMD_COPY_SPECIAL;
     public static final String CMD_COPY_SPECIAL_LAST = IActionConstants.CMD_COPY_SPECIAL_LAST;
-    //private AdvancedCopyConfigDialog lastConfigDialog = null;
     private static ResultSetCopySettings copySettingsLast = null;
 
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerCopySpecial.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerCopySpecial.java
@@ -55,7 +55,8 @@ public class ResultSetHandlerCopySpecial extends ResultSetHandlerMain implements
     public static final Log log = Log.getLog(ResultSetHandlerCopySpecial.class);
     public static final String CMD_COPY_SPECIAL = IActionConstants.CMD_COPY_SPECIAL;
     public static final String CMD_COPY_SPECIAL_LAST = IActionConstants.CMD_COPY_SPECIAL_LAST;
-    private AdvancedCopyConfigDialog lastConfigDialog = null;
+    //private AdvancedCopyConfigDialog lastConfigDialog = null;
+    private static ResultSetCopySettings copySettingsLast = null;
 
 
     @Override
@@ -70,11 +71,11 @@ public class ResultSetHandlerCopySpecial extends ResultSetHandlerMain implements
                 showAdvancedCopyDialog(resultSet, HandlerUtil.getActiveShell(event));
                 break;
             case CMD_COPY_SPECIAL_LAST:
-                if (lastConfigDialog == null) {
+                if (copySettingsLast == null) {
                     showAdvancedCopyDialog(resultSet, HandlerUtil.getActiveShell(event));
                 } else {
                     ResultSetUtils.copyToClipboard(
-                        resultSet.getActivePresentation().copySelection(lastConfigDialog.copySettings));
+                        resultSet.getActivePresentation().copySelection(copySettingsLast));
                 }
                 break;
             default:
@@ -85,10 +86,10 @@ public class ResultSetHandlerCopySpecial extends ResultSetHandlerMain implements
     }
 
     public void showAdvancedCopyDialog(IResultSetController resultSet, Shell shell) {
-        lastConfigDialog = new AdvancedCopyConfigDialog(shell);
-        if (lastConfigDialog.open() == IDialogConstants.OK_ID) {
-            ResultSetUtils.copyToClipboard(
-                resultSet.getActivePresentation().copySelection(lastConfigDialog.copySettings));
+        AdvancedCopyConfigDialog configDialog = new AdvancedCopyConfigDialog(shell);
+        if (configDialog.open() == IDialogConstants.OK_ID) {
+            copySettingsLast = configDialog.copySettings;
+            ResultSetUtils.copyToClipboard(resultSet.getActivePresentation().copySelection(configDialog.copySettings));
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerCopySpecial.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerCopySpecial.java
@@ -20,15 +20,21 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.IElementUpdater;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.menus.UIElement;
+import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.data.DBDDisplayFormat;
+import org.jkiss.dbeaver.ui.ActionUtils;
 import org.jkiss.dbeaver.ui.IActionConstants;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.controls.ValueFormatSelector;
@@ -46,7 +52,11 @@ import java.util.Map;
  */
 public class ResultSetHandlerCopySpecial extends ResultSetHandlerMain implements IElementUpdater {
 
+    public static final Log log = Log.getLog(ResultSetHandlerCopySpecial.class);
     public static final String CMD_COPY_SPECIAL = IActionConstants.CMD_COPY_SPECIAL;
+    public static final String CMD_COPY_SPECIAL_LAST = IActionConstants.CMD_COPY_SPECIAL_LAST;
+    private AdvancedCopyConfigDialog lastConfigDialog = null;
+
 
     @Override
     public Object execute(ExecutionEvent event) throws ExecutionException {
@@ -59,15 +69,26 @@ public class ResultSetHandlerCopySpecial extends ResultSetHandlerMain implements
             case CMD_COPY_SPECIAL:
                 showAdvancedCopyDialog(resultSet, HandlerUtil.getActiveShell(event));
                 break;
+            case CMD_COPY_SPECIAL_LAST:
+                if (lastConfigDialog == null) {
+                    showAdvancedCopyDialog(resultSet, HandlerUtil.getActiveShell(event));
+                } else {
+                    ResultSetUtils.copyToClipboard(
+                        resultSet.getActivePresentation().copySelection(lastConfigDialog.copySettings));
+                }
+                break;
+            default:
+                log.warn(String.format("Unexpected command id: %s",  event.getCommand().getId()));
+                break;
         }
         return null;
     }
 
-    public static void showAdvancedCopyDialog(IResultSetController resultSet, Shell shell) {
-        AdvancedCopyConfigDialog configDialog = new AdvancedCopyConfigDialog(shell);
-        if (configDialog.open() == IDialogConstants.OK_ID) {
+    public void showAdvancedCopyDialog(IResultSetController resultSet, Shell shell) {
+        lastConfigDialog = new AdvancedCopyConfigDialog(shell);
+        if (lastConfigDialog.open() == IDialogConstants.OK_ID) {
             ResultSetUtils.copyToClipboard(
-                resultSet.getActivePresentation().copySelection(configDialog.copySettings));
+                resultSet.getActivePresentation().copySelection(lastConfigDialog.copySettings));
         }
     }
 
@@ -124,6 +145,13 @@ public class ResultSetHandlerCopySpecial extends ResultSetHandlerMain implements
             colDelimCombo = UIUtils.createDelimiterCombo(group, ResultSetMessages.copy_special_column_delimiter, new String[] {"\t", ";", ","}, copySettings.getColumnDelimiter(), false);
             rowDelimCombo = UIUtils.createDelimiterCombo(group, ResultSetMessages.copy_special_row_delimiter, new String[] {"\n", "|", "^"}, copySettings.getRowDelimiter(), false);
             quoteStringCombo = UIUtils.createDelimiterCombo(group, ResultSetMessages.copy_special_quote_character, new String[] {"\"", "'"}, copySettings.getQuoteString(), false);
+
+            Composite placeholder = UIUtils.createPlaceholder(group, 2);
+
+            placeholder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
+            UIUtils.createLabel(placeholder, NLS.bind(ResultSetMessages.copy_special_hint_for_hotkey,
+                ActionUtils.findCommandDescription(CMD_COPY_SPECIAL_LAST, PlatformUI.getWorkbench(), true)
+            ));
             createControlsAfter(group);
             return group;
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.java
@@ -468,6 +468,7 @@ public class ResultSetMessages extends NLS {
     public static String copy_special_force_quote_cell_values_tip;
     public static String copy_special_copy_as_html_text;
     public static String copy_special_copy_as_html_tip;
+    public static String copy_special_hint_for_hotkey;
 
     public static String filter_panel_filters_history_text;
     public static String filter_panel_expand_panel_text;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
@@ -450,6 +450,7 @@ copy_special_force_quote_cell_values_text = Always quote values
 copy_special_force_quote_cell_values_tip = Place all cell values in quotes
 copy_special_copy_as_html_text = Copy as HTML
 copy_special_copy_as_html_tip = Copy as HTML (in addition to plaintext format)
+copy_special_hint_for_hotkey = For future use with the same settings, you\nmay use the hotkey: {0}
 
 filter_panel_filters_history_text = Filters history
 filter_panel_expand_panel_text = Expand filter panel

--- a/plugins/org.jkiss.dbeaver.ui.navigator/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/OSGI-INF/l10n/bundle.properties
@@ -47,6 +47,9 @@ command.org.jkiss.dbeaver.core.edit.copy.special.label = Advanced copy
 command.org.jkiss.dbeaver.core.edit.copy.special.name=Advanced Copy
 command.org.jkiss.dbeaver.core.edit.copy.special.description=Copy special
 
+org.jkiss.dbeaver.core.edit.copy.special.with.last.settings.name=Advanced Copy with last settings
+org.jkiss.dbeaver.core.edit.copy.special.with.last.settings.description = Advanced Copy with last settings
+
 command.org.jkiss.dbeaver.core.edit.paste.special.name=Advanced Paste ...
 command.org.jkiss.dbeaver.core.edit.paste.special.description=Paste with extra settings
 

--- a/plugins/org.jkiss.dbeaver.ui.navigator/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/plugin.xml
@@ -223,6 +223,7 @@
         <command id="org.jkiss.dbeaver.core.edit.save.resource" name="%command.org.jkiss.dbeaver.core.edit.save.resource.name" description="%command.org.jkiss.dbeaver.core.edit.save.resource.description" categoryId="org.jkiss.dbeaver.core.util"/>
         <command id="org.jkiss.dbeaver.core.edit.load.resource" name="%command.org.jkiss.dbeaver.core.edit.load.resource.name" description="%command.org.jkiss.dbeaver.core.edit.load.resource.description" categoryId="org.jkiss.dbeaver.core.util"/>
         <command id="org.jkiss.dbeaver.core.edit.copy.special" name="%command.org.jkiss.dbeaver.core.edit.copy.special.name" description="%command.org.jkiss.dbeaver.core.edit.copy.special.description" categoryId="org.jkiss.dbeaver.core.util"/>
+        <command id="org.jkiss.dbeaver.core.edit.copy.special.with.last.settings" name="%org.jkiss.dbeaver.core.edit.copy.special.with.last.settings.name" description="%org.jkiss.dbeaver.core.edit.copy.special.with.last.settings.description" categoryId="org.jkiss.dbeaver.core.util"/>
         <command id="org.jkiss.dbeaver.core.edit.paste.special" name="%command.org.jkiss.dbeaver.core.edit.paste.special.name" description="%command.org.jkiss.dbeaver.core.edit.paste.special.description" categoryId="org.jkiss.dbeaver.core.util"/>
 
         <command id="org.jkiss.dbeaver.core.object.open" name="%command.org.jkiss.dbeaver.core.object.open.name" description="%command.org.jkiss.dbeaver.core.object.open.description" categoryId="org.jkiss.dbeaver.core.database">

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/IActionConstants.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/IActionConstants.java
@@ -47,5 +47,6 @@ public interface IActionConstants {
     String EXTRA_CONNECTION_POINT = "org.jkiss.dbeaver.ext.ui.extraConnectionPage"; //$NON-NLS-1$
 
     String CMD_COPY_SPECIAL = "org.jkiss.dbeaver.core.edit.copy.special"; //$NON-NLS-1$
+    String CMD_COPY_SPECIAL_LAST = "org.jkiss.dbeaver.core.edit.copy.special.with.last.settings"; //$NON-NLS-1$
     String CMD_PASTE_SPECIAL = "org.jkiss.dbeaver.core.edit.paste.special"; //$NON-NLS-1$
 }


### PR DESCRIPTION
Added a shortcut Ctrl+Shift+Alt+C for an advance copy with the last settings. If the last settings are undefined (e.g. at the first time) then it should work as a usual advance copy. Added hint on the form.
![image](https://github.com/user-attachments/assets/0e79288d-49fe-4fbf-a04a-b2b24b220261)
