### PR TITLE
#34899 Add dark theme color for composite types field

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/css/e4-dark_dbeaver_prefstyle.css
+++ b/plugins/org.jkiss.dbeaver.core/css/e4-dark_dbeaver_prefstyle.css
@@ -28,6 +28,7 @@
             'org.jkiss.dbeaver.sql.editor.color.column.foreground=0,184,184'
             'org.jkiss.dbeaver.sql.editor.color.table.alias.foreground=183,136,211'
             'org.jkiss.dbeaver.sql.editor.color.table.foreground=183,136,211'
+            'org.jkiss.dbeaver.sql.editor.color.composite.field.foreground=215,185,140'
 
             'org.jkiss.dbeaver.sql.editor.color.text.foreground=158,158,158'
             'org.jkiss.dbeaver.sql.editor.color.text.background=0,0,0'


### PR DESCRIPTION
It's dark yellow in dark theme now
![image](https://github.com/user-attachments/assets/4bc45932-7565-4c18-9503-a26d850927e6)
