### PR TITLE
Fixes the problem of being unable to connect to HiveServer2 4.0.1 with Zookeeper Service Discovery enabled

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.hive/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.hive/plugin.xml
@@ -40,9 +40,7 @@
                         categories="hadoop">
                     <replace provider="generic" driver="apache_hive2"/>
 
-                    <file type="jar"
-                          path="https://github.com/timveil/hive-jdbc-uber-jar/releases/download/v1.9-2.6.5/hive-jdbc-uber-2.6.5.0-292.jar"
-                          bundle="!drivers.hive"/>
+                    <file type="jar" path="maven:/org.apache.hive:hive-jdbc:standalone:RELEASE[4.0.1]" bundle="!drivers.hive"/>
                     <file type="license" path="https://www.apache.org/licenses/LICENSE-2.0.txt" bundle="!drivers.hive"/>
                     <file type="jar" path="drivers/hive" bundle="drivers.hive"/>
                     <file type="license" path="drivers/apache_lic/LICENSE.txt" bundle="drivers.hive"/>


### PR DESCRIPTION
- Fixes #22777 .
- Fixes the problem of being unable to connect to HiveServer2 4.0.1 with Zookeeper Service Discovery enabled. For more information, see https://github.com/dbeaver/dbeaver/issues/22777#issuecomment-2264969480 .
- ![image](https://github.com/user-attachments/assets/202edcc7-7a2d-4227-929e-4a2474229c39)


