### PR TITLE
dbeaver/pro#3181 Fix parsing of fully qualified column type name in create table statement

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
@@ -87,8 +87,8 @@ identifier: (Introducer characterSetSpecification)? actualIdentifier;
 actualIdentifier: (Identifier|DelimitedIdentifier|nonReserved|Quotted);
 
 // data types
-dataType: (datetimeType|intervalType|anyWordsWithProperty (CHARACTER SET characterSetSpecification)?);
-datetimeType: (DATE|TIME (LeftParen UnsignedInteger RightParen)? (WITH TIME ZONE)?|TIMESTAMP (LeftParen UnsignedInteger RightParen)? (WITH TIME ZONE)?);
+dataType: (datetimeType|intervalType|qualifiedName|anyWordsWithProperty (CHARACTER SET characterSetSpecification)?);
+datetimeType: DATE|TIME (LeftParen UnsignedInteger RightParen)? (WITH TIME ZONE)?|TIMESTAMP (LeftParen UnsignedInteger RightParen)? (WITH TIME ZONE)?;
 intervalType: INTERVAL intervalQualifier;
 intervalQualifier: (startField TO endField|singleDatetimeField);
 startField: nonSecondDatetimeField (LeftParen intervalLeadingFieldPrecision RightParen)?;
@@ -440,7 +440,7 @@ nonReserved: COMMITTED | REPEATABLE | SERIALIZABLE | TYPE | UNCOMMITTED |
     CURRENT_USER | SESSION_USER | SYSTEM_USER | USER | VALUE | RIGHT | LEFT |
     DATE | YEAR | MONTH | DAY | HOUR | MINUTE | SECOND | ZONE |
     ACTION | ADD | AUTHORIZATION | BY | CASCADE | CASCADED | CATALOG | COALESCE | COMMIT |
-    CONSTRAINT | CONSTRAINTS | CORRESPONDING | COUNT | DEFERRABLE | DEFERRED | IMMEDIATE |
+    CONSTRAINTS | CORRESPONDING | COUNT | DEFERRABLE | DEFERRED | IMMEDIATE |
     EXTRACT | FULL | GLOBAL | LOCAL | INDICATOR | INITIALLY | INTERVAL | ISOLATION | KEY | LEVEL |
     NAMES | NO | NULLIF| ONLY | OVERLAPS| PARTIAL | PRESERVE | READ | RESTRICT | ROLLBACK | SCHEMA |
     SESSION | SET | TEMPORARY | TIME | TIMESTAMP | TIMEZONE_HOUR | TIMEZONE_MINUTE | TRANSACTION |

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryTableCreateModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryTableCreateModel.java
@@ -27,6 +27,7 @@ import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryNodeModelVisitor;
 import org.jkiss.dbeaver.model.sql.semantics.model.select.SQLQueryRowsTableValueModel;
 import org.jkiss.dbeaver.model.stm.STMKnownRuleNames;
 import org.jkiss.dbeaver.model.stm.STMTreeNode;
+import org.jkiss.dbeaver.model.stm.STMTreeTermErrorNode;
 import org.jkiss.dbeaver.model.struct.DBSEntity;
 
 import java.util.ArrayList;
@@ -149,12 +150,15 @@ public class SQLQueryTableCreateModel extends SQLQueryModelContent {
         STMTreeNode elementsNode = node.findChildOfName(STMKnownRuleNames.tableElementList);
         if (elementsNode != null) {
             for (int i = 1; i < elementsNode.getChildCount(); i += 2) {
-                STMTreeNode elementNode = elementsNode.getStmChild(i).getStmChild(0);
-                switch (elementNode.getNodeKindId()) {
-                    case SQLStandardParser.RULE_columnDefinition ->
-                        columns.addLast(SQLQueryColumnSpec.recognize(recognizer, elementNode));
-                    case SQLStandardParser.RULE_tableConstraintDefinition ->
-                        constraints.addLast(SQLQueryTableConstraintSpec.recognize(recognizer, elementNode));
+                STMTreeNode elementNode = elementsNode.getStmChild(i);
+                if (!(elementNode instanceof STMTreeTermErrorNode)) {
+                    STMTreeNode payloadNode = elementNode.getStmChild(0);
+                    switch (payloadNode.getNodeKindId()) {
+                        case SQLStandardParser.RULE_columnDefinition ->
+                            columns.addLast(SQLQueryColumnSpec.recognize(recognizer, payloadNode));
+                        case SQLStandardParser.RULE_tableConstraintDefinition ->
+                            constraints.addLast(SQLQueryTableConstraintSpec.recognize(recognizer, payloadNode));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Errors should not appear in the log on table ddl opening