### PR TITLE
#22843 Improve error handling for project renaming

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNLocalFolder.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNLocalFolder.java
@@ -17,7 +17,6 @@
 package org.jkiss.dbeaver.model.navigator;
 
 import org.jkiss.code.NotNull;
-import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.*;
 import org.jkiss.dbeaver.model.app.DBPDataSourceRegistry;
@@ -26,6 +25,7 @@ import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.utils.ArrayUtils;
 import org.jkiss.utils.CommonUtils;
@@ -247,7 +247,11 @@ public class DBNLocalFolder extends DBNNode implements DBNContainer
     @Override
     public void rename(DBRProgressMonitor monitor, String newName) throws DBException
     {
-        GeneralUtils.validateResourceName(newName);
+        boolean notDesktop = !DBWorkbench.isDistributed() && !DBWorkbench.getPlatform().getApplication().isMultiuser();
+        if (!notDesktop) {
+            GeneralUtils.validateResourceName(newName);
+        }
+
         getDataSourceRegistry().moveFolder(folder.getFolderPath(), generateNewFolderPath(folder.getParent(), newName));
         DBNModel.updateConfigAndRefreshDatabases(this);
     }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNLocalFolder.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNLocalFolder.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.model.navigator;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.*;
 import org.jkiss.dbeaver.model.app.DBPDataSourceRegistry;
@@ -25,7 +26,6 @@ import org.jkiss.dbeaver.model.meta.Property;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
-import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.utils.ArrayUtils;
 import org.jkiss.utils.CommonUtils;
@@ -247,11 +247,7 @@ public class DBNLocalFolder extends DBNNode implements DBNContainer
     @Override
     public void rename(DBRProgressMonitor monitor, String newName) throws DBException
     {
-        boolean notDesktop = !DBWorkbench.isDistributed() && !DBWorkbench.getPlatform().getApplication().isMultiuser();
-        if (!notDesktop) {
-            GeneralUtils.validateResourceName(newName);
-        }
-
+        GeneralUtils.validateResourceName(newName);
         getDataSourceRegistry().moveFolder(folder.getFolderPath(), generateNewFolderPath(folder.getParent(), newName));
         DBNModel.updateConfigAndRefreshDatabases(this);
     }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNProject.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNProject.java
@@ -152,7 +152,7 @@ public class DBNProject extends DBNResource implements DBNNodeExtendable {
 
     @Override
     public void rename(DBRProgressMonitor monitor, String newName) throws DBException {
-        GeneralUtils.validateResourceName(newName);
+        GeneralUtils.validateResourceNameUnconditionally(newName);
 
         project.ensureOpen();
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNProject.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNProject.java
@@ -31,6 +31,7 @@ import org.jkiss.dbeaver.model.rm.RMConstants;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
+import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.utils.ArrayUtils;
 import org.jkiss.utils.CommonUtils;
 
@@ -151,6 +152,8 @@ public class DBNProject extends DBNResource implements DBNNodeExtendable {
 
     @Override
     public void rename(DBRProgressMonitor monitor, String newName) throws DBException {
+        GeneralUtils.validateResourceName(newName);
+
         project.ensureOpen();
 
         try {
@@ -161,8 +164,8 @@ public class DBNProject extends DBNResource implements DBNNodeExtendable {
             final IProjectDescription description = eclipseProject.getDescription();
             description.setName(newName);
             eclipseProject.move(description, true, monitor.getNestedMonitor());
-        } catch (CoreException e) {
-            throw new DBException("Can't rename project", e);
+        } catch (Exception e) {
+            throw new DBException("Can't rename project: " + e.getMessage(), e);
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
@@ -891,6 +891,13 @@ public class GeneralUtils {
     }
 
     public static void validateResourceName(String name) throws DBException {
+        if (!DBWorkbench.isDistributed() && !DBWorkbench.getPlatform().getApplication().isMultiuser()) {
+            return;
+        }
+        validateResourceNameUnconditionally(name);
+    }
+
+    public static void validateResourceNameUnconditionally(String name) throws DBException {
         if (name.startsWith(".")) {
             throw new DBException("Resource name '" + name + "' can't start with dot");
         }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
@@ -890,6 +890,12 @@ public class GeneralUtils {
         return new UUID(target.getLong(), target.getLong());
     }
 
+    /**
+     * Validates the resource name, only if the application is running in desktop mode.
+     *
+     * @param name the resource name to validate
+     * @throws DBException if the resource name is invalid
+     */
     public static void validateResourceName(String name) throws DBException {
         if (!DBWorkbench.isDistributed() && !DBWorkbench.getPlatform().getApplication().isMultiuser()) {
             return;
@@ -897,6 +903,12 @@ public class GeneralUtils {
         validateResourceNameUnconditionally(name);
     }
 
+    /**
+     * Validates the resource name unconditionally.
+     *
+     * @param name resource name to validate
+     * @throws DBException if resource name is invalid
+     */
     public static void validateResourceNameUnconditionally(String name) throws DBException {
         if (name.startsWith(".")) {
             throw new DBException("Resource name '" + name + "' can't start with dot");

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
@@ -891,9 +891,6 @@ public class GeneralUtils {
     }
 
     public static void validateResourceName(String name) throws DBException {
-        if (!DBWorkbench.isDistributed() && !DBWorkbench.getPlatform().getApplication().isMultiuser()) {
-            return;
-        }
         if (name.startsWith(".")) {
             throw new DBException("Resource name '" + name + "' can't start with dot");
         }


### PR DESCRIPTION
- Added validation for project renaming: the name cannot start with a dot or contain any characters that match the pattern (?U)[^/:'\"\\\\<>|?*]+.
- Display an error message to the user if project rename validation fails.

<img width="471" alt="image" src="https://github.com/user-attachments/assets/166cc825-f260-45d6-b623-946ab4447a92">
