### PR TITLE
#34692 Fix color rendering for shapes

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/GeometryDataUtils.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/GeometryDataUtils.java
@@ -86,7 +86,22 @@ public class GeometryDataUtils {
         return result;
     }
 
-    public static void setGeometryProperties(@NotNull IResultSetController controller, @NotNull GeomAttrs geomAttrs, @NotNull DBGeometry geometry, @NotNull RGB geometryColor, @NotNull ResultSetRow row) {
+    /**
+     * Set geometry properties for the given geometry.
+     *
+     * @param controller result set controller to get the model.
+     * @param geomAttrs  geometry attributes.
+     * @param geometry   geometry to set properties.
+     * @param index      index of the geometry in the result set.
+     * @param row        row of the result set.
+     */
+    public static void setGeometryProperties(
+        @NotNull IResultSetController controller,
+        @NotNull GeomAttrs geomAttrs,
+        @NotNull DBGeometry geometry,
+        int index,
+        @NotNull ResultSetRow row
+    ) {
         final ResultSetModel model = controller.getModel();
         final Map<String, String> info = new LinkedHashMap<>();
         for (DBDAttributeBinding binding : geomAttrs.descAttrs) {
@@ -97,7 +112,9 @@ public class GeometryDataUtils {
         }
         final Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("id", DBUtils.getObjectFullName(geomAttrs.geomAttr, DBPEvaluationContext.UI));
-        properties.put("color", String.format("#%02x%02x%02x", geometryColor.red, geometryColor.green, geometryColor.blue));
+        properties.put("color",
+            info.getOrDefault("color", rgbToHex(makeGeometryColor(index)))
+        );
         properties.put("info", info);
         geometry.setProperties(properties);
 
@@ -124,12 +141,16 @@ public class GeometryDataUtils {
     }
 
     @NotNull
-    public static RGB makeGeometryColor(int index) {
+    private static RGB makeGeometryColor(int index) {
         if (index == 0) {
             return Display.getCurrent().getSystemColor(SWT.COLOR_BLUE).getRGB();
         } else {
             return UIColors.getColor(index).getRGB();
         }
+    }
+
+    private static String rgbToHex(RGB rgb) {
+        return String.format("#%02x%02x%02x", rgb.red, rgb.green, rgb.blue);
     }
 
     public static int getDefaultSRID() {

--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/GeometryDataUtils.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/GeometryDataUtils.java
@@ -112,9 +112,7 @@ public class GeometryDataUtils {
         }
         final Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("id", DBUtils.getObjectFullName(geomAttrs.geomAttr, DBPEvaluationContext.UI));
-        properties.put("color",
-            info.getOrDefault("color", rgbToHex(makeGeometryColor(index)))
-        );
+        properties.put("color", info.getOrDefault("color", rgbToHex(makeGeometryColor(index))));
         properties.put("info", info);
         geometry.setProperties(properties);
 
@@ -149,6 +147,7 @@ public class GeometryDataUtils {
         }
     }
 
+    @NotNull
     private static String rgbToHex(RGB rgb) {
         return String.format("#%02x%02x%02x", rgb.red, rgb.green, rgb.blue);
     }

--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/panel/GISBrowserViewer.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/panel/GISBrowserViewer.java
@@ -130,7 +130,7 @@ public class GISBrowserViewer extends BaseValueEditor<Browser> implements IGeome
                         for (int i = 0; i < geomAttrs.size(); i++) {
                             final GeometryDataUtils.GeomAttrs ga = geomAttrs.get(i);
                             if (ga.geomAttr.matches(attr, false)) {
-                                GeometryDataUtils.setGeometryProperties(resultSetController, ga, geometry, GeometryDataUtils.makeGeometryColor(i), row);
+                                GeometryDataUtils.setGeometryProperties(resultSetController, ga, geometry, i, row);
                                 break;
                             }
                         }

--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/presentation/GeometryPresentation.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/presentation/GeometryPresentation.java
@@ -146,7 +146,7 @@ public class GeometryPresentation extends AbstractPresentation {
 
                 if (geometry != null && !(geometry.getSRID() != 0 && geometry.isEmpty())) {
                     geometries.add(geometry);
-                    GeometryDataUtils.setGeometryProperties(getController(), geomAttrs, geometry, GeometryDataUtils.makeGeometryColor(i), row);
+                    GeometryDataUtils.setGeometryProperties(getController(), geomAttrs, geometry, i, row);
                 }
             }
         }


### PR DESCRIPTION
- Added functionality to render shapes in their assigned color if a 'color' column is present in the result set.
- If no 'color' column is available, shapes are rendered based on their index in the row.

The first case
<img width="574" alt="image" src="https://github.com/user-attachments/assets/b6fae8fa-de77-4d14-a7b8-db29659b1aab">

The second case
<img width="578" alt="image" src="https://github.com/user-attachments/assets/c8468da7-76af-4700-bf27-61a372787cd1">
