### PR TITLE
#35085 Return back `Open auth links in embedded browser` setting to false

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/DesktopPreferencesInitializer.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/core/DesktopPreferencesInitializer.java
@@ -61,7 +61,7 @@ public class DesktopPreferencesInitializer extends AbstractPreferenceInitializer
         // General UI
         PrefUtils.setDefaultPreferenceValue(store, DBeaverPreferences.UI_AUTO_UPDATE_CHECK,
             !ApplicationPolicyService.getInstance().isInstallUpdateDisabled());
-        PrefUtils.setDefaultPreferenceValue(store, DBeaverPreferences.UI_USE_EMBEDDED_AUTH, RuntimeUtils.isWindows());
+        PrefUtils.setDefaultPreferenceValue(store, DBeaverPreferences.UI_USE_EMBEDDED_AUTH, false);
         PrefUtils.setDefaultPreferenceValue(store, DBeaverPreferences.UI_SHOW_HOLIDAY_DECORATIONS, true);
 
         PrefUtils.setDefaultPreferenceValue(store, DBeaverPreferences.UI_KEEP_DATABASE_EDITORS, true);


### PR DESCRIPTION
This preference should be false by default on Windows again (as it was before 24.1.3)