### PR TITLE
dbeaver#35279 Handle NULL values in POINT type column in MySQL 5.7

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.gis/src/org/jkiss/dbeaver/data/gis/handlers/GISGeometryValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.data.gis/src/org/jkiss/dbeaver/data/gis/handlers/GISGeometryValueHandler.java
@@ -129,6 +129,9 @@ public class GISGeometryValueHandler extends JDBCAbstractValueHandler {
             } else {
                 bytes = (byte[]) object;
             }
+            if (bytes.length == 0) {
+                return new DBGeometry();
+            }
             try {
                 geometry = new DBGeometry(convertGeometryFromBinaryFormat(session, bytes));
             } catch (DBCException e) {


### PR DESCRIPTION
fix MySQL 5.7 Error parsing geometry value from binary when NULL is inserted into POINT column
<img width="328" alt="正确" src="https://github.com/user-attachments/assets/d3a902b2-d17d-429e-8ad3-ce8d47328417">
