### PR TITLE
dbeaver/pro#3252 Show warning instead of error if table used in DDL doesn't exist

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionContext.java
@@ -37,7 +37,7 @@ public class SQLQueryRecognitionContext {
     private final DBRProgressMonitor monitor;
 
     @Nullable
-    DBCExecutionContext executionContext;
+    private final DBCExecutionContext executionContext;
 
     private final boolean useRealMetadata;
 
@@ -46,6 +46,8 @@ public class SQLQueryRecognitionContext {
 
     @NotNull
     private final Deque<SQLQueryRecognitionProblemInfo> problems = new LinkedList<>();
+
+    private boolean errorsAsWarnings = false;
 
     public SQLQueryRecognitionContext(
         @NotNull DBRProgressMonitor monitor,
@@ -57,6 +59,14 @@ public class SQLQueryRecognitionContext {
         this.executionContext = executionContext;
         this.useRealMetadata = useRealMetadata;
         this.syntaxManager = syntaxManager;
+    }
+
+    public void setTreatErrorAsWarnings(boolean errorsAsWarnings) {
+        this.errorsAsWarnings = errorsAsWarnings;
+    }
+
+    public boolean isTreatErrorsAsWarnings() {
+        return this.errorsAsWarnings;
     }
 
     @NotNull
@@ -82,24 +92,46 @@ public class SQLQueryRecognitionContext {
         return List.copyOf(this.problems);
     }
 
+
+    private SQLQueryRecognitionProblemInfo makeError(
+        @NotNull STMTreeNode syntaxNode,
+        @Nullable SQLQuerySymbolEntry symbol,
+        @NotNull String message,
+        @Nullable DBException exception
+    ) {
+        SQLQueryRecognitionProblemInfo.Severity severity = this.errorsAsWarnings
+            ? SQLQueryRecognitionProblemInfo.Severity.WARNING
+            : SQLQueryRecognitionProblemInfo.Severity.ERROR;
+        return new SQLQueryRecognitionProblemInfo(severity, syntaxNode, symbol, message, exception);
+    }
+
+    private SQLQueryRecognitionProblemInfo makeWarning(
+        @NotNull STMTreeNode syntaxNode,
+        @Nullable SQLQuerySymbolEntry symbol,
+        @NotNull String message,
+        @Nullable DBException exception
+    ) {
+        return new SQLQueryRecognitionProblemInfo(SQLQueryRecognitionProblemInfo.Severity.WARNING, syntaxNode, symbol, message, exception);
+    }
+
     public void appendError(@NotNull SQLQuerySymbolEntry symbol, @NotNull String error, @NotNull DBException ex) {
-        this.problems.addLast(SQLQueryRecognitionProblemInfo.makeError(symbol.getSyntaxNode(), symbol, error, ex));
+        this.problems.addLast(this.makeError(symbol.getSyntaxNode(), symbol, error, ex));
     }
 
     public void appendError(@NotNull SQLQuerySymbolEntry symbol, @NotNull String error) {
-        this.problems.addLast(SQLQueryRecognitionProblemInfo.makeError(symbol.getSyntaxNode(), symbol, error, null));
+        this.problems.addLast(this.makeError(symbol.getSyntaxNode(), symbol, error, null));
     }
 
     public void appendError(@NotNull STMTreeNode treeNode, @NotNull String error) {
-        this.problems.addLast(SQLQueryRecognitionProblemInfo.makeError(treeNode, null, error, null));
+        this.problems.addLast(this.makeError(treeNode, null, error, null));
     }
 
     public void appendWarning(@NotNull SQLQuerySymbolEntry symbol, @NotNull String error) {
-        this.problems.addLast(SQLQueryRecognitionProblemInfo.makeWarning(symbol.getSyntaxNode(), symbol, error, null));
+        this.problems.addLast(this.makeWarning(symbol.getSyntaxNode(), symbol, error, null));
     }
 
     public void appendWarning(@NotNull STMTreeNode treeNode, @NotNull String error) {
-        this.problems.addLast(SQLQueryRecognitionProblemInfo.makeWarning(treeNode, null, error, null));
+        this.problems.addLast(this.makeWarning(treeNode, null, error, null));
     }
 
     public void reset() {

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionProblemInfo.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQueryRecognitionProblemInfo.java
@@ -50,36 +50,18 @@ public class SQLQueryRecognitionProblemInfo {
     @Nullable
     private final DBException exception;
 
-    private SQLQueryRecognitionProblemInfo(
-            @NotNull Severity severity,
-            @NotNull STMTreeNode syntaxNode,
-            @Nullable SQLQuerySymbolEntry symbol,
-            @NotNull String message,
-            @Nullable DBException exception
+    public SQLQueryRecognitionProblemInfo(
+        @NotNull Severity severity,
+        @NotNull STMTreeNode syntaxNode,
+        @Nullable SQLQuerySymbolEntry symbol,
+        @NotNull String message,
+        @Nullable DBException exception
     ) {
         this.severity = severity;
         this.syntaxNode = syntaxNode;
         this.symbol = symbol;
         this.message = message;
         this.exception = exception;
-    }
-
-    public static SQLQueryRecognitionProblemInfo makeError(
-            @NotNull STMTreeNode syntaxNode,
-            @Nullable SQLQuerySymbolEntry symbol,
-            @NotNull String message,
-            @Nullable DBException exception
-    ) {
-        return new SQLQueryRecognitionProblemInfo(Severity.ERROR, syntaxNode, symbol, message, exception);
-    }
-
-    public static SQLQueryRecognitionProblemInfo makeWarning(
-            @NotNull STMTreeNode syntaxNode,
-            @Nullable SQLQuerySymbolEntry symbol,
-            @NotNull String message,
-            @Nullable DBException exception
-    ) {
-        return new SQLQueryRecognitionProblemInfo(Severity.WARNING, syntaxNode, symbol, message, exception);
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryColumnConstraintSpec.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryColumnConstraintSpec.java
@@ -122,7 +122,9 @@ public class SQLQueryColumnConstraintSpec extends SQLQueryNodeModel {
         @NotNull SQLQueryDataContext dataContext,
         @NotNull SQLQueryRecognitionContext statistics
     ) {
+        statistics.setTreatErrorAsWarnings(true);
         SQLQueryDataContext referencedContext = referencedTable.propagateContext(dataContext, statistics);
+        statistics.setTreatErrorAsWarnings(false);
         DBSEntity realTable = referencedTable.getTable();
         SQLQueryDataContext resultContext;
 
@@ -151,7 +153,8 @@ public class SQLQueryColumnConstraintSpec extends SQLQueryNodeModel {
                 // table reference resolution failed, so cannot resolve its columns as well
                 statistics.appendWarning(
                     referencedTable.getName().entityName,
-                    "Failed to resolve table " + referencedTable.getName().toIdentifierString() + " to validate compound foreign key columns"
+                    "Failed to validate " + (referencedColumns.size() > 1 ? "compound " : "") +
+                    "foreign key columns of table " + referencedTable.getName().toIdentifierString()
                 );
                 for (SQLQuerySymbolEntry columnRef : referencedColumns) {
                     if (columnRef.isNotClassified()) {

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryTableConstraintSpec.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryTableConstraintSpec.java
@@ -97,7 +97,12 @@ public class SQLQueryTableConstraintSpec extends SQLQueryNodeModel {
             for (SQLQuerySymbolEntry columnRef : this.tupleColumnsList) {
                 if (columnRef.isNotClassified()) {
                     SQLQueryResultColumn rc = tableContext.resolveColumn(statistics.getMonitor(), columnRef.getName());
-                    SQLQueryValueColumnReferenceExpression.propagateColumnDefinition(columnRef, rc, statistics);
+                    if (rc != null) {
+                        SQLQueryValueColumnReferenceExpression.propagateColumnDefinition(columnRef, rc, statistics);
+                    } else {
+                        columnRef.getSymbol().setSymbolClass(SQLQuerySymbolClass.COLUMN);
+                        statistics.appendWarning(columnRef, "Column " + columnRef.getName() + " not found");
+                    }
                     referenceKey.add(rc);
                 }
             }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryTableCreateModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/ddl/SQLQueryTableCreateModel.java
@@ -149,9 +149,8 @@ public class SQLQueryTableCreateModel extends SQLQueryModelContent {
 
         STMTreeNode elementsNode = node.findChildOfName(STMKnownRuleNames.tableElementList);
         if (elementsNode != null) {
-            for (int i = 1; i < elementsNode.getChildCount(); i += 2) {
-                STMTreeNode elementNode = elementsNode.getStmChild(i);
-                if (!(elementNode instanceof STMTreeTermErrorNode)) {
+            for (STMTreeNode elementNode : elementsNode.getChildren()) {
+                if (STMKnownRuleNames.tableElement.equals(elementNode.getNodeName())) {
                     STMTreeNode payloadNode = elementNode.getStmChild(0);
                     switch (payloadNode.getNodeKindId()) {
                         case SQLStandardParser.RULE_columnDefinition ->

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsTableDataModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/select/SQLQueryRowsTableDataModel.java
@@ -167,7 +167,10 @@ public class SQLQueryRowsTableDataModel extends SQLQueryRowsSourceModel implemen
                     this.name.entityName.setDefinition(rr.aliasOrNull.getDefinition());
                     context = context.overrideResultTuple(rr.source.getResultDataContext().getColumnsList());
                 } else {
-                    this.name.setSymbolClass(SQLQuerySymbolClass.ERROR);
+                    SQLQuerySymbolClass tableSymbolClass = statistics.isTreatErrorsAsWarnings()
+                        ? SQLQuerySymbolClass.TABLE
+                        : SQLQuerySymbolClass.ERROR;
+                    this.name.setSymbolClass(tableSymbolClass);
                     statistics.appendError(this.name.entityName, "Table " + this.name.toIdentifierString() + " not found");
                 }
             }


### PR DESCRIPTION
For example, here should be only warnings, no errors and no red highlighting
![image](https://github.com/user-attachments/assets/61baf875-ccfa-426d-ae31-b09eccf738fd)


```
CREATE TABLE ArtWithRowid2 (
    [ArtistId] INTEGER NOT NULL PRIMARY KEY ,
    [Name] NVARCHAR(120),
    [something] int  REFERENCES Artist (address)
);

ALTER TABLE Album ADD CONSTRAINT dfk FOREIGN KEY (AlbumId) REFERENCES Artist (address) NOT VALID; 

```