### PR TITLE
Update JDBCTable.java to add `AS` before table alias

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCTable.java
+++ b/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCTable.java
@@ -162,7 +162,7 @@ public abstract class JDBCTable<DATASOURCE extends DBPDataSource, CONTAINER exte
         appendSelectSource(monitor, query, tableAlias, rowIdAttribute);
         query.append(" FROM ").append(getTableName());
         if (tableAlias != null) {
-            query.append(" ").append(tableAlias); //$NON-NLS-1$
+            query.append(" AS ").append(tableAlias); //$NON-NLS-1$
         }
         appendExtraSelectParameters(query);
         SQLUtils.appendQueryConditions(dataSource, query, tableAlias, dataFilter);


### PR DESCRIPTION
A very simple change
* Currently when a user clicks the `Data` tab for a table in DBeaver, it will generate a SQL like `SELECT x.* FROM my_table x`
* This PR will add `AS` so the SQL will be `SELECT x.* FROM my_table AS x`
* The reason for making such changes is that some databases enforce the `AS` keyword for making alias, sometimes the organizations also apply some SQL auditing or block SQL without meeting the standard. Having the `AS` will make the SQL a bit easier to read.

Not a big deal, but very low risk.

Reference

https://github.com/brooklyn-data/co/blob/main/sql_style_guide.md
Always use the `as` keyword when aliasing columns, expressions, and tables.
```sql
/* Good */
select count(*) as customers_count
from customers

/* Bad */
select count(*) customers_count
from customers
```