### PR TITLE
dbeaver/pro#2828 Fix scheduling tasks

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DataTransferJob.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/DataTransferJob.java
@@ -30,6 +30,7 @@ import org.jkiss.dbeaver.tools.transfer.internal.DTMessages;
 import org.jkiss.utils.CommonUtils;
 
 import java.io.PrintStream;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Data transfer job
@@ -87,7 +88,9 @@ public class DataTransferJob extends AbstractJob {
         long startTime = System.currentTimeMillis();
         for (; ;) {
             if (monitor.isCanceled()) {
-                break;
+                monitor.done();
+                elapsedTime = System.currentTimeMillis() - startTime;
+                return new Status(IStatus.OK, getClass(), DTMessages.data_transfer_task_failed_name, new TimeoutException(DTMessages.data_transfer_task_failed_description));
             }
             DataTransferPipe transferPipe = settings.acquireDataPipe(monitor, task);
             if (transferPipe == null) {
@@ -107,7 +110,7 @@ public class DataTransferJob extends AbstractJob {
                 jobMonitor.worked(1);
             } catch (Exception e) {
                 // Report as an OK status to avoid showing the error in the UI (it's handled by the caller)
-                return new Status(IStatus.OK, getClass(), "Data transfer failed", e);
+                return new Status(IStatus.OK, getClass(), DTMessages.data_transfer_task_failed_name, e);
             }
         }
         monitor.done();

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/internal/DTMessages.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/internal/DTMessages.java
@@ -190,6 +190,8 @@ public class DTMessages extends NLS {
     public static String pref_data_transfer_replacing_combo_do_not;
     public static String pref_data_transfer_replacing_combo_underscores;
     public static String pref_data_transfer_replacing_combo_camel_case;
+    public static String data_transfer_task_failed_name;
+    public static String data_transfer_task_failed_description;
 
     static {
         // initialize resource bundle

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/internal/DTMessages.properties
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/internal/DTMessages.properties
@@ -168,3 +168,6 @@ pref_data_transfer_name_case_lower = Lower case
 pref_data_transfer_replacing_combo_do_not = Do not replace
 pref_data_transfer_replacing_combo_underscores = Replace with underscore
 pref_data_transfer_replacing_combo_camel_case = Remove, convert to CamelCase
+
+data_transfer_task_failed_name = Data transfer failed 
+data_transfer_task_failed_description = Timeout exceeded. Adjust your settings or reduce data size.


### PR DESCRIPTION
Fixed:
3. UE and TE: Success status is displayed in the pop up message for Canceled due to a timeout setting task. See project guzeeva, folder status_test, task exp_XML_timeout_test