### PR TITLE
dbeaver#34917 Remove splash for console using

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/rpc/DBeaverInstanceServer.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/rpc/DBeaverInstanceServer.java
@@ -164,7 +164,7 @@ public class DBeaverInstanceServer implements IInstanceController {
 
         final IWorkbenchWindow window = UIUtils.getActiveWorkbenchWindow();
         final Shell shell = window.getShell();
-        UIUtils.syncExec(() -> {
+        UIUtils.asyncExec(() -> {
             for (String filePath : fileNames) {
                 File file = new File(filePath);
                 if (file.exists()) {


### PR DESCRIPTION
The issue appears when we try to start another instance of DBeaver with an error path, so an error appears in the first instance, and the second one gets blocked. Now, It will not block the second one