### PR TITLE
dbeaver/dbeaver#35478 Fix unexpected bolder of single quoted string text in SQL Editor

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLTokenAdapter.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLTokenAdapter.java
@@ -62,7 +62,7 @@ public class SQLTokenAdapter extends Token {
                     break;
                 case T_STRING:
                     colorKey = SQLConstants.CONFIG_COLOR_STRING;
-                    style = scanner.getKeywordStyle();
+                    style = SWT.NORMAL;
                     break;
                 case T_QUOTED:
                 case T_TYPE:


### PR DESCRIPTION
Closes #35478.

*After change
![sql-editor-after-change](https://github.com/user-attachments/assets/a073ad32-dfa6-46ee-b839-942d5b0724f0)
