### PR TITLE
#35207 Fix highlighting update on disconnect

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -3074,13 +3074,11 @@ public class SQLEditor extends SQLEditorBase implements
     }
 
     @Override
-    public void beforeConnect()
-    {
+    public void beforeConnect() {
     }
 
     @Override
-    public void beforeDisconnect()
-    {
+    public void beforeDisconnect() {
         closeAllJobs();
     }
 
@@ -3238,11 +3236,9 @@ public class SQLEditor extends SQLEditorBase implements
 
     private boolean isContextChanged(DBPEvent event) {
         DBPEvent.Action eventAction = event.getAction();
-        boolean contextChanged = eventAction.equals(DBPEvent.Action.OBJECT_UPDATE); // update highlighting on connect/disconnect
-        if (!contextChanged && eventAction.equals(DBPEvent.Action.OBJECT_SELECT)
-            && event.getData() == this.getExecutionContext()
-            && event.getEnabled()
-        ) {
+        boolean isEditorContext = event.getData() == this.getExecutionContext();
+        boolean contextChanged = isEditorContext && eventAction.equals(DBPEvent.Action.OBJECT_UPDATE);
+        if (!contextChanged && isEditorContext && eventAction.equals(DBPEvent.Action.OBJECT_SELECT) && event.getEnabled()) {
             DBCExecutionContext execContext = this.getExecutionContext();
             DBCExecutionContextDefaults<?, ?> ctxDefault = execContext == null
                 ? null

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -3228,26 +3228,32 @@ public class SQLEditor extends SQLEditorBase implements
                             break;
                     }
                     updateExecutionContext(null);
-                    
-                    boolean contextChanged = false;
-                    if (event.getAction().equals(DBPEvent.Action.OBJECT_SELECT)
-                        && event.getData() == this.getExecutionContext()
-                        && event.getEnabled()
-                    ) {
-                        DBCExecutionContext execContext = this.getExecutionContext();
-                        DBCExecutionContextDefaults<DBSCatalog, DBSSchema> ctxDefault = execContext == null
-                            ? null
-                            : execContext.getContextDefaults();
-                        if (ctxDefault != null
-                            && (event.getObject() == ctxDefault.getDefaultCatalog() || event.getObject() == ctxDefault.getDefaultSchema())
-                        ) {
-                            contextChanged = true;
-                        }
-                    }
+
+                    boolean contextChanged = isContextChanged(event);
                     onDataSourceChange(contextChanged);
                 }
             );
         }
+    }
+
+    private boolean isContextChanged(DBPEvent event) {
+        DBPEvent.Action eventAction = event.getAction();
+        boolean contextChanged = eventAction.equals(DBPEvent.Action.OBJECT_UPDATE); // update highlighting on connect/disconnect
+        if (!contextChanged && eventAction.equals(DBPEvent.Action.OBJECT_SELECT)
+            && event.getData() == this.getExecutionContext()
+            && event.getEnabled()
+        ) {
+            DBCExecutionContext execContext = this.getExecutionContext();
+            DBCExecutionContextDefaults<?, ?> ctxDefault = execContext == null
+                ? null
+                : execContext.getContextDefaults();
+            if (ctxDefault != null
+                && (event.getObject() == ctxDefault.getDefaultCatalog() || event.getObject() == ctxDefault.getDefaultSchema())
+            ) {
+                contextChanged = true;
+            }
+        }
+        return contextChanged;
     }
 
     @Override


### PR DESCRIPTION
How to reproduce and test:
1. Create a script for PostgreSQL containing, when there is no table Employee in the active scheme
```
ALTER TABLE "Employee"
    ALTER COLUMN employeename DROP DEFAULT,
    ADD COLUMN code uuid default null REFERENCES "Elizabeth"."actor_uuid"(code7_uuid),
    ALTER COLUMN employeename TYPE timestamp with time zone
    USING
        timestamp with time zone 'epoch' + foo_timestamp * interval '1 second',
    ALTER COLUMN foo_timestamp SET DEFAULT now()
;
```
2. Connect to the database and see that  "Employee" is highlighted in red
3. Disconnect from the database - highlighting should be updated and red highlighting should disappear for this query