### PR TITLE
[CUBRID] For 'Use SQL to limit fetch size'

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.cubrid/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/plugin.xml
@@ -214,6 +214,7 @@
                     <property name="preparedStmtCacheSize" value="25"/>
                     <property name="preparedStmtCacheSqlLimit" value="256"/>
                     <property name="hold_cursor" value="true"/>
+                    <property name="@dbeaver-default-resultset.maxrows.sql" value="true"/>
                 </driver>
              </drivers>
         </datasource>

--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/QueryTransformerLimitCubrid.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/QueryTransformerLimitCubrid.java
@@ -1,0 +1,56 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.cubrid.model;
+
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformerExt;
+import org.jkiss.dbeaver.model.impl.sql.QueryTransformerLimit;
+import org.jkiss.dbeaver.model.sql.SQLQuery;
+
+public class QueryTransformerLimitCubrid extends QueryTransformerLimit
+        implements DBCQueryTransformerExt {
+
+    public QueryTransformerLimitCubrid() {
+        super(true);
+    }
+
+    @Override
+    public boolean isApplicableTo(SQLQuery query) {
+        Statement statement = query.getStatement();
+        return statement != null && isLimitApplicable(statement);
+    }
+
+    public boolean isLimitApplicable(Statement statement) {
+        if (statement instanceof Select
+                && ((Select) statement).getSelectBody() instanceof PlainSelect) {
+            PlainSelect selectBody = (PlainSelect) ((Select) statement).getSelectBody();
+            String where = String.valueOf(selectBody.getWhere()).toUpperCase();
+            if (where.contains("ROWNUM") || where.contains("INST_NUM")) {
+                return false;
+            }
+
+            String having = String.valueOf(selectBody.getHaving()).toUpperCase();
+            if (having.contains("GROUPBY_NUM")) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/QueryTransformerLimitCubrid.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/QueryTransformerLimitCubrid.java
@@ -37,9 +37,8 @@ public class QueryTransformerLimitCubrid extends QueryTransformerLimit
     }
 
     public boolean isLimitApplicable(Statement statement) {
-        if (statement instanceof Select
-                && ((Select) statement).getSelectBody() instanceof PlainSelect) {
-            PlainSelect selectBody = (PlainSelect) ((Select) statement).getSelectBody();
+        if (statement instanceof Select select
+                && select.getSelectBody() instanceof PlainSelect selectBody) {
             String where = String.valueOf(selectBody.getWhere()).toUpperCase();
             if (where.contains("ROWNUM") || where.contains("INST_NUM")) {
                 return false;

--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/meta/CubridMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/meta/CubridMetaModel.java
@@ -27,6 +27,9 @@ import org.jkiss.dbeaver.ext.generic.model.*;
 import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaModel;
 import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaObject;
 import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformProvider;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformType;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformer;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
@@ -44,7 +47,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class CubridMetaModel extends GenericMetaModel
+public class CubridMetaModel extends GenericMetaModel implements DBCQueryTransformProvider
 {
     private static final Log log = Log.getLog(CubridMetaModel.class);
 
@@ -400,5 +403,14 @@ public class CubridMetaModel extends GenericMetaModel
     @Override
     public DBCQueryPlanner getQueryPlanner(@NotNull GenericDataSource dataSource) {
         return new CubridQueryPlanner((CubridDataSource) dataSource);
+    }
+
+    @Nullable
+    @Override
+    public DBCQueryTransformer createQueryTransformer(@NotNull DBCQueryTransformType type) {
+        if (type == DBCQueryTransformType.RESULT_SET_LIMIT) {
+            return new QueryTransformerLimitCubrid();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Issue : https://github.com/dbeaver/dbeaver/issues/35896
Description :
- Set the default value of 'Data Editor -> Limit import size using SQL' to true
- Add constraints related to 'Limit' for CUBRID (ROWNUM, INST_NUM, GROUPBY_NUM).