### PR TITLE
Added_code_for_previously_used_path_for_diagnostic_dialog_box

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/actions/CollectDiagnosticInfoHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/actions/CollectDiagnosticInfoHandler.java
@@ -66,6 +66,7 @@ import java.util.zip.ZipOutputStream;
  */
 public class CollectDiagnosticInfoHandler extends AbstractHandler {
     private static final Log log = Log.getLog(CollectDiagnosticInfoHandler.class);
+    private static String folderPath = "";
 
     @Nullable
     @Override
@@ -195,7 +196,11 @@ public class CollectDiagnosticInfoHandler extends AbstractHandler {
             );
             textWithOpen.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
             String userHome = System.getProperty(StandardConstants.ENV_USER_HOME);
-            if (userHome != null) {
+            if(folderPath.length()>0 && !folderPath.equals(userHome))
+            {
+                textWithOpen.setText(folderPath);
+            }
+            else if (userHome != null) {
                 textWithOpen.setText(userHome);
             } else {
                 enableOk(false);
@@ -228,6 +233,7 @@ public class CollectDiagnosticInfoHandler extends AbstractHandler {
         protected void okPressed() {
             if (textWithOpen != null) {
                 String outputFolderPathString = textWithOpen.getText();
+                folderPath = outputFolderPathString;
                 if (!CommonUtils.isEmpty(outputFolderPathString)) {
                     outputFolder = new File(outputFolderPathString);
                 }

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/actions/CollectDiagnosticInfoHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/actions/CollectDiagnosticInfoHandler.java
@@ -66,7 +66,7 @@ import java.util.zip.ZipOutputStream;
  */
 public class CollectDiagnosticInfoHandler extends AbstractHandler {
     private static final Log log = Log.getLog(CollectDiagnosticInfoHandler.class);
-    private static String folderPath = "";
+    private static String userHome = null;
 
     @Nullable
     @Override
@@ -195,14 +195,15 @@ public class CollectDiagnosticInfoHandler extends AbstractHandler {
                 CoreApplicationMessages.collect_diagnostic_info_pick_path_title
             );
             textWithOpen.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-            String userHome = System.getProperty(StandardConstants.ENV_USER_HOME);
-            if(folderPath.length()>0 && !folderPath.equals(userHome))
+            if(userHome == null)
             {
-                textWithOpen.setText(folderPath);
+                userHome = System.getProperty(StandardConstants.ENV_USER_HOME);
+                textWithOpen.setText(userHome);
             }
             else if (userHome != null) {
                 textWithOpen.setText(userHome);
-            } else {
+            }
+            else {
                 enableOk(false);
             }
             Text textControl = textWithOpen.getTextControl();
@@ -233,7 +234,7 @@ public class CollectDiagnosticInfoHandler extends AbstractHandler {
         protected void okPressed() {
             if (textWithOpen != null) {
                 String outputFolderPathString = textWithOpen.getText();
-                folderPath = outputFolderPathString;
+                userHome = outputFolderPathString;
                 if (!CommonUtils.isEmpty(outputFolderPathString)) {
                     outputFolder = new File(outputFolderPathString);
                 }


### PR DESCRIPTION
Issue : 
User wish the application to remember the path to the output folder  used earlier , instead of default path to user root folder .

Fix : 
Modified code in CollectDiagnosticInfoHandler to store the path of user's folder , if the path is set to user's folder use this path instead of default root folder .