### PR TITLE
dbeaver/dbeaver#3232 Allow empty value in database tasks

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/json/JSONUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/json/JSONUtils.java
@@ -257,7 +257,7 @@ public class JSONUtils {
             } else if (propValue instanceof Collection collectionValue) {
                 serializeObjectList(json, fieldName, collectionValue);
             } else if (propValue instanceof Map mapValue) {
-                serializeProperties(json, fieldName, mapValue);
+                serializeProperties(json, fieldName, mapValue, allowsEmptyValue);
             } else if (propValue instanceof Enum anEnum) {
                 field(json, fieldName, anEnum.name());
             } else if (propValue instanceof URI uri) {

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskManagerImpl.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/task/TaskManagerImpl.java
@@ -562,7 +562,7 @@ public class TaskManagerImpl implements DBTTaskManager {
             }
             JSONUtils.field(jsonWriter, TaskConstants.TAG_CREATE_TIME, systemDateFormat.format(task.getCreateTime()));
             JSONUtils.field(jsonWriter, TaskConstants.TAG_UPDATE_TIME, systemDateFormat.format(task.getUpdateTime()));
-            JSONUtils.serializeProperties(jsonWriter, TaskConstants.TAG_STATE, task.getProperties());
+            JSONUtils.serializeProperties(jsonWriter, TaskConstants.TAG_STATE, task.getProperties(), true);
             if (task.getMaxExecutionTime() > 0) {
                 JSONUtils.field(jsonWriter, TaskConstants.TAG_MAX_EXEC_TIME, task.getMaxExecutionTime());
             }


### PR DESCRIPTION
Now, the configuration with such an empty parameter will be saved correctly and will be displayed after restarting the application.
![image](https://github.com/user-attachments/assets/68a18c98-bc48-4f47-a5c3-6926e25e19c0)
