### PR TITLE
#36162 Restore the “Show all databases” checkbox for Azure SQL

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql.ui/src/org/jkiss/dbeaver/ext/mssql/ui/SQLServerConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql.ui/src/org/jkiss/dbeaver/ext/mssql/ui/SQLServerConnectionPage.java
@@ -187,7 +187,7 @@ public class SQLServerConnectionPage extends ConnectionPageWithAuth implements I
             if (!isSqlServer) {
                 encryptPassword = UIUtils.createCheckbox(secureGroup, SQLServerUIMessages.dialog_setting_encrypt_password, SQLServerUIMessages.dialog_setting_encrypt_password_tip, false, 1);
             }
-            if (isDriverBabelfish()) {
+            if (isDriverAzure || isDriverBabelfish()) {
                 showAllDatabases = UIUtils.createCheckbox(
                     secureGroup,
                     SQLServerUIMessages.dialog_setting_show_all_databases,

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
@@ -48,6 +48,7 @@ import org.jkiss.utils.CommonUtils;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -410,9 +411,12 @@ public class SQLServerUtils {
     @NotNull
     public static DBException mapException(@NotNull DBException e) {
         if (e instanceof DBSQLException dbsqlException) {
-            if (CROSS_DATABASE_QUERY_ERROR_PATTERN.matcher(dbsqlException.getMessage()).find()) {
+            Matcher croosDatabaseMatcher = CROSS_DATABASE_QUERY_ERROR_PATTERN.matcher(dbsqlException.getMessage());
+            if (croosDatabaseMatcher.find()) {
                 return new DBException(
-                    "Cross-database queries are not supported in this version of SQL Server. Create a new connection to the selected database.");
+                    "Cross-database queries are not supported in this version of SQL Server. Create a new connection to the '"
+                    + croosDatabaseMatcher.group(1).split("\\.")[0]
+                    + "' database.");
             }
         }
 

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
@@ -407,7 +407,8 @@ public class SQLServerUtils {
         return dbStat;
     }
 
-    public static DBException mapException(DBException e) {
+    @NotNull
+    public static DBException mapException(@NotNull DBException e) {
         if (e instanceof DBSQLException dbsqlException) {
             if (CROSS_DATABASE_QUERY_ERROR_PATTERN.matcher(dbsqlException.getMessage()).find()) {
                 return new DBException(

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
@@ -37,6 +37,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCDataSource;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.exec.JDBCConnectionImpl;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.sql.DBSQLException;
 import org.jkiss.dbeaver.model.sql.SQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLQuery;
 import org.jkiss.dbeaver.model.sql.SQLUtils;
@@ -47,6 +48,7 @@ import org.jkiss.utils.CommonUtils;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.regex.Pattern;
 
 /**
  * SQLServerUtils
@@ -55,6 +57,8 @@ public class SQLServerUtils {
 
     private static final Log log = Log.getLog(SQLServerUtils.class);
 
+    private static final Pattern CROSS_DATABASE_QUERY_ERROR_PATTERN =
+        Pattern.compile("Reference to database and/or server name in '([^']+)' is not supported in this version of SQL Server\\.");
 
     public static boolean isDriverSqlServer(DBPDriver driver) {
         return driver.getSampleURL().contains(":sqlserver");
@@ -403,4 +407,14 @@ public class SQLServerUtils {
         return dbStat;
     }
 
+    public static DBException mapException(DBException e) {
+        if (e instanceof DBSQLException dbsqlException) {
+            if (CROSS_DATABASE_QUERY_ERROR_PATTERN.matcher(dbsqlException.getMessage()).find()) {
+                return new DBException(
+                    "Cross-database queries are not supported in this version of SQL Server. Create a new connection to the selected database.");
+            }
+        }
+
+        return e;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDatabase.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDatabase.java
@@ -36,6 +36,7 @@ import org.jkiss.dbeaver.model.meta.PropertyLength;
 import org.jkiss.dbeaver.model.preferences.DBPPropertySource;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
+import org.jkiss.dbeaver.model.sql.DBSQLException;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSObjectFilter;
 import org.jkiss.dbeaver.model.struct.rdb.DBSCatalog;
@@ -337,7 +338,11 @@ public class SQLServerDatabase
 
     @Override
     public Collection<SQLServerSchema> getChildren(@NotNull DBRProgressMonitor monitor) throws DBException {
-        return schemaCache.getAllObjects(monitor, this);
+        try {
+            return schemaCache.getAllObjects(monitor, this);
+        } catch (DBSQLException exception) {
+            throw SQLServerUtils.mapException(exception);
+        }
     }
 
     @Override
@@ -416,7 +421,11 @@ public class SQLServerDatabase
 
     @Association
     public Collection<SQLServerDatabaseTrigger> getTriggers(DBRProgressMonitor monitor) throws DBException {
-        return triggerCache.getAllObjects(monitor, this);
+        try {
+            return triggerCache.getAllObjects(monitor, this);
+        } catch (DBSQLException exception) {
+            throw SQLServerUtils.mapException(exception);
+        }
     }
 
     TriggerCache getTriggerCache() {


### PR DESCRIPTION
Restore the “Show all databases” checkbox for Azure SQL and provide a detailed error message for cross-database queries.


<img width="504" alt="image" src="https://github.com/user-attachments/assets/84d56f62-126b-44eb-8087-912fda9dc1d2">

