### PR TITLE
#35782 Fix multiline node description rendering in the navigator

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/database/StatisticsNavigatorNodeRenderer.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/database/StatisticsNavigatorNodeRenderer.java
@@ -209,7 +209,7 @@ public class StatisticsNavigatorNodeRenderer extends DefaultNavigatorNodeRendere
         if (object != null) {
             String description = object.getDescription();
             if (!CommonUtils.isEmptyTrimmed(description)) {
-                drawText(gc, description, bounds);
+                drawText(gc, CommonUtils.getSingleLineString(description), bounds);
             }
         }
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9ada9988-3cfb-49e6-a436-22d5ef72649d)
