### PR TITLE
#36605 Databend - Quote name when setting active db

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.databend/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.databend/plugin.xml
@@ -49,7 +49,7 @@
                     <parameter name="omit-catalog" value="false"/>
                     <parameter name="omit-schema" value="false"/>
                     <parameter name="query-get-active-db" value="SELECT CURRENT_DATABASE()"/>
-                    <parameter name="query-set-active-db" value="USE ?"/>
+                    <parameter name="query-set-active-db" value="USE &quot;?&quot;"/>
                 </driver>
             </drivers>
 


### PR DESCRIPTION
Fixes issue changing catalog when catalog name contains e.g. dashes, such as `my-schema`