### PR TITLE
#36693 Fix tableReferences rule in sql grammar

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardParser.g4
@@ -224,7 +224,7 @@ queryExpression: (joinedTable|nonJoinQueryTerm) (unionTerm|exceptTerm)*;
 // from
 fromClause: FROM tableReference (Comma tableReference)*;
 nonjoinedTableReference: ((tableName (PARTITION anyProperty)?)|derivedTable) correlationSpecification?;
-tableReference: nonjoinedTableReference|joinedTable|tableReferenceHints|anyUnexpected??; // '.*' to handle incomplete queries
+tableReference: (nonjoinedTableReference|joinedTable) tableReferenceHints?? anyUnexpected??;
 tableReferenceHints: (tableHintKeywords|anyWord)+ anyProperty; // dialect-specific options, should be described and moved to dialects in future
 joinedTable: (nonjoinedTableReference|(LeftParen joinedTable RightParen)) (naturalJoinTerm|crossJoinTerm)+;
 correlationSpecification: { validCorrelationNameFollows() }? (AS)? correlationName (LeftParen derivedColumnList RightParen)?;


### PR DESCRIPTION
Autocomplete in `|` for the following query should work now
```
select c.id, c.Customer
from dbo.Customers c with(nolock)
where c.|
```