### PR TITLE
#35194 Properly close single tab result containers on new multitabs execution

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -2961,7 +2961,8 @@ public class SQLEditor extends SQLEditorBase implements
             if (tabsToClose.get(0).getData() instanceof SingleTabQueryProcessor sqp) {
                 // to avoid concurrent modification exception
                 List<QueryResultsContainer> results = new ArrayList<>(sqp.getResultContainers());
-                results.stream().skip(1).forEach(QueryResultsContainer::dispose);
+                results.forEach(QueryResultsContainer::dispose);
+                tabsToClose.get(0).dispose();
             }
         }
         // No need to close anything


### PR DESCRIPTION
See https://github.com/dbeaver/dbeaver/issues/35194#issuecomment-2512443624. Now it should be fixed