### PR TITLE
dbeaver/pro#3932 Don't expose packages for completion proposals

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/completion/SQLQueryCompletionContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/completion/SQLQueryCompletionContext.java
@@ -865,6 +865,8 @@ public abstract class SQLQueryCompletionContext {
                             if (alreadyReferencedObjects.add(child) && score > 0) {
                                 accumulator.add(completionItemFabric.produce(score, childName, (T) child));
                             }
+                        } else if (child instanceof DBSPackage) {
+                            // don't expose packages, do nothing
                         } else if (child instanceof DBSObjectContainer sc && DBStructUtils.isConnectedContainer(child)) {
                             collectObjectsRecursively(monitor, sc, alreadyReferencedObjects, accumulator, filterOrNull, types, completionItemFabric);
                         }


### PR DESCRIPTION
If you write `select * from |` in Oracle with the default SYS schema, the following should not happen in Query manager anymore
![image](https://github.com/user-attachments/assets/6f680a60-d5c9-44e7-aef3-b66f12e0bae4)
