### PR TITLE
dbeaver/dbeaver#36814 Implemented support for editing table and column comments in the GBase8s driver

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/plugin.xml
@@ -38,8 +38,8 @@
 					webURL="https://cdn.gbase.cn/products/27/duljCAzDVSy_SLTpy7j1l/GBase%208s%20V8.8%20JDBC%20Driver%20%E7%A8%8B%E5%BA%8F%E5%91%98%E6%8C%87%E5%8D%97.pdf"
 					supportedPageFields="host,port,database,server"
 					categories="sql">
-					<property name="opt_goal" value="0" />
-					<property name="sqlMode" value="oracle" />
+					<property name="OPT_GOAL" value="0" />
+					<property name="SQLMODE" value="oracle" />
 
 					<property name="@dbeaver-default-database.meta.client.name.disable" value="true" />
 					<property name="@dbeaver-default-dataformat.type.timestamp.pattern" value="yyyy-MM-dd HH.mm.ss.ffffff" />

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sConstants.java
@@ -1,0 +1,29 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jkiss.dbeaver.ext.gbase8s;
+
+/**
+ * GBase8sConstants
+ */
+public class GBase8sConstants {
+
+    public static final String JDBC_SQL_MODE = "SQLMODE";
+    public static final String JDBC_SQL_MODE_ORACLE = "oracle";
+    public static final String JDBC_SQL_MODE_GBASE = "gbase";
+
+}

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sConstants.java
@@ -26,6 +26,6 @@ public class GBase8sConstants {
     public static final String JDBC_SQL_MODE_ORACLE = "oracle";
     public static final String JDBC_SQL_MODE_GBASE = "gbase";
 
-    public static final String SQL_TABLE_COMMENT = "COMMENT ON TABLE %s IS '%s'";
-    public static final String SQL_COLUMN_COMMENT = "COMMENT ON COLUMN %s.%s IS '%s'";
+    public static final String SQL_TABLE_COMMENT = "COMMENT ON TABLE %s IS %s";
+    public static final String SQL_COLUMN_COMMENT = "COMMENT ON COLUMN %s.%s IS %s";
 }

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sConstants.java
@@ -26,4 +26,6 @@ public class GBase8sConstants {
     public static final String JDBC_SQL_MODE_ORACLE = "oracle";
     public static final String JDBC_SQL_MODE_GBASE = "gbase";
 
+    public static final String SQL_TABLE_COMMENT = "COMMENT ON TABLE %s IS '%s'";
+    public static final String SQL_COLUMN_COMMENT = "COMMENT ON COLUMN %s.%s IS '%s'";
 }

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sConstants.java
@@ -27,5 +27,4 @@ public class GBase8sConstants {
     public static final String JDBC_SQL_MODE_GBASE = "gbase";
 
     public static final String SQL_TABLE_COMMENT = "COMMENT ON TABLE %s IS %s";
-    public static final String SQL_COLUMN_COMMENT = "COMMENT ON COLUMN %s.%s IS %s";
 }

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sUtils.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
@@ -31,6 +32,7 @@ import org.jkiss.dbeaver.ext.generic.model.GenericTrigger;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
+import org.jkiss.dbeaver.model.connection.DBPDriver;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
@@ -67,16 +69,20 @@ public class GBase8sUtils {
     }
 
     public static boolean isOracleSqlMode(DBPDataSourceContainer container) {
-        final DBPConnectionConfiguration configuration = container.getConnectionConfiguration();
+        DBPConnectionConfiguration configuration = container.getConnectionConfiguration();
         Map<String, String> cprops = configuration.getProperties();
-        for (Map.Entry<String, String> entry : cprops.entrySet()) {
-            if (Objects.equals(entry.getKey().toLowerCase(), "sqlmode")) {
-                if (Objects.equals(entry.getValue().toString().trim().toLowerCase(), "oracle")) {
-                    return true;
-                }
+        for (String key : cprops.keySet()) {
+            if ("sqlmode".equalsIgnoreCase(key)) {
+                return "oracle".equalsIgnoreCase(cprops.get(key).trim());
             }
         }
-        return false;
+        DBPDriver driver = container.getDriver();
+        Map<String, Object> driverProps = driver.getConnectionProperties();
+        return driverProps.values().stream()
+                .filter(Objects::nonNull)
+                .map(Object::toString)
+                .map(String::trim)
+                .anyMatch(value -> "oracle".equalsIgnoreCase(value));
     }
 
     public static String listToString(List<String> value, String delimiter) {

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sUtils.java
@@ -30,7 +30,7 @@ import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
 import org.jkiss.dbeaver.ext.generic.model.GenericTrigger;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBUtils;
-import org.jkiss.dbeaver.model.connection.DBPDriver;
+import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
@@ -67,9 +67,9 @@ public class GBase8sUtils {
     }
 
     public static boolean isOracleSqlMode(DBPDataSourceContainer container) {
-        final DBPDriver driver = container.getDriver();
-        Map<String, Object> cprops = driver.getConnectionProperties();
-        for (Map.Entry<String, Object> entry : cprops.entrySet()) {
+        final DBPConnectionConfiguration configuration = container.getConnectionConfiguration();
+        Map<String, String> cprops = configuration.getProperties();
+        for (Map.Entry<String, String> entry : cprops.entrySet()) {
             if (Objects.equals(entry.getKey().toLowerCase(), "sqlmode")) {
                 if (Objects.equals(entry.getValue().toString().trim().toLowerCase(), "oracle")) {
                     return true;

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sUtils.java
@@ -70,19 +70,30 @@ public class GBase8sUtils {
     public static boolean isOracleSqlMode(DBPDataSourceContainer container) {
         DBPConnectionConfiguration configuration = container.getConnectionConfiguration();
         Map<String, String> cprops = configuration.getProperties();
-        for (String key : cprops.keySet()) {
-            if ("sqlmode".equalsIgnoreCase(key)) {
-                return "oracle".equalsIgnoreCase(cprops.get(key).trim());
-            }
+        if (containsSqlModeKey(cprops)) {
+            return isOracleSqlModeFromProperties(cprops);
         }
         DBPDriver driver = container.getDriver();
         Map<String, Object> driverProps = driver.getConnectionProperties();
-        for (String key : driverProps.keySet()) {
-            if ("sqlmode".equalsIgnoreCase(key)) {
-                return "oracle".equalsIgnoreCase(Objects.toString(driverProps.get(key), "").trim());
-            }
+        // If driverProps does not have SQLMODE, return true. Default is Oracle mode.
+        if (!containsSqlModeKey(driverProps)) {
+            return true;
         }
-        return true;
+        return isOracleSqlModeFromProperties(driverProps);
+    }
+
+    private static boolean containsSqlModeKey(Map<String, ?> properties) {
+        return properties != null && !properties.isEmpty() && properties.keySet().stream()
+                .anyMatch(key -> key != null && GBase8sConstants.JDBC_SQL_MODE.equalsIgnoreCase(key));
+    }
+
+    private static boolean isOracleSqlModeFromProperties(Map<String, ?> properties) {
+        return properties != null && !properties.isEmpty()
+                && properties.entrySet().stream()
+                        .anyMatch(entry -> entry.getKey() != null
+                                && GBase8sConstants.JDBC_SQL_MODE.equalsIgnoreCase(entry.getKey().toString())
+                                && GBase8sConstants.JDBC_SQL_MODE_ORACLE
+                                        .equalsIgnoreCase(Objects.toString(entry.getValue(), "").trim()));
     }
 
     public static String listToString(List<String> value, String delimiter) {

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/GBase8sUtils.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.TreeMap;
 
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
@@ -78,11 +77,12 @@ public class GBase8sUtils {
         }
         DBPDriver driver = container.getDriver();
         Map<String, Object> driverProps = driver.getConnectionProperties();
-        return driverProps.values().stream()
-                .filter(Objects::nonNull)
-                .map(Object::toString)
-                .map(String::trim)
-                .anyMatch(value -> "oracle".equalsIgnoreCase(value));
+        for (String key : driverProps.keySet()) {
+            if ("sqlmode".equalsIgnoreCase(key)) {
+                return "oracle".equalsIgnoreCase(Objects.toString(driverProps.get(key), "").trim());
+            }
+        }
+        return true;
     }
 
     public static String listToString(List<String> value, String delimiter) {

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableColumnManager.java
@@ -43,10 +43,12 @@ public class GBase8sTableColumnManager extends GenericTableColumnManager
         implements DBEObjectRenamer<GenericTableColumn> {
 
     @Override
-    protected void addObjectCreateActions(DBRProgressMonitor monitor, DBCExecutionContext executionContext,
-            List<DBEPersistAction> actions,
-            SQLObjectEditor<GenericTableColumn, GenericTableBase>.ObjectCreateCommand command,
-            Map<String, Object> options) throws DBException {
+    protected void addObjectCreateActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actions,
+            @NotNull SQLObjectEditor<GenericTableColumn, GenericTableBase>.ObjectCreateCommand command,
+            @NotNull Map<String, Object> options) throws DBException {
         super.addObjectCreateActions(monitor, executionContext, actions, command, options);
         if (CommonUtils.isNotEmpty(command.getObject().getDescription())) {
             addColumnCommentAction(actions, command.getObject(), command.getObject().getParentObject());
@@ -54,8 +56,10 @@ public class GBase8sTableColumnManager extends GenericTableColumnManager
     }
 
     @Override
-    protected void addObjectRenameActions(@NotNull DBRProgressMonitor monitor,
-            @NotNull DBCExecutionContext executionContext, @NotNull List<DBEPersistAction> actions,
+    protected void addObjectRenameActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actions,
             @NotNull SQLObjectEditor<GenericTableColumn, GenericTableBase>.ObjectRenameCommand command,
             @NotNull Map<String, Object> options) {
         final GenericTableColumn column = command.getObject();
@@ -66,7 +70,10 @@ public class GBase8sTableColumnManager extends GenericTableColumnManager
     }
 
     @Override
-    public void renameObject(DBECommandContext commandContext, GenericTableColumn object, Map<String, Object> options,
+    public void renameObject(
+            DBECommandContext commandContext,
+            GenericTableColumn object,
+            Map<String, Object> options,
             String newName) throws DBException {
         processObjectRename(commandContext, object, options, newName);
     }

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableColumnManager.java
@@ -22,9 +22,11 @@ import java.util.Map;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.gbase8s.model.GBase8sTableColumn;
 import org.jkiss.dbeaver.ext.generic.edit.GenericTableColumnManager;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableColumn;
+import org.jkiss.dbeaver.model.DBConstants;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.edit.DBECommandContext;
@@ -52,6 +54,24 @@ public class GBase8sTableColumnManager extends GenericTableColumnManager
         super.addObjectCreateActions(monitor, executionContext, actions, command, options);
         if (CommonUtils.isNotEmpty(command.getObject().getDescription())) {
             addColumnCommentAction(actions, command.getObject(), command.getObject().getParentObject());
+        }
+    }
+
+    @Override
+    protected void addObjectModifyActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actionList,
+            @NotNull SQLObjectEditor<GenericTableColumn, GenericTableBase>.ObjectChangeCommand command,
+            @NotNull Map<String, Object> options) throws DBException {
+        final GBase8sTableColumn column = (GBase8sTableColumn) command.getObject();
+        // Modify column
+        actionList.add(new SQLDatabasePersistAction("Modify column",
+                "ALTER TABLE " + column.getTable().getFullyQualifiedName(DBPEvaluationContext.DDL) + " MODIFY "
+                        + getNestedDeclaration(monitor, column.getTable(), command, options)));
+        // Modify remark
+        if (command.hasProperty(DBConstants.PROP_ID_DESCRIPTION)) {
+            addColumnCommentAction(actionList, column, column.getTable());
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableColumnManager.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
-import org.jkiss.dbeaver.ext.gbase8s.model.GBase8sTableColumn;
 import org.jkiss.dbeaver.ext.generic.edit.GenericTableColumnManager;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableColumn;
@@ -35,12 +34,24 @@ import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
 import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
 import org.jkiss.dbeaver.model.impl.sql.edit.SQLObjectEditor;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.utils.CommonUtils;
 
 /**
  * @author Chao Tian
  */
 public class GBase8sTableColumnManager extends GenericTableColumnManager
         implements DBEObjectRenamer<GenericTableColumn> {
+
+    @Override
+    protected void addObjectCreateActions(DBRProgressMonitor monitor, DBCExecutionContext executionContext,
+            List<DBEPersistAction> actions,
+            SQLObjectEditor<GenericTableColumn, GenericTableBase>.ObjectCreateCommand command,
+            Map<String, Object> options) throws DBException {
+        super.addObjectCreateActions(monitor, executionContext, actions, command, options);
+        if (CommonUtils.isNotEmpty(command.getObject().getDescription())) {
+            addColumnCommentAction(actions, command.getObject(), command.getObject().getParentObject());
+        }
+    }
 
     @Override
     protected void addObjectRenameActions(@NotNull DBRProgressMonitor monitor,
@@ -58,17 +69,5 @@ public class GBase8sTableColumnManager extends GenericTableColumnManager
     public void renameObject(DBECommandContext commandContext, GenericTableColumn object, Map<String, Object> options,
             String newName) throws DBException {
         processObjectRename(commandContext, object, options, newName);
-    }
-
-    @Override
-    protected void addObjectModifyActions(@NotNull DBRProgressMonitor monitor,
-            @NotNull DBCExecutionContext executionContext, @NotNull List<DBEPersistAction> actionList,
-            @NotNull SQLObjectEditor<GenericTableColumn, GenericTableBase>.ObjectChangeCommand command,
-            @NotNull Map<String, Object> options) throws DBException {
-        final GBase8sTableColumn column = (GBase8sTableColumn) command.getObject();
-        actionList.add(new SQLDatabasePersistAction("Modify column",
-                "ALTER TABLE " + column.getTable().getFullyQualifiedName(DBPEvaluationContext.DDL) + " MODIFY "
-                        + getNestedDeclaration(monitor, column.getTable(), command, options)));
-
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableColumnManager.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
-import org.jkiss.dbeaver.ext.gbase8s.model.GBase8sTableColumn;
 import org.jkiss.dbeaver.ext.generic.edit.GenericTableColumnManager;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableColumn;
@@ -64,14 +63,23 @@ public class GBase8sTableColumnManager extends GenericTableColumnManager
             @NotNull List<DBEPersistAction> actionList,
             @NotNull SQLObjectEditor<GenericTableColumn, GenericTableBase>.ObjectChangeCommand command,
             @NotNull Map<String, Object> options) throws DBException {
-        final GBase8sTableColumn column = (GBase8sTableColumn) command.getObject();
-        // Modify column
+        GenericTableColumn column = command.getObject();
         actionList.add(new SQLDatabasePersistAction("Modify column",
                 "ALTER TABLE " + column.getTable().getFullyQualifiedName(DBPEvaluationContext.DDL) + " MODIFY "
                         + getNestedDeclaration(monitor, column.getTable(), command, options)));
-        // Modify remark
+    }
+
+    @Override
+    protected void addObjectExtraActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actions,
+            @NotNull NestedObjectCommand<GenericTableColumn, PropertyHandler> command,
+            @NotNull Map<String, Object> options) throws DBException {
+        // Add column comment action if column description is specified
         if (command.hasProperty(DBConstants.PROP_ID_DESCRIPTION)) {
-            addColumnCommentAction(actionList, column, column.getTable());
+            GenericTableColumn column = command.getObject();
+            addColumnCommentAction(actions, column, column.getTable());
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableManager.java
@@ -37,6 +37,7 @@ import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
 import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
 import org.jkiss.dbeaver.model.impl.sql.edit.SQLObjectEditor;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.sql.SQLUtils;
 import org.jkiss.utils.CommonUtils;
 
 /**
@@ -110,8 +111,9 @@ public class GBase8sTableManager extends GenericTableManager implements DBEObjec
     private DBEPersistAction buildTableCommentAction(GenericTableBase table) {
         String description = table.getDescription();
         if (CommonUtils.isNotEmpty(description)) {
-            String tableName = table.getFullyQualifiedName(DBPEvaluationContext.DDL);
-            String commentSQL = String.format(GBase8sConstants.SQL_TABLE_COMMENT, tableName, description);
+            String tableName = DBUtils.getObjectFullName(table, DBPEvaluationContext.DDL);
+            String commentSQL = String.format(GBase8sConstants.SQL_TABLE_COMMENT, tableName,
+                    SQLUtils.quoteString(table, description));
             return new SQLDatabasePersistAction("Comment on Table", commentSQL);
         }
         return null;
@@ -120,9 +122,10 @@ public class GBase8sTableManager extends GenericTableManager implements DBEObjec
     private DBEPersistAction buildColumnCommentAction(GenericTableColumn column) {
         String description = column.getDescription();
         if (CommonUtils.isNotEmpty(description)) {
-            String tableName = column.getTable().getFullyQualifiedName(DBPEvaluationContext.DDL);
-            String columnName = column.getName();
-            String commentSQL = String.format(GBase8sConstants.SQL_COLUMN_COMMENT, tableName, columnName, description);
+            String tableName = DBUtils.getObjectFullName(column.getTable(), DBPEvaluationContext.DDL);
+            String columnName = DBUtils.getQuotedIdentifier(column);
+            String commentSQL = String.format(GBase8sConstants.SQL_COLUMN_COMMENT, tableName, columnName,
+                    SQLUtils.quoteString(column, description));
             return new SQLDatabasePersistAction("Comment on Column", commentSQL);
         }
         return null;

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableManager.java
@@ -22,10 +22,13 @@ import java.util.Map;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.gbase8s.GBase8sConstants;
 import org.jkiss.dbeaver.ext.generic.edit.GenericTableManager;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
+import org.jkiss.dbeaver.ext.generic.model.GenericTableColumn;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.edit.DBECommandContext;
 import org.jkiss.dbeaver.model.edit.DBEObjectRenamer;
@@ -34,6 +37,7 @@ import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
 import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
 import org.jkiss.dbeaver.model.impl.sql.edit.SQLObjectEditor;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.utils.CommonUtils;
 
 /**
  * @author Chao Tian
@@ -65,6 +69,28 @@ public class GBase8sTableManager extends GenericTableManager implements DBEObjec
     }
 
     @Override
+    protected void addStructObjectCreateActions(
+            DBRProgressMonitor monitor,
+            DBCExecutionContext executionContext,
+            List<DBEPersistAction> actions,
+            StructCreateCommand command,
+            Map<String, Object> options) throws DBException {
+        super.addStructObjectCreateActions(monitor, executionContext, actions, command, options);
+        // Add a table comment
+        DBEPersistAction commentAction = buildTableCommentAction(command.getObject());
+        if (commentAction != null) {
+            actions.add(commentAction);
+        }
+        for (GenericTableColumn column : command.getObject().getAttributes(monitor)) {
+            // Add a column comment
+            DBEPersistAction action = buildColumnCommentAction(column);
+            if (action != null) {
+                actions.add(action);
+            }
+        }
+    }
+
+    @Override
     protected void addObjectRenameActions(@NotNull DBRProgressMonitor monitor,
             @NotNull DBCExecutionContext executionContext, @NotNull List<DBEPersistAction> actions,
             @NotNull SQLObjectEditor<GenericTableBase, GenericStructContainer>.ObjectRenameCommand command,
@@ -79,5 +105,26 @@ public class GBase8sTableManager extends GenericTableManager implements DBEObjec
                                         : "")
                                 + DBUtils.getQuotedIdentifier(dataSource, command.getOldName()) + " RENAME TO "
                                 + DBUtils.getQuotedIdentifier(dataSource, command.getNewName())));
+    }
+
+    private DBEPersistAction buildTableCommentAction(GenericTableBase table) {
+        String description = table.getDescription();
+        if (CommonUtils.isNotEmpty(description)) {
+            String tableName = table.getFullyQualifiedName(DBPEvaluationContext.DDL);
+            String commentSQL = String.format(GBase8sConstants.SQL_TABLE_COMMENT, tableName, description);
+            return new SQLDatabasePersistAction("Comment on Table", commentSQL);
+        }
+        return null;
+    }
+
+    private DBEPersistAction buildColumnCommentAction(GenericTableColumn column) {
+        String description = column.getDescription();
+        if (CommonUtils.isNotEmpty(description)) {
+            String tableName = column.getTable().getFullyQualifiedName(DBPEvaluationContext.DDL);
+            String columnName = column.getName();
+            String commentSQL = String.format(GBase8sConstants.SQL_COLUMN_COMMENT, tableName, columnName, description);
+            return new SQLDatabasePersistAction("Comment on Column", commentSQL);
+        }
+        return null;
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableManager.java
@@ -92,7 +92,7 @@ public class GBase8sTableManager extends GenericTableManager implements DBEObjec
             addTableCommentAction(actions, tableBase);
         }
         // Add column comments if needed
-        if (objectSave || includeComments) {
+        if (!tableBase.isPersisted() ? (objectSave || includeComments) : (!objectSave && includeComments)) {
             for (GenericTableColumn column : CommonUtils.safeCollection(tableBase.getAttributes(monitor))) {
                 if (!CommonUtils.isEmpty(column.getDescription())) {
                     GenericTableColumnManager.addColumnCommentAction(actions, column, column.getTable());

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/edit/GBase8sTableManager.java
@@ -21,14 +21,18 @@ import java.util.List;
 import java.util.Map;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.gbase8s.GBase8sConstants;
+import org.jkiss.dbeaver.ext.generic.edit.GenericTableColumnManager;
 import org.jkiss.dbeaver.ext.generic.edit.GenericTableManager;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableColumn;
+import org.jkiss.dbeaver.model.DBConstants;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.edit.DBECommandContext;
 import org.jkiss.dbeaver.model.edit.DBEObjectRenamer;
@@ -61,8 +65,11 @@ public class GBase8sTableManager extends GenericTableManager implements DBEObjec
     }
 
     @Override
-    public void renameObject(DBECommandContext commandContext, GenericTableBase object, Map<String, Object> options,
-            String newName) throws DBException {
+    public void renameObject(
+            @NotNull DBECommandContext commandContext,
+            @NotNull GenericTableBase object,
+            @NotNull Map<String, Object> options,
+            @Nullable String newName) throws DBException {
         if (object.isView()) {
             throw new DBException("View rename is not supported");
         }
@@ -70,30 +77,35 @@ public class GBase8sTableManager extends GenericTableManager implements DBEObjec
     }
 
     @Override
-    protected void addStructObjectCreateActions(
-            DBRProgressMonitor monitor,
-            DBCExecutionContext executionContext,
-            List<DBEPersistAction> actions,
-            StructCreateCommand command,
-            Map<String, Object> options) throws DBException {
-        super.addStructObjectCreateActions(monitor, executionContext, actions, command, options);
-        // Add a table comment
-        DBEPersistAction commentAction = buildTableCommentAction(command.getObject());
-        if (commentAction != null) {
-            actions.add(commentAction);
+    protected void addObjectExtraActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actions,
+            @NotNull NestedObjectCommand<GenericTableBase, PropertyHandler> command,
+            @NotNull Map<String, Object> options) throws DBException {
+        GenericTableBase tableBase = command.getObject();
+        boolean objectSave = CommonUtils.getOption(options, DBPScriptObject.OPTION_OBJECT_SAVE);
+        boolean includeComments = CommonUtils.getOption(options, DBPScriptObject.OPTION_INCLUDE_COMMENTS);
+        boolean hasDescription = !CommonUtils.isEmpty(tableBase.getDescription());
+        // Add table comment if needed
+        if ((objectSave && command.hasProperty(DBConstants.PROP_ID_DESCRIPTION)) || hasDescription) {
+            addTableCommentAction(actions, tableBase);
         }
-        for (GenericTableColumn column : command.getObject().getAttributes(monitor)) {
-            // Add a column comment
-            DBEPersistAction action = buildColumnCommentAction(column);
-            if (action != null) {
-                actions.add(action);
+        // Add column comments if needed
+        if (objectSave || includeComments) {
+            for (GenericTableColumn column : CommonUtils.safeCollection(tableBase.getAttributes(monitor))) {
+                if (!CommonUtils.isEmpty(column.getDescription())) {
+                    GenericTableColumnManager.addColumnCommentAction(actions, column, column.getTable());
+                }
             }
         }
     }
 
     @Override
-    protected void addObjectRenameActions(@NotNull DBRProgressMonitor monitor,
-            @NotNull DBCExecutionContext executionContext, @NotNull List<DBEPersistAction> actions,
+    protected void addObjectRenameActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actions,
             @NotNull SQLObjectEditor<GenericTableBase, GenericStructContainer>.ObjectRenameCommand command,
             @NotNull Map<String, Object> options) {
         final GenericDataSource dataSource = command.getObject().getDataSource();
@@ -108,26 +120,12 @@ public class GBase8sTableManager extends GenericTableManager implements DBEObjec
                                 + DBUtils.getQuotedIdentifier(dataSource, command.getNewName())));
     }
 
-    private DBEPersistAction buildTableCommentAction(GenericTableBase table) {
-        String description = table.getDescription();
-        if (CommonUtils.isNotEmpty(description)) {
-            String tableName = DBUtils.getObjectFullName(table, DBPEvaluationContext.DDL);
-            String commentSQL = String.format(GBase8sConstants.SQL_TABLE_COMMENT, tableName,
-                    SQLUtils.quoteString(table, description));
-            return new SQLDatabasePersistAction("Comment on Table", commentSQL);
-        }
-        return null;
-    }
-
-    private DBEPersistAction buildColumnCommentAction(GenericTableColumn column) {
-        String description = column.getDescription();
-        if (CommonUtils.isNotEmpty(description)) {
-            String tableName = DBUtils.getObjectFullName(column.getTable(), DBPEvaluationContext.DDL);
-            String columnName = DBUtils.getQuotedIdentifier(column);
-            String commentSQL = String.format(GBase8sConstants.SQL_COLUMN_COMMENT, tableName, columnName,
-                    SQLUtils.quoteString(column, description));
-            return new SQLDatabasePersistAction("Comment on Column", commentSQL);
-        }
-        return null;
+    private void addTableCommentAction(
+            @NotNull List<DBEPersistAction> actionList,
+            @NotNull GenericTableBase table) {
+        String tableName = DBUtils.getObjectFullName(table, DBPEvaluationContext.DDL);
+        String commentSQL = String.format(GBase8sConstants.SQL_TABLE_COMMENT, tableName,
+                SQLUtils.quoteString(table, CommonUtils.notEmpty(table.getDescription())));
+        actionList.add(new SQLDatabasePersistAction("Comment on Table", commentSQL));
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/model/GBase8sTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/model/GBase8sTable.java
@@ -20,6 +20,7 @@ package org.jkiss.dbeaver.ext.gbase8s.model;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
 import org.jkiss.dbeaver.ext.generic.model.GenericTable;
+import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 
 /**
@@ -37,4 +38,13 @@ public class GBase8sTable extends GenericTable {
         super(container, tableName, tableCatalogName, tableSchemaName);
     }
 
+    @Override
+    protected boolean isCacheDDL() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsObjectDefinitionOption(String option) {
+        return DBPScriptObject.OPTION_INCLUDE_COMMENTS.equals(option);
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/model/meta/GBase8sMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.gbase8s/src/org/jkiss/dbeaver/ext/gbase8s/model/meta/GBase8sMetaModel.java
@@ -295,17 +295,17 @@ public class GBase8sMetaModel extends GenericMetaModel {
     }
 
     @Override
-    public JDBCStatement prepareTableColumnLoadStatement(@NotNull JDBCSession session,
-            @NotNull GenericStructContainer owner, @Nullable GenericTableBase forTable) throws SQLException {
+    public JDBCStatement prepareTableColumnLoadStatement(
+            @NotNull JDBCSession session,
+            @NotNull GenericStructContainer owner,
+            @Nullable GenericTableBase forTable) throws SQLException {
         String tableName = forTable == null ? owner.getDataSource().getAllObjectsPattern()
                 : JDBCUtils.escapeWildCards(session, forTable.getName());
         String catalog = owner.getCatalog() == null ? null : owner.getCatalog().getName();
         String schema = owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ? null
                 : JDBCUtils.escapeWildCards(session, owner.getSchema().getName());
         boolean isOracleMode = GBase8sUtils.isOracleSqlMode(owner.getDataSource().getContainer());
-        String ownerPattern = """
-                %s%s
-                """.formatted(isOracleMode ? schema : catalog, isOracleMode ? "." : ":");
+        String ownerPattern = "%s%s".formatted(isOracleMode ? schema : catalog, isOracleMode ? "." : ":");
         String sql = """
                 SELECT
                     t.tabname::VARCHAR(128) AS TABLE_NAME,
@@ -397,9 +397,7 @@ public class GBase8sMetaModel extends GenericMetaModel {
         String schema = owner.getSchema() == null || DBUtils.isVirtualObject(owner.getSchema()) ? null
                 : JDBCUtils.escapeWildCards(session, owner.getSchema().getName());
         boolean isOracleMode = GBase8sUtils.isOracleSqlMode(owner.getDataSource().getContainer());
-        String ownerPattern = """
-                %s%s
-                """.formatted(isOracleMode ? schema : catalog, isOracleMode ? "." : ":");
+        String ownerPattern = "%s%s".formatted(isOracleMode ? schema : catalog, isOracleMode ? "." : ":");
         String sql = """
                 SELECT t.tabid, t.tabname AS TABLE_NAME, t.owner AS
                     %s,


### PR DESCRIPTION
### Overview:
This PR introduces the ability to edit table and column comments in the GBase8s driver, addressing a feature gap in the database management capabilities.
### Key Changes:
- Implemented support for editing comments at the table and column levels.
### Related Issue:
Closes dbeaver/dbeaver#36814.
### Testing:
*  Created new columns with comments.
*  Added comments to existing columns.
*  Removed comments from columns.
*  Deleted columns with comments.
*  All test cases have been successfully validated and executed to ensure proper comment operations.
### Scope of Impact:
This change affects only the GBase8s driver and is backward-compatible.
### Checklist:
*  Local tests passed.
*  No breaking changes identified.