### PR TITLE
#36907 [CUBRID] Create and modify Synonyms using UI

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.cubrid/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/plugin.xml
@@ -229,6 +229,7 @@
         <manager class="org.jkiss.dbeaver.ext.cubrid.edit.CubridTriggerManager" objectType="org.jkiss.dbeaver.ext.cubrid.model.CubridTrigger"/>
         <manager class="org.jkiss.dbeaver.ext.cubrid.edit.CubridServerManager" objectType="org.jkiss.dbeaver.ext.cubrid.model.CubridServer"/>
         <manager class="org.jkiss.dbeaver.ext.cubrid.edit.CubridSequenceManager" objectType="org.jkiss.dbeaver.ext.cubrid.model.CubridSequence"/>
+        <manager class="org.jkiss.dbeaver.ext.cubrid.edit.CubridSynonymManager" objectType="org.jkiss.dbeaver.ext.cubrid.model.CubridSynonym"/>
         <manager class="org.jkiss.dbeaver.ext.cubrid.edit.CubridViewManager" objectType="org.jkiss.dbeaver.ext.cubrid.model.CubridView"/>
     </extension>
 </plugin>

--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/edit/CubridSynonymManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/edit/CubridSynonymManager.java
@@ -1,0 +1,118 @@
+package org.jkiss.dbeaver.ext.cubrid.edit;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.cubrid.model.CubridSynonym;
+import org.jkiss.dbeaver.ext.generic.model.GenericObjectContainer;
+import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
+import org.jkiss.dbeaver.ext.generic.model.GenericSynonym;
+import org.jkiss.dbeaver.model.DBPDataSource;
+import org.jkiss.dbeaver.model.edit.DBECommandContext;
+import org.jkiss.dbeaver.model.edit.DBEObjectRenamer;
+import org.jkiss.dbeaver.model.edit.DBEPersistAction;
+import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
+import org.jkiss.dbeaver.model.impl.edit.SQLDatabasePersistAction;
+import org.jkiss.dbeaver.model.impl.sql.edit.SQLObjectEditor;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.sql.SQLUtils;
+import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.dbeaver.model.struct.cache.DBSObjectCache;
+import org.jkiss.utils.CommonUtils;
+
+public class CubridSynonymManager extends SQLObjectEditor<GenericSynonym, GenericStructContainer> implements DBEObjectRenamer<GenericSynonym> {
+
+    public static final String BASE_SYNONYM_NAME = "new_synonym";
+
+    @Override
+    public long getMakerOptions(DBPDataSource dataSource) {
+        return FEATURE_EDITOR_ON_CREATE;
+    }
+
+    @Override
+    public DBSObjectCache<? extends DBSObject, GenericSynonym> getObjectsCache(GenericSynonym object) {
+        DBSObject parentObject = object.getParentObject();
+        if (parentObject instanceof GenericObjectContainer container) {
+            return container.getSynonymCache();
+        }
+        return null;
+    }
+
+    @Override
+    protected CubridSynonym createDatabaseObject(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBECommandContext context,
+            @Nullable Object container,
+            @Nullable Object copyFrom,
+            @NotNull Map<String, Object> options) {
+        return new CubridSynonym((GenericStructContainer) container, BASE_SYNONYM_NAME);
+    }
+
+    public String buildStatement(@NotNull NestedObjectCommand command, @NotNull boolean isCreate) {
+        StringBuilder query = new StringBuilder();
+        CubridSynonym synonym = (CubridSynonym) command.getObject();
+        query.append(isCreate ? "CREATE SYNONYM " : "ALTER SYNONYM ");
+        query.append(synonym.getOwner() + "." + synonym.getName());
+        query.append(" FOR ").append(synonym.getTargetObject());
+        if ((!synonym.isPersisted() && synonym.getDescription() != null) || command.hasProperty("description")) {
+            query.append(" COMMENT ").append(SQLUtils.quoteString(synonym, CommonUtils.notEmpty(synonym.getDescription())));
+        }
+        return query.toString();
+    }
+
+    @Override
+    protected void addObjectCreateActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actions,
+            @NotNull ObjectCreateCommand command,
+            @NotNull Map<String, Object> options) {
+        actions.add(new SQLDatabasePersistAction("Create Synonym", buildStatement(command, true)));
+    }
+
+    @Override
+    protected void addObjectModifyActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actions,
+            @NotNull ObjectChangeCommand command,
+            @NotNull Map<String, Object> options) {
+        actions.add(new SQLDatabasePersistAction("Modify Serial", buildStatement(command, false)));
+    }
+
+    @Override
+    protected void addObjectDeleteActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actions,
+            @NotNull ObjectDeleteCommand command,
+            @NotNull Map<String, Object> options) {
+        CubridSynonym synonym = (CubridSynonym) command.getObject();
+        actions.add(new SQLDatabasePersistAction("Drop Synonym",
+        "DROP SYNONYM " + synonym.getOwner() + "." + synonym.getName()));
+    }
+
+    @Override
+    protected void addObjectRenameActions(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull DBCExecutionContext executionContext,
+            @NotNull List<DBEPersistAction> actions,
+            @NotNull ObjectRenameCommand command,
+            @NotNull Map<String, Object> options) {
+        CubridSynonym synonym = (CubridSynonym) command.getObject();
+        actions.add(new SQLDatabasePersistAction("Rename Synonym",
+        "RENAME SYNONYM " + synonym.getOwner() + "." + command.getOldName() + " TO " + synonym.getOwner() + "." + command.getNewName()));
+    }
+
+    @Override
+    public void renameObject(
+            @NotNull DBECommandContext commandContext,
+            @NotNull GenericSynonym object,
+            @NotNull Map<String, Object> options,
+            @NotNull String newName) throws DBException {
+        processObjectRename(commandContext, object, options, newName);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridSynonym.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridSynonym.java
@@ -24,6 +24,7 @@ import org.jkiss.dbeaver.ext.generic.model.GenericSynonym;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.meta.Property;
+import org.jkiss.dbeaver.model.meta.PropertyLength;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 
@@ -32,6 +33,7 @@ public class CubridSynonym extends GenericSynonym
     private String owner;
     private String targetName;
     private String targetOwner;
+    private String description;
 
     public CubridSynonym(
             @NotNull GenericStructContainer container,
@@ -39,21 +41,48 @@ public class CubridSynonym extends GenericSynonym
             @Nullable String description,
             @NotNull JDBCResultSet dbResult) {
         super(container, name, description);
+        this.description = description;
         this.owner = JDBCUtils.safeGetString(dbResult, "synonym_owner_name");
         this.targetName = JDBCUtils.safeGetString(dbResult, "target_name");
         this.targetOwner = JDBCUtils.safeGetString(dbResult, "target_owner_name");
     }
 
+    public CubridSynonym(
+            @NotNull GenericStructContainer container,
+            @NotNull String name) {
+        super(container, name, null);
+        this.owner = container.getName();
+    }
+
     @NotNull
     @Property(viewable = true, order = 2)
-    public String getOwner() {
-        return owner;
+    public CubridUser getOwner() {
+        return new CubridUser(getDataSource(), owner, null);
+    }
+
+    @Override
+    public DBSObject getTargetObject(@NotNull DBRProgressMonitor monitor) throws DBException {
+        return getDataSource().findTable(monitor, null, targetOwner, targetName);
+    }
+
+    @Property(viewable = true, editable = true, updatable = true, order = 4)
+    public String getTargetObject() {
+        return targetName;
+    }
+
+    public void setTargetObject(String targetObject) {
+        this.targetName = targetObject;
     }
 
     @Nullable
     @Override
-    @Property(viewable = true, editable = false, order = 3)
-    public DBSObject getTargetObject(@NotNull DBRProgressMonitor monitor) throws DBException {
-        return getDataSource().findTable(monitor, null, targetOwner, targetName);
+    @Property(viewable = true, editable = true, updatable = true, length = PropertyLength.MULTILINE, order = 10)
+    public String getDescription() {
+        return description;
     }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
 }


### PR DESCRIPTION
Currently, users can only create and modify synonyms through scripts. We want to add UI to enable users to create and modify synonyms via the user interface.

**Note: Synonym supports from Cubrid Server 11.2 onwards.**