### PR TITLE
Cancellable Background Parsing job for CTEs (improving #36542)

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryAliasedRowsContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryAliasedRowsContext.java
@@ -44,6 +44,7 @@ public class SQLQueryAliasedRowsContext extends SQLQuerySyntaxContext {
     @Nullable
     @Override
     public SourceResolutionResult resolveSource(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
+        monitor.assertNotCancelled();
         return tableName.size() == 1 && tableName.get(0).equals(this.alias.getName())
             ? SourceResolutionResult.forSourceByAlias(this.source, this.alias)
             : super.resolveSource(monitor, tableName);

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryCombinedContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryCombinedContext.java
@@ -62,6 +62,7 @@ public class SQLQueryCombinedContext extends SQLQueryResultTupleContext {
     @Nullable
     @Override
     public DBSEntity findRealTable(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
+        monitor.assertNotCancelled();
         return anyOfTwo(parent.findRealTable(monitor, tableName), otherParent.findRealTable(monitor, tableName)); // TODO consider ambiguity
     }
 
@@ -72,12 +73,14 @@ public class SQLQueryCombinedContext extends SQLQueryResultTupleContext {
         @NotNull DBSObjectType objectType,
         @NotNull List<String> objectName
     ) {
+        monitor.assertNotCancelled();
         return anyOfTwo(parent.findRealObject(monitor, objectType, objectName), otherParent.findRealObject(monitor, objectType, objectName)); // TODO consider ambiguity
     }
 
     @Nullable
     @Override
     public SourceResolutionResult resolveSource(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
+        monitor.assertNotCancelled();
         return anyOfTwo(parent.resolveSource(monitor, tableName), otherParent.resolveSource(monitor, tableName)); // TODO consider ambiguity
     }
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDataContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDataContext.java
@@ -103,6 +103,7 @@ public abstract class SQLQueryDataContext {
      */
     @Nullable
     public SourceResolutionResult resolveSource(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
+        monitor.assertNotCancelled();
         DBSEntity table = this.findRealTable(monitor, tableName);
         SQLQueryRowsSourceModel source = table == null ? null : this.findRealSource(table);
         return source == null ? null : SourceResolutionResult.forRealTableByName(source, table); 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDataSourceContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDataSourceContext.java
@@ -88,6 +88,7 @@ public class SQLQueryDataSourceContext extends SQLQueryDataContext {
     @Nullable
     @Override
     public DBSEntity findRealTable(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
+        monitor.assertNotCancelled();
         // TODO consider differentiating direct references vs expanded aliases: each alias expansion should be treated as a virtual table
         DBSObject obj = expandAliases(monitor, this.findRealObjectImpl(monitor, tableName));
         return obj instanceof DBSTable table ? table : (obj instanceof DBSView view ? view : null);
@@ -100,6 +101,7 @@ public class SQLQueryDataSourceContext extends SQLQueryDataContext {
         @NotNull DBSObjectType objectType,
         @NotNull List<String> objectName
     ) {
+        monitor.assertNotCancelled();
         DBSObject obj = this.findRealObjectImpl(monitor, objectName);
         return obj != null && objectType.getTypeClass().isInstance(obj) ? obj : null;
     }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDummyDataSourceContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryDummyDataSourceContext.java
@@ -456,6 +456,7 @@ public class SQLQueryDummyDataSourceContext extends SQLQueryDataContext {
 
     @Override
     public DBSEntity findRealTable(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
+        monitor.assertNotCancelled();
         List<String> rawTableName = tableName.stream().map(this.dialect::getUnquotedIdentifier).toList();
         DummyDbObject catalog = rawTableName.size() > 2
             ? this.dummyDataSource.getChildrenMapImpl().get(rawTableName.get(rawTableName.size() - 3)) : this.defaultDummyCatalog;
@@ -476,6 +477,7 @@ public class SQLQueryDummyDataSourceContext extends SQLQueryDataContext {
         @NotNull DBSObjectType objectType,
         @NotNull List<String> objectName
     ) {
+        monitor.assertNotCancelled();
         return objectType.isCompatibleWith(RelationalObjectType.TYPE_TABLE) || objectType.isCompatibleWith(RelationalObjectType.TYPE_VIEW)
             ? this.findRealTable(monitor, objectName)
             : null;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQuerySyntaxContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQuerySyntaxContext.java
@@ -58,6 +58,7 @@ public abstract class SQLQuerySyntaxContext extends SQLQueryDataContext {
     @Nullable
     @Override
     public DBSEntity findRealTable(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
+        monitor.assertNotCancelled();
         return this.parent.findRealTable(monitor, tableName);
     }
 
@@ -74,30 +75,35 @@ public abstract class SQLQuerySyntaxContext extends SQLQueryDataContext {
         @NotNull DBSObjectType objectType,
         @NotNull List<String> objectName
     ) {
+        monitor.assertNotCancelled();
         return this.parent.findRealObject(monitor, objectType, objectName);
     }
 
     @Nullable
     @Override
-    public SQLQueryResultColumn resolveColumn(@NotNull DBRProgressMonitor monitor, @NotNull String columnName) {
+    public SQLQueryResultColumn resolveColumn(@NotNull DBRProgressMonitor monitor, @NotNull String columnName){
+        monitor.assertNotCancelled();
         return this.parent.resolveColumn(monitor, columnName);
     }
 
     @Override
     @Nullable
-    public SQLQueryResultPseudoColumn resolvePseudoColumn(DBRProgressMonitor monitor, @NotNull String name) {
+    public SQLQueryResultPseudoColumn resolvePseudoColumn(DBRProgressMonitor monitor, @NotNull String name){
+        monitor.assertNotCancelled();
         return this.parent.resolvePseudoColumn(monitor, name);
     }
 
     @Nullable
     @Override
-    public SQLQueryResultPseudoColumn resolveGlobalPseudoColumn(@NotNull DBRProgressMonitor monitor, @NotNull String name) {
+    public SQLQueryResultPseudoColumn resolveGlobalPseudoColumn(@NotNull DBRProgressMonitor monitor, @NotNull String name){
+        monitor.assertNotCancelled();
         return this.parent.resolveGlobalPseudoColumn(monitor, name);
     }
 
     @Nullable
     @Override
-    public SourceResolutionResult resolveSource(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName) {
+    public SourceResolutionResult resolveSource(@NotNull DBRProgressMonitor monitor, @NotNull List<String> tableName){
+        monitor.assertNotCancelled();
         SourceResolutionResult result = super.resolveSource(monitor, tableName);
         return result != null ? result : this.parent.resolveSource(monitor, tableName);
     }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/runtime/DBRProgressMonitor.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/runtime/DBRProgressMonitor.java
@@ -53,4 +53,12 @@ public interface DBRProgressMonitor {
         return false;
     }
 
+    default void assertNotCancelled() {
+        if (isCanceled()) {
+            throw new CancelledException();
+        }
+    }
+
+    class CancelledException extends RuntimeException {
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLBackgroundParsingJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLBackgroundParsingJob.java
@@ -670,6 +670,8 @@ public class SQLBackgroundParsingJob {
                         }
                         itemContext.refreshCompleted();
                     }
+                } catch (DBRProgressMonitor.CancelledException e) {
+                    // just ignore, don't spam logs
                 } catch (Throwable ex) {
                     log.debug("Error while analyzing query text: " + element.getOriginalText(), ex);
                 }


### PR DESCRIPTION
As described in #36542 and #34829 , I have an issue with CTE expressions (https://github.com/dbeaver/dbeaver/issues/36542#issuecomment-2614158628).

The cost of query analysis is exponential so that the backround job may never finish, consuming one core of CPU, draining battery, etc.

With the changes in this commit, I just made the background job interruptible.

Tested on the following query:
```
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
),a as (
select * from file('flights-1m.parquet')
) select * from a;
```

A better solution in my opinion needs to schedule an automatic cancellation of a background parsing job in, say, 10 seconds. I don't think anyone would wait longer, anyway. Or, if the focus of window is lost. I did not manage to find a similar code in the solution. Otherwise, I would have implemented this.