### PR TITLE
dbeaver/pro#4079 Remove duplicated proposals when combinin proposals from both completion engines

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/CompletionProposalBase.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/CompletionProposalBase.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.model.sql.completion;
 public abstract class CompletionProposalBase {
 
     protected abstract int getReplacementOffset();
+    
     protected abstract String getReplacementString();
 
     @Override
@@ -33,9 +34,10 @@ public abstract class CompletionProposalBase {
 
     @Override
     public int hashCode() {
-        int hashCode = 181846194;
-        hashCode = hashCode * -1521134295 + this.getReplacementString().hashCode();
-        hashCode = hashCode * -1521134295 + Integer.hashCode(this.getReplacementOffset());
+        int hashCode = 7;
+        hashCode = hashCode * 31 + this.getReplacementString().hashCode();
+        hashCode = hashCode * 31 + Integer.hashCode(this.getReplacementOffset());
+        jdk.internal.util.ArraysSupport.hashCode
         return hashCode;
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/CompletionProposalBase.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/CompletionProposalBase.java
@@ -1,0 +1,41 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.completion;
+
+public abstract class CompletionProposalBase {
+
+    protected abstract int getReplacementOffset();
+    protected abstract String getReplacementString();
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof CompletionProposalBase other) {
+            return this.getReplacementOffset() == other.getReplacementOffset()
+                && this.getReplacementString().equals(other.getReplacementString());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 181846194;
+        hashCode = hashCode * -1521134295 + this.getReplacementString().hashCode();
+        hashCode = hashCode * -1521134295 + Integer.hashCode(this.getReplacementOffset());
+        return hashCode;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/CompletionProposalBase.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/CompletionProposalBase.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.model.sql.completion;
 public abstract class CompletionProposalBase {
 
     protected abstract int getReplacementOffset();
+
     protected abstract String getReplacementString();
 
     @Override
@@ -33,9 +34,9 @@ public abstract class CompletionProposalBase {
 
     @Override
     public int hashCode() {
-        int hashCode = 181846194;
-        hashCode = hashCode * -1521134295 + this.getReplacementString().hashCode();
-        hashCode = hashCode * -1521134295 + Integer.hashCode(this.getReplacementOffset());
+        int hashCode = 7;
+        hashCode = hashCode * 31 + this.getReplacementString().hashCode();
+        hashCode = hashCode * 31 + Integer.hashCode(this.getReplacementOffset());
         return hashCode;
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionProposalBase.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionProposalBase.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import java.util.Map;
 /**
  * SQL Completion proposal
  */
-public class SQLCompletionProposalBase {
+public class SQLCompletionProposalBase extends CompletionProposalBase {
 
     public static final String PARAM_EXEC = "exec";
 
@@ -89,8 +89,8 @@ public class SQLCompletionProposalBase {
         DBPKeywordType proposalType,
         String description,
         DBPNamedObject object,
-        Map<String, Object> params)
-    {
+        Map<String, Object> params
+    ) {
         this.request = request;
         DBPDataSource dataSource = request.getContext().getDataSource();
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryCompletionProposal.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLQueryCompletionProposal.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.text.*;
 import org.eclipse.jface.text.contentassist.*;
 import org.eclipse.jface.viewers.StyledString;
-import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
@@ -28,6 +29,7 @@ import org.jkiss.dbeaver.model.DBPImage;
 import org.jkiss.dbeaver.model.DBPKeywordType;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.DefaultProgressMonitor;
+import org.jkiss.dbeaver.model.sql.completion.CompletionProposalBase;
 import org.jkiss.dbeaver.model.sql.completion.SQLCompletionHelper;
 import org.jkiss.dbeaver.model.sql.semantics.completion.SQLQueryCompletionItemKind;
 import org.jkiss.dbeaver.model.sql.semantics.completion.SQLQueryWordEntry;
@@ -37,8 +39,8 @@ import org.jkiss.dbeaver.ui.DBeaverIcons;
 import org.jkiss.dbeaver.ui.editors.sql.dialogs.SuggestionInformationControlCreator;
 import org.jkiss.utils.CommonUtils;
 
-public class SQLQueryCompletionProposal implements ICompletionProposal, ICompletionProposalExtension2, ICompletionProposalExtension3,
-        ICompletionProposalExtension4, ICompletionProposalExtension5, ICompletionProposalExtension6 {
+public class SQLQueryCompletionProposal extends CompletionProposalBase implements ICompletionProposal, ICompletionProposalExtension2,
+    ICompletionProposalExtension3, ICompletionProposalExtension4, ICompletionProposalExtension5, ICompletionProposalExtension6 {
 
     private static final Log log = Log.getLog(SQLQueryCompletionProposal.class);
     private static final boolean DEBUG = false;
@@ -94,6 +96,16 @@ public class SQLQueryCompletionProposal implements ICompletionProposal, IComplet
 
         this.filterString = filterString;
         this.proposalScore = proposalScore;
+    }
+
+    @Override
+    protected int getReplacementOffset() {
+        return this.replacementOffset;
+    }
+
+    @Override
+    protected String getReplacementString() {
+        return this.displayString; // because actual replacement string includes extra whitespaces
     }
 
     public int getProposalScore() {


### PR DESCRIPTION
No duplicated strings to replace should be proposed anymore.
Proposals from legacy completion engine come last.
![image](https://github.com/user-attachments/assets/e5901012-bb39-4886-9edd-c8e7aa243bf9)
