### PR TITLE
dbeaver/dbeaver#3957 sort db level objects

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericObjectContainer.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericObjectContainer.java
@@ -28,6 +28,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
 import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCObjectCache;
+import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTableIndex;
 import org.jkiss.dbeaver.model.meta.Association;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSDataType;
@@ -36,10 +37,7 @@ import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
 import org.jkiss.utils.CommonUtils;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
  * GenericEntityContainer
@@ -229,6 +227,8 @@ public abstract class GenericObjectContainer implements GenericStructContainer, 
                         }
                     }
                 }
+                newIndexCache.sort(Comparator.comparing((GenericTableIndex o) -> o.getTable().getName())
+                    .thenComparing(JDBCTableIndex::getName));
                 indexCache.setCache(newIndexCache);
             }
         }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSchema.java
@@ -1207,7 +1207,7 @@ public class OracleSchema extends OracleGlobalObject implements
             } else {
                 sql.append("i.TABLE_OWNER=? AND i.TABLE_NAME=?");
             }
-            sql.append("\nORDER BY i.INDEX_NAME,ic.COLUMN_POSITION");
+            sql.append("\nORDER BY i.TABLE_NAME,i.INDEX_NAME,ic.COLUMN_POSITION");
 
             JDBCPreparedStatement dbStat = session.prepareStatement(sql.toString());
             if (forTable == null) {

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
@@ -1115,7 +1115,7 @@ public class PostgreSchema implements
                 sql.append(" c.relnamespace=?");
             }
             //sql.append(" AND NOT i.indisprimary");
-            sql.append(" ORDER BY c.relname");
+            sql.append(" ORDER BY tabrelname, c.relname");
 
             JDBCPreparedStatement dbStat = session.prepareStatement(sql.toString());
             if (forTable != null) {

--- a/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/cache/JDBCCompositeCache.java
+++ b/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/cache/JDBCCompositeCache.java
@@ -65,7 +65,7 @@ public abstract class JDBCCompositeCache<
     private final Object parentColumnName;
     private final Object objectColumnName;
 
-    private final Map<PARENT, List<OBJECT>> objectCache = new IdentityHashMap<>();
+    private final Map<PARENT, List<OBJECT>> objectCache = new LinkedHashMap<>();
 
     protected JDBCCompositeCache(
         JDBCStructCache<OWNER,?,?> parentCache,

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNUtils.java
@@ -37,6 +37,7 @@ import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSEntity;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSWrapper;
+import org.jkiss.dbeaver.model.struct.rdb.DBSTableColumn;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.utils.ArrayUtils;
 import org.jkiss.utils.CommonUtils;
@@ -135,7 +136,7 @@ public class DBNUtils {
             {
                 if (isResources) {
                     Arrays.sort(children, NodeFolderComparator.INSTANCE);
-                } else if (prefStore.getBoolean(ModelPreferences.NAVIGATOR_SORT_ALPHABETICALLY) || isMergedEntity(firstChild)) {
+                } else if (isSortingRequired(prefStore, firstChild) || isMergedEntity(firstChild)) {
                     if (!(firstChild instanceof DBNContainer)) {
                         Arrays.sort(children, NodeNameComparator.INSTANCE);
                     }
@@ -145,6 +146,17 @@ public class DBNUtils {
             }
         }
 
+    }
+
+    private static boolean isSortingRequired(DBPPreferenceStore prefStore,  DBNNode child) {
+        if (prefStore.getBoolean(ModelPreferences.NAVIGATOR_SORT_ALPHABETICALLY)) {
+            return true;
+        } else if (child instanceof DBNDatabaseItem item) {
+            DBSObject object = item.getObject();
+            return !(object instanceof DBSTableColumn);
+        } else {
+            return false;
+        }
     }
 
     private static boolean isMergedEntity(DBNNode node) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNUtils.java
@@ -37,7 +37,6 @@ import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSEntity;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSWrapper;
-import org.jkiss.dbeaver.model.struct.rdb.DBSTableColumn;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.utils.ArrayUtils;
 import org.jkiss.utils.CommonUtils;
@@ -136,7 +135,7 @@ public class DBNUtils {
             {
                 if (isResources) {
                     Arrays.sort(children, NodeFolderComparator.INSTANCE);
-                } else if (isSortingRequired(prefStore, firstChild) || isMergedEntity(firstChild)) {
+                } else if (prefStore.getBoolean(ModelPreferences.NAVIGATOR_SORT_ALPHABETICALLY) || isMergedEntity(firstChild)) {
                     if (!(firstChild instanceof DBNContainer)) {
                         Arrays.sort(children, NodeNameComparator.INSTANCE);
                     }
@@ -146,17 +145,6 @@ public class DBNUtils {
             }
         }
 
-    }
-
-    private static boolean isSortingRequired(DBPPreferenceStore prefStore,  DBNNode child) {
-        if (prefStore.getBoolean(ModelPreferences.NAVIGATOR_SORT_ALPHABETICALLY)) {
-            return true;
-        } else if (child instanceof DBNDatabaseItem item) {
-            DBSObject object = item.getObject();
-            return !(object instanceof DBSTableColumn);
-        } else {
-            return false;
-        }
     }
 
     private static boolean isMergedEntity(DBNNode node) {


### PR DESCRIPTION
How we sort indexes, triggers and others db entities in ascending order. Previous behaviour was incorrect and didn't sort them. 
![image](https://github.com/user-attachments/assets/5aa4f6aa-487b-492f-9b7e-48e4e8966abf)
incorrect