### PR TITLE
Update Cloudberry site URL

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/plugin.xml
@@ -104,7 +104,7 @@
                         class="org.postgresql.Driver"
                         sampleURL="jdbc:postgresql://{host}[:{port}]/[{database}]"
                         defaultPort="5432"
-                        webURL="https://cloudberrydb.org/"
+                        webURL="https://cloudberry.apache.org/"
                         propertiesURL="https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters"
                         databaseDocumentationSuffixURL=""
                         description="%driver.cloudberry.description"


### PR DESCRIPTION
Update the old Cloudberry site URL to the latest Apache site.

If any changes are needed to this PR, welcome to have your feedback!