### PR TITLE
dbeaver/pro#4069 DBeaver control commands model and their support by Outline

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/stm/LSMInspections.java
+++ b/plugins/org.jkiss.dbeaver.model.lsm/src/org/jkiss/dbeaver/model/stm/LSMInspections.java
@@ -30,6 +30,7 @@ import org.jkiss.dbeaver.utils.ListNode;
 import org.jkiss.utils.Pair;
 
 import java.util.*;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -37,9 +38,18 @@ import java.util.stream.StreamSupport;
 public class LSMInspections {
 
     private static final Pattern anyWordPattern = Pattern.compile("^\\w+$");
+    private static final Pattern anyWordHeadPattern = Pattern.compile("^\\w+");
 
     public static boolean matchesAnyWord(String str) {
         return anyWordPattern.matcher(str).matches();
+    }
+
+    /**
+     * Returns the information about the location of the first found match of any word in the provided string
+     */
+    public static Interval matchAnyWordHead(String str) {
+        Matcher m = anyWordHeadPattern.matcher(str);
+        return m.find() ? new Interval(m.start(), m.end() - 1) : null;
     }
 
     private static final Set<Integer> KNOWN_IDENTIFIER_PART_TOKENS = Set.of(

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLCommandModelRecognizer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLCommandModelRecognizer.java
@@ -1,0 +1,110 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.semantics;
+
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.misc.Pair;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.sql.SQLScriptContext;
+import org.jkiss.dbeaver.model.sql.eval.ScriptVariablesResolver;
+import org.jkiss.dbeaver.model.sql.semantics.model.SQLCommandModel;
+import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryModel;
+import org.jkiss.dbeaver.model.stm.LSMInspections;
+import org.jkiss.dbeaver.model.stm.STMTreeNode;
+import org.jkiss.dbeaver.model.stm.STMTreeTermNode;
+import org.jkiss.dbeaver.utils.GeneralUtils;
+
+import java.util.*;
+
+public class SQLCommandModelRecognizer {
+
+    private static STMTreeTermNode makeNode(int start, int length) {
+        return new STMTreeTermNode(new CommonToken(new Pair<>(null, null), -1, 0, start, start + length - 1));
+    }
+
+    private static SQLQuerySymbolEntry makeSymbol(int start, int length, @NotNull String name, @NotNull SQLQuerySymbolClass symbolClass) {
+        SQLQuerySymbolEntry symbol = new SQLQuerySymbolEntry(makeNode(start, length), name, name, null);
+        symbol.getSymbol().setSymbolClass(symbolClass);
+        return symbol;
+    }
+
+
+    /**
+     * Makes new SQLQueryModel instance for the control command in the script
+     */
+    public static SQLQueryModel recognizeCommand(
+        @NotNull SQLQueryRecognitionContext recognitionContext,
+        @NotNull String text,
+        @NotNull SQLScriptContext scriptContext
+    ) {
+        Set<SQLQuerySymbolEntry> symbolEntries = new HashSet<>();
+        String cmdPrefix = recognitionContext.getSyntaxManager().getControlCommandPrefix();
+        String multilinePrefix = cmdPrefix.repeat(2);
+
+        int start;
+        int end;
+        if (text.startsWith(multilinePrefix)) {
+            start = multilinePrefix.length();
+            symbolEntries.add(makeSymbol(0, multilinePrefix.length(), multilinePrefix, SQLQuerySymbolClass.DBEAVER_COMMAND));
+
+            if (text.endsWith(multilinePrefix)) {
+                end = text.length() - multilinePrefix.length();
+                symbolEntries.add(makeSymbol(end, multilinePrefix.length(), multilinePrefix, SQLQuerySymbolClass.DBEAVER_COMMAND));
+            } else {
+                end = text.length();
+            }
+        } else if (text.startsWith(cmdPrefix)) {
+            start = cmdPrefix.length();
+            end = text.length();
+            symbolEntries.add(makeSymbol(0, cmdPrefix.length(), cmdPrefix, SQLQuerySymbolClass.DBEAVER_COMMAND));
+        } else {
+            start = 0;
+            end = text.length();
+        }
+        String cmdText = text.substring(start, end);
+
+        Interval nameInterval = LSMInspections.matchAnyWordHead(cmdText);
+        if (nameInterval != null) {
+            symbolEntries.add(makeSymbol(
+                start, nameInterval.length(),
+                cmdText.substring(nameInterval.a, nameInterval.b + 1),
+                SQLQuerySymbolClass.DBEAVER_COMMAND
+            ));
+        }
+
+        STMTreeNode fakeTree = makeNode(0, text.length());
+        SQLCommandModel cmdModel = new SQLCommandModel(fakeTree, text);
+
+        ScriptVariablesResolver variablesResolver = new ScriptVariablesResolver(scriptContext);
+        List<GeneralUtils.VariableEntryInfo> vars = GeneralUtils.findAllVariableEntries(cmdText);
+        for (GeneralUtils.VariableEntryInfo varEntry : vars) {
+            SQLQuerySymbolEntry symbolEntry = makeSymbol(
+                start + varEntry.start(), varEntry.end() - varEntry.start(),
+                cmdText.substring(varEntry.start(), varEntry.end()),
+                SQLQuerySymbolClass.DBEAVER_VARIABLE
+            );
+            symbolEntries.add(symbolEntry);
+            scriptContext.getVariable(varEntry.name().toUpperCase(Locale.ENGLISH));
+            cmdModel.addVariable(symbolEntry, variablesResolver.get(varEntry.name()));
+        }
+
+        return new SQLQueryModel(fakeTree, cmdModel, symbolEntries, Collections.emptyList());
+    }
+
+
+}

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLCommandModelRecognizer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLCommandModelRecognizer.java
@@ -26,6 +26,7 @@ import org.jkiss.dbeaver.model.sql.semantics.model.SQLCommandModel;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryModel;
 import org.jkiss.dbeaver.model.stm.LSMInspections;
 import org.jkiss.dbeaver.model.stm.STMTreeNode;
+import org.jkiss.dbeaver.model.stm.STMTreeRuleNode;
 import org.jkiss.dbeaver.model.stm.STMTreeTermNode;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 
@@ -87,10 +88,10 @@ public class SQLCommandModelRecognizer {
             ));
         }
 
-        STMTreeNode fakeTree = makeNode(0, text.length());
+        STMTreeNode fakeTree = new STMTreeRuleNode();
         SQLCommandModel cmdModel = new SQLCommandModel(fakeTree, text);
 
-        ScriptVariablesResolver variablesResolver = new ScriptVariablesResolver(scriptContext);
+        ScriptVariablesResolver variablesResolver = scriptContext.getExecutionContext() == null ? null : new ScriptVariablesResolver(scriptContext);
         List<GeneralUtils.VariableEntryInfo> vars = GeneralUtils.findAllVariableEntries(cmdText);
         for (GeneralUtils.VariableEntryInfo varEntry : vars) {
             SQLQuerySymbolEntry symbolEntry = makeSymbol(
@@ -100,7 +101,7 @@ public class SQLCommandModelRecognizer {
             );
             symbolEntries.add(symbolEntry);
             scriptContext.getVariable(varEntry.name().toUpperCase(Locale.ENGLISH));
-            cmdModel.addVariable(symbolEntry, variablesResolver.get(varEntry.name()));
+            cmdModel.addVariable(symbolEntry, variablesResolver == null ? "?" : variablesResolver.get(varEntry.name()));
         }
 
         return new SQLQueryModel(fakeTree, cmdModel, symbolEntries, Collections.emptyList());

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQuerySymbolClass.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/SQLQuerySymbolClass.java
@@ -35,6 +35,7 @@ public enum SQLQuerySymbolClass {
     SQL_BATCH_VARIABLE(SQLTokenType.T_SQL_VARIABLE),
     DBEAVER_VARIABLE(SQLTokenType.T_VARIABLE),
     DBEAVER_PARAMETER(SQLTokenType.T_PARAMETER),
+    DBEAVER_COMMAND(SQLTokenType.T_CONTROL),
     ERROR(SQLTokenType.T_SEMANTIC_ERROR);
     
     private final SQLTokenType tokenType;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/SQLCommandModel.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/SQLCommandModel.java
@@ -1,0 +1,105 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.semantics.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQueryRecognitionContext;
+import org.jkiss.dbeaver.model.sql.semantics.SQLQuerySymbolEntry;
+import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDataContext;
+import org.jkiss.dbeaver.model.stm.STMTreeNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SQLCommandModel extends SQLQueryModelContent {
+
+    public static class VariableNode extends SQLQueryNodeModel {
+        public final SQLQuerySymbolEntry name;
+        public final String value;
+
+        public VariableNode(SQLQuerySymbolEntry symbol, String value) {
+            super(symbol.getSyntaxNode().getRealInterval(), symbol.getSyntaxNode());
+            this.name = symbol;
+            this.value = value;
+        }
+
+        @Override
+        protected <R, T> R applyImpl(@NotNull SQLQueryNodeModelVisitor<T, R> visitor, T arg) {
+            return visitor.visitCommandVariable(this, arg);
+        }
+
+        @Nullable
+        @Override
+        public SQLQueryDataContext getGivenDataContext() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public SQLQueryDataContext getResultDataContext() {
+            return null;
+        }
+    }
+
+    @NotNull
+    private final String commandText;
+
+    @NotNull
+    private final List<VariableNode> variables = new ArrayList<>();
+
+    public SQLCommandModel(@NotNull STMTreeNode fakeTree, @NotNull String commandText) {
+        super(fakeTree.getRealInterval(), fakeTree);
+        this.commandText = commandText;
+    }
+
+    @NotNull
+    public String getCommandText() {
+        return this.commandText;
+    }
+
+    @NotNull
+    public VariableNode[] getVariables() {
+        return this.variables.toArray(VariableNode[]::new);
+    }
+
+    public void addVariable(SQLQuerySymbolEntry symbol, String value) {
+        this.variables.add(new VariableNode(symbol, value));
+    }
+
+    @Override
+    protected void applyContext(@NotNull SQLQueryDataContext dataContext, @NotNull SQLQueryRecognitionContext recognitionContext) {
+        // do nothing
+    }
+
+    @Override
+    protected <R, T> R applyImpl(@NotNull SQLQueryNodeModelVisitor<T, R> visitor, T arg) {
+        return visitor.visitCommand(this, arg);
+    }
+
+    @Nullable
+    @Override
+    public SQLQueryDataContext getGivenDataContext() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public SQLQueryDataContext getResultDataContext() {
+        return null;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/SQLQueryNodeModelVisitor.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/SQLQueryNodeModelVisitor.java
@@ -226,4 +226,16 @@ public interface SQLQueryNodeModelVisitor<T, R> {
      */
     @Nullable
     R visitCallStatement(@NotNull SQLQueryCallModel callStatement, T arg);
+
+    /**
+     * Visit DBeaver control command (like @echo, @set, @export and so on)
+     */
+    @Nullable
+    R visitCommand(@NotNull SQLCommandModel command, T arg);
+
+    /**
+     * Visit DBeaver variable used in the DBeaver control command
+     */
+    @Nullable
+    R visitCommandVariable(@NotNull SQLCommandModel.VariableNode variable, T arg);
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
@@ -513,6 +513,36 @@ public class GeneralUtils {
         return name;
     }
 
+    public record VariableEntryInfo(
+        @NotNull String name,
+        int start,
+        int end
+    ) {
+    }
+
+    /**
+     * Returns information about all variable entries in the provided text
+     */
+    @NotNull
+    public static List<VariableEntryInfo> findAllVariableEntries(@NotNull String string) {
+        if (CommonUtils.isEmpty(string)) {
+            return Collections.emptyList();
+        }
+        List<VariableEntryInfo> variables = new LinkedList<>();
+        try {
+            Matcher matcher = GeneralUtils.VAR_PATTERN.matcher(string);
+            int pos = 0;
+            while (matcher.find(pos)) {
+                pos = matcher.end();
+                String varName = matcher.group(2);
+                variables.add(new VariableEntryInfo(varName, matcher.start(), matcher.end()));
+            }
+        } catch (Exception e) {
+            log.warn("Error matching regex", e);
+        }
+        return variables;
+    }
+
     @NotNull
     public static String replaceVariables(@NotNull String string, IVariableResolver resolver) {
         return replaceVariables(string, resolver, false);

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLBackgroundParsingJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLBackgroundParsingJob.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,19 +40,18 @@ import org.jkiss.dbeaver.model.sql.semantics.OffsetKeyedTreeMap.NodesIterator;
 import org.jkiss.dbeaver.model.sql.semantics.completion.SQLQueryCompletionContext;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryMemberAccessEntry;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryModel;
-import org.jkiss.dbeaver.model.stm.*;
+import org.jkiss.dbeaver.model.stm.LSMInspections;
+import org.jkiss.dbeaver.model.stm.STMTreeNode;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.editors.EditorUtils;
+import org.jkiss.dbeaver.ui.editors.sql.SQLEditor;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorUtils;
 import org.jkiss.dbeaver.utils.ListNode;
 
 import java.util.ArrayDeque;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.*;
-import java.util.regex.Pattern;
 
 public class SQLBackgroundParsingJob {
 
@@ -639,7 +638,13 @@ public class SQLBackgroundParsingJob {
                 }
                 try {
                     recognitionContext.reset();
-                    SQLQueryModel queryModel = SQLQueryModelRecognizer.recognizeQuery(recognitionContext, element.getOriginalText());
+                    SQLQueryModel queryModel = element instanceof SQLControlCommand
+                        ? SQLCommandModelRecognizer.recognizeCommand(
+                            recognitionContext,
+                            element.getText(),
+                            this.editor instanceof SQLEditor e ? e.getGlobalScriptContext() : null
+                        )
+                        : SQLQueryModelRecognizer.recognizeQuery(recognitionContext, element.getOriginalText());
 
                     if (queryModel != null) {
                         if (DEBUG) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLEditorOutlinePage.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/semantics/SQLEditorOutlinePage.java
@@ -39,6 +39,7 @@ import org.jkiss.dbeaver.model.sql.SQLConstants;
 import org.jkiss.dbeaver.model.sql.semantics.*;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryDummyDataSourceContext.DummyTableRowsSource;
 import org.jkiss.dbeaver.model.sql.semantics.context.SQLQueryExprType;
+import org.jkiss.dbeaver.model.sql.semantics.model.SQLCommandModel;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryModel;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryNodeModel;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryNodeModelVisitor;
@@ -1092,6 +1093,20 @@ public class SQLEditorOutlinePage extends ContentOutlinePage implements IContent
             if (obj != null) {
                 obj.apply(this, node);
             }
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Object visitCommand(@NotNull SQLCommandModel command, OutlineQueryNode arg) {
+            this.makeNode(arg, command, command.getCommandText(), UIIcon.SQL_CONSOLE, command.getVariables());
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Object visitCommandVariable(@NotNull SQLCommandModel.VariableNode variable, OutlineQueryNode arg) {
+            this.makeNode(arg, variable, variable.name.getName() + " = " + variable.value, UIIcon.SQL_PARAMETER);
             return null;
         }
 


### PR DESCRIPTION
Now, we highlight with violet only the command name and @ or @@. Command parameters are highlighted with default highlighting depending on the type of the token.

Also, I added support by Outline. Variables used in commands can be seen there, along with their values at the moment of parsing.

![image](https://github.com/user-attachments/assets/3052db17-1e67-487a-bcd9-a912f199374b)
