### PR TITLE
dbeaver/pro#3961 Remove not installed drivers in TE from connection page

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/actions/datasource/NewConnectionDriverSelectorContributor.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/actions/datasource/NewConnectionDriverSelectorContributor.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.connection.DBPDriver;
 import org.jkiss.dbeaver.registry.driver.DriverUtils;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.ui.DBeaverIcons;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.dialogs.connection.NewConnectionDialog;
@@ -43,6 +44,13 @@ public class NewConnectionDriverSelectorContributor extends DataSourceMenuContri
         }
 
         List<DBPDriver> allDrivers = DriverUtils.getAllDrivers();
+        if (DBWorkbench.isDistributed()) {
+            for (int i = allDrivers.size() - 1; i > 0; i--) {
+                if (!allDrivers.get(i).isDriverInstalled()) {
+                    allDrivers.remove(i);
+                }
+            }
+        }
         List<DBPDriver> recentDrivers = DriverUtils.getRecentDrivers(allDrivers, 10);
         for (DBPDriver driver : recentDrivers) {
             menuItems.add(new ActionContributionItem(new NewConnectionAction(window, driver)));

--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/actions/datasource/NewConnectionDriverSelectorContributor.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/actions/datasource/NewConnectionDriverSelectorContributor.java
@@ -30,6 +30,7 @@ import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.dialogs.connection.NewConnectionDialog;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 public class NewConnectionDriverSelectorContributor extends DataSourceMenuContributor
 {
@@ -45,11 +46,7 @@ public class NewConnectionDriverSelectorContributor extends DataSourceMenuContri
 
         List<DBPDriver> allDrivers = DriverUtils.getAllDrivers();
         if (DBWorkbench.isDistributed()) {
-            for (int i = allDrivers.size() - 1; i > 0; i--) {
-                if (!allDrivers.get(i).isDriverInstalled()) {
-                    allDrivers.remove(i);
-                }
-            }
+            allDrivers.removeIf(Predicate.not(DBPDriver::isDriverInstalled));
         }
         List<DBPDriver> recentDrivers = DriverUtils.getRecentDrivers(allDrivers, 10);
         for (DBPDriver driver : recentDrivers) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/driver/DriverSelectViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/driver/DriverSelectViewer.java
@@ -173,6 +173,7 @@ public class DriverSelectViewer extends Viewer {
         });
 
         refreshJob = createRefreshJob();
+        refreshJob.schedule();
     }
 
     public static OrderBy getDefaultOrderBy() {
@@ -401,16 +402,17 @@ public class DriverSelectViewer extends Viewer {
 
                 selectorViewer.getControl().setRedraw(false);
                 try {
+                    List<ViewerFilter> filters = new ArrayList<>();
                     String text = getFilterString();
-                    if (CommonUtils.isEmpty(text)) {
-                        selectorViewer.setFilters();
-                        return Status.OK_STATUS;
+                    if (CommonUtils.isNotEmpty(text)) {
+                        DriverFilter driverFilter = new DriverFilter();
+                        driverFilter.setPattern(text);
+                        filters.add(driverFilter);
                     }
-
-                    DriverFilter driverFilter = new DriverFilter();
-                    driverFilter.setPattern(text);
-
-                    selectorViewer.setFilters(driverFilter);
+                    if (DBWorkbench.isDistributed()) {
+                        filters.add(new DriverInstalledFilter());
+                    }
+                    selectorViewer.setFilters(filters.toArray(new ViewerFilter[0]));
                     if (selectorViewer instanceof AbstractTreeViewer) {
                         ((AbstractTreeViewer) selectorViewer).expandAll();
                     }
@@ -492,6 +494,16 @@ public class DriverSelectViewer extends Viewer {
             return super.isLeafMatch(viewer, element);
         }
 
+    }
+
+    private static class DriverInstalledFilter extends ViewerFilter {
+        @Override
+        public boolean select(Viewer viewer, Object parentElement, Object element) {
+            if (element instanceof DBPDriver driver) {
+                return driver.isDriverInstalled();
+            }
+            return true;
+        }
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/driver/DriverTabbedViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/driver/DriverTabbedViewer.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,10 +105,14 @@ public class DriverTabbedViewer extends StructuredViewer {
         List<TabbedFolderInfo> extFolders = new ArrayList<>();
         for (DriverCategoryDescriptor category : DriverManagerRegistry.getInstance().getCategories()) {
             if (category.isPromoted()) {
-                extFolders.add(
-                    new TabbedFolderInfo(
-                        category.getId(), category.getName(), category.getIcon(), category.getDescription(), false,
-                        new DriverListFolder(category, getCategoryDrivers(category, allDrivers))));
+                List<DBPDriver> drivers = getCategoryDrivers(category, allDrivers);
+                if (!drivers.isEmpty()) {
+                    extFolders.add(
+                        new TabbedFolderInfo(
+                            category.getId(), category.getName(), category.getIcon(), category.getDescription(), false,
+                            new DriverListFolder(category, drivers)
+                        ));
+                }
             }
         }
         extFolders.sort((o1, o2) -> {

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/driver/DriverTabbedViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/driver/DriverTabbedViewer.java
@@ -107,11 +107,14 @@ public class DriverTabbedViewer extends StructuredViewer {
             if (category.isPromoted()) {
                 List<DBPDriver> drivers = getCategoryDrivers(category, allDrivers);
                 if (!drivers.isEmpty()) {
-                    extFolders.add(
-                        new TabbedFolderInfo(
-                            category.getId(), category.getName(), category.getIcon(), category.getDescription(), false,
-                            new DriverListFolder(category, drivers)
-                        ));
+                    extFolders.add(new TabbedFolderInfo(
+                        category.getId(),
+                        category.getName(),
+                        category.getIcon(),
+                        category.getDescription(),
+                        false,
+                        new DriverListFolder(category, drivers)
+                    ));
                 }
             }
         }


### PR DESCRIPTION
In this PR was removed drivers without jars from connection list in 2 places
![image](https://github.com/user-attachments/assets/7d1af2eb-4b8f-42c4-9888-f770c0c10a00)
![image](https://github.com/user-attachments/assets/a4de6a51-94d4-4b8d-b693-f913eb7887d7)
Folders without drivers was hided