### PR TITLE
dbeaver/dbeaver#37190 Removing .toLowerCase()

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridProcedure.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridProcedure.java
@@ -67,7 +67,7 @@ public class CubridProcedure extends GenericProcedure implements DBSObjectWithSc
     @Override
     @Property(viewable = true, order = 1)
     public String getName() {
-        return super.getName().toLowerCase();
+        return super.getName();
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridTable.java
@@ -79,7 +79,7 @@ public class CubridTable extends GenericTable
     @Override
     @Property(viewable = true, editable = true, updatable = true, order = 1)
     public String getName() {
-        return super.getName().toLowerCase();
+        return super.getName();
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridTableColumn.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridTableColumn.java
@@ -77,7 +77,7 @@ public class CubridTableColumn extends GenericTableColumn
     @Override
     @Property(viewable = true, editable = true, order = 10)
     public String getName() {
-        return super.getName().toLowerCase();
+        return super.getName();
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridTableIndex.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridTableIndex.java
@@ -40,7 +40,7 @@ public class CubridTableIndex extends GenericTableIndex {
     @Override
     @Property(viewable = true, editable = true, valueTransformer = DBObjectNameCaseTransformer.class, order = 1)
     public String getName() {
-        return super.getName().toLowerCase();
+        return super.getName();
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridView.java
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/src/org/jkiss/dbeaver/ext/cubrid/model/CubridView.java
@@ -51,7 +51,7 @@ public class CubridView extends GenericView
     @Property(viewable = true, editable = true, order =1)
     @Override
     public String getName() {
-        return super.getName().toLowerCase();
+        return super.getName();
     }
 
     public void setSchema(@NotNull CubridUser owner) {


### PR DESCRIPTION
I removed the **.toLowerCase()** to resolve the issue.

I compared it with other drivers, and they don't use any functions on getName(). I tested both table creation and editing with this fix, and I didn't encounter any problems.

If you need any more information, I will be happy to provide it.

**Issue: [#37190](https://github.com/dbeaver/dbeaver/issues/37190)**

### **Problem:**
The problem is likely on this line.

![Image](https://github.com/user-attachments/assets/6b8d2c5f-b67a-41af-a7f6-c4f0cd44c7b9)

Another file has a similar issue if the name is deleted:

![Image](https://github.com/user-attachments/assets/c16c1849-f33a-4e25-8de5-5ab359143c54)

There are more files where getName().toLowerCase() is used without checking if the variable is null, such as:

- CubridTableIndex
- CubridProcedure
- CubridTableColumn

### **Diagnosis:**
We have three ways to resolve this issue:

- Remove .toLowerCase()
- Add a null check before getting the name
- Ensure the name is never null by setting it to an empty string ("") when assigned

### **Solution:** 
I choose to remove the .toLowerCase() and resolved the problem.
