### PR TITLE
#36818 Check if the result set has visible spatial columns

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/internal/GISMessages.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/internal/GISMessages.java
@@ -91,6 +91,9 @@ public class GISMessages extends NLS {
 	public static String panel_show_labels_action_label;
 	public static String panel_hide_labels_action_label;
 
+	public static String presentation_no_spatial_columns_title;
+	public static String presentation_no_spatial_columns_message;
+
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, GISMessages.class);
 	}

--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/internal/GISResources.properties
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/internal/GISResources.properties
@@ -69,3 +69,6 @@ panel_select_tiles_action_manage_dialog_tile_layer_definition_dialog_layers_defi
 panel_configure_labels_action_label=Configure labels...
 panel_show_labels_action_label = Show labels
 panel_hide_labels_action_label = Hide labels
+
+presentation_no_spatial_columns_title = Spatial Presentation
+presentation_no_spatial_columns_message = Can't switch to spatial view because no spatial data is found.\nEnsure one or more columns containing spatial data are visible.

--- a/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/presentation/GeometryPresentation.java
+++ b/plugins/org.jkiss.dbeaver.data.gis.view/src/org/jkiss/dbeaver/ui/gis/presentation/GeometryPresentation.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.jkiss.dbeaver.model.gis.GisTransformUtils;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.ui.controls.resultset.*;
 import org.jkiss.dbeaver.ui.gis.GeometryDataUtils;
+import org.jkiss.dbeaver.ui.gis.internal.GISMessages;
 import org.jkiss.dbeaver.ui.gis.panel.GISLeafletViewer;
 
 import java.util.ArrayList;
@@ -64,6 +65,19 @@ public class GeometryPresentation extends AbstractPresentation {
             this
         );
         leafletViewer.getBrowserComposite().setLayoutData(new GridData(GridData.FILL_BOTH));
+    }
+
+    @Override
+    public boolean canShowPresentation(@NotNull IResultSetController controller) {
+        if (GeometryDataUtils.extractGeometryAttributes(controller).isEmpty()) {
+            DBWorkbench.getPlatformUI().showWarningMessageBox(
+                GISMessages.presentation_no_spatial_columns_title,
+                GISMessages.presentation_no_spatial_columns_message
+            );
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/IResultSetPresentation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/IResultSetPresentation.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,19 @@ public interface IResultSetPresentation {
         NEXT,
         LAST,
         CURRENT
+    }
+
+    /**
+     * A predicate that decides whether the presentation can be shown or not.
+     * <p>
+     * An implementation may opt not to be opened. This can be useful if
+     * an interactive confirmation is shown with an option to cancel the operation.
+     *
+     * @param controller associated result set controller
+     * @return {@code true} if the presentation can be shown, or {@code false} if not
+     */
+    default boolean canShowPresentation(@NotNull IResultSetController controller) {
+        return true;
     }
 
     void createPresentation(@NotNull IResultSetController controller, @NotNull Composite parent);

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetViewer.java
@@ -885,7 +885,7 @@ public class ResultSetViewer extends Viewer
                         @Override
                         public void widgetSelected(SelectionEvent e) {
                             if (e.widget != null && e.widget.getData() != null) {
-                                switchPresentation((ResultSetPresentationDescriptor) e.widget.getData());
+                                e.doit = switchPresentation((ResultSetPresentationDescriptor) e.widget.getData());
                             }
                         }
                     });
@@ -1093,12 +1093,16 @@ public class ResultSetViewer extends Viewer
         switchPresentation(availablePresentations.get(index));
     }
 
-    public void switchPresentation(ResultSetPresentationDescriptor selectedPresentation) {
+    public boolean switchPresentation(ResultSetPresentationDescriptor selectedPresentation) {
         if (selectedPresentation == activePresentationDescriptor) {
-            return;
+            return false;
         }
         try {
             IResultSetPresentation instance = selectedPresentation.createInstance();
+            if (!instance.canShowPresentation(this)) {
+                return false;
+            }
+
             activePresentationDescriptor = selectedPresentation;
             setActivePresentation(instance);
             instance.refreshData(true, false, false);
@@ -1119,11 +1123,13 @@ public class ResultSetViewer extends Viewer
                     ResultSetPreferences.RESULT_SET_PRESENTATION, activePresentationDescriptor.getId());
             }
             savePresentationSettings();
+            return true;
         } catch (Throwable e1) {
             DBWorkbench.getPlatformUI().showError(
                     "Presentation switch",
                 "Can't switch presentation",
                 e1);
+            return false;
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/VerticalButton.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/VerticalButton.java
@@ -130,6 +130,9 @@ public class VerticalButton extends Canvas {
 
     private void runAction(Event event) {
         notifyListeners(SWT.Selection, event);
+        if (!event.doit) {
+            return;
+        }
         if ((getStyle() & SWT.RADIO) == SWT.RADIO) {
             getFolder().setSelection(this);
         }
@@ -312,7 +315,11 @@ public class VerticalButton extends Canvas {
     }
 
     public void addSelectionListener(SelectionListener listener) {
-        addListener(SWT.Selection, event -> listener.widgetSelected(new SelectionEvent(event)));
+        addListener(SWT.Selection, event -> {
+            SelectionEvent selectionEvent = new SelectionEvent(event);
+            listener.widgetSelected(selectionEvent);
+            event.doit = selectionEvent.doit;
+        });
     }
 
     public IAction getAction() {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bf252154-406c-4f4b-b4b7-46d712a39159)

> [!NOTE]
> The better approach would be to hide the presentation completely. Unfortunately, I failed to accomplish that; the only solution I found is to trigger a complete refresh when an attribute changes its visibility which itself triggers a refresh of visible presentations for the current context. Unfortunately, it would be a regression.
