### PR TITLE
dbeaver/pro#4237 Remove procedures from proposals for table completions

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/completion/SQLQueryCompletionContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/completion/SQLQueryCompletionContext.java
@@ -1037,7 +1037,8 @@ public abstract class SQLQueryCompletionContext {
                     try {
                         Collection<DBSObjectContainer> containers = this.obtainDefaultContext(monitor, request);
                         this.collectTables(monitor, context, containers, null, filterOrNull, completions);
-                        this.collectProcedures(monitor, request, containers, null, filterOrNull, completions);
+                        // usually we don't want procedures in FROM
+                        //this.collectProcedures(monitor, request, containers, null, filterOrNull, completions);
                         this.collectPackages(monitor, request, context, this.exposedContexts,  null, filterOrNull, completions);
                     } catch (DBException e) {
                         log.error(e);


### PR DESCRIPTION
Procedures completions don't come to `from`, `join`, etc anymore