### PR TITLE
dbeaver/dbeaver#37354 Fix error with non-default timezone in preferences

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageDatabaseUserInterface.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageDatabaseUserInterface.java
@@ -270,7 +270,7 @@ public class PrefPageDatabaseUserInterface extends AbstractPrefPage implements I
             if (DBConstants.DEFAULT_TIMEZONE.equals(timezone)) {
                 clientTimezone.setText(DBConstants.DEFAULT_TIMEZONE);
             } else {
-                clientTimezone.setText(timezone);
+                clientTimezone.setText(TimezoneRegistry.getGMTString(timezone));
             }
         }
 


### PR DESCRIPTION
Show timezone again in GMT and it fixes the error
![image](https://github.com/user-attachments/assets/2375ed82-a909-4cd8-ad44-28787acdaab0)
