### PR TITLE
#36197 Support Oracle global variables for query validation

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/internal/OracleMessages.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/internal/OracleMessages.java
@@ -44,4 +44,14 @@ public class OracleMessages extends NLS {
     public static String oracle_server_session_manager_display_exec_plan_description;
     public static String pseudo_column_rowid_description;
     public static String pseudo_column_ora_rowscn_description;
+    public static String global_variable_sysdate;
+    public static String global_variable_systimestamp;
+    public static String global_variable_dbtimezone;
+    public static String global_variable_sessiontimezone;
+    public static String global_variable_current_timestamp;
+    public static String global_variable_current_date;
+    public static String global_variable_ora_invoking_user;
+    public static String global_variable_ora_invoking_userid;
+    public static String global_variable_uid;
+    public static String global_variable_user;
 }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/internal/OracleMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/internal/OracleMessages.properties
@@ -15,3 +15,15 @@ oracle_server_session_manager_display_exec_plan_description = Displays execute p
 
 pseudo_column_rowid_description = Unique row identifier
 pseudo_column_ora_rowscn_description = System Change Number
+
+global_variable_sysdate = The current date and time set for the operating system on which the database server resides
+global_variable_systimestamp = The system date, including fractional seconds and time zone, of the system on which the database resides
+global_variable_dbtimezone = The value of the database time zone
+global_variable_sessiontimezone = The time zone of the current session
+global_variable_current_timestamp = The current date and time in the session time zone
+global_variable_current_date = The current date in the session time zone
+global_variable_ora_invoking_user = The name of the database user who invoked the current statement or view
+global_variable_ora_invoking_userid = The identifier of the database user who invoked the current statement or view
+global_variable_uid = An integer that uniquely identifies the session user (the user who logged on)
+global_variable_user = The name of the session user (the user who logged on)
+

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
@@ -85,16 +85,6 @@ public class OracleSQLDialect extends JDBCSQLDialect
         "IS",
     };
 
-    private static final String[] OTHER_TYPES_FUNCTIONS = {
-        //functions without parentheses #8710
-        "CURRENT_DATE",
-        "CURRENT_TIMESTAMP",
-        "DBTIMEZONE",
-        "SESSIONTIMEZONE",
-        "SYSDATE",
-        "SYSTIMESTAMP"
-    };
-
     private static final String[] ADVANCED_KEYWORDS = {
         "REPLACE",
         "PACKAGE",
@@ -125,6 +115,19 @@ public class OracleSQLDialect extends JDBCSQLDialect
         "TEMPFILE",
         "DATAFILE",
         "TABLESPACE"
+    };
+
+    private static final GlobalVariableInfo[] GLOBAL_VARIABLES = {
+        new GlobalVariableInfo("SYSDATE", "", DBPDataKind.DATETIME),
+        new GlobalVariableInfo("SYSTIMESTAMP", "", DBPDataKind.DATETIME),
+        new GlobalVariableInfo("DBTIMEZONE", "", DBPDataKind.DATETIME),
+        new GlobalVariableInfo("SESSIONTIMEZONE", "", DBPDataKind.DATETIME),
+        new GlobalVariableInfo("CURRENT_DATE", "", DBPDataKind.DATETIME),
+        new GlobalVariableInfo("CURRENT_TIMESTAMP", "", DBPDataKind.DATETIME),
+        new GlobalVariableInfo("ORA_INVOKING_USER", "", DBPDataKind.STRING),
+        new GlobalVariableInfo("ORA_INVOKING_USERID", "", DBPDataKind.NUMERIC),
+        new GlobalVariableInfo("UID", "", DBPDataKind.NUMERIC),
+        new GlobalVariableInfo("USER", "", DBPDataKind.STRING),
     };
 
     private static final String AUTO_INCREMENT_KEYWORD = "GENERATED ALWAYS AS IDENTITY";
@@ -372,7 +375,7 @@ public class OracleSQLDialect extends JDBCSQLDialect
             addSQLKeyword(kw);
         }
 
-        addKeywords(Arrays.asList(OTHER_TYPES_FUNCTIONS), DBPKeywordType.OTHER);
+        addKeywords(Arrays.stream(GLOBAL_VARIABLES).map(GlobalVariableInfo::name).toList(), DBPKeywordType.OTHER);
         turnFunctionIntoKeyword("TRUNCATE");
 
         cachedDialectSkipTokenPredicates = this.makeDialectSkipTokenPredicates(dataSource);
@@ -404,6 +407,12 @@ public class OracleSQLDialect extends JDBCSQLDialect
     @Override
     public String[] getExecuteKeywords() {
         return EXEC_KEYWORDS;
+    }
+
+    @NotNull
+    @Override
+    public GlobalVariableInfo[] getGlobalVariables() {
+        return GLOBAL_VARIABLES;
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSQLDialect.java
@@ -21,6 +21,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.oracle.data.OracleBinaryFormatter;
+import org.jkiss.dbeaver.ext.oracle.internal.OracleMessages;
 import org.jkiss.dbeaver.model.*;
 import org.jkiss.dbeaver.model.data.DBDBinaryFormatter;
 import org.jkiss.dbeaver.model.exec.DBCLogicalOperator;
@@ -118,16 +119,16 @@ public class OracleSQLDialect extends JDBCSQLDialect
     };
 
     private static final GlobalVariableInfo[] GLOBAL_VARIABLES = {
-        new GlobalVariableInfo("SYSDATE", "", DBPDataKind.DATETIME),
-        new GlobalVariableInfo("SYSTIMESTAMP", "", DBPDataKind.DATETIME),
-        new GlobalVariableInfo("DBTIMEZONE", "", DBPDataKind.DATETIME),
-        new GlobalVariableInfo("SESSIONTIMEZONE", "", DBPDataKind.DATETIME),
-        new GlobalVariableInfo("CURRENT_DATE", "", DBPDataKind.DATETIME),
-        new GlobalVariableInfo("CURRENT_TIMESTAMP", "", DBPDataKind.DATETIME),
-        new GlobalVariableInfo("ORA_INVOKING_USER", "", DBPDataKind.STRING),
-        new GlobalVariableInfo("ORA_INVOKING_USERID", "", DBPDataKind.NUMERIC),
-        new GlobalVariableInfo("UID", "", DBPDataKind.NUMERIC),
-        new GlobalVariableInfo("USER", "", DBPDataKind.STRING),
+        new GlobalVariableInfo("SYSDATE", OracleMessages.global_variable_sysdate, DBPDataKind.DATETIME),
+        new GlobalVariableInfo("SYSTIMESTAMP", OracleMessages.global_variable_systimestamp, DBPDataKind.DATETIME),
+        new GlobalVariableInfo("DBTIMEZONE", OracleMessages.global_variable_dbtimezone, DBPDataKind.DATETIME),
+        new GlobalVariableInfo("SESSIONTIMEZONE", OracleMessages.global_variable_sessiontimezone, DBPDataKind.DATETIME),
+        new GlobalVariableInfo("CURRENT_DATE", OracleMessages.global_variable_current_date, DBPDataKind.DATETIME),
+        new GlobalVariableInfo("CURRENT_TIMESTAMP", OracleMessages.global_variable_current_timestamp, DBPDataKind.DATETIME),
+        new GlobalVariableInfo("ORA_INVOKING_USER", OracleMessages.global_variable_ora_invoking_user, DBPDataKind.STRING),
+        new GlobalVariableInfo("ORA_INVOKING_USERID", OracleMessages.global_variable_ora_invoking_userid, DBPDataKind.NUMERIC),
+        new GlobalVariableInfo("UID", OracleMessages.global_variable_uid, DBPDataKind.NUMERIC),
+        new GlobalVariableInfo("USER", OracleMessages.global_variable_user, DBPDataKind.STRING),
     };
 
     private static final String AUTO_INCREMENT_KEYWORD = "GENERATED ALWAYS AS IDENTITY";


### PR DESCRIPTION
Now, we don't say that there is no such column
![image](https://github.com/user-attachments/assets/d48f96bc-019e-45fb-bc95-ecb732f61967)

```
SELECT
	SYSDATE,
	SYSTIMESTAMP,
	DBTIMEZONE,
	SESSIONTIMEZONE,
	CURRENT_DATE,
	CURRENT_TIMESTAMP,
	ORA_INVOKING_USER,
	ORA_INVOKING_USERID,
	UID
FROM DUAL;
```