### PR TITLE
fix Oracle sequence DDL not including 'START WITH'

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSequence.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSequence.java
@@ -155,6 +155,9 @@ public class OracleSequence extends OracleSchemaObject implements DBSSequence, D
         }
         sb.append(getFullyQualifiedName(DBPEvaluationContext.DDL)).append(" ");
 
+        if (getLastValue() != null) {
+            sb.append("START WITH ").append(getLastValue()).append(" ");
+        }
         if (getIncrementBy() != null) {
             sb.append("INCREMENT BY ").append(getIncrementBy()).append(" ");
         }


### PR DESCRIPTION
An example from Toad for Oracle

```sql
DROP SEQUENCE USER.VERSION_NO;

CREATE SEQUENCE USER.VERSION_NO
  START WITH 480
  MAXVALUE 99999999999999999
  MINVALUE 0
  CYCLE
  NOCACHE
  NOORDER;
```