### PR TITLE
Fix error during building

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -4,6 +4,6 @@ cd ..
 [ ! -d ../dbeaver-jdbc-libsql ] && git clone https://github.com/dbeaver/dbeaver-jdbc-libsql.git ../dbeaver-jdbc-libsql
 
 cd product/aggregate
-mvn clean install -Pall-platforms -T 1C
+mvn clean install -Pall-platforms -T 1C -Djdk.xml.maxGeneralEntitySizeLimit=2097152 -Djdk.xml.totalEntitySizeLimit=2097152
 cd ../..
 


### PR DESCRIPTION
This is a possible fix for #37843 

This adds the 2 settings that remove the limit of download sizes.
This was tested using the docker container in the issue but with `FROM amazoncorretto:21.0.7-alpine3.21` and still works for java 21. Another dev can verify it still works on there test environment.