### PR TITLE
dbeaver/dbeaver#36687 Remove replacing localhost to IP when connect via SSH

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/net/DBWUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/net/DBWUtils.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,10 @@ public class DBWUtils {
         int localPort
     ) {
         // Replace database host/port and URL
-        if (CommonUtils.isEmpty(localHost)) {
-            connectionInfo.setHostName(LOOPBACK_HOST_NAME);
-        } else {
+        if (CommonUtils.isNotEmpty(localHost)) {
             connectionInfo.setHostName(localHost);
+        } else if (!LOCALHOST_NAME.equals(connectionInfo.getHostName()) && !LOCAL_NAME.equals(connectionInfo.getHostName())) {
+            connectionInfo.setHostName(LOOPBACK_HOST_NAME);
         }
         connectionInfo.setHostPort(Integer.toString(localPort));
         if (configuration.getDriver() != null) {


### PR DESCRIPTION
In this PR, I remove the replacement of localhost or local hosts to 127.0.0.1

I couldn't reproduce exactly the same situation where a user can log in via user@localhost but can't via user@127.0.0.1. But you can check if localhost is replaced or not when you try to connect to a server with a wrong password (can't reproduce on contained databases, including our sample databases).

![image](https://github.com/user-attachments/assets/bd13af68-61a7-47b0-897e-1c5305d59676)
