### PR TITLE
#38265 Fix varchar mapping in data transfer for Clickhouse

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseConstants.java
@@ -30,4 +30,5 @@ public class ClickhouseConstants {
 
     public static final String DATA_TYPE_IPV4 = "ipv4";
     public static final String DATA_TYPE_IPV6 = "ipv6";
+    public static final String DATA_TYPE_STRING = "String";
 }

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseDataSource.java
@@ -28,10 +28,7 @@ import org.jkiss.dbeaver.ext.clickhouse.model.jdbc.ClickhouseJdbcFactory;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaModel;
 import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaObject;
-import org.jkiss.dbeaver.model.DBConstants;
-import org.jkiss.dbeaver.model.DBPDataSourceContainer;
-import org.jkiss.dbeaver.model.DBPDataSourceInfo;
-import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.*;
 import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.jdbc.*;
@@ -196,6 +193,16 @@ public class ClickhouseDataSource extends GenericDataSource {
             }
         }
         return super.resolveDataType(monitor, typeFullName);
+    }
+
+    @Override
+    public String getDefaultDataTypeName(@NotNull DBPDataKind dataKind) {
+        switch (dataKind) {
+            case STRING:
+                return ClickhouseConstants.DATA_TYPE_STRING;
+            default:
+                return super.getDefaultDataTypeName(dataKind);
+        }
     }
 
     @Override


### PR DESCRIPTION
The provided example csv should successfully pass the import with table creation.
As stated in docs https://clickhouse.com/docs/sql-reference/data-types/string, Clickhouse ignores varchar and other string data type aliases anyway and uses String data type instead.