### PR TITLE
#34424 Change active object panel text for result set viewer for db entities

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterPanel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterPanel.java
@@ -451,8 +451,8 @@ class ResultSetFilterPanel extends Composite implements IContentProposalProvider
     private String getActiveSourceQuery() {
         String displayName;
         DBSDataContainer dataContainer = viewer.getDataContainer();
-        if (dataContainer != null) {
-            displayName = dataContainer.getName();
+        if (dataContainer instanceof DBSEntity) {
+            displayName = ResultSetMessages.sql_editor_resultset_filter_panel_show_sql_label;
         } else {
             displayName = viewer.getActiveQueryText();
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.java
@@ -148,6 +148,7 @@ public class ResultSetMessages extends NLS {
     public static String sql_editor_resultset_filter_panel_btn_open_console;
     public static String sql_editor_resultset_filter_panel_control_no_data;
     public static String sql_editor_resultset_filter_panel_control_execute_to_see_reslut;
+    public static String sql_editor_resultset_filter_panel_show_sql_label;
 
     public static String actions_name_color_by;
     public static String actions_name_color_reset_by;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
@@ -128,6 +128,7 @@ sql_editor_resultset_filter_panel_label = Click to open query in editor
 sql_editor_resultset_filter_panel_btn_open_console = Ctrl+click to open SQL console
 sql_editor_resultset_filter_panel_control_no_data = No Data
 sql_editor_resultset_filter_panel_control_execute_to_see_reslut = Execute query with {0} or script with {1} to see results
+sql_editor_resultset_filter_panel_show_sql_label = Show SQL
 ## SQL editor resultset filter panel ##
 
 actions_name_color_by=Set row color for "{0}"

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_ru.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_ru.properties
@@ -75,6 +75,7 @@ sql_editor_resultset_filter_panel_label = Кликните по панели ч�
 sql_editor_resultset_filter_panel_btn_open_console = Ctrl+клик чтобы открыть в SQL консоли
 sql_editor_resultset_filter_panel_control_no_data = Нет данных
 sql_editor_resultset_filter_panel_control_execute_to_see_reslut = Запустите выполнение запроса ({0}) или скрипта ({1}) чтобы увидеть результаты
+sql_editor_resultset_filter_panel_show_sql_label = Показать SQL
 ## SQL editor resultset filter panel ##
 
 dialog_row_colors_title = Настроить цвета для "{0}"


### PR DESCRIPTION
Shows query text for queries and "Show SQL" for tables/views/etc.
![image](https://github.com/user-attachments/assets/ad81760a-ff76-4416-84fd-0500d97dc9ce)
