### PR TITLE
#38189 Show MariaDB native clients only for MariaDB connections

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/plugin.xml
@@ -311,6 +311,7 @@
             <nativeClients>
                 <client id="mariadb_client" label="MariaDB Binaries">
                     <dist os="win32" targetPath="clients/mariadb/win" remotePath="repo:/drivers/mariadb/client/win" resourcePath="clients/mariadb/win">
+                        <driver id="mariaDB"/>
                         <file type="exec" name="mariadb.exe"/>
                         <file type="exec" name="mariadb-dump.exe"/>
                     </dist>

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/NativeClientDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/NativeClientDescriptor.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@
 package org.jkiss.dbeaver.registry;
 
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.app.DBPApplication;
+import org.jkiss.dbeaver.model.connection.DBPDriver;
 import org.jkiss.dbeaver.model.impl.AbstractDescriptor;
 import org.jkiss.dbeaver.model.runtime.OSDescriptor;
 import org.jkiss.dbeaver.registry.driver.DriverDescriptor;
@@ -73,11 +76,16 @@ public class NativeClientDescriptor extends AbstractDescriptor {
             && clientFile.startsWith(System.getenv("AppData")));
     }
 
-    public NativeClientDistributionDescriptor findDistribution() {
+    @Nullable
+    public NativeClientDistributionDescriptor findDistribution(@NotNull DBPDriver driver) {
         OSDescriptor localSystem = DBWorkbench.getPlatform().getLocalSystem();
         final Path driversHome = DriverDescriptor.getCustomDriversHome().toAbsolutePath();
 
         for (NativeClientDistributionDescriptor distr : distributions) {
+            // Include all clients for custom drivers
+            if (!driver.isCustom() && !distr.supports(driver)) {
+                continue;
+            }
             if (distr.getOs().matches(localSystem)
                 && !isClientsPathVirtualizedByWindows(driversHome.resolve(distr.getTargetPath()))) {
                 return distr;

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/NativeClientDistributionDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/NativeClientDistributionDescriptor.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ package org.jkiss.dbeaver.registry;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.model.connection.DBPDriver;
 import org.jkiss.dbeaver.model.connection.DBPNativeClientLocation;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.OSDescriptor;
@@ -32,8 +34,7 @@ import org.jkiss.dbeaver.utils.ContentUtils;
 
 import java.io.*;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 /**
  * NativeClientDistributionDescriptor
@@ -42,6 +43,7 @@ public class NativeClientDistributionDescriptor {
     private static final Log log = Log.getLog(NativeClientDistributionDescriptor.class);
 
     private final List<NativeClientFileDescriptor> files = new ArrayList<>();
+    private final Set<String> supportedDrivers = new HashSet<>();
     private OSDescriptor os;
     private String targetPath;
     private String remotePath;
@@ -61,10 +63,17 @@ public class NativeClientDistributionDescriptor {
                 this.files.add(new NativeClientFileDescriptor(fileElement));
             }
         }
+        for (IConfigurationElement element : config.getChildren(RegistryConstants.TAG_DRIVER)) {
+            supportedDrivers.add(element.getAttribute(RegistryConstants.ATTR_ID));
+        }
     }
 
     public OSDescriptor getOs() {
         return os;
+    }
+
+    public boolean supports(@NotNull DBPDriver driver) {
+        return supportedDrivers.isEmpty() || supportedDrivers.contains(driver.getId());
     }
 
     public String getTargetPath() {

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverDescriptor.java
@@ -927,8 +927,8 @@ public class DriverDescriptor extends AbstractDescriptor implements DBPDriver {
     public List<DBPNativeClientLocation> getNativeClientLocations() {
         List<DBPNativeClientLocation> ids = new ArrayList<>();
         for (NativeClientDescriptor nc : getProviderDescriptor().getNativeClients()) {
-            if (nc.findDistribution() != null) {
-                ids.add(new RemoteNativeClientLocation(nc));
+            if (nc.findDistribution(this) != null) {
+                ids.add(new RemoteNativeClientLocation(nc, this));
             }
         }
         ids.addAll(nativeClientHomes);

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/RemoteNativeClientLocation.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/RemoteNativeClientLocation.java
@@ -18,6 +18,7 @@ package org.jkiss.dbeaver.registry.driver;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.connection.DBPDriver;
 import org.jkiss.dbeaver.model.connection.DBPNativeClientLocation;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.registry.NativeClientDescriptor;
@@ -30,9 +31,11 @@ import java.io.File;
  */
 public class RemoteNativeClientLocation implements DBPNativeClientLocation {
     private final NativeClientDescriptor clientDescriptor;
+    private final DBPDriver driver;
 
-    public RemoteNativeClientLocation(NativeClientDescriptor clientDescriptor) {
+    public RemoteNativeClientLocation(@NotNull NativeClientDescriptor clientDescriptor, @NotNull DBPDriver driver) {
         this.clientDescriptor = clientDescriptor;
+        this.driver = driver;
     }
 
     @Override
@@ -43,7 +46,7 @@ public class RemoteNativeClientLocation implements DBPNativeClientLocation {
     @NotNull
     @Override
     public File getPath() {
-        NativeClientDistributionDescriptor distribution = clientDescriptor.findDistribution();
+        NativeClientDistributionDescriptor distribution = clientDescriptor.findDistribution(driver);
         if (distribution != null) {
             File driversHome = DriverDescriptor.getCustomDriversHome().toFile();
             return new File(driversHome, distribution.getTargetPath());
@@ -59,7 +62,7 @@ public class RemoteNativeClientLocation implements DBPNativeClientLocation {
 
     @Override
     public boolean validateFilesPresence(@NotNull DBRProgressMonitor progressMonitor) throws DBException, InterruptedException {
-        NativeClientDistributionDescriptor distribution = clientDescriptor.findDistribution();
+        NativeClientDistributionDescriptor distribution = clientDescriptor.findDistribution(driver);
         if (distribution != null) {
             return distribution.downloadFiles(progressMonitor, this);
         }


### PR DESCRIPTION
The MariaDB client must only appear on MariaDB connections. MySQL clients will still appear on MariaDB connections as well.