### PR TITLE
dbeaver/dbeaver#38471 Update plugin.xml to include BigQuery in the DBeaver UI "SQL" category

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.bigquery/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.bigquery/plugin.xml
@@ -31,7 +31,7 @@
                         webURL="https://cloud.google.com/bigquery/partners/simba-drivers/"
                         propertiesURL="https://cdn.simba.com/products/BigQuery/doc/JDBC_InstallGuide/"
                         databaseDocumentationSuffixURL="Database-driver-BigQuery"
-                        categories="bigdata,gcp"
+                        categories="bigdata,gcp,sql"
                         singleConnection="true">
                     <file type="jar" path="https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.5.4.1008.zip" bundle="!drivers.bigquery"/>
                     <file type="license" path="licenses/external/lgpl-3.0.txt"/>


### PR DESCRIPTION
BigQuery only shows up in the connector search when you choose the "All" category, this change will allow it to show up using the "SQL" category