### PR TITLE
fix arrow_top

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui/icons/misc/arrow_top.svg
+++ b/plugins/org.jkiss.dbeaver.ui/icons/misc/arrow_top.svg
@@ -1,11 +1,11 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_3794_782)">
-<path d="M8 9.06L3.33 4H2L8 10.5L14 4H12.67L8 9.06Z" fill="#3387C5"/>
-<path d="M14 12H2V13H14V12Z" fill="#3387C5"/>
+<path d="M8 6.94L12.67 12H14L8 5.5L2 12H3.33L8 6.94Z" fill="#3387C5"/>
+<path d="M2 4H14V3H2V4Z" fill="#3387C5"/>
 </g>
 <defs>
 <clipPath id="clip0_3794_782">
-<rect width="12" height="9" fill="white" transform="translate(2 4)"/>
+<rect width="12" height="9" fill="white" transform="translate(2 3)"/>
 </clipPath>
 </defs>
 </svg>


### PR DESCRIPTION
regression probably introduced by #38445 

regression screenshot:
<img width="432" height="499" alt="image" src="https://github.com/user-attachments/assets/da5eb7ea-62f0-4c63-afa5-ece243abb2dd" />
