### PR TITLE
Potential fix for code scanning alert no. 78: Resolving XML external entity in user-controlled data

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/tipoftheday/ShowTipOfTheDayHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/tipoftheday/ShowTipOfTheDayHandler.java
@@ -82,7 +82,9 @@ public class ShowTipOfTheDayHandler extends AbstractHandler {
             try (InputStream tipsInputStream = url.openConnection().getInputStream()) {
 
                 SAXParserFactory factory = SAXParserFactory.newInstance();
-                factory.setFeature( XMLConstants.FEATURE_SECURE_PROCESSING, true );
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 
                 SAXParser saxParser = factory.newSAXParser();
 


### PR DESCRIPTION
How to test: verify that Tip of the day dialog works

Potential fix for [https://github.com/dbeaver/dbeaver/security/code-scanning/78](https://github.com/dbeaver/dbeaver/security/code-scanning/78)

To fix the issue, we need to explicitly disable external entity resolution in the `SAXParserFactory` configuration. This can be achieved by setting the `http://xml.org/sax/features/external-general-entities` and `http://xml.org/sax/features/external-parameter-entities` features to `false`. These settings ensure that the parser does not process external entities, mitigating the risk of XXE attacks.

The changes will be made in the `loadTips` method, where the `SAXParserFactory` is configured. Specifically:
1. Add the `setFeature` calls to disable external entity resolution.
2. Ensure no other changes are made to preserve existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
