### PR TITLE
dbeaver/dbeaver#38923 Add a way to set custom OpenAI base URL

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIBaseProperties.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIBaseProperties.java
@@ -23,6 +23,9 @@ import org.jkiss.utils.CommonUtils;
 public interface OpenAIBaseProperties extends AIEngineProperties {
 
     @Nullable
+    String getBaseUrl();
+
+    @Nullable
     String getToken();
 
     @Nullable

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIClient.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIClient.java
@@ -61,9 +61,9 @@ public class OpenAIClient implements Closeable {
         return client.getHttpClient();
     }
 
-    public static OpenAIClient createClient(String token) {
+    public static OpenAIClient createClient(String baseUrl, String token) {
         return new OpenAIClient(
-            OPENAI_ENDPOINT,
+            baseUrl,
             List.of(new OpenAIRequestFilter(token))
         );
     }

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAICompletionEngine.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAICompletionEngine.java
@@ -179,7 +179,7 @@ public class OpenAICompletionEngine<PROPS extends OpenAIBaseProperties>
             throw new DBException("OpenAI API token is not set");
         }
 
-        return OpenAIClient.createClient(token);
+        return OpenAIClient.createClient(properties.getBaseUrl(), token);
     }
 
     @Nullable

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIProperties.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIProperties.java
@@ -27,6 +27,10 @@ import org.jkiss.dbeaver.runtime.DBWorkbench;
 
 public class OpenAIProperties implements OpenAIBaseProperties {
     @Nullable
+    @SerializedName("gpt.base_url")
+    private String baseUrl;
+
+    @Nullable
     @SecureProperty
     @SerializedName("gpt.token")
     private String token;
@@ -46,6 +50,11 @@ public class OpenAIProperties implements OpenAIBaseProperties {
     private Boolean loggingEnabled;
 
     @Nullable
+    @Override
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
     @Override
     public String getToken() {
         return token;
@@ -95,6 +104,10 @@ public class OpenAIProperties implements OpenAIBaseProperties {
         if (token != null) {
             DBSSecretController.getGlobalSecretController().setPrivateSecretValue(OpenAIConstants.GPT_API_TOKEN, token);
         }
+    }
+
+    public void setBaseUrl(@Nullable String baseUrl) {
+        this.baseUrl = baseUrl;
     }
 
     public void setToken(@Nullable String token) {

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/openai/OpenAiConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/openai/OpenAiConfigurator.java
@@ -34,6 +34,7 @@ import org.jkiss.dbeaver.model.ai.engine.AIEngine;
 import org.jkiss.dbeaver.model.ai.engine.AIModel;
 import org.jkiss.dbeaver.model.ai.engine.AIModelFeature;
 import org.jkiss.dbeaver.model.ai.engine.LegacyAISettings;
+import org.jkiss.dbeaver.model.ai.engine.openai.OpenAIClient;
 import org.jkiss.dbeaver.model.ai.engine.openai.OpenAICompletionEngine;
 import org.jkiss.dbeaver.model.ai.engine.openai.OpenAIModels;
 import org.jkiss.dbeaver.model.ai.engine.openai.OpenAIProperties;
@@ -50,9 +51,13 @@ import java.util.Locale;
 public class OpenAiConfigurator<ENGINE extends AIEngine, PROPERTIES extends OpenAIProperties>
     implements IObjectPropertyConfigurator<ENGINE, LegacyAISettings<PROPERTIES>> {
     private static final String API_KEY_URL = "https://platform.openai.com/account/api-keys";
+    protected String baseUrl;
     protected volatile String token = "";
     private String temperature = "0.0";
     private boolean logQuery = false;
+
+    @Nullable
+    private Text baseUrlText;
 
     @Nullable
     protected Text tokenText;
@@ -74,6 +79,7 @@ public class OpenAiConfigurator<ENGINE extends AIEngine, PROPERTIES extends Open
         createConnectionParameters(composite);
 
         createModelParameters(composite);
+        createBaseUrlParameter(composite);
 
         createAdditionalSettings(composite);
         UIUtils.syncExec(this::applySettings);
@@ -81,6 +87,10 @@ public class OpenAiConfigurator<ENGINE extends AIEngine, PROPERTIES extends Open
 
     @Override
     public void loadSettings(@NotNull LegacyAISettings<PROPERTIES> configuration) {
+        baseUrl = CommonUtils.toString(configuration.getProperties().getBaseUrl());
+        if (baseUrl.isEmpty()) {
+            baseUrl = OpenAIClient.OPENAI_ENDPOINT;
+        }
         token = CommonUtils.toString(configuration.getProperties().getToken());
         modelSelectorField.setSelectedModel(
             CommonUtils.toString(configuration.getProperties().getModel(), OpenAIModels.DEFAULT_MODEL)
@@ -96,6 +106,7 @@ public class OpenAiConfigurator<ENGINE extends AIEngine, PROPERTIES extends Open
 
     @Override
     public void saveSettings(@NotNull LegacyAISettings<PROPERTIES> configuration) {
+        configuration.getProperties().setBaseUrl(baseUrl);
         configuration.getProperties().setToken(token);
         configuration.getProperties().setModel(modelSelectorField.getSelectedModel());
         configuration.getProperties().setContextWindowSize(contextWindowSizeField.getValue());
@@ -160,6 +171,7 @@ public class OpenAiConfigurator<ENGINE extends AIEngine, PROPERTIES extends Open
 
         OpenAIProperties properties = new OpenAIProperties();
         properties.setToken(token);
+        properties.setBaseUrl(baseUrl);
 
         try (OpenAICompletionEngine<OpenAIProperties> engine = new OpenAICompletionEngine<>(properties)) {
             return engine.getModels(monitor);
@@ -179,6 +191,18 @@ public class OpenAiConfigurator<ENGINE extends AIEngine, PROPERTIES extends Open
         tokenText.addModifyListener((e -> token = tokenText.getText()));
         tokenText.setMessage("API access token");
         createURLInfoLink(parent);
+    }
+
+    protected void createBaseUrlParameter(@NotNull Composite parent) {
+        baseUrlText = UIUtils.createLabelText(
+            parent,
+            AIUIMessages.gpt_preference_page_selector_base_url,
+            ""
+        );
+        baseUrlText.addModifyListener((e -> baseUrl = baseUrlText.getText()));
+        GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+        gd.widthHint = 150;
+        baseUrlText.setLayoutData(gd);
     }
 
     protected void createURLInfoLink(@NotNull Composite parent) {
@@ -202,6 +226,9 @@ public class OpenAiConfigurator<ENGINE extends AIEngine, PROPERTIES extends Open
     }
 
     protected void applySettings() {
+        if (baseUrlText != null) {
+            baseUrlText.setText(baseUrl);
+        }
         if (tokenText != null) {
             tokenText.setText(token);
         }

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/internal/AIUIMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/internal/AIUIMessages.java
@@ -23,6 +23,7 @@ public class AIUIMessages extends NLS {
 
     public static String gpt_preference_page_checkbox_enable_ai_label;
     public static String gpt_preference_page_checkbox_enable_ai_tip;
+    public static String gpt_preference_page_selector_base_url;
     public static String gpt_preference_page_selector_token;
     public static String gpt_preference_page_token_info;
     public static String gpt_preference_page_completion_group;

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/internal/AIUIMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/internal/AIUIMessages.properties
@@ -1,6 +1,7 @@
 gpt_preference_page_checkbox_enable_ai_label = Enable AI integration
 gpt_preference_page_checkbox_enable_ai_tip = Enable AI integration. If you don't want to see it in SQL editor and other parts of user interface then you can disable this feature.
 gpt_preference_page_selector_token = API token
+gpt_preference_page_selector_base_url = API base URL
 gpt_preference_page_combo_engine = Model
 gpt_preference_page_text_temperature = Temperature
 gpt_preference_page_refresh_models = Refresh models


### PR DESCRIPTION
This is useful when using a custom AI provider that exposes OpenAI API. This allows to not be limited by what models, privacy guarantees and pricing OpenAI provides.

This PR does not include a way to select custom model. Hopefully https://github.com/dbeaver/dbeaver/pull/38565 lands, and if not, I will create a PR with a smaller model selector implementation which I'm currently using.