### PR TITLE
dbeaver/pro#6479 Fixed empty context menu

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/NavigatorUtils.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/NavigatorUtils.java
@@ -722,8 +722,6 @@ public class NavigatorUtils {
                     ) {
                         item.dispose();
                     }
-                } else {
-                    item.dispose();
                 }
             }
         }


### PR DESCRIPTION
Fixed empty context menu when no item is selected in metadata editor
<img width="622" height="490" alt="image" src="https://github.com/user-attachments/assets/c79ad4d9-c75a-4cec-b218-26772adc2be0" />
