### PR TITLE
dbeaver/pro#4344 Make it clear that the library version can be changed

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.java
@@ -168,6 +168,9 @@ public class UIConnectionMessages extends NLS {
     public static String dialog_driver_download_network_unavailable_msg;
     public static String dialog_driver_download_network_unavailable_cert_msg;
     public static String dialog_driver_download_network_unavailable_cert_msg_advanced;
+    public static String dialog_driver_download_version_change_label;
+    public static String dialog_driver_download_current_version_label;
+
     // Driver edit
 	public static String dialog_edit_driver_setting;
     public static String dialog_edit_driver_type_label;

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/internal/UIConnectionMessages.properties
@@ -212,6 +212,10 @@ dialog_driver_download_auto_page_download_failed_cert_msg_advanced = Driver file
 dialog_driver_download_network_unavailable_msg = Network unavailable
 dialog_driver_download_network_unavailable_cert_msg = Network unavailable due to a certificate issue.\nTry changing the setting `Use Windows trust store` in Preferences->Connections and restart DBeaver. It might help if you haven't overridden the trust store.
 dialog_driver_download_network_unavailable_cert_msg_advanced = Network unavailable due to a certificate issue.\nTry switching to `Windows Truststore` in General->Security->Certificates Trust Store or adding the required certificate manually and restarting DBeaver.\nIt might help if you haven't overridden the trust store.\nDo you want to retry?
+
+dialog_driver_download_version_change_label = {0} (click to change)
+dialog_driver_download_current_version_label = {0} (current)
+
 ## Driver download ##
 viewer_selector_control_text_classic=Classic
 viewer_selector_control_text_gallery=Gallery


### PR DESCRIPTION
|Dialog|Drop-down|
|-|-|
|<img width="966" height="675" alt="java_qNFeNWSrYy" src="https://github.com/user-attachments/assets/31589cc8-1e17-492c-8582-6c39357b0fac" />|<img width="966" height="675" alt="java_peWmWx6H7U" src="https://github.com/user-attachments/assets/0dc1b916-3d98-4429-9f5e-e0129fabef2d" />|

I decided not to add the context menu because having a single entry there would be silly.