### PR TITLE
dbeaver/pro#6576 Fix complex name parts handling after falling back t…

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/expressions/SQLQueryValueReferenceExpression.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/model/expressions/SQLQueryValueReferenceExpression.java
@@ -226,6 +226,7 @@ public class SQLQueryValueReferenceExpression extends SQLQueryValueExpression {
             if (forcedClass != null) {
                 this.name.parts.getFirst().getSymbol().setSymbolClass(forcedClass);
                 type = forcedClass == SQLQuerySymbolClass.STRING ? SQLQueryExprType.STRING : SQLQueryExprType.UNKNOWN;
+                restParts = this.name.parts.subList(1, restParts.size());
             } else if (dbObject != null) {
                 // TODO consider bringing DB objects like sequences to the autocompletion proposals
                 SQLQuerySymbolClass objClass;


### PR DESCRIPTION
Check that there is no exception in logs for 
```
SELECT
	*
FROM
	Employee e
WHERE
	e.EmployeeId > 0
	AND e.HireDate < '2025-01-01';
	
	
 select 'point(1 1)';
 
```