### PR TITLE
dbeaver/pro#6607 Added navigator filters tip, resized filter tables

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.java
@@ -50,6 +50,7 @@ public class UINavigatorMessages extends NLS {
     public static String dialog_filter_save_label;
     public static String dialog_filter_name_label;
     public static String dialog_filter_hint_text;
+    public static String dialog_filter_objects_scope_hint_text;
 
     public static String actions_navigator__objects;
     public static String actions_navigator_hide_objects;

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
@@ -44,6 +44,7 @@ dialog_filter_remove_button = Remove
 dialog_filter_save_label = Saved filter
 dialog_filter_name_label = Name
 dialog_filter_hint_text = You can use masks (%, _ and *) in filters
+dialog_filter_objects_scope_hint_text = Filtered objects won't be visible in any scope\n(e.g., Database Navigator, Table Editor, Auto-complete)
 
 actions_navigator_search_tip = Enter a part of object name here
 actions_navigator_search_filter_connection_name = Filter connections

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
@@ -44,7 +44,7 @@ dialog_filter_remove_button = Remove
 dialog_filter_save_label = Saved filter
 dialog_filter_name_label = Name
 dialog_filter_hint_text = You can use masks (%, _ and *) in filters
-dialog_filter_objects_scope_hint_text = Filtered objects won't be visible in any scope\n(e.g., Database Navigator, Table Editor, Auto-complete)
+dialog_filter_objects_scope_hint_text = Filtered objects will not be visible in any context, including\nNavigator, Metadata Editor, AI-chat and Autocomplete
 
 actions_navigator_search_tip = Enter a part of object name here
 actions_navigator_search_filter_connection_name = Filter connections

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/internal/UINavigatorMessages.properties
@@ -44,7 +44,7 @@ dialog_filter_remove_button = Remove
 dialog_filter_save_label = Saved filter
 dialog_filter_name_label = Name
 dialog_filter_hint_text = You can use masks (%, _ and *) in filters
-dialog_filter_objects_scope_hint_text = Filtered objects will not be visible in any context, including\nNavigator, Metadata Editor, AI-chat and Autocomplete
+dialog_filter_objects_scope_hint_text = Filtered objects will not be visible in any context, including\nNavigator, SQL Editor, Metadata Editor and AI-chat
 
 actions_navigator_search_tip = Enter a part of object name here
 actions_navigator_search_filter_connection_name = Filter connections

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/dialogs/EditObjectFilterDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/dialogs/EditObjectFilterDialog.java
@@ -98,12 +98,21 @@ public class EditObjectFilterDialog extends HelpEnabledDialog {
             globalLink.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_END));
         }
         blockControl = UIUtils.createPlaceholder(composite, 1);
-        blockControl.setLayoutData(new GridData(GridData.FILL_BOTH));
+        GridData blockControlGd = new GridData(GridData.FILL_BOTH);
+        blockControlGd.heightHint = 350;
+        blockControl.setLayoutData(blockControlGd);
 
-        includeTable = StringEditorTable.createEditableList(blockControl, UINavigatorMessages.dialog_filter_list_include, filter.getInclude(), null, null);
-        excludeTable = StringEditorTable.createEditableList(blockControl, UINavigatorMessages.dialog_filter_list_exclude, filter.getExclude(), null, null);
+        includeTable = StringEditorTable.createEditableList(
+            blockControl, UINavigatorMessages.dialog_filter_list_include,
+            filter.getInclude(), null, null
+        );
+        excludeTable = StringEditorTable.createEditableList(
+            blockControl, UINavigatorMessages.dialog_filter_list_exclude,
+            filter.getExclude(), null, null
+        );
 
         UIUtils.createInfoLabel(blockControl, UINavigatorMessages.dialog_filter_hint_text);
+        UIUtils.createInfoLabel(blockControl, UINavigatorMessages.dialog_filter_objects_scope_hint_text);
 
         {
             Group sfGroup = UIUtils.createControlGroup(composite, UINavigatorMessages.dialog_filter_save_label, 4, GridData.FILL_HORIZONTAL, 0);


### PR DESCRIPTION
* Added a tip in the filters dialog explaining that filtered objects won't be visible anywhere
* Reduced tables size to take less space
<img width="467" height="577" alt="image" src="https://github.com/user-attachments/assets/8c6c2e44-dbba-4ceb-bce7-589f379c338c" />
