### PR TITLE
Resolve the issues with GaussDB usage in #37811, #38176, #38892, and #38893.

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.gaussdb.ui/src/org/jkiss/dbeaver/ext/gaussdb/ui/GaussDBCreateDatabaseDialog.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb.ui/src/org/jkiss/dbeaver/ext/gaussdb/ui/GaussDBCreateDatabaseDialog.java
@@ -32,6 +32,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.gaussdb.model.DBCompatibilityEnum;
 import org.jkiss.dbeaver.ext.gaussdb.model.GaussDBDataSource;
 import org.jkiss.dbeaver.ext.postgresql.PostgreMessages;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreCharset;
@@ -87,15 +88,7 @@ public class GaussDBCreateDatabaseDialog extends BaseDialog {
         supportsEncodings(supportsEncodings, groupDefinition);
         supportsTablespaces(supportsTablespaces, groupDefinition);
 
-        dbCompatibleMode = UIUtils.createLabelCombo(groupDefinition, "DataBase Compatibility Mode",
-            SWT.BORDER | SWT.DROP_DOWN | SWT.READ_ONLY);
-        dbCompatibleMode.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                compatibleMode = dbCompatibleMode.getText();
-            }
-        });
-
+        supportsCompatibleMode(groupDefinition);
         scheduleLoadUsersJob(supportsRoles, supportsEncodings, supportsTablespaces);
 
         return composite;
@@ -164,6 +157,25 @@ public class GaussDBCreateDatabaseDialog extends BaseDialog {
                 tablespaceCombo.setText(defTablespace.getName());
             }
         }
+    }
+
+    private void supportsCompatibleMode(final Composite groupDefinition) {
+        dbCompatibleMode = UIUtils.createLabelCombo(groupDefinition, "DataBase Compatibility Mode",
+            SWT.BORDER | SWT.DROP_DOWN | SWT.READ_ONLY);
+        DBCompatibilityEnum[] compatibilityModes = DBCompatibilityEnum.values();
+        for (DBCompatibilityEnum mode : compatibilityModes) {
+            dbCompatibleMode.add(mode.getcValue());
+        }
+        if (compatibilityModes.length > 0) {
+            dbCompatibleMode.select(0);
+            compatibleMode = dbCompatibleMode.getText();
+        }
+        dbCompatibleMode.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                compatibleMode = dbCompatibleMode.getText();
+            }
+        });
     }
 
     private void supportsTablespaces(boolean supportsTablespaces, final Composite groupDefinition) {

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb.ui/src/org/jkiss/dbeaver/ext/gaussdb/ui/views/GaussDBConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb.ui/src/org/jkiss/dbeaver/ext/gaussdb/ui/views/GaussDBConnectionPage.java
@@ -50,6 +50,10 @@ import java.util.Locale;
 
 /**
  * GaussDBConnectionPage
+ *
+ * @author Acewuye 2025/03/14
+ *
+ *     Notes: Fix the issue of automatic input synchronization on the GaussDB connection management page.
  */
 public class GaussDBConnectionPage extends ConnectionPageWithAuth implements IDialogPageProvider {
 
@@ -217,12 +221,16 @@ public class GaussDBConnectionPage extends ConnectionPageWithAuth implements IDi
         setupConnectionModeSelection(urlText, useURL, GROUP_CONNECTION_ARR);
         updateUrl();
 
-        activated = false;
+        activated = true;
     }
 
     @Override
     public void saveSettings(DBPDataSourceContainer dataSource) {
         DBPConnectionConfiguration connectionInfo = dataSource.getConnectionConfiguration();
+        if (typeURLRadio != null) {
+            connectionInfo.setConfigurationType(
+                typeURLRadio.getSelection() ? DBPDriverConfigurationType.URL : DBPDriverConfigurationType.MANUAL);
+        }
 
         if (hostText != null) {
             connectionInfo.setHostName(hostText.getText().trim());
@@ -232,6 +240,9 @@ public class GaussDBConnectionPage extends ConnectionPageWithAuth implements IDi
         }
         if (dbText != null) {
             connectionInfo.setDatabaseName(dbText.getText().trim());
+        }
+        if (typeURLRadio != null && typeURLRadio.getSelection()) {
+            connectionInfo.setUrl(urlText.getText());
         }
 
         super.saveSettings(dataSource);
@@ -246,6 +257,10 @@ public class GaussDBConnectionPage extends ConnectionPageWithAuth implements IDi
     private void updateUrl() {
         DBPDataSourceContainer dataSourceContainer = site.getActiveDataSource();
         saveSettings(dataSourceContainer);
-        urlText.setText(dataSourceContainer.getDriver().getConnectionURL(site.getActiveDataSource().getConnectionConfiguration()));
+        if (typeURLRadio != null && typeURLRadio.getSelection()) {
+            urlText.setText(dataSourceContainer.getConnectionConfiguration().getUrl());
+        } else {
+            urlText.setText(dataSourceContainer.getDriver().getConnectionURL(site.getActiveDataSource().getConnectionConfiguration()));
+        }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/plugin.xml
@@ -28,12 +28,12 @@
                         label="GaussDB"
                         icon="icons/gaussdb_icon.png"
                         iconBig="icons/gaussdb_icon_big.png"
-                        class="org.postgresql.Driver"
-                        sampleURL="jdbc:postgresql://{host}[:{port}]/[{database}]"
+                        class="com.huawei.gaussdb.jdbc.Driver"
+                        sampleURL="jdbc:gaussdb://{host}[:{port}]/[{database}]"
                         defaultPort="8000"
                         description="%driver.gaussdb.description"
                         categories="sql">
-                    <file type="jar" path="https://repo.huaweicloud.com/repository/maven/huaweicloudsdk/gsjdbc4/gsjdbc4/1.1/gsjdbc4-1.1.jar" bundle="!drivers.gaussdb"/>
+                    <file type="jar" path="maven:/com.huaweicloud.gaussdb:gaussdbjdbc:RELEASE[506.0.0.b058]" bundle="!drivers.gaussdb"/>
                     <file type="jar" path="drivers/gaussdb" bundle="drivers.gaussdb"/>
                     <parameter name="serverType" value="gaussdb"/>
                     <property name="loginTimeout" value="20"/>

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBConstants.java
@@ -18,4 +18,5 @@ package org.jkiss.dbeaver.ext.gaussdb;
 
 public class GaussDBConstants {
     public static final String GAUSSDB_PG_OBJECT_CLASS = "com.huawei.gaussdb.jdbc.util.PGobject";
+    public static final String GAUSSDB_M_COMPATIBLE_MODE = "M";
 }

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBConstants.java
@@ -1,0 +1,21 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.gaussdb;
+
+public class GaussDBConstants {
+    public static final String GAUSSDB_PG_OBJECT_CLASS = "com.huawei.gaussdb.jdbc.util.PGobject";
+}

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBDataSourceProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBDataSourceProvider.java
@@ -87,7 +87,7 @@ public class GaussDBDataSourceProvider extends JDBCDataSourceProvider {
         }
 
         StringBuilder url = new StringBuilder();
-        url.append("jdbc:postgresql://");
+        url.append("jdbc:gaussdb://");
 
         url.append(connectionInfo.getHostName());
         if (!CommonUtils.isEmpty(connectionInfo.getHostPort())) {

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/DBCompatibilityEnum.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/DBCompatibilityEnum.java
@@ -19,7 +19,7 @@ package org.jkiss.dbeaver.ext.gaussdb.model;
 
 public enum DBCompatibilityEnum {
 
-    ORACLE("Oracle", "A", "ORA"), MYSQL("MySQL", "B", "MYSQL"), TEDATA("Teradata", "C", "TD"), POSTGRES("PostgreSQL", "PG", "PG");
+    ORACLE("Oracle", "A", "ORA"), MYSQL("MySQL", "M", "MYSQL"), TEDATA("Teradata", "C", "TD"), POSTGRES("PostgreSQL", "PG", "PG");
 
     private final String text;
     private final String cValue;

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDataSource.java
@@ -31,9 +31,10 @@ import java.sql.ResultSet;
 public class GaussDBDataSource extends PostgreDataSource {
 
     private PostgreServerExtension serverExtension;
-    
+
     public GaussDBDataSource(DBRProgressMonitor monitor, DBPDataSourceContainer container) throws DBException {
         super(monitor, container, new GaussDBDialect());
+        ((GaussDBDialect) getSQLDialect()).setDataSource(this);
     }
 
     @Override
@@ -56,7 +57,7 @@ public class GaussDBDataSource extends PostgreDataSource {
     @NotNull
     @Override
     public GaussDBDatabase createDatabaseImpl(DBRProgressMonitor monitor, String name, PostgreRole owner, String templateName,
-        PostgreTablespace tablespace, PostgreCharset encoding) throws DBException {
+                                              PostgreTablespace tablespace, PostgreCharset encoding) throws DBException {
         return new GaussDBDatabase(monitor, this, name, owner, templateName, tablespace, encoding);
     }
 
@@ -72,7 +73,7 @@ public class GaussDBDataSource extends PostgreDataSource {
         // Reserved: Modify the logic for determining the PG version.
         return super.isServerVersionAtLeast(major, minor);
     }
-    
+
     @Override
     public PostgreServerExtension getServerType() {
         if (serverExtension == null) {

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDataTypeCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDataTypeCache.java
@@ -1,0 +1,149 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.gaussdb.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.gaussdb.GaussDBConstants;
+import org.jkiss.dbeaver.ext.postgresql.model.*;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataTypeCache;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.model.exec.DBCExecutionPurpose;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+
+import java.sql.SQLException;
+import java.util.function.Consumer;
+
+public class GaussDBDataTypeCache extends PostgreDataTypeCache {
+
+    @NotNull
+    @Override
+    protected JDBCStatement prepareObjectsStatement(@NotNull JDBCSession session, @NotNull PostgreSchema owner) throws SQLException {
+        // Initially cache only base types (everything but composite and some arrays)
+        PostgreDataSource dataSource = owner.getDataSource();
+
+        String baseTypeNameClause = GaussDBDataTypeCache.getBaseTypeNameClause(
+            dataSource,
+            ((GaussDBDatabase) owner.getDatabase()).getDatabaseCompatibleMode());
+        //or getCurrentDatabase
+        boolean readAllTypes = dataSource.supportReadingAllDataTypes();
+        boolean supportsSysTypColumn = owner.getDatabase().supportsSysTypCategoryColumn(session);
+        StringBuilder sql = new StringBuilder(256);
+        sql.append("SELECT t.oid,t.*,c.relkind,").append(baseTypeNameClause).append(", d.description" +
+            "\nFROM pg_catalog.pg_type t");
+        if (!readAllTypes && supportsSysTypColumn) {
+            sql.append("\nLEFT OUTER JOIN pg_catalog.pg_type et ON et.oid=t.typelem ");
+        }
+        sql.append("\nLEFT OUTER JOIN pg_catalog.pg_class c ON c.oid=t.typrelid" +
+            "\nLEFT OUTER JOIN pg_catalog.pg_description d ON t.oid=d.objoid" +
+            "\nWHERE t.typname IS NOT NULL");
+        if (!readAllTypes) {
+            sql.append("\nAND (c.relkind IS NULL OR c.relkind = 'c')");
+            if (supportsSysTypColumn) {
+                sql.append(" AND (et.typcategory IS NULL OR et.typcategory <> 'C')");
+            }
+        }
+        sql.append("\nAND t.typnamespace=? ");
+        final JDBCPreparedStatement dbStat = session.prepareStatement(sql.toString());
+        dbStat.setLong(1, owner.getObjectId());
+        return dbStat;
+    }
+
+    @NotNull
+    static String getBaseTypeNameClause(@NotNull PostgreDataSource dataSource, @NotNull String databaseCompatibleMode) {
+        if (GaussDBConstants.GAUSSDB_M_COMPATIBLE_MODE.equals(databaseCompatibleMode)) {
+            return "t.typname as base_type_name";
+        }
+        if (dataSource.isServerVersionAtLeast(7, 3)) {
+            return "format_type(nullif(t.typbasetype, 0), t.typtypmod) as base_type_name";
+        } else {
+            return "NULL as base_type_name";
+        }
+    }
+
+    @NotNull
+    public static PostgreDataType resolveDataType(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull PostgreDatabase database,
+        @NotNull Object typeIdentifier
+    ) throws SQLException, DBException {
+        String whereClause;
+        Consumer<JDBCPreparedStatement> binder;
+        String identifier;
+        if (typeIdentifier instanceof Long oid) {
+            whereClause = "t.oid = ?";
+            binder = ps -> {
+                try {
+                    ps.setLong(1, oid);
+                } catch (SQLException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+            identifier = String.valueOf(oid);
+        } else if (typeIdentifier instanceof String name) {
+            whereClause = "t.typname = ?";
+            binder = ps -> {
+                try {
+                    ps.setString(1, name);
+                } catch (SQLException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+            identifier = name;
+        } else {
+            throw new IllegalArgumentException("Unsupported type identifier: " + typeIdentifier);
+        }
+        try (JDBCSession session = database.getDefaultContext(monitor, true)
+            .openSession(monitor, DBCExecutionPurpose.META, "Resolve data type")) {
+
+            String sql = "SELECT t.oid,t.*,c.relkind," +
+                GaussDBDataTypeCache.getBaseTypeNameClause(
+                    database.getDataSource(),
+                    ((GaussDBDatabase) database).getDatabaseCompatibleMode()
+                ) +
+                " FROM pg_catalog.pg_type t" +
+                "\nLEFT OUTER JOIN pg_class c ON c.oid=t.typrelid" +
+                "\nLEFT OUTER JOIN pg_catalog.pg_description d ON t.oid=d.objoid" +
+                "\nWHERE " + whereClause;
+            try (JDBCPreparedStatement dbStat = session.prepareStatement(sql)) {
+                binder.accept(dbStat);
+                try (JDBCResultSet dbResult = dbStat.executeQuery()) {
+                    if (!dbResult.next()) {
+                        throw new DBException("Data type " + identifier + " not found in database " + database.getName());
+                    }
+                    long schemaOid = JDBCUtils.safeGetLong(dbResult, "typnamespace");
+                    PostgreSchema schema = database.getSchema(monitor, schemaOid);
+                    if (schema == null) {
+                        throw new DBException("Schema " + schemaOid + " not found for data type " + identifier);
+                    }
+                    PostgreDataType dataType = PostgreDataType.readDataType(session, database, dbResult, false);
+                    if (dataType == null) {
+                        throw new DBException("Failed to read data type " + identifier + " in database " + database.getName());
+                    }
+                    return dataType;
+                }
+            }
+        }
+    }
+
+}

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDatabase.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDatabase.java
@@ -19,14 +19,15 @@ package org.jkiss.dbeaver.ext.gaussdb.model;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreCharset;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreRole;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreTablespace;
+import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
+import org.jkiss.dbeaver.ext.postgresql.model.*;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.DBCExecutionPurpose;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
@@ -41,6 +42,7 @@ import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 public class GaussDBDatabase extends PostgreDatabase {
 
     private DBRProgressMonitor monitor;
+    private static final Log log = Log.getLog(GaussDBDatabase.class);
 
     /**
      * Character Type
@@ -99,7 +101,7 @@ public class GaussDBDatabase extends PostgreDatabase {
 
     /**
      * is package supported
-     * 
+     *
      * @return is package supported
      */
     public boolean isPackageSupported() {
@@ -141,7 +143,8 @@ public class GaussDBDatabase extends PostgreDatabase {
         public JDBCStatement prepareLookupStatement(@NotNull JDBCSession session, @NotNull PostgreDatabase database,
             @Nullable PostgreSchema object, @Nullable String objectName) throws SQLException {
             StringBuilder catalogQuery = new StringBuilder("SELECT n.oid,n.*,d.description FROM pg_catalog.pg_namespace n\n"
-                + "LEFT OUTER JOIN pg_catalog.pg_description d ON d.objoid=n.oid AND d.objsubid=0 AND d.classoid='pg_namespace'::regclass\n");
+                + "LEFT OUTER JOIN pg_catalog.pg_description d ON d.objoid=n.oid AND d.objsubid=0 " +
+                "AND d.classoid='pg_namespace'::regclass\n");
             catalogQuery.append(" ORDER BY nspname");
             JDBCPreparedStatement dbStat = session.prepareStatement(catalogQuery.toString());
             return dbStat;
@@ -171,7 +174,7 @@ public class GaussDBDatabase extends PostgreDatabase {
     
     /**
      * set package supported
-     * 
+     *
      * @param isPackageSupported
      *            is package supported
      */
@@ -182,4 +185,104 @@ public class GaussDBDatabase extends PostgreDatabase {
     public void checkPackageSupport(DBRProgressMonitor monitor) {
         setPackageSupported("Oracle".equalsIgnoreCase(DBCompatibilityEnum.queryTextByValue(this.databaseCompatibleMode)));
     }
+
+    @Override
+    @NotNull
+    protected String getBaseTypeNameClause() {
+        return GaussDBDataTypeCache.getBaseTypeNameClause((PostgreDataSource) dataSource, databaseCompatibleMode);
+    }
+
+    @Override
+    @Nullable
+    public PostgreDataType getDataType(@Nullable DBRProgressMonitor monitor, @Nullable long typeId) {
+        if (typeId <= 0) {
+            return null;
+        }
+        PostgreDataType dataType;
+        synchronized (dataTypeCache) {
+            dataType = dataTypeCache.get(typeId);
+            if (dataType != null) {
+                return dataType;
+            }
+        }
+        for (PostgreSchema schema : schemaCache.getCachedObjects()) {
+            dataType = schema.getDataTypeCache().getDataType(typeId);
+            if (dataType != null) {
+                synchronized (dataTypeCache) {
+                    dataTypeCache.put(typeId, dataType);
+                }
+                return dataType;
+            }
+        }
+        // Type not found. Let's resolve it
+        return resolveAndCacheType(monitor, typeId);
+    }
+
+    @Override
+    @Nullable
+    public PostgreDataType getDataType(@Nullable DBRProgressMonitor monitor, @Nullable String typeName) {
+        if (typeName.endsWith("[]")) {
+            // In some cases ResultSetMetadata returns it as []
+            typeName = "_" + typeName.substring(0, typeName.length() - 2);
+        }
+        {
+            // First check system catalog
+            final PostgreSchema schema = getCatalogSchema();
+            if (schema != null) {
+                final PostgreDataType dataType = schema.getDataTypeCache().getCachedObject(typeName);
+                if (dataType != null) {
+                    return dataType;
+                }
+            }
+        }
+
+        // Check schemas in search path
+        PostgreExecutionContext metaContext = getMetaContext();
+        List<String> searchPath =
+                metaContext == null ? Collections.singletonList(PostgreConstants.CATALOG_SCHEMA_NAME) : metaContext.getSearchPath();
+        for (String schemaName : searchPath) {
+            final PostgreSchema schema = schemaCache.getCachedObject(schemaName);
+            if (schema != null) {
+                final PostgreDataType dataType = schema.getDataTypeCache().getCachedObject(typeName);
+                if (dataType != null) {
+                    return dataType;
+                }
+            }
+        }
+        // Check the rest
+        for (PostgreSchema schema : schemaCache.getCachedObjects()) {
+            if (searchPath.contains(schema.getName())) {
+                continue;
+            }
+            final PostgreDataType dataType = schema.getDataTypeCache().getCachedObject(typeName);
+            if (dataType != null) {
+                return dataType;
+            }
+        }
+        if (monitor.isForceCacheUsage()) {
+            return null;
+        }
+        // Type not found. Let's resolve it
+        return resolveAndCacheType(monitor, typeName);
+    }
+
+    @Nullable
+    private <T> PostgreDataType resolveAndCacheType(
+            @Nullable DBRProgressMonitor monitor,
+            @NotNull T typeIdentifier
+    ) {
+        try {
+            PostgreDataType dataType;
+            dataType = GaussDBDataTypeCache.resolveDataType(monitor, this, typeIdentifier);
+            dataType.getParentObject().getDataTypeCache().cacheObject(dataType);
+            synchronized (dataTypeCache) {
+                dataTypeCache.put(dataType.getObjectId(), dataType);
+            }
+            return dataType;
+        } catch (Exception e) {
+            log.debug("Can't resolve data type '" + typeIdentifier.getClass() + "' in database '" + getName() + "'");
+            return null;
+        }
+    }
+
 }

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDependency.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDependency.java
@@ -1,0 +1,151 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.gaussdb.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.ext.gaussdb.GaussDBConstants;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDependency;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreObject;
+import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.utils.CommonUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GaussDBDependency extends PostgreDependency {
+    public GaussDBDependency(PostgreDatabase database, long objectId, String depType, String name,
+                             String description, String objectType, String tableName, String schemaName) {
+        super(database, objectId, depType, name, description, objectType, tableName, schemaName);
+    }
+
+    /**
+     * Reads list of dependent objects.
+     * SQL query originally copy-pasted from pgAdmin sources with some modifications.
+     */
+    @NotNull
+    public static List<PostgreDependency> readDependencies(
+        @Nullable DBRProgressMonitor monitor,
+        @NotNull PostgreObject object,
+        @NotNull boolean dependents
+    ) throws DBCException {
+        boolean isMMode = ((GaussDBDatabase) object.getDatabase())
+            .getDatabaseCompatibleMode().equals(GaussDBConstants.GAUSSDB_M_COMPATIBLE_MODE);
+
+        List<PostgreDependency> dependencies = new ArrayList<>();
+        try (JDBCSession session = DBUtils.openMetaSession(monitor, object, "Load object dependencies")) {
+            String queryObjId = dependents ? "objid" : "refobjid";
+            String condObjId = dependents ? "refobjid" : "objid";
+
+            String sql =
+                "SELECT DISTINCT dep.deptype, dep.classid, dep." + queryObjId + ", cl.relkind, attr.attname," +
+                    " pg_get_expr(ad.adbin, ad.adrelid) adefval,\n" +
+                    "    CASE WHEN cl.relkind IS NOT NULL THEN cl.relkind::text || COALESCE(dep.objsubid::text, '')::text\n" +
+                    "        WHEN tg.oid IS NOT NULL THEN 'T'::text\n" +
+                    "        WHEN ty.oid IS NOT NULL THEN 'y'::text\n" +
+                    "        WHEN ns.oid IS NOT NULL THEN 'n'::text\n" +
+                    "        WHEN pr.oid IS NOT NULL THEN 'p'::text\n" +
+                    "        WHEN la.oid IS NOT NULL THEN 'l'::text\n" +
+                    "        WHEN rw.oid IS NOT NULL THEN 'R'::text\n" +
+                    "        WHEN co.oid IS NOT NULL THEN 'C'::text || contype::text\n" +
+                    "        WHEN ad.oid IS NOT NULL THEN 'A'::text\n" +
+                    "        ELSE '' END AS type"
+                    + ",\n" +
+                    buildModeSpecificSelect(isMMode) +
+                    "FROM pg_depend dep\n" +
+                    "LEFT JOIN pg_class cl ON dep." + queryObjId + "=cl.oid\n" +
+                    "LEFT JOIN pg_attribute att ON dep." + queryObjId + "=att.attrelid AND dep.objsubid=att.attnum\n" +
+                    "LEFT JOIN pg_namespace nsc ON cl.relnamespace=nsc.oid\n" +
+                    "LEFT JOIN pg_proc pr ON dep." + queryObjId + "=pr.oid\n" +
+                    "LEFT JOIN pg_namespace nsp ON pr.pronamespace=nsp.oid\n" +
+                    "LEFT JOIN pg_trigger tg ON dep." + queryObjId + "=tg.oid\n" +
+                    "LEFT JOIN pg_class tgr ON tg.tgrelid=tgr.oid\n" +
+                    "LEFT JOIN pg_namespace tgrn ON tgr.relnamespace=tgrn.oid\n" +
+                    "LEFT JOIN pg_type ty ON dep." + queryObjId + "=ty.oid\n" +
+                    "LEFT JOIN pg_namespace nst ON ty.typnamespace=nst.oid\n" +
+                    "LEFT JOIN pg_constraint co ON dep." + queryObjId + "=co.oid\n" +
+                    "LEFT JOIN pg_class coc ON co.conrelid=coc.oid\n" +
+                    "LEFT JOIN pg_namespace nso ON co.connamespace=nso.oid\n" +
+                    "LEFT JOIN pg_rewrite rw ON dep." + queryObjId + "=rw.oid\n" +
+                    "LEFT JOIN pg_class clrw ON clrw.oid=rw.ev_class\n" +
+                    "LEFT JOIN pg_namespace nsrw ON clrw.relnamespace=nsrw.oid\n" +
+                    "LEFT JOIN pg_language la ON dep." + queryObjId + "=la.oid\n" +
+                    "LEFT JOIN pg_namespace ns ON dep." + queryObjId + "=ns.oid\n" +
+                    "LEFT JOIN pg_attrdef ad ON ad.oid=dep." + queryObjId + "\n" +
+                    "LEFT JOIN pg_attribute attr ON attr.attrelid=ad.adrelid and attr.attnum=ad.adnum\n" +
+                    "WHERE dep." + condObjId + "=?\n" +
+                    "ORDER BY type";
+
+            try (JDBCPreparedStatement dbStat = session.prepareStatement(sql)) {
+                dbStat.setLong(1, object.getObjectId());
+                try (JDBCResultSet dbResult = dbStat.executeQuery()) {
+                    while (dbResult.next()) {
+                        String tableName = JDBCUtils.safeGetString(dbResult, "ownertable");
+                        String schemaName = JDBCUtils.safeGetString(dbResult, "nspname");
+                        String objName = JDBCUtils.safeGetString(dbResult, "refname");
+                        if (CommonUtils.isEmpty(objName)) {
+                            objName = JDBCUtils.safeGetString(dbResult, "attname");
+                        }
+                        String objDesc = JDBCUtils.safeGetString(dbResult, "adefval");
+                        PostgreDependency dependency = new PostgreDependency(
+                            object.getDatabase(),
+                            JDBCUtils.safeGetLong(dbResult, queryObjId),
+                            JDBCUtils.safeGetString(dbResult, "deptype"),
+                            objName,
+                            objDesc,
+                            JDBCUtils.safeGetString(dbResult, "type"),
+                            tableName,
+                            schemaName
+                        );
+                        dependencies.add(dependency);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new DBCException("Error reading dependencies", e);
+        }
+
+        return dependencies;
+    }
+
+    private static String buildModeSpecificSelect(boolean isMMode) {
+        if (isMMode) {
+            return "    COALESCE(coc.relname::text, clrw.relname::text, tgr.relname::text) AS ownertable,\n" +
+                "    CASE WHEN cl.relname IS NOT NULL AND att.attname IS NOT NULL " +
+                "THEN CONCAT(cl.relname, '.', att.attname)::text\n" +
+                "    ELSE COALESCE(cl.relname::text, co.conname::text, pr.proname::text, tg.tgname::text, " +
+                "ty.typname::text, la.lanname::text, rw.rulename::text, ns.nspname::text) END AS refname,\n" +
+                "    COALESCE(nsc.nspname::text, nso.nspname::text, nsp.nspname::text, nst.nspname::text, " +
+                "nsrw.nspname::text, tgrn.nspname::text) AS nspname\n";
+        } else {
+            return "    COALESCE(coc.relname, clrw.relname, tgr.relname) AS ownertable,\n" +
+                "    CASE WHEN cl.relname IS NOT NULL AND att.attname IS NOT NULL " +
+                "THEN cl.relname || '.' || att.attname\n" +
+                "    ELSE COALESCE(cl.relname, co.conname, pr.proname, tg.tgname, ty.typname, " +
+                "la.lanname, rw.rulename, ns.nspname) END AS refname,\n" +
+                "    COALESCE(nsc.nspname, nso.nspname, nsp.nspname, nst.nspname, " +
+                "nsrw.nspname, tgrn.nspname) AS nspname\n";
+        }
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBDialect.java
@@ -21,25 +21,50 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ModelPreferences;
+import org.jkiss.dbeaver.ext.gaussdb.GaussDBConstants;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDialect;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
 import org.jkiss.dbeaver.model.struct.rdb.DBSProcedure;
 import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureParameter;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
+import org.jkiss.utils.ArrayUtils;
 import org.jkiss.utils.CommonUtils;
 
 public class GaussDBDialect extends PostgreDialect {
+
+    private GaussDBDataSource dataSource;
+
+    public static final String[][] MYSQL_QUOTE_STRINGS = {
+        {"`", "`"},
+        {"\"", "\""},
+    };
+
+    public void setDataSource(GaussDBDataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public GaussDBDataSource getDataSource() {
+        return dataSource;
+    }
 
     @Override
     public boolean isDelimiterAfterBlock() {
         return true;
     }
 
+    @Nullable
+    @Override
+    public String[][] getIdentifierQuoteStrings() {
+        return DEFAULT_IDENTIFIER_QUOTES;
+    }
+
     @Override
     public void generateStoredProcedureCall(StringBuilder sql, DBSProcedure proc,
-        Collection<? extends DBSProcedureParameter> parameters, boolean castParams) {
+                                            Collection<? extends DBSProcedureParameter> parameters, boolean castParams) {
         List<DBSProcedureParameter> inParameters = new ArrayList<>();
         if (parameters != null) {
             inParameters.addAll(parameters);
@@ -53,8 +78,9 @@ public class GaussDBDialect extends PostgreDialect {
         }
         String namedParameterPrefix = prefStore.getString(ModelPreferences.SQL_NAMED_PARAMETERS_PREFIX);
         boolean useBrackets = useBracketsForExec(proc);
-        if (useBrackets)
+        if (useBrackets) {
             sql.append("{ ");
+        }
         sql.append(getStoredProcedureCallInitialClause(proc)).append("(");
         if (!inParameters.isEmpty()) {
             inParametersProc(sql, castParams, inParameters, namedParameterPrefix);
@@ -73,7 +99,7 @@ public class GaussDBDialect extends PostgreDialect {
     }
 
     private void inParametersProc(StringBuilder sql, boolean castParams, List<DBSProcedureParameter> inParameters,
-        String namedParameterPrefix) {
+                                  String namedParameterPrefix) {
         boolean first = true;
         for (DBSProcedureParameter parameter : inParameters) {
             String typeName = parameter.getParameterType().getFullTypeName();
@@ -107,6 +133,36 @@ public class GaussDBDialect extends PostgreDialect {
                 break;
             }
             first = false;
+        }
+    }
+
+    @Override
+    @NotNull
+    public String getQuotedIdentifier(@NotNull String str, @Nullable boolean forceCaseSensitive, @Nullable boolean forceQuotes) {
+        if (isQuotedIdentifier(str)) {
+            // Already quoted
+            return str;
+        }
+        String[][] quoteStrings;
+        String databaseCompatibleMode = "";
+        boolean effectiveForceCaseSensitive = forceCaseSensitive;
+        GaussDBDataSource dataSource = getDataSource();
+        databaseCompatibleMode = ((GaussDBDatabase) dataSource.getDefaultInstance()).getDatabaseCompatibleMode();
+        if (!databaseCompatibleMode.isEmpty() && GaussDBConstants.GAUSSDB_M_COMPATIBLE_MODE.equals(databaseCompatibleMode)) {
+            quoteStrings = this.MYSQL_QUOTE_STRINGS;
+            effectiveForceCaseSensitive = false;
+        } else {
+            quoteStrings = this.getIdentifierQuoteStrings();
+        }
+
+        if (ArrayUtils.isEmpty(quoteStrings)) {
+            return str;
+        }
+
+        if (mustBeQuoted(str, effectiveForceCaseSensitive) || forceQuotes) {
+            return quoteIdentifier(str, quoteStrings);
+        } else {
+            return str;
         }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBSchema.java
@@ -18,6 +18,7 @@
 package org.jkiss.dbeaver.ext.gaussdb.model;
 
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -25,11 +26,8 @@ import java.util.stream.Collectors;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedureKind;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreRole;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreServerExtension;
+import org.jkiss.dbeaver.ext.gaussdb.GaussDBConstants;
+import org.jkiss.dbeaver.ext.postgresql.model.*;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
@@ -44,19 +42,27 @@ public class GaussDBSchema extends PostgreSchema {
     public final PackageCache packageCache;
     private final ProceduresCache proceduresCache;
     private final FunctionsCache functionsCache;
+    private final ConstraintCache constraintCache;
+    private final IndexCache indexCache;
 
     public GaussDBSchema(PostgreDatabase owner, String name, JDBCResultSet resultSet) throws SQLException {
         super(owner, name, resultSet);
+        dataTypeCache = new GaussDBDataTypeCache();
         this.packageCache = new PackageCache();
         this.proceduresCache = new ProceduresCache();
         this.functionsCache = new FunctionsCache();
+        this.constraintCache = new ConstraintCache();
+        this.indexCache = owner.getDataSource().getServerType().supportsIndexes() ? new IndexCache() : null;
     }
 
     public GaussDBSchema(PostgreDatabase database, String name, PostgreRole owner) {
         super(database, name, owner);
+        dataTypeCache = new GaussDBDataTypeCache();
         this.packageCache = new PackageCache();
         this.proceduresCache = new ProceduresCache();
         this.functionsCache = new FunctionsCache();
+        this.constraintCache = new ConstraintCache();
+        this.indexCache = database.getDataSource().getServerType().supportsIndexes() ? new IndexCache() : null;
     }
 
     @Override
@@ -104,7 +110,7 @@ public class GaussDBSchema extends PostgreSchema {
         @NotNull
         @Override
         protected JDBCStatement prepareObjectsStatement(@NotNull JDBCSession session,
-            @NotNull GaussDBSchema owner) throws SQLException {
+            @Nullable GaussDBSchema owner) throws SQLException {
             final JDBCPreparedStatement dbStat = session
                 .prepareStatement("select g.oid, g.pkgnamespace, g.pkgname as name from gs_package g where g.pkgnamespace = ?");
             dbStat.setLong(1, GaussDBSchema.this.getObjectId());
@@ -182,5 +188,112 @@ public class GaussDBSchema extends PostgreSchema {
             return new GaussDBFunction(session.getProgressMonitor(), owner, dbResult);
         }
 
+    }
+
+    public class ConstraintCache extends PostgreSchema.ConstraintCache {
+        protected ConstraintCache() {}
+
+        @NotNull
+        @Override
+        protected JDBCStatement prepareObjectsStatement(@Nullable JDBCSession session, @Nullable PostgreTableContainer container,
+                                                        @Nullable PostgreTableBase forParent) throws SQLException {
+            StringBuilder sql = new StringBuilder(
+                "SELECT c.oid,c.*,t.relname as tabrelname,rt.relnamespace as refnamespace,d.description" +
+                    (!getDataSource().getServerType().supportsPGConstraintExpressionColumn() ? ", null as consrc_copy" :
+                    ", case when c.contype='c' then " + (isMMode(container) ? "substring" : "\"substring\"") +
+                        "(pg_get_constraintdef(c.oid), 7) else null end consrc_copy") +
+                    "\nFROM pg_catalog.pg_constraint c" +
+                    "\nINNER JOIN pg_catalog.pg_class t ON t.oid=c.conrelid" +
+                    "\nLEFT OUTER JOIN pg_catalog.pg_class rt ON rt.oid=c.confrelid" +
+                    "\nLEFT OUTER JOIN " +
+                        "pg_catalog.pg_description d ON d.objoid=c.oid AND d.objsubid=0 AND d.classoid='pg_constraint'::regclass" +
+                    "\nWHERE ");
+            if (forParent == null) {
+                sql.append("t.relnamespace=?");
+            } else {
+                sql.append("c.conrelid=?");
+            }
+            sql.append("\nORDER BY c.oid");
+            JDBCPreparedStatement dbStat = session.prepareStatement(sql.toString());
+            if (forParent == null) {
+                dbStat.setLong(1, container.getSchema().getObjectId());
+            } else {
+                dbStat.setLong(1, forParent.getObjectId());
+            }
+            return dbStat;
+        }
+    }
+
+    public class IndexCache extends PostgreSchema.IndexCache {
+        protected IndexCache() {}
+
+        @NotNull
+        @Override
+        protected JDBCStatement prepareObjectsStatement(@Nullable JDBCSession session,
+                                                        @Nullable PostgreTableContainer container,
+                                                        @Nullable PostgreTableBase forTable)
+                throws SQLException {
+            boolean supportsExprIndex = getDataSource().isServerVersionAtLeast(7, 4);
+            StringBuilder sql = new StringBuilder();
+            sql.append(
+                "SELECT i.*,i.indkey as " + (isMMode(container) ? "\"keys\"" : "keys") + ",c.relname,c.relnamespace,c.relam," +
+                    "c.reltablespace,tc.relname " +
+                    "as tabrelname,dsc.description");
+            if (supportsExprIndex) {
+                sql.append(",pg_catalog.pg_get_expr(i.indpred, i.indrelid) as pred_expr");
+                sql.append(",pg_catalog.pg_get_expr(i.indexprs, i.indrelid, true) as expr");
+            }
+            if (getDataSource().getServerType().supportsRelationSizeCalc()) {
+                sql.append(",pg_catalog.pg_relation_size(i.indexrelid) as index_rel_size");
+                sql.append(",pg_catalog.pg_stat_get_numscans(i.indexrelid) as index_num_scans");
+            }
+            sql.append(
+                "\nFROM pg_catalog.pg_index i" +
+                    "\nINNER JOIN pg_catalog.pg_class c ON c.oid=i.indexrelid" +
+                    "\nINNER JOIN pg_catalog.pg_class tc ON tc.oid=i.indrelid" +
+                    "\nLEFT OUTER JOIN pg_catalog.pg_description dsc ON i.indexrelid=dsc.objoid" +
+                    "\nWHERE ");
+            if (forTable != null) {
+                sql.append(" i.indrelid=?");
+            } else {
+                sql.append(" c.relnamespace=?");
+            }
+            //sql.append(" AND NOT i.indisprimary");
+            sql.append(" ORDER BY tabrelname, c.relname");
+
+            JDBCPreparedStatement dbStat = session.prepareStatement(sql.toString());
+            if (forTable != null) {
+                dbStat.setLong(1, forTable.getObjectId());
+            } else {
+                dbStat.setLong(1, GaussDBSchema.this.getObjectId());
+            }
+            return dbStat;
+        }
+    }
+
+    @Override
+    public ConstraintCache getConstraintCache() {
+        return this.constraintCache;
+    }
+
+    @Nullable
+    @Override
+    public IndexCache getIndexCache() {
+        return indexCache;
+    }
+
+    @Override
+    public List<PostgreIndex> getIndexes(@NotNull DBRProgressMonitor monitor, @Nullable PostgreTableBase parent) throws DBException {
+        if (indexCache == null) {
+            return Collections.emptyList();
+        }
+        return indexCache.getObjects(monitor, this, parent);
+    }
+
+    @NotNull
+    private boolean isMMode(@NotNull PostgreTableContainer tableContainer) {
+        GaussDBDatabase database = (GaussDBDatabase) tableContainer.getDatabase();
+        String compatibilityMode = database.getDatabaseCompatibleMode();
+        return GaussDBConstants.GAUSSDB_M_COMPATIBLE_MODE.equals(compatibilityMode);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBSequence.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBSequence.java
@@ -1,0 +1,66 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.gaussdb.model;
+
+import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSequence;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+
+public class GaussDBSequence extends PostgreSequence {
+
+    private static final Log log = Log.getLog(GaussDBSequence.class);
+
+    public GaussDBSequence(PostgreSchema schema, JDBCResultSet dbResult) {
+        super(schema, dbResult);
+    }
+
+    public GaussDBSequence(PostgreSchema catalog) {
+        super(catalog);
+    }
+
+    @Override
+    public void loadAdditionalInfo(DBRProgressMonitor monitor) {
+        AdditionalInfo additionalInfo = getAdditionalInfo();
+        try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Load sequence additional info")) {
+            try (JDBCPreparedStatement dbSeqStat = session.prepareStatement(
+                "SELECT * from " + getFullyQualifiedName(DBPEvaluationContext.DML))) {
+                try (JDBCResultSet seqResults = dbSeqStat.executeQuery()) {
+                    if (seqResults.next()) {
+                        additionalInfo.setStartValue(JDBCUtils.safeGetLong(seqResults, "start_value"));
+                        additionalInfo.setLastValue(JDBCUtils.safeGetLongNullable(seqResults, "last_value"));
+                        additionalInfo.setMinValue(JDBCUtils.safeGetLong(seqResults, "min_value"));
+                        additionalInfo.setMaxValue(JDBCUtils.safeGetLong(seqResults, "max_value"));
+                        additionalInfo.setIncrementBy(JDBCUtils.safeGetLong(seqResults, "increment_by"));
+                        additionalInfo.setCacheValue(JDBCUtils.safeGetLong(seqResults, "cache_value"));
+                        additionalInfo.setCycled(JDBCUtils.safeGetBoolean(seqResults, "is_cycled"));
+                    }
+                }
+            }
+            additionalInfo.setLoaded(true);
+        } catch (Exception e) {
+            log.warn("Error reading sequence values", e);
+        }
+        ;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBTableRegular.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBTableRegular.java
@@ -1,0 +1,49 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.gaussdb.model;
+
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDependency;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableRegular;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+
+import java.sql.ResultSet;
+import java.util.List;
+
+public class GaussDBTableRegular extends PostgreTableRegular {
+
+    public GaussDBTableRegular(PostgreSchema catalog) {
+        super(catalog);
+    }
+
+    public GaussDBTableRegular(DBRProgressMonitor monitor, PostgreSchema catalog, PostgreTableRegular source)
+            throws DBException {
+        super(monitor, catalog, source);
+    }
+
+    public GaussDBTableRegular(PostgreSchema catalog, ResultSet dbResult) {
+        super(catalog, dbResult);
+    }
+
+    @Override
+    public List<PostgreDependency> getDependencies(DBRProgressMonitor monitor) throws DBCException {
+        return GaussDBDependency.readDependencies(monitor, this, true);
+    }
+
+}

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/PostgreServerGaussDB.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/PostgreServerGaussDB.java
@@ -17,6 +17,8 @@
 
 package org.jkiss.dbeaver.ext.gaussdb.model;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.ext.gaussdb.GaussDBConstants;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
 import org.jkiss.dbeaver.ext.postgresql.model.impls.PostgreServerExtensionBase;
@@ -61,5 +63,11 @@ public class PostgreServerGaussDB extends PostgreServerExtensionBase {
     @Override
     public PostgreDatabase.SchemaCache createSchemaCache(PostgreDatabase database) {
         return new GaussDBSchemaCache();
+    }
+
+    @Override
+    public boolean isPGObject(@NotNull Object object) {
+        String className = object.getClass().getName();
+        return GaussDBConstants.GAUSSDB_PG_OBJECT_CLASS.equals(className);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/PostgreServerGaussDB.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/PostgreServerGaussDB.java
@@ -81,6 +81,8 @@ public class PostgreServerGaussDB extends PostgreServerExtensionBase {
     public PostgreTableBase createRelationOfClass(PostgreSchema schema, PostgreClass.RelKind kind, JDBCResultSet dbResult) {
         if (kind == PostgreClass.RelKind.S) {
             return new GaussDBSequence(schema, dbResult);
+        } else if (kind == PostgreClass.RelKind.r) {
+            return new GaussDBTableRegular(schema, dbResult);
         }
         return super.createRelationOfClass(schema, kind, dbResult);
     }

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/PostgreServerGaussDB.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/PostgreServerGaussDB.java
@@ -18,10 +18,17 @@
 package org.jkiss.dbeaver.ext.gaussdb.model;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.gaussdb.GaussDBConstants;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreClass;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSequence;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableBase;
 import org.jkiss.dbeaver.ext.postgresql.model.impls.PostgreServerExtensionBase;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 
 public class PostgreServerGaussDB extends PostgreServerExtensionBase {
 
@@ -63,6 +70,28 @@ public class PostgreServerGaussDB extends PostgreServerExtensionBase {
     @Override
     public PostgreDatabase.SchemaCache createSchemaCache(PostgreDatabase database) {
         return new GaussDBSchemaCache();
+    }
+
+    @Override
+    public PostgreSequence createSequence(@NotNull PostgreSchema schema) {
+        return new GaussDBSequence(schema);
+    }
+
+    @Override
+    public PostgreTableBase createRelationOfClass(PostgreSchema schema, PostgreClass.RelKind kind, JDBCResultSet dbResult) {
+        if (kind == PostgreClass.RelKind.S) {
+            return new GaussDBSequence(schema, dbResult);
+        }
+        return super.createRelationOfClass(schema, kind, dbResult);
+    }
+
+    @Override
+    public PostgreTableBase createNewRelation(DBRProgressMonitor monitor, PostgreSchema schema, PostgreClass.RelKind kind, Object copyFrom)
+            throws DBException {
+        if (kind == PostgreClass.RelKind.S) {
+            return new GaussDBSequence(schema);
+        }
+        return super.createNewRelation(monitor, schema, kind, copyFrom);
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataTypeCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataTypeCache.java
@@ -46,7 +46,7 @@ public class PostgreDataTypeCache extends JDBCObjectCache<PostgreSchema, Postgre
 
     private final LongKeyMap<PostgreDataType> dataTypeMap = new LongKeyMap<>();
 
-    PostgreDataTypeCache() {
+    protected PostgreDataTypeCache() {
         setListOrderComparator(DBUtils.nameComparator());
         setCaseSensitive(false);
     }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
@@ -99,7 +99,7 @@ public class PostgreDatabase extends JDBCRemoteInstance
     private final AvailableExtensionCache availableExtensionCache = new AvailableExtensionCache();
     private final CollationCache collationCache = new CollationCache();
     public final TablespaceCache tablespaceCache = new TablespaceCache();
-    private final LongKeyMap<PostgreDataType> dataTypeCache = new LongKeyMap<>();
+    protected final LongKeyMap<PostgreDataType> dataTypeCache = new LongKeyMap<>();
     public final JobCache jobCache = new JobCache();
     public final JobClassCache jobClassCache = new JobClassCache();
 
@@ -236,8 +236,9 @@ public class PostgreDatabase extends JDBCRemoteInstance
         if (!isSharedDatabase() && executionContext == null) {
             initializeMainContext(monitor);
             initializeMetaContext(monitor);
-            if (cacheMetadata)
+            if (cacheMetadata) {
                 cacheDataTypes(monitor, true);
+            }
         }
     }
 
@@ -678,7 +679,7 @@ public class PostgreDatabase extends JDBCRemoteInstance
     }
 
     @Nullable
-    PostgreSchema getCatalogSchema() {
+    protected PostgreSchema getCatalogSchema() {
         return schemaCache.getCachedObject(PostgreConstants.CATALOG_SCHEMA_NAME);
     }
 
@@ -692,7 +693,11 @@ public class PostgreDatabase extends JDBCRemoteInstance
         return schemaCache.getCachedObject(PostgreConstants.PUBLIC_SCHEMA_NAME);
     }
 
-    void cacheDataTypes(DBRProgressMonitor monitor, boolean forceRefresh) throws DBException {
+    protected String getBaseTypeNameClause() {
+        return PostgreDataTypeCache.getBaseTypeNameClause((PostgreDataSource) dataSource);
+    }
+
+    protected void cacheDataTypes(DBRProgressMonitor monitor, boolean forceRefresh) throws DBException {
         boolean hasDataTypes;
         synchronized (dataTypeCache) {
             hasDataTypes = !dataTypeCache.isEmpty();
@@ -710,7 +715,7 @@ public class PostgreDatabase extends JDBCRemoteInstance
             try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Read data types")) {
                 StringBuilder sql = new StringBuilder(256);
                 boolean supportsSysTypColumn = supportsSysTypCategoryColumn(session); // Do not read all array and table types, unless the user has decided otherwise
-                sql.append("SELECT t.oid,t.*,c.relkind,").append(PostgreDataTypeCache.getBaseTypeNameClause(postgreDataSource)).append(", d.description" +
+                sql.append("SELECT t.oid,t.*,c.relkind,").append(getBaseTypeNameClause()).append(", d.description" +
                         "\nFROM pg_catalog.pg_type t");
                 if (!readAllTypes && supportsSysTypColumn) {
                     sql.append("\nLEFT OUTER JOIN pg_catalog.pg_type et ON et.oid=t.typelem "); // If typelem is not 0 then it identifies another row in pg_type
@@ -763,7 +768,7 @@ public class PostgreDatabase extends JDBCRemoteInstance
 
     // Column "typcategory" appeared only in PG version 8.4 and before we relied on DB version to verify the conditions, but it was not the most universal solution.
     // So make a separate request to the database for checking.
-    boolean supportsSysTypCategoryColumn(JDBCSession session) {
+    public boolean supportsSysTypCategoryColumn(JDBCSession session) {
         if (supportTypColumn == null) {
             if (!dataSource.isServerVersionAtLeast(10, 0)) {
                 if (!dataSource.isServerVersionAtLeast(8, 4)) {
@@ -970,7 +975,8 @@ public class PostgreDatabase extends JDBCRemoteInstance
         }
     }
 
-    public PostgreDataType getDataType(@Nullable DBRProgressMonitor monitor, String typeName) {
+    @Nullable
+    public PostgreDataType getDataType(@Nullable DBRProgressMonitor monitor, @Nullable String typeName) {
         if (typeName.endsWith("[]")) {
             // In some cases ResultSetMetadata returns it as []
             typeName = "_" + typeName.substring(0, typeName.length() - 2);
@@ -1009,7 +1015,7 @@ public class PostgreDatabase extends JDBCRemoteInstance
             }
         }
 
-        if (monitor == null || monitor.isForceCacheUsage()) {
+        if (monitor.isForceCacheUsage()) {
             return null;
         }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
@@ -89,7 +89,7 @@ public class PostgreSchema implements
     private final ConstraintCache constraintCache;
     private final ProceduresCache proceduresCache;
     private final IndexCache indexCache;
-    private final PostgreDataTypeCache dataTypeCache;
+    protected PostgreDataTypeCache dataTypeCache;
     private ArrayList<PostgrePrivilege> defaultPrivileges;
     protected volatile boolean hasStatistics;
 
@@ -1079,7 +1079,7 @@ public class PostgreSchema implements
     /**
      * Index cache implementation
      */
-    class IndexCache extends JDBCCompositeCache<PostgreTableContainer, PostgreTableBase, PostgreIndex, PostgreIndexColumn> {
+    public class IndexCache extends JDBCCompositeCache<PostgreTableContainer, PostgreTableBase, PostgreIndex, PostgreIndexColumn> {
         protected IndexCache() {
             super(getTableCache(), PostgreTableBase.class, "tabrelname", "relname");
         }


### PR DESCRIPTION
1. Fix the automatic synchronization function for input content on the GaussDB connection management page and add gaussdbjdbc-506.0.0.b058.jar to resolve the error "Unsupported vector type: com.huawei.gaussdb.jdbc.util.PGobject" when using gaussdbjdbc - 506.0.0.b058.jar. Additionally, address the issue where the cached value after the sequence definition cannot be correctly retrieved when viewing sequence details.
2. Successfully connecting to the GaussDB M-Compatibility database allows for accurate retrieval of its constraints, foreign keys, indexes, and dependency information.
3. When creating a new database under the connected GaussDB, the selection of database compatibility mode is supported.
4. Addressing some issues encountered when connecting to the GaussDB M-Compatibility database and attempting various operations on table columns, particularly when column names contain uppercase letters.

**Issue reference:** 

- #37811 
- #38176
- #38892
- #38893