### PR TITLE
dbeaver/pro#6475 Enabled bigquery sessions for datagrid tx support

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.bigquery/src/org/jkiss/dbeaver/ext/bigquery/model/BigQueryDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.bigquery/src/org/jkiss/dbeaver/ext/bigquery/model/BigQueryDataSource.java
@@ -29,7 +29,6 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCExecutionContext;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.utils.CommonUtils;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -53,7 +52,7 @@ public class BigQueryDataSource extends GenericDataSource {
             DBPDriver driver = getContainer().getDriver();
             return driver.getDataSourceProvider().getConnectionURL(driver, connectionInfo);
         }
-        return connectionURL;
+        return connectionURL + ";EnableSession=1;";
     }
 
     @NotNull


### PR DESCRIPTION
For Bigquery:

* Fixes the error when trying to persist data grid changes in CB **with/without autocommit**:
<img width="756" height="595" alt="image" src="https://github.com/user-attachments/assets/a4f050ba-dd54-44ba-b6b3-442b3c7e6eba" />

* Fixes the error when trying to persist data grid changes in desktop **with manual commit**:
<img width="866" height="423" alt="image" src="https://github.com/user-attachments/assets/43a224e4-2e09-4151-a381-cb3ccf68ff03" />

Doc: https://docs.simba.insightsoftware.com/hc/en-us/articles/30350148329101-EnableSession

Closes https://github.com/dbeaver/pro/issues/6475