### PR TITLE
Dbeaver/dbeaver#39228 fix model config uppercase modification

### DIFF
--- a/features/org.jkiss.dbeaver.test.feature/feature.xml
+++ b/features/org.jkiss.dbeaver.test.feature/feature.xml
@@ -23,4 +23,5 @@
     <plugin id="org.jkiss.dbeaver.ext.altibase.test" version="0.0.0"/>
     <plugin id="org.jkiss.dbeaver.ext.clickhouse.test" version="0.0.0"/>
     <plugin id="org.jkiss.dbeaver.ext.generic.test" version="0.0.0"/>
+    <plugin id="org.jkiss.dbeaver.model.ai.test" version="0.0.0"/>
 </feature>

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModels.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModels.java
@@ -87,7 +87,7 @@ public final class OpenAIModels {
         if (DEPRECATED_MODELS.contains(lowerCaseModelName)) {
             return DEFAULT_MODEL;
         }
-        return lowerCaseModelName;
+        return modelName;
     }
 
     @NotNull

--- a/test/org.jkiss.dbeaver.model.ai.test/META-INF/MANIFEST.MF
+++ b/test/org.jkiss.dbeaver.model.ai.test/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: DBeaver AI Tests
+Bundle-SymbolicName: org.jkiss.dbeaver.model.ai.test
+Bundle-Version: 1.0.0.qualifier
+Bundle-Release-Date: 20251006
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Bundle-Vendor: DBeaver Corp
+Fragment-Host: org.jkiss.dbeaver.model.ai
+Bundle-ActivationPolicy: lazy
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.core.resources,
+ org.junit,
+ org.mockito.mockito-core,
+ org.jkiss.dbeaver.test.platform,
+ org.jkiss.dbeaver.model.ai

--- a/test/org.jkiss.dbeaver.model.ai.test/build.properties
+++ b/test/org.jkiss.dbeaver.model.ai.test/build.properties
@@ -1,0 +1,5 @@
+source..=src/
+output..=target/classes/
+bin.includes=.,\
+               META-INF/
+.

--- a/test/org.jkiss.dbeaver.model.ai.test/pom.xml
+++ b/test/org.jkiss.dbeaver.model.ai.test/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ DBeaver - Universal Database Manager
+  ~ Copyright (C) 2010-2024 DBeaver Corp and others
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jkiss.dbeaver</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <artifactId>org.jkiss.dbeaver.model.ai.test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>eclipse-test-plugin</packaging>
+
+</project>

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModelsTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModelsTest.java
@@ -19,12 +19,42 @@ package org.jkiss.dbeaver.model.ai.engine.openai;
 import org.jkiss.junit.DBeaverUnitTest;
 import org.junit.Test;
 
+import static org.jkiss.dbeaver.model.ai.engine.openai.OpenAIModels.*;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 public class OpenAIModelsTest extends DBeaverUnitTest {
 
     @Test
-    public void test() {
-        fail();
+    public void effectiveModelNameNullShouldReturnDefaultModelName() throws Exception {
+        //when
+        var result = OpenAIModels.getEffectiveModelName(null);
+        //then
+        assertEquals(DEFAULT_MODEL,result);
     }
+
+    @Test
+    public void effectiveModelNameKnownUppercaseShouldReturnKnownModelLowercase() throws Exception {
+        //given
+        var expectedModelName = KNOWN_MODELS.keySet().stream().findFirst().orElseThrow();
+        var inputModelName = expectedModelName.toUpperCase();
+        //when
+        var result = OpenAIModels.getEffectiveModelName(inputModelName);
+        //then
+        assertEquals(expectedModelName,result);
+    }
+
+    @Test
+    public void effectiveModelNameUnknownUppercaseShouldReturnKnownModelUppercase() throws Exception {
+        //given
+        var inputModelName = "some-UNKNOWN-MODEL";
+        assumeFalse(KNOWN_MODELS.containsKey(inputModelName.toLowerCase()));
+        //when
+        var result = OpenAIModels.getEffectiveModelName(inputModelName);
+        //then
+        assertEquals(inputModelName,result);
+    }
+
+
 }

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModelsTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModelsTest.java
@@ -1,0 +1,30 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.engine.openai;
+
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class OpenAIModelsTest extends DBeaverUnitTest {
+
+    @Test
+    public void test() {
+        fail();
+    }
+}

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModelsTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModelsTest.java
@@ -28,7 +28,7 @@ public class OpenAIModelsTest extends DBeaverUnitTest {
     @Test
     public void effectiveModelNameNullShouldReturnDefaultModelName() {
         //when
-        var result = OpenAIModels.getEffectiveModelName(null);
+        var result = getEffectiveModelName(null);
         //then
         assertEquals(DEFAULT_MODEL, result);
     }

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModelsTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIModelsTest.java
@@ -21,39 +21,38 @@ import org.junit.Test;
 
 import static org.jkiss.dbeaver.model.ai.engine.openai.OpenAIModels.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 public class OpenAIModelsTest extends DBeaverUnitTest {
 
     @Test
-    public void effectiveModelNameNullShouldReturnDefaultModelName() throws Exception {
+    public void effectiveModelNameNullShouldReturnDefaultModelName() {
         //when
         var result = OpenAIModels.getEffectiveModelName(null);
         //then
-        assertEquals(DEFAULT_MODEL,result);
+        assertEquals(DEFAULT_MODEL, result);
     }
 
     @Test
-    public void effectiveModelNameKnownUppercaseShouldReturnKnownModelLowercase() throws Exception {
+    public void effectiveModelNameKnownUppercaseShouldReturnKnownModelLowercase() {
         //given
         var expectedModelName = KNOWN_MODELS.keySet().stream().findFirst().orElseThrow();
         var inputModelName = expectedModelName.toUpperCase();
         //when
-        var result = OpenAIModels.getEffectiveModelName(inputModelName);
+        var result = getEffectiveModelName(inputModelName);
         //then
-        assertEquals(expectedModelName,result);
+        assertEquals(expectedModelName, result);
     }
 
     @Test
-    public void effectiveModelNameUnknownUppercaseShouldReturnKnownModelUppercase() throws Exception {
+    public void effectiveModelNameUnknownUppercaseShouldReturnKnownModelUppercase() {
         //given
         var inputModelName = "some-UNKNOWN-MODEL";
         assumeFalse(KNOWN_MODELS.containsKey(inputModelName.toLowerCase()));
         //when
-        var result = OpenAIModels.getEffectiveModelName(inputModelName);
+        var result = getEffectiveModelName(inputModelName);
         //then
-        assertEquals(inputModelName,result);
+        assertEquals(inputModelName, result);
     }
 
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -26,6 +26,7 @@
         <module>org.jkiss.dbeaver.ext.snowflake.test</module>
         <module>org.jkiss.dbeaver.ext.sqlite.test</module>
         <module>org.jkiss.dbeaver.model.lsm.test</module>
+        <module>org.jkiss.dbeaver.model.ai.test</module>
     </modules>
 
     <build>


### PR DESCRIPTION
fixes #39228 
changed getEffectiveModelName. Now returns model in original case, if its unknown