### PR TITLE
dbeaver/dbeaver#37811 Update the GaussDB driver jar package and corresponding configuration template

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/plugin.xml
@@ -28,12 +28,12 @@
                         label="GaussDB"
                         icon="icons/gaussdb_icon.png"
                         iconBig="icons/gaussdb_icon_big.png"
-                        class="org.postgresql.Driver"
-                        sampleURL="jdbc:postgresql://{host}[:{port}]/[{database}]"
+                        class="com.huawei.gaussdb.jdbc.Driver"
+                        sampleURL="jdbc:gaussdb://{host}[:{port}]/[{database}]"
                         defaultPort="8000"
                         description="%driver.gaussdb.description"
                         categories="sql">
-                    <file type="jar" path="https://repo.huaweicloud.com/repository/maven/huaweicloudsdk/gsjdbc4/gsjdbc4/1.1/gsjdbc4-1.1.jar" bundle="!drivers.gaussdb"/>
+                    <file type="jar" path="maven:/com.huaweicloud.gaussdb:gaussdbjdbc:RELEASE[506.0.0.b058]" bundle="!drivers.gaussdb"/>
                     <file type="jar" path="drivers/gaussdb" bundle="drivers.gaussdb"/>
                     <parameter name="serverType" value="gaussdb"/>
                     <property name="loginTimeout" value="20"/>

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBDataSourceProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBDataSourceProvider.java
@@ -90,7 +90,7 @@ public class GaussDBDataSourceProvider extends JDBCDataSourceProvider {
         }
 
         StringBuilder url = new StringBuilder();
-        url.append("jdbc:postgresql://");
+        url.append("jdbc:gaussdb://");
 
         url.append(connectionInfo.getHostName());
         if (!CommonUtils.isEmpty(connectionInfo.getHostPort())) {


### PR DESCRIPTION
Our original commit #39162 encountered the “org.jkiss.dbeaver.ext.postgresql.test 1.0.120-SNAPSHOT FAILURE” issue, which we could not reproduce locally.
So we split the original commit into a number of small feature commits.
This commit is the first one, which resolves the following problem in issue #37811: "Secondly, the GaussDB driver jar package provided by Huawei Cloud is outdated and needs to be updated to gaussdbjdbc - 506.0.0.b058.jar."