### PR TITLE
Dbeaver/pro#6504 add test ai button

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/copilot/CopilotConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/copilot/CopilotConfigurator.java
@@ -249,7 +249,7 @@ public class CopilotConfigurator implements AIIObjectPropertyConfigurator<AIEngi
 
     @Override
     public Optional<AIEngineProperties> getCurrentProperties() {
-        CopilotProperties copilotPropertiesCopy= new CopilotProperties();
+        CopilotProperties copilotPropertiesCopy = new CopilotProperties();
         saveSettings(copilotPropertiesCopy);
         return Optional.of(copilotPropertiesCopy);
     }

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/copilot/CopilotConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/copilot/CopilotConfigurator.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.ai.engine.AIEngineProperties;
 import org.jkiss.dbeaver.model.ai.engine.AIModel;
 import org.jkiss.dbeaver.model.ai.engine.copilot.CopilotClient;
 import org.jkiss.dbeaver.model.ai.engine.copilot.CopilotCompletionEngine;
@@ -38,7 +39,6 @@ import org.jkiss.dbeaver.model.ai.registry.AIEngineDescriptor;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.runtime.ui.UIServiceAuth;
-import org.jkiss.dbeaver.ui.IObjectPropertyConfigurator;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.ai.internal.AIUIMessages;
 import org.jkiss.dbeaver.ui.ai.model.ContextWindowSizeField;
@@ -48,6 +48,7 @@ import org.jkiss.utils.CommonUtils;
 
 import java.net.URI;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class CopilotConfigurator implements AIIObjectPropertyConfigurator<AIEngineDescriptor, CopilotProperties> {
@@ -244,5 +245,12 @@ public class CopilotConfigurator implements AIIObjectPropertyConfigurator<AIEngi
         } catch (InterruptedException e) {
             throw new DBException("Authorization was interrupted", e);
         }
+    }
+
+    @Override
+    public Optional<AIEngineProperties> getCurrentProperties() {
+        CopilotProperties copilotPropertiesCopy= new CopilotProperties();
+        saveSettings(copilotPropertiesCopy);
+        return Optional.of(copilotPropertiesCopy);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/copilot/CopilotConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/copilot/CopilotConfigurator.java
@@ -43,13 +43,14 @@ import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.ai.internal.AIUIMessages;
 import org.jkiss.dbeaver.ui.ai.model.ContextWindowSizeField;
 import org.jkiss.dbeaver.ui.ai.model.ModelSelectorField;
+import org.jkiss.dbeaver.ui.ai.preferences.AIIObjectPropertyConfigurator;
 import org.jkiss.utils.CommonUtils;
 
 import java.net.URI;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
-public class CopilotConfigurator implements IObjectPropertyConfigurator<AIEngineDescriptor, CopilotProperties> {
+public class CopilotConfigurator implements AIIObjectPropertyConfigurator<AIEngineDescriptor, CopilotProperties> {
 
     private Text temperatureText;
     private ContextWindowSizeField contextWindowSizeField;

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/openai/OpenAiConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/openai/OpenAiConfigurator.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.widgets.Text;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.ai.engine.AIEngineProperties;
 import org.jkiss.dbeaver.model.ai.engine.AIModel;
 import org.jkiss.dbeaver.model.ai.engine.AIModelFeature;
 import org.jkiss.dbeaver.model.ai.engine.openai.OpenAIClient;
@@ -49,6 +50,7 @@ import org.jkiss.utils.CommonUtils;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 public class OpenAiConfigurator<ENGINE extends AIEngineDescriptor, PROPERTIES extends OpenAIProperties>
     implements AIIObjectPropertyConfigurator<ENGINE, PROPERTIES> {
@@ -254,5 +256,15 @@ public class OpenAiConfigurator<ENGINE extends AIEngineDescriptor, PROPERTIES ex
             && contextWindowSizeField.isComplete();
     }
 
-
+    @Override
+    public Optional<AIEngineProperties> getCurrentProperties() {
+        OpenAIProperties  propertiesCopy = new OpenAIProperties();
+        propertiesCopy.setBaseUrl(baseUrl);
+        propertiesCopy.setToken(token);
+        propertiesCopy.setModel(modelSelectorField.getSelectedModel());
+        propertiesCopy.setContextWindowSize(contextWindowSizeField.getValue());
+        propertiesCopy.setTemperature(CommonUtils.toDouble(temperature));
+        propertiesCopy.setLoggingEnabled(logQuery);
+        return Optional.of(propertiesCopy);
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/openai/OpenAiConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/openai/OpenAiConfigurator.java
@@ -44,13 +44,14 @@ import org.jkiss.dbeaver.ui.ai.internal.AIUIMessages;
 import org.jkiss.dbeaver.ui.ai.model.CachedValue;
 import org.jkiss.dbeaver.ui.ai.model.ContextWindowSizeField;
 import org.jkiss.dbeaver.ui.ai.model.ModelSelectorField;
+import org.jkiss.dbeaver.ui.ai.preferences.AIIObjectPropertyConfigurator;
 import org.jkiss.utils.CommonUtils;
 
 import java.util.List;
 import java.util.Locale;
 
 public class OpenAiConfigurator<ENGINE extends AIEngineDescriptor, PROPERTIES extends OpenAIProperties>
-    implements IObjectPropertyConfigurator<ENGINE, PROPERTIES> {
+    implements AIIObjectPropertyConfigurator<ENGINE, PROPERTIES> {
     private static final String API_KEY_URL = "https://platform.openai.com/account/api-keys";
     protected String baseUrl;
     protected volatile String token = "";

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/openai/OpenAiConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/openai/OpenAiConfigurator.java
@@ -258,7 +258,7 @@ public class OpenAiConfigurator<ENGINE extends AIEngineDescriptor, PROPERTIES ex
 
     @Override
     public Optional<AIEngineProperties> getCurrentProperties() {
-        OpenAIProperties  propertiesCopy = new OpenAIProperties();
+        OpenAIProperties propertiesCopy = new OpenAIProperties();
         propertiesCopy.setBaseUrl(baseUrl);
         propertiesCopy.setToken(token);
         propertiesCopy.setModel(modelSelectorField.getSelectedModel());

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/internal/AIUIMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/internal/AIUIMessages.java
@@ -47,6 +47,12 @@ public class AIUIMessages extends NLS {
     public static String gpt_preference_page_ai_query_confirm_rule_confirm;
     public static String gpt_preference_page_ai_query_confirm_rule_disable_autocommit;
 
+    public static String gpt_preference_page_ai_connection_test_label;
+    public static String gpt_preference_page_ai_connection_test_connection_success_title;
+    public static String gpt_preference_page_ai_connection_test_connection_success_message;
+    public static String gpt_preference_page_ai_connection_test_connection_error_title;
+    public static String gpt_preference_page_ai_connection_test_connection_error_message;
+
     public static String confirm_meta_transfer_usage_title;
     public static String confirm_meta_transfer_usage_message;
 

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/internal/AIUIMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/internal/AIUIMessages.properties
@@ -23,6 +23,11 @@ gpt_preference_page_ai_query_confirm_tip = Confirm {0} queries from AI chat befo
 gpt_preference_page_ai_query_confirm_rule_execute = Execute immediately
 gpt_preference_page_ai_query_confirm_rule_confirm = Show confirmation
 gpt_preference_page_ai_query_confirm_rule_disable_autocommit = Disable autocommit
+gpt_preference_page_ai_connection_test_label=Test Connection ...
+gpt_preference_page_ai_connection_test_connection_success_title=Connection Test Success
+gpt_preference_page_ai_connection_test_connection_success_message=You are connected to the {0} AI assistant
+gpt_preference_page_ai_connection_test_connection_error_title=Connection Test Error
+gpt_preference_page_ai_connection_test_connection_error_message=Error while connecting the {0} AI assistant
 
 confirm_meta_transfer_usage_title = Transfer information to AI Vendor
 confirm_meta_transfer_usage_message = To use AI features, DBeaver needs to transfer your database metadata information (table and column names) to the AI vendor API.\n\nDo you confirm it for connection ''{0}''?

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIIObjectPropertyConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIIObjectPropertyConfigurator.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 public interface AIIObjectPropertyConfigurator<ENGINE extends AIEngineDescriptor, PROPERTIES extends AIEngineProperties> extends
     IObjectPropertyConfigurator<ENGINE, PROPERTIES> {
 
-    default Optional<PROPERTIES> getCurrentProperties() {
+    default Optional<AIEngineProperties> getCurrentProperties() {
         return Optional.empty();
     }
 }

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIIObjectPropertyConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIIObjectPropertyConfigurator.java
@@ -1,0 +1,31 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.ai.preferences;
+
+import org.jkiss.dbeaver.model.ai.engine.AIEngineProperties;
+import org.jkiss.dbeaver.model.ai.registry.AIEngineDescriptor;
+import org.jkiss.dbeaver.ui.IObjectPropertyConfigurator;
+
+import java.util.Optional;
+
+public interface AIIObjectPropertyConfigurator<ENGINE extends AIEngineDescriptor, PROPERTIES extends AIEngineProperties> extends
+    IObjectPropertyConfigurator<ENGINE, PROPERTIES> {
+
+    default Optional<PROPERTIES> getCurrentProperties() {
+        return Optional.empty();
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIIObjectPropertyConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIIObjectPropertyConfigurator.java
@@ -22,6 +22,9 @@ import org.jkiss.dbeaver.ui.IObjectPropertyConfigurator;
 
 import java.util.Optional;
 
+/**
+ * AIIObjectPropertyConfigurator used to get a copy of current AIEngineProperties if present
+ */
 public interface AIIObjectPropertyConfigurator<ENGINE extends AIEngineDescriptor, PROPERTIES extends AIEngineProperties> extends
     IObjectPropertyConfigurator<ENGINE, PROPERTIES> {
 

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
@@ -233,7 +233,7 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
             null,
             SelectionListener.widgetSelectedAdapter(e -> {
                 String engineId = serviceCombo.getText();
-                try{
+                try {
                     testConnection();
                     DBWorkbench.getPlatformUI().showMessageBox(
                         AIUIMessages.gpt_preference_page_ai_connection_test_connection_success_title,
@@ -244,9 +244,9 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
                         false
                     );
                 } catch (DBException | InterruptedException ex) {
-                    showConnectionErrorMessage(ex,engineId );
+                    showConnectionErrorMessage(ex, engineId);
                 } catch (InvocationTargetException ex) {
-                    showConnectionErrorMessage(ex.getCause(),engineId );
+                    showConnectionErrorMessage(ex.getCause(), engineId);
                 }
             })
         );

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
@@ -273,11 +273,11 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
 
 
     private void showConnectionErrorMessage(Throwable ex, String engineId) {
-    DBWorkbench.getPlatformUI().showError(
-        AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_title,
-        NLS.bind(AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_message, engineId),
-        ex
-    );
+        DBWorkbench.getPlatformUI().showError(
+            AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_title,
+            NLS.bind(AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_message, engineId),
+            ex
+        );
 }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
@@ -63,6 +63,7 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
     private final Map<String, EngineConfiguratorPage> engineConfiguratorMapping = new HashMap<>();
     private EngineConfiguratorPage activeEngineConfiguratorPage;
     private Button enableAICheck;
+    private Button connectionTestButton;
 
     public AIPreferencePageMain() {
         this.settings = AISettingsManager.getInstance().getSettings();
@@ -219,11 +220,14 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
                 e
             );
         }
+        if (Objects.nonNull(connectionTestButton)) {
+            connectionTestButton.setEnabled(activeEngineConfiguratorPage.getCurrentProperties().isPresent());
+        }
     }
 
 
     private void createTestConnectionButton(@NotNull Composite parent) {
-        Button testConnectionButton = UIUtils.createPushButton(
+        connectionTestButton = UIUtils.createPushButton(
             parent,
             AIUIMessages.gpt_preference_page_ai_connection_test_label,
             null,
@@ -244,10 +248,9 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
                     showConnectionErrorMessage(ex.getCause());
                 }
             })
-
         );
 
-        testConnectionButton.setEnabled(activeEngineConfiguratorPage.getCurrentProperties().isPresent());
+        connectionTestButton.setEnabled(activeEngineConfiguratorPage.getCurrentProperties().isPresent());
     }
 
     private void testConnection() throws DBException, InterruptedException, InvocationTargetException {
@@ -268,7 +271,7 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
     }
 
 
-private void showConnectionErrorMessage(Throwable ex) {
+    private void showConnectionErrorMessage(Throwable ex) {
     DBWorkbench.getPlatformUI().showError(
         AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_title,
         NLS.bind(AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_message, settings.activeEngine()),

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
@@ -232,20 +232,21 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
             AIUIMessages.gpt_preference_page_ai_connection_test_label,
             null,
             SelectionListener.widgetSelectedAdapter(e -> {
+                String engineId = serviceCombo.getText();
                 try{
                     testConnection();
                     DBWorkbench.getPlatformUI().showMessageBox(
                         AIUIMessages.gpt_preference_page_ai_connection_test_connection_success_title,
                         NLS.bind(
                             AIUIMessages.gpt_preference_page_ai_connection_test_connection_success_message,
-                            settings.activeEngine()
+                            engineId
                         ),
                         false
                     );
                 } catch (DBException | InterruptedException ex) {
-                    showConnectionErrorMessage(ex);
+                    showConnectionErrorMessage(ex,engineId );
                 } catch (InvocationTargetException ex) {
-                    showConnectionErrorMessage(ex.getCause());
+                    showConnectionErrorMessage(ex.getCause(),engineId );
                 }
             })
         );
@@ -271,10 +272,10 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
     }
 
 
-    private void showConnectionErrorMessage(Throwable ex) {
+    private void showConnectionErrorMessage(Throwable ex, String engineId) {
     DBWorkbench.getPlatformUI().showError(
         AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_title,
-        NLS.bind(AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_message, settings.activeEngine()),
+        NLS.bind(AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_message, engineId),
         ex
     );
 }

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
@@ -42,17 +42,14 @@ import org.jkiss.dbeaver.model.rm.RMConstants;
 import org.jkiss.dbeaver.registry.configurator.UIPropertyConfiguratorDescriptor;
 import org.jkiss.dbeaver.registry.configurator.UIPropertyConfiguratorRegistry;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
-import org.jkiss.dbeaver.ui.IObjectPropertyConfigurator;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.ai.internal.AIUIMessages;
 import org.jkiss.dbeaver.ui.preferences.AbstractPrefPage;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbenchPreferencePage, IWorkbenchPropertyPage {
     private static final Log log = Log.getLog(AIPreferencePageMain.class);
@@ -84,7 +81,7 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
     }
 
     @Nullable
-    private IObjectPropertyConfigurator<AIEngineDescriptor, AIEngineProperties> createEngineConfigurator() {
+    private AIIObjectPropertyConfigurator<AIEngineDescriptor, AIEngineProperties> createEngineConfigurator() {
         UIPropertyConfiguratorDescriptor engineDescriptor =
             UIPropertyConfiguratorRegistry.getInstance().getDescriptor(completionEngine.getEngineObjectType().getImplName());
         if (engineDescriptor != null) {
@@ -201,7 +198,7 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
         activeEngineConfiguratorPage = engineConfiguratorMapping.get(id);
 
         if (activeEngineConfiguratorPage == null) {
-            IObjectPropertyConfigurator<AIEngineDescriptor, AIEngineProperties> engineConfigurator
+            AIIObjectPropertyConfigurator<AIEngineDescriptor, AIEngineProperties> engineConfigurator
                 = createEngineConfigurator();
             if (engineConfigurator == null) {
                 log.error("Engine configurator not found for " + completionEngine.getId());
@@ -226,7 +223,7 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
 
 
     private void createTestConnectionButton(@NotNull Composite parent) {
-        UIUtils.createPushButton(
+        Button testConnectionButton = UIUtils.createPushButton(
             parent,
             AIUIMessages.gpt_preference_page_ai_connection_test_label,
             null,
@@ -249,10 +246,17 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
             })
 
         );
+
+        testConnectionButton.setEnabled(activeEngineConfiguratorPage.getCurrentProperties().isPresent());
     }
 
     private void testConnection() throws DBException, InterruptedException, InvocationTargetException {
-        try (AIEngine selectedEngine = completionEngine.createEngineInstance()) {
+        Optional<AIEngineProperties> currentProperties = activeEngineConfiguratorPage.getCurrentProperties();
+        try (
+            AIEngine selectedEngine = currentProperties.isPresent()
+                ? completionEngine.createEngineInstance(currentProperties.get())
+                : completionEngine.createEngineInstance()
+        ) {
             UIUtils.getDialogRunnableContext().run(true, true, monitor -> {
                 try {
                     selectedEngine.getModels(monitor);
@@ -278,10 +282,10 @@ private void showConnectionErrorMessage(Throwable ex) {
     }
 
     private static class EngineConfiguratorPage {
-        private final IObjectPropertyConfigurator<AIEngineDescriptor, AIEngineProperties> configurator;
+        private final AIIObjectPropertyConfigurator<AIEngineDescriptor, AIEngineProperties> configurator;
         private Composite composite;
 
-        EngineConfiguratorPage(IObjectPropertyConfigurator<AIEngineDescriptor, AIEngineProperties> configurator) {
+        EngineConfiguratorPage(@Nullable AIIObjectPropertyConfigurator<AIEngineDescriptor, AIEngineProperties> configurator) {
             this.configurator = configurator;
         }
 
@@ -307,6 +311,12 @@ private void showConnectionErrorMessage(Throwable ex) {
             if (configurator != null) {
                 configurator.saveSettings(settings);
             }
+        }
+
+        private Optional<AIEngineProperties> getCurrentProperties() {
+            return Optional
+                .ofNullable(configurator)
+                .flatMap(AIIObjectPropertyConfigurator::getCurrentProperties);
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
@@ -278,7 +278,7 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
             NLS.bind(AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_message, engineId),
             ex
         );
-}
+    }
 
     @Override
     public void init(IWorkbench workbench) {

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIPreferencePageMain.java
@@ -17,9 +17,11 @@
 package org.jkiss.dbeaver.ui.ai.preferences;
 
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.*;
 import org.eclipse.ui.IWorkbench;
@@ -30,6 +32,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.ai.AISettings;
+import org.jkiss.dbeaver.model.ai.engine.AIEngine;
 import org.jkiss.dbeaver.model.ai.engine.AIEngineProperties;
 import org.jkiss.dbeaver.model.ai.registry.AIEngineDescriptor;
 import org.jkiss.dbeaver.model.ai.registry.AIEngineRegistry;
@@ -45,6 +48,7 @@ import org.jkiss.dbeaver.ui.ai.internal.AIUIMessages;
 import org.jkiss.dbeaver.ui.preferences.AbstractPrefPage;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -170,7 +174,7 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
         }
 
         final Group engineGroup = UIUtils.createControlGroup(composite, "Engine Settings", 2, SWT.BORDER, 5);
-        engineGroup.setLayoutData(new GridData(GridData.FILL_BOTH));
+        engineGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
         if (completionEngine != null) {
             drawConfiguratorComposite(this.settings.activeEngine(), engineGroup);
         }
@@ -189,6 +193,7 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
         });
         performDefaults();
 
+        createTestConnectionButton(composite);
         return composite;
     }
 
@@ -218,6 +223,54 @@ public class AIPreferencePageMain extends AbstractPrefPage implements IWorkbench
             );
         }
     }
+
+
+    private void createTestConnectionButton(@NotNull Composite parent) {
+        UIUtils.createPushButton(
+            parent,
+            AIUIMessages.gpt_preference_page_ai_connection_test_label,
+            null,
+            SelectionListener.widgetSelectedAdapter(e -> {
+                try{
+                    testConnection();
+                    DBWorkbench.getPlatformUI().showMessageBox(
+                        AIUIMessages.gpt_preference_page_ai_connection_test_connection_success_title,
+                        NLS.bind(
+                            AIUIMessages.gpt_preference_page_ai_connection_test_connection_success_message,
+                            settings.activeEngine()
+                        ),
+                        false
+                    );
+                } catch (DBException | InterruptedException ex) {
+                    showConnectionErrorMessage(ex);
+                } catch (InvocationTargetException ex) {
+                    showConnectionErrorMessage(ex.getCause());
+                }
+            })
+
+        );
+    }
+
+    private void testConnection() throws DBException, InterruptedException, InvocationTargetException {
+        try (AIEngine selectedEngine = completionEngine.createEngineInstance()) {
+            UIUtils.getDialogRunnableContext().run(true, true, monitor -> {
+                try {
+                    selectedEngine.getModels(monitor);
+                } catch (DBException e) {
+                    throw new InvocationTargetException(e);
+                }
+            });
+        }
+    }
+
+
+private void showConnectionErrorMessage(Throwable ex) {
+    DBWorkbench.getPlatformUI().showError(
+        AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_title,
+        NLS.bind(AIUIMessages.gpt_preference_page_ai_connection_test_connection_error_message, settings.activeEngine()),
+        ex
+    );
+}
 
     @Override
     public void init(IWorkbench workbench) {


### PR DESCRIPTION
closes dbeaver/pro#6504
add test connection button. It should be disabled, if engineConfiguration does not support return of current AIEngineproperties.
button should use current settings even, if they are not applied by user, however, it should not save settings by itself