### PR TITLE
dbeaver/pro#5395 Fix semantic analysis not recognizing temp tables

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDataSource.java
@@ -57,7 +57,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
-public class SQLServerDataSource extends JDBCDataSource implements DBSInstanceContainer, DBPObjectStatisticsCollector, DBPAdaptable, DBCQueryTransformProviderExt {
+public class SQLServerDataSource
+    extends JDBCDataSource
+    implements DBSInstanceContainer, DBPObjectStatisticsCollector, DBPAdaptable, DBCQueryTransformProviderExt, DBSVisibilityScopeProvider {
 
     private static final Log log = Log.getLog(SQLServerDataSource.class);
     private static final String PROP_ENCRYPT_SSL = "encrypt";
@@ -585,7 +587,20 @@ public class SQLServerDataSource extends JDBCDataSource implements DBSInstanceCo
         }
         return !hasNextValExpr;
     }
-    
+
+    @NotNull
+    @Override
+    public List<DBSObjectContainer> getPublicScopes(@NotNull DBRProgressMonitor monitor) throws DBException {
+        var tempdb = getDatabase(monitor, SQLServerConstants.TEMPDB_DATABASE);
+        if (tempdb != null) {
+            var dbo = tempdb.getSchema(monitor, SQLServerConstants.DEFAULT_SCHEMA_NAME);
+            if (dbo != null) {
+                return List.of(dbo);
+            }
+        }
+        return List.of();
+    }
+
     public static class DatabaseCache extends JDBCObjectCache<SQLServerDataSource, SQLServerDatabase> {
         DatabaseCache() {
             setListOrderComparator(DBUtils.nameComparator());

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDatabase.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDatabase.java
@@ -64,6 +64,7 @@ public class SQLServerDatabase
 
     private final SQLServerDataSource dataSource;
     private final long databaseId;
+    private final boolean isTempDatabase;
     private boolean persisted;
     private String name;
     private String description;
@@ -82,6 +83,7 @@ public class SQLServerDatabase
         this.dataSource = dataSource;
         this.databaseId = JDBCUtils.safeGetLong(resultSet, "database_id");
         this.name = name;
+        this.isTempDatabase = name.equalsIgnoreCase(SQLServerConstants.TEMPDB_DATABASE);
         //this.description = JDBCUtils.safeGetString(resultSet, "description");
 
         this.persisted = true;
@@ -102,6 +104,7 @@ public class SQLServerDatabase
         this.dataSource = dataSource;
         this.databaseId = 0;
         this.persisted = false;
+        this.isTempDatabase = false;
     }
 
     @NotNull
@@ -175,6 +178,12 @@ public class SQLServerDatabase
         typesCache.clearCache();
     }
 
+    /**
+     * Whether this database represents the {@code tempdb} database.
+     */
+    public boolean isTempDatabase() {
+        return isTempDatabase;
+    }
 
     //////////////////////////////////////////////////
     // Data types

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerSchema.java
@@ -278,7 +278,7 @@ public class SQLServerSchema implements DBSSchema, DBPSaveableObject, DBPQualifi
             return object;
         }
         // tempdb tables have special naming convention. See SQLServerUtils.stripTempdbTableName
-        if (database.getName().equalsIgnoreCase(SQLServerConstants.TEMPDB_DATABASE)) {
+        if (database.isTempDatabase()) {
             for (SQLServerTableTemp table : tableCache.getTypedObjects(monitor, this, SQLServerTableTemp.class)) {
                 if (table.getOriginalName().equalsIgnoreCase(childName)) {
                     return table;

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerSchema.java
@@ -272,7 +272,20 @@ public class SQLServerSchema implements DBSSchema, DBPSaveableObject, DBPQualifi
 
     @Override
     public SQLServerTableBase getChild(@NotNull DBRProgressMonitor monitor, @NotNull String childName) throws DBException {
-        return tableCache.getObject(monitor, this, childName);
+        SQLServerTableBase object = tableCache.getObject(monitor, this, childName);
+        if (object != null) {
+            return object;
+        }
+        // tempdb tables have special naming convention. See SQLServerUtils.stripTempdbTableName
+        if (database.getName().equalsIgnoreCase(SQLServerConstants.TEMPDB_DATABASE)) {
+            for (SQLServerTableBase table : tableCache.getAllObjects(monitor, this)) {
+                String name = SQLServerUtils.stripTempdbTableName(table.getName());
+                if (name != null && name.equalsIgnoreCase(childName)) {
+                    return table;
+                }
+            }
+        }
+        return null;
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerSchema.java
@@ -120,6 +120,7 @@ public class SQLServerSchema implements DBSSchema, DBPSaveableObject, DBPQualifi
         return database.getDataSource();
     }
 
+    @NotNull
     @Property(viewable = false, editable = true, order = 10)
     public SQLServerDatabase getDatabase() {
         return database;
@@ -278,9 +279,8 @@ public class SQLServerSchema implements DBSSchema, DBPSaveableObject, DBPQualifi
         }
         // tempdb tables have special naming convention. See SQLServerUtils.stripTempdbTableName
         if (database.getName().equalsIgnoreCase(SQLServerConstants.TEMPDB_DATABASE)) {
-            for (SQLServerTableBase table : tableCache.getAllObjects(monitor, this)) {
-                String name = SQLServerUtils.stripTempdbTableName(table.getName());
-                if (name != null && name.equalsIgnoreCase(childName)) {
+            for (SQLServerTableTemp table : tableCache.getTypedObjects(monitor, this, SQLServerTableTemp.class)) {
+                if (table.getOriginalName().equalsIgnoreCase(childName)) {
                     return table;
                 }
             }
@@ -441,6 +441,12 @@ public class SQLServerSchema implements DBSSchema, DBPSaveableObject, DBPQualifi
             }
             String type = JDBCUtils.safeGetStringTrimmed(dbResult, "type");
             if (SQLServerObjectType.U.name().equals(type) || SQLServerObjectType.S.name().equals(type)) {
+                if (owner.getDatabase().isTempDatabase()) {
+                    String originalName = SQLServerUtils.stripTempdbTableName(name);
+                    if (originalName != null) {
+                        return new SQLServerTableTemp(owner, dbResult, name, originalName);
+                    }
+                }
                 return new SQLServerTable(owner, dbResult, name);
             } else if (SQLServerObjectType.TT.name().equals(type)) {
                 return new SQLServerTableType(owner, dbResult, name);

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerTableTemp.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerTableTemp.java
@@ -1,0 +1,49 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.mssql.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.ext.mssql.SQLServerUtils;
+
+import java.sql.ResultSet;
+
+/**
+ * Represents a user-created temporary table that resides in the {@code tempdb} database.
+ */
+public class SQLServerTableTemp extends SQLServerTable {
+    private final String originalName;
+
+    public SQLServerTableTemp(
+        @NotNull SQLServerSchema catalog,
+        @NotNull ResultSet dbResult,
+        @NotNull String tempName,
+        @NotNull String originalName
+    ) {
+        super(catalog, dbResult, tempName);
+        this.originalName = originalName;
+    }
+
+    /**
+     * Returns the original, stripped name of this temporary table.
+     *
+     * @see SQLServerUtils#stripTempdbTableName(String)
+     */
+    @NotNull
+    public String getOriginalName() {
+        return originalName;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleSchema.java
@@ -424,6 +424,7 @@ public class OracleSchema extends OracleGlobalObject implements
         return OracleTable.class;
     }
 
+    @NotNull
     @Override
     public List<DBSObjectContainer> getPublicScopes(@NotNull DBRProgressMonitor monitor) {
         return List.of(this.getDataSource().getPublicSchema());

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreSchema.java
@@ -106,6 +106,7 @@ public class PostgreSchema implements
         dataTypeCache = new PostgreDataTypeCache();
     }
 
+    @NotNull
     @Override
     public List<DBSObjectContainer> getPublicScopes(@NotNull DBRProgressMonitor monitor) throws DBException {
         return List.of(

--- a/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
+++ b/plugins/org.jkiss.dbeaver.model.lsm/grammar/SQLStandardLexer.g4
@@ -445,6 +445,7 @@ QuestionMark: '?';
 Underscore: '_';
 VerticalBar: '|';
 Tilda: '~';
+Hashtag: '#';
 
 
 // characters
@@ -466,10 +467,6 @@ ApproximateNumericLiteral: (UnsignedInteger|DecimalLiteral) 'E' SignedInteger;
 fragment SignedInteger: (PlusSign|MinusSign)? UnsignedInteger;
 
 
-Comment: (LineComment | MultilineComment) -> channel (HIDDEN);
-LineComment : ('--'|'#') ~ [\r\n]*;
-MultilineComment: ('/*' .*? '*/');
-
 // special characters and character sequences
 fragment NonquoteCharacter: ~'\'';
 fragment QuoteSymbol: SingleQuote SingleQuote;
@@ -480,10 +477,13 @@ Space: [ \t]+;
 
 
 Identifier: IdentifierBody;
-fragment IdentifierBody: IdentifierStart ((Underscore|IdentifierPart)+)?;
-fragment IdentifierStart: SimpleLatinLetter|Underscore;
-fragment IdentifierPart: (IdentifierStart|Digit);
+fragment IdentifierBody:  IdentifierStart IdentifierPart*;
+fragment IdentifierStart: SimpleLatinLetter|Underscore|Hashtag;
+fragment IdentifierPart:  SimpleLatinLetter|Underscore|Digit;
 
+Comment: (LineComment | MultilineComment) -> channel (HIDDEN);
+LineComment : ('--'|'#') ~ [\r\n]*;
+MultilineComment: ('/*' .*? '*/');
 
 // string literals
 fragment CharacterRepresentation: (NonquoteCharacter|QuoteSymbol);

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryConnectionRealContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryConnectionRealContext.java
@@ -84,7 +84,7 @@ public class SQLQueryConnectionRealContext extends SQLQueryConnectionContext {
                 container,
                 this.executionContext,
                 objectName,
-                true,
+                false,
                 this.identifierDetector,
                 this.validateFunctions
             );

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryConnectionRealContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/context/SQLQueryConnectionRealContext.java
@@ -27,7 +27,9 @@ import org.jkiss.dbeaver.model.sql.SQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLSearchUtils;
 import org.jkiss.dbeaver.model.sql.parser.SQLIdentifierDetector;
 import org.jkiss.dbeaver.model.sql.semantics.model.select.SQLQueryRowsSourceModel;
-import org.jkiss.dbeaver.model.struct.*;
+import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.dbeaver.model.struct.DBSObjectContainer;
+import org.jkiss.dbeaver.model.struct.DBSVisibilityScopeProvider;
 
 import java.util.List;
 import java.util.Map;
@@ -82,7 +84,7 @@ public class SQLQueryConnectionRealContext extends SQLQueryConnectionContext {
                 container,
                 this.executionContext,
                 objectName,
-                false,
+                true,
                 this.identifierDetector,
                 this.validateFunctions
             );

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/DBSVisibilityScopeProvider.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/DBSVisibilityScopeProvider.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,5 +29,6 @@ public interface DBSVisibilityScopeProvider {
     /**
      * Returns additional globally visible scopes, like information_schema
      */
+    @NotNull
     List<DBSObjectContainer> getPublicScopes(@NotNull DBRProgressMonitor monitor) throws DBException;
 }


### PR DESCRIPTION
- [x] Please verify that comment recognition (`-- comment`, `# comment`) behaves as before
- [x] Please verify that semantic analysis takes roughly the same time to complete against the same queries as before

~~I enabled fallback to the structure assistant if an object couldn't be found. Theoretically, it should only affect the worst-case scenario when we couldn't find a cached object. In other cases, it would improve database-specific object recognition.~~ obsolete