### PR TITLE
dbeaver/dbeaver#38176 GaussDB Drive - Connection and Operations of the M-Compatibility Database (part)

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/GaussDBConstants.java
@@ -1,0 +1,21 @@
+/*
+     * DBeaver - Universal Database Manager
+     * Copyright (C) 2010-2025 DBeaver Corp and others
+     *
+     * Licensed under the Apache License, Version 2.0 (the "License");
+     * you may not use this file except in compliance with the License.
+     * You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+package org.jkiss.dbeaver.ext.gaussdb;
+
+public class GaussDBConstants {
+    public static final String GAUSSDB_M_COMPATIBLE_MODE = "M";
+}

--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/GaussDBSchema.java
@@ -17,19 +17,11 @@
 
 package org.jkiss.dbeaver.ext.gaussdb.model;
 
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.Collectors;
-
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreProcedureKind;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreRole;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
-import org.jkiss.dbeaver.ext.postgresql.model.PostgreServerExtension;
+import org.jkiss.dbeaver.ext.gaussdb.GaussDBConstants;
+import org.jkiss.dbeaver.ext.postgresql.model.*;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
@@ -39,17 +31,25 @@ import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCObjectLookupCache;
 import org.jkiss.dbeaver.model.meta.Association;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+
 public class GaussDBSchema extends PostgreSchema {
 
     public final PackageCache packageCache;
     private final ProceduresCache proceduresCache;
     private final FunctionsCache functionsCache;
+    private final ConstraintCache constraintCache;
 
     public GaussDBSchema(PostgreDatabase owner, String name, JDBCResultSet resultSet) throws SQLException {
         super(owner, name, resultSet);
         this.packageCache = new PackageCache();
         this.proceduresCache = new ProceduresCache();
         this.functionsCache = new FunctionsCache();
+        this.constraintCache = new ConstraintCache();
     }
 
     public GaussDBSchema(PostgreDatabase database, String name, PostgreRole owner) {
@@ -57,6 +57,7 @@ public class GaussDBSchema extends PostgreSchema {
         this.packageCache = new PackageCache();
         this.proceduresCache = new ProceduresCache();
         this.functionsCache = new FunctionsCache();
+        this.constraintCache = new ConstraintCache();
     }
 
     @Override
@@ -182,5 +183,51 @@ public class GaussDBSchema extends PostgreSchema {
             return new GaussDBFunction(session.getProgressMonitor(), owner, dbResult);
         }
 
+    }
+
+    public class ConstraintCache extends PostgreSchema.ConstraintCache {
+        protected ConstraintCache() {}
+
+        @NotNull
+        @Override
+        protected JDBCStatement prepareObjectsStatement(@Nullable JDBCSession session, @Nullable PostgreTableContainer container,
+                                                        @Nullable PostgreTableBase forParent) throws SQLException {
+            StringBuilder sql = new StringBuilder(
+                "SELECT c.oid,c.*,t.relname as tabrelname,rt.relnamespace as refnamespace,d.description" +
+                    (!getDataSource().getServerType().supportsPGConstraintExpressionColumn() ? ", null as consrc_copy" :
+                        ", case when c.contype='c' then " + (isMMode(container) ? "substring" : "\"substring\"") +
+                            "(pg_get_constraintdef(c.oid), 7) else null end consrc_copy") +
+                    "\nFROM pg_catalog.pg_constraint c" +
+                    "\nINNER JOIN pg_catalog.pg_class t ON t.oid=c.conrelid" +
+                    "\nLEFT OUTER JOIN pg_catalog.pg_class rt ON rt.oid=c.confrelid" +
+                    "\nLEFT OUTER JOIN " +
+                    "pg_catalog.pg_description d ON d.objoid=c.oid AND d.objsubid=0 AND d.classoid='pg_constraint'::regclass" +
+                    "\nWHERE ");
+            if (forParent == null) {
+                sql.append("t.relnamespace=?");
+            } else {
+                sql.append("c.conrelid=?");
+            }
+            sql.append("\nORDER BY c.oid");
+            JDBCPreparedStatement dbStat = session.prepareStatement(sql.toString());
+            if (forParent == null) {
+                dbStat.setLong(1, container.getSchema().getObjectId());
+            } else {
+                dbStat.setLong(1, forParent.getObjectId());
+            }
+            return dbStat;
+        }
+    }
+
+    @Override
+    public ConstraintCache getConstraintCache() {
+        return this.constraintCache;
+    }
+
+    @NotNull
+    private boolean isMMode(@NotNull PostgreTableContainer tableContainer) {
+        GaussDBDatabase database = (GaussDBDatabase) tableContainer.getDatabase();
+        String compatibilityMode = database.getDatabaseCompatibleMode();
+        return GaussDBConstants.GAUSSDB_M_COMPATIBLE_MODE.equals(compatibilityMode);
     }
 }


### PR DESCRIPTION
Our original commit https://github.com/dbeaver/dbeaver/pull/39162 encountered the “org.jkiss.dbeaver.ext.postgresql.test 1.0.120-SNAPSHOT FAILURE” issue, which we could not reproduce locally.
So we split the original commit into a number of small feature commits.
This commit is the second one, which resolves the following problems in issue https://github.com/dbeaver/dbeaver/issues/38176: "
1.When the GaussDB driver is used to connect to the GaussDB M-Compatibility database, an error is reported and the connection cannot be directly connected.
2.In the M-Compatibility database of GaussDB, an error message is displayed when you click Constraints. The constraint information cannot be displayed.
3.In the M-Compatibility database of GaussDB, when you click Foreign Key, an error message is displayed, indicating that foreign key information cannot be displayed."