### PR TITLE
#39344 Fix execution time formatting

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/RuntimeUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/RuntimeUtils.java
@@ -46,6 +46,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.*;
 import java.nio.file.Path;
+import java.text.DecimalFormat;
+import java.text.Format;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
@@ -212,7 +214,7 @@ public final class RuntimeUtils {
         } else if (seconds >= 10) {
             return String.format("%ds", seconds);
         } else {
-            return String.format("%d.%ds", seconds, millis / 100);
+            return Lazy.EXECUTION_SECONDS_FORMAT.format(seconds + millis * 0.001);
         }
     }
 
@@ -814,10 +816,11 @@ public final class RuntimeUtils {
     }
 
     private static class Lazy {
-        static final MessageFormat DURATION_HOURS_FORMAT = new MessageFormat(ModelMessages.duration_hours);
-        static final MessageFormat DURATION_MINUTES_FORMAT = new MessageFormat(ModelMessages.duration_minutes);
-        static final MessageFormat DURATION_SECONDS_FORMAT = new MessageFormat(ModelMessages.duration_seconds);
-        static final MessageFormat DURATION_MILLISECONDS_FORMAT = new MessageFormat(ModelMessages.duration_milliseconds);
+        static final Format DURATION_HOURS_FORMAT = new MessageFormat(ModelMessages.duration_hours);
+        static final Format DURATION_MINUTES_FORMAT = new MessageFormat(ModelMessages.duration_minutes);
+        static final Format DURATION_SECONDS_FORMAT = new MessageFormat(ModelMessages.duration_seconds);
+        static final Format DURATION_MILLISECONDS_FORMAT = new MessageFormat(ModelMessages.duration_milliseconds);
+        static final Format EXECUTION_SECONDS_FORMAT = new DecimalFormat("#.###s");
 
         private Lazy() {
         }

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/utils/RuntimeUtilsTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/utils/RuntimeUtilsTest.java
@@ -48,12 +48,16 @@ public class RuntimeUtilsTest extends DBeaverUnitTest {
 
     @Test
     public void testFormatExecutionTime() {
+        // NOTE: Depends on the localization!
+        Assume.assumeTrue(Locale.getDefault().equals(Locale.ENGLISH));
+
         Assert.assertEquals("1h 0m 0s", RuntimeUtils.formatExecutionTime(Duration.ofHours(1)));
         Assert.assertEquals("1h 1m 1s", RuntimeUtils.formatExecutionTime(Duration.ofHours(1).plusMinutes(1).plusSeconds(1)));
         Assert.assertEquals("1h 1m 0s", RuntimeUtils.formatExecutionTime(Duration.ofHours(1).plusMinutes(1).plusMillis(500)));
         Assert.assertEquals("11h 41m 9s", RuntimeUtils.formatExecutionTime(Duration.ofSeconds(42069)));
-        Assert.assertEquals("1.0s", RuntimeUtils.formatExecutionTime(Duration.ofSeconds(1)));
+        Assert.assertEquals("1s", RuntimeUtils.formatExecutionTime(Duration.ofSeconds(1)));
         Assert.assertEquals("0.5s", RuntimeUtils.formatExecutionTime(Duration.ofMillis(500)));
+        Assert.assertEquals("0.025s", RuntimeUtils.formatExecutionTime(Duration.ofMillis(25)));
         Assert.assertEquals("10s", RuntimeUtils.formatExecutionTime(Duration.ofSeconds(10)));
         Assert.assertEquals("1m 1s", RuntimeUtils.formatExecutionTime(Duration.ofMinutes(1).plusSeconds(1)));
         Assert.assertEquals("1m 0s", RuntimeUtils.formatExecutionTime(Duration.ofMinutes(1)));

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/utils/RuntimeUtilsTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/utils/RuntimeUtilsTest.java
@@ -58,6 +58,7 @@ public class RuntimeUtilsTest extends DBeaverUnitTest {
         Assert.assertEquals("1s", RuntimeUtils.formatExecutionTime(Duration.ofSeconds(1)));
         Assert.assertEquals("0.5s", RuntimeUtils.formatExecutionTime(Duration.ofMillis(500)));
         Assert.assertEquals("0.025s", RuntimeUtils.formatExecutionTime(Duration.ofMillis(25)));
+        Assert.assertEquals("0.001s", RuntimeUtils.formatExecutionTime(Duration.ofMillis(1)));
         Assert.assertEquals("10s", RuntimeUtils.formatExecutionTime(Duration.ofSeconds(10)));
         Assert.assertEquals("1m 1s", RuntimeUtils.formatExecutionTime(Duration.ofMinutes(1).plusSeconds(1)));
         Assert.assertEquals("1m 0s", RuntimeUtils.formatExecutionTime(Duration.ofMinutes(1)));


### PR DESCRIPTION
Now duration that is less than 10 seconds should be formatted **without** trailing zeroes, like `1.2s`, `1.23s`