### PR TITLE
dbeaver/pro#7230: fix provider properties copied to authmodelselector

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/connection/AuthModelSelector.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/dialogs/connection/AuthModelSelector.java
@@ -191,6 +191,7 @@ public class AuthModelSelector extends Composite implements DBPEventListener {
                 currentConfig.setUserPassword(newConfig.getUserPassword());
                 currentConfig.setUrl(newConfig.getUrl());
                 currentConfig.setAuthProperties(newConfig.getAuthProperties());
+                currentConfig.setProviderProperties(newConfig.getProviderProperties());
 
                 if (authModelConfigurator != null && !isDisposed()) {
                     authModelConfigurator.loadSettings(activeDataSource);


### PR DESCRIPTION
closes dbeaver/pro#7230: fix problem with resetting chosen auth model