### PR TITLE
dbeaver/dbeaver-devops#2294 Snapcraft publisher vetting

### DIFF
--- a/product/snap-build/snap/snapcraft.yaml
+++ b/product/snap-build/snap/snapcraft.yaml
@@ -85,3 +85,4 @@ parts:
     override-prime: |
       snapcraftctl prime
       rm -vf usr/lib/jvm/java-*/lib/security/blacklisted.certs
+


### PR DESCRIPTION
A dummy commit including a token for publisher vetting in order to grant classic confinement