### PR TITLE
dbeaver/pro#8030 Fix tabs styling

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/css/e4-dark_dbeaver_prefstyle.css
+++ b/plugins/org.jkiss.dbeaver.core/css/e4-dark_dbeaver_prefstyle.css
@@ -64,11 +64,7 @@ IEclipsePreferences#org-eclipse-ui-editors:org-eclipse-ui-themes {
     background-color: #2F2F2F;
 }
 
-.EditorStack, .MPartStack {
-    swt-tab-renderer: url('bundleclass://org.jkiss.dbeaver.core/org.jkiss.dbeaver.ui.e4.DBeaverCTabFolderRenderer');
-}
-
-#org-eclipse-ui-editorss CTabFolder.coloredByConnectionType {
+CTabFolder, .EditorStack, .MPartStack, #org-eclipse-ui-editorss {
     swt-tab-renderer: url('bundleclass://org.jkiss.dbeaver.core/org.jkiss.dbeaver.ui.e4.DBeaverCTabFolderRenderer');
 
     /* Workaround for org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering.TAB_OUTLINE_WIDTH */

--- a/plugins/org.jkiss.dbeaver.core/css/e4-dbeaver_prefstyle.css
+++ b/plugins/org.jkiss.dbeaver.core/css/e4-dbeaver_prefstyle.css
@@ -34,11 +34,7 @@
     background-color: #fbfbfb;
 }
 
-.EditorStack, .MPartStack {
-    swt-tab-renderer: url('bundleclass://org.jkiss.dbeaver.core/org.jkiss.dbeaver.ui.e4.DBeaverCTabFolderRenderer');
-}
-
-#org-eclipse-ui-editorss CTabFolder.coloredByConnectionType {
+CTabFolder, .EditorStack, .MPartStack, #org-eclipse-ui-editorss {
     swt-tab-renderer: url('bundleclass://org.jkiss.dbeaver.core/org.jkiss.dbeaver.ui.e4.DBeaverCTabFolderRenderer');
 
     /* Workaround for org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering.TAB_OUTLINE_WIDTH */


### PR DESCRIPTION
Fixed background and selected colors of tabs:

<img width="345" height="80" alt="image" src="https://github.com/user-attachments/assets/d9f13cfd-72d4-4bc5-a2b7-4664852f26e3" />

Must be tested against light, dark themes, colored connection types (prod, qa), and Linux, Windows, and macOS.