### PR TITLE
dbeaver/dbeaver#40190 Fix row count estimate for TimescaleDB hypertables

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/timescale/TimescaleSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/timescale/TimescaleSchema.java
@@ -46,7 +46,8 @@ public class TimescaleSchema extends PostgreSchema {
                 """
                 SELECT c.oid,
                        (size_info).total_bytes as total_rel_size,
-                       (size_info).table_bytes as rel_size
+                       (size_info).table_bytes as rel_size,
+                       approximate_row_count(c.oid::regclass) as approx_rows
                 FROM pg_class c
                 JOIN timescaledb_information.hypertables h
                   ON h.hypertable_schema = ? AND h.hypertable_name = c.relname
@@ -57,10 +58,13 @@ public class TimescaleSchema extends PostgreSchema {
                 stmt.setLong(2, getObjectId());
                 try (JDBCResultSet dbResult = stmt.executeQuery()) {
                     while (dbResult.next()) {
-                        long tableId = dbResult.getLong(1);
+                        long tableId = dbResult.getLong("oid");
                         PostgreTableBase table = getTable(monitor, tableId);
                         if (table instanceof TimescaleTable timescaleTable) {
+                            timescaleTable.markAsHypertable();
                             timescaleTable.fetchStatistics(dbResult);
+                            long approxRows = dbResult.getLong("approx_rows");
+                            timescaleTable.setRowCountEstimateFromBulk(approxRows);
                         }
                     }
                 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/timescale/TimescaleTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/timescale/TimescaleTable.java
@@ -32,6 +32,10 @@ public class TimescaleTable extends PostgreTableRegular {
 
     private static final Log log = Log.getLog(TimescaleTable.class);
 
+    private volatile Boolean cachedIsHypertable;
+
+    private volatile boolean rowCountEstimateSetFromBulk = false;
+
     public TimescaleTable(PostgreSchema schema, ResultSet dbResult) {
         super(schema, dbResult);
     }
@@ -57,9 +61,20 @@ public class TimescaleTable extends PostgreTableRegular {
                 }
             }
         }
+
+        if (!rowCountEstimateSetFromBulk) {
+            long approximateRowCount = fetchApproximateRowCount(session);
+            if (approximateRowCount >= 0) {
+                rowCountEstimate = approximateRowCount;
+            }
+        }
     }
 
-    private boolean isHypertable(@NotNull JDBCSession session) throws SQLException {
+    private synchronized boolean isHypertable(@NotNull JDBCSession session) throws SQLException {
+        if (cachedIsHypertable != null) {
+            return cachedIsHypertable;
+        }
+
         String sql =
             "SELECT 1 FROM timescaledb_information.hypertables " +
             "WHERE hypertable_schema = ? AND hypertable_name = ?";
@@ -68,12 +83,39 @@ public class TimescaleTable extends PostgreTableRegular {
             stmt.setString(1, getSchema().getName());
             stmt.setString(2, getName());
             try (JDBCResultSet rs = stmt.executeQuery()) {
-                return rs.next();
+                cachedIsHypertable = rs.next();
+                return cachedIsHypertable;
             }
         } catch (SQLException e) {
             log.error("Failed to check if table is a hypertable: " + e.getMessage(), e);
             return false;
         }
+    }
+
+    private long fetchApproximateRowCount(@NotNull JDBCSession session) {
+        String sql = "SELECT approximate_row_count(format('%I.%I', ?, ?)::regclass)";
+        try (JDBCPreparedStatement stmt = session.prepareStatement(sql)) {
+            stmt.setString(1, getSchema().getName());
+            stmt.setString(2, getName());
+            try (JDBCResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+                return -1L;
+            }
+        } catch (SQLException e) {
+            log.debug("Failed to get approximate row count: " + e.getMessage(), e);
+            return -1L;
+        }
+    }
+
+    synchronized void markAsHypertable() {
+        this.cachedIsHypertable = true;
+    }
+
+    synchronized void setRowCountEstimateFromBulk(long rowCount) {
+        this.rowCountEstimate = rowCount;
+        this.rowCountEstimateSetFromBulk = true;
     }
 
     @Override


### PR DESCRIPTION
## Summary

This pull request resolves issue #40190, fixing incorrect row count estimate display for TimescaleDB hypertables.

## Solution

```
getRowCountEstimate()
  ↓
Check isHypertable()
  ├─ Yes → approximate_row_count() (TimescaleDB function)
  └─ No  → pg_class.reltuples (existing behavior)
```

Similar to PR #40030's disk space fix.

## Test Results

### Test Environment
- **Docker Image**: `timescale/timescaledb:latest-pg16`

### Test Table Creation
```sql
CREATE TABLE sensor_data (
    time TIMESTAMPTZ NOT NULL,
    sensor_id INTEGER,
    value FLOAT
);

SELECT create_hypertable('sensor_data', 'time');

-- Insert large amount of data
INSERT INTO sensor_data
SELECT time, sensor_id, random() * 100
FROM generate_series(NOW() - INTERVAL '1 year', NOW(), INTERVAL '1 minute') AS time,
     generate_series(1, 100) AS sensor_id;

-- Verify row count
SELECT approximate_row_count('sensor_data');
```

### Test: Hypertable Row Count Display
**before**
<img width="1389" height="571" alt="image" src="https://github.com/user-attachments/assets/c38e696f-89e1-412f-a25a-296932f97f47" />
<img width="1392" height="572" alt="image" src="https://github.com/user-attachments/assets/618bd821-0fe6-4250-a013-a649a51e521c" />


**after**
<img width="1387" height="569" alt="image" src="https://github.com/user-attachments/assets/5aa086a9-f477-4e0d-9d96-85a349cc22e0" />
<img width="1389" height="572" alt="image" src="https://github.com/user-attachments/assets/f6849e0f-589f-4d5e-9cf9-fb3a0ac30ef0" />

---

## Related Issues

- **Closes** #40190
- **Related** #40030