### PR TITLE
dbeaver/dbeaver#40264 Fix text clipping in ERD notes

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.erd/src/org/jkiss/dbeaver/ui/editors/erd/figures/NoteFigure.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.erd/src/org/jkiss/dbeaver/ui/editors/erd/figures/NoteFigure.java
@@ -24,6 +24,7 @@ import org.eclipse.draw2d.CompoundBorder;
 import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.text.FlowPage;
 import org.eclipse.draw2d.text.TextFlow;
 import org.jkiss.dbeaver.model.erd.ERDNote;
@@ -66,10 +67,22 @@ public class NoteFigure extends FlowPage {
     }
 
     @Override
-    public Dimension getPreferredSize(int width, int h) {
+    public Dimension getPreferredSize(int wHint, int hHint) {
+        Insets insets = getInsets();
+        int widthLimit = wHint;
+        if (widthLimit > -1) {
+            widthLimit -= insets.getWidth();
+        }
+        int heightLimit = hHint;
+        if (heightLimit > -1) {
+            heightLimit -= insets.getHeight();
+        }
+
+        Dimension textPrefSize = textFlow.getPreferredSize(widthLimit, heightLimit).getCopy();
+        textPrefSize.expand(insets.getWidth(), insets.getHeight());
+
         // Return current size if it is bigger than text (means it was changed manually)
         Dimension currentSize = getSize();
-        Dimension textPrefSize = textFlow.getPreferredSize(width, h);
         if (currentSize.width >= textPrefSize.width && currentSize.height >= textPrefSize.height) {
             return currentSize;
         }
@@ -78,8 +91,12 @@ public class NoteFigure extends FlowPage {
 
     @Override
     public void setPreferredSize(Dimension size) {
-        textFlow.setSize(size);
-        textFlow.setPreferredSize(size);
+        if (size != null) {
+            Insets insets = getInsets();
+            Dimension innerSize = size.getCopy().shrink(insets.getWidth(), insets.getHeight());
+            textFlow.setSize(innerSize);
+            textFlow.setPreferredSize(innerSize);
+        }
         super.setPreferredSize(size);
     }
 


### PR DESCRIPTION
Refers to #40264

#### System information:
- Operating system: Windows 11 (High DPI Scaling 175%/200%)
- DBeaver version: 25.3.4
- Java version: Java 11/17

#### Describe the problem you're observing:
In ERD diagrams, text within **Notes** is clipped or truncated when high DPI scaling (e.g., 200%) is used. The `NoteFigure` class failed to account for its internal `MarginBorder` and `LineBorder` insets during size calculations, leading to the `TextFlow` overlapping with borders.

#### Describe the solution:
Fixed `NoteFigure.java` logic:
- Updated `getPreferredSize` to correctly subtract insets from layout hints and expand the final result to include those insets.
- Updated `setPreferredSize` to ensure the internal `TextFlow` stays within the note's inner area (total size minus insets).
- Added missing `org.eclipse.draw2d.geometry.Insets` import.

#### Steps to reproduce:
1. Set Windows display scaling to 200%.
2. Create an ERD diagram and add a Note.
3. Type "External Business Services" and resize the note to fit the text on one line.
4. Observe the text being clipped by the border.

#### Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/dbeaver/dbeaver/blob/develop/CONTRIBUTING.md) guide.
- [x] My code follows the coding style of this project.
- [x] I have performed a self-review of my own code.
- [x] Commit is signed-off (DCO).