### PR TITLE
#39027 Add back P2 Sites preference page

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConstants.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConstants.java
@@ -16,9 +16,15 @@
  */
 package org.jkiss.dbeaver.ui.preferences;
 
-public class PrefPageConstants {
+public final class PrefPageConstants {
 
     public static final String WORKBENCH_PREF_PAGE_ID = "org.eclipse.ui.preferencePages.Workbench";
     public static final String APPEARANCE_PREF_PAGE_ID = "org.eclipse.ui.preferencePages.Views";
     public static final String EDITORS_PREF_PAGE_ID = "org.eclipse.ui.preferencePages.Editors";
+
+    public static final String P2_PROVISIONING_PREF_PAGE_ID = "org.eclipse.equinox.internal.p2.ui.sdk.ProvisioningPreferencePage";
+    public static final String P2_SITES_PREF_PAGE_ID = "org.eclipse.equinox.internal.p2.ui.sdk.SitesPreferencePage";
+
+    private PrefPageConstants() {
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchAdvisor.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/ApplicationWorkbenchAdvisor.java
@@ -85,8 +85,8 @@ import java.awt.*;
 import java.awt.desktop.SystemEventListener;
 import java.awt.desktop.SystemSleepEvent;
 import java.awt.desktop.SystemSleepListener;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 
 /**
  * This workbench advisor creates the window advisor, and specifies
@@ -122,7 +122,7 @@ public class ApplicationWorkbenchAdvisor extends IDEWorkbenchAdvisor {
         PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/" + PrefPageConstants.EDITORS_PREF_PAGE_ID,
         PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/" + PrefPageConstants.EDITORS_PREF_PAGE_ID + "/org.eclipse.ui.preferencePages.AutoSave",
 
-        "org.eclipse.equinox.internal.p2.ui.sdk.ProvisioningPreferencePage",    // Install-Update
+        PrefPageConstants.P2_PROVISIONING_PREF_PAGE_ID,
 
         // Team preferences - not needed in CE
         //"org.eclipse.team.ui.TeamPreferences",
@@ -130,11 +130,12 @@ public class ApplicationWorkbenchAdvisor extends IDEWorkbenchAdvisor {
 
     // Move to UI
     private static final String[] UI_PREF_PAGES = {
-            PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/org.eclipse.ui.preferencePages.Views",
-            PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/org.eclipse.ui.preferencePages.Keys",
-            PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/org.eclipse.search.preferences.SearchPreferencePage",
-            PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/org.eclipse.text.quicksearch.PreferencesPage",
-            PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/" + PrefPageConstants.EDITORS_PREF_PAGE_ID + "/org.eclipse.ui.preferencePages.FileEditors" //"File Associations"
+        PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/org.eclipse.ui.preferencePages.Views",
+        PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/org.eclipse.ui.preferencePages.Keys",
+        PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/org.eclipse.search.preferences.SearchPreferencePage",
+        PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/org.eclipse.text.quicksearch.PreferencesPage",
+        PrefPageConstants.WORKBENCH_PREF_PAGE_ID + "/" + PrefPageConstants.EDITORS_PREF_PAGE_ID + "/org.eclipse.ui.preferencePages.FileEditors", //"File Associations"
+        PrefPageConstants.P2_PROVISIONING_PREF_PAGE_ID + "/" + PrefPageConstants.P2_SITES_PREF_PAGE_ID,
     };
 
     // Move to Editors


### PR DESCRIPTION
I couldn't find an easy way to conditionally reveal an externally defined preference page without modifying the registry, so I followed a rather simple approach of putting **Sites** under **User Interface** and removing the two other unrelated pages:

<img width="988" height="517" alt="dbeaver_gUluUNUZnY" src="https://github.com/user-attachments/assets/46dce993-5e60-4b63-b215-7a108ed1ce75" />

I think it will do for now.