### PR TITLE
fix: enable lazy description loading for ERD entity comments

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDContentProviderDefault.java
+++ b/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDContentProviderDefault.java
@@ -70,7 +70,7 @@ public class ERDContentProviderDefault implements ERDContentProvider {
             try {
                 ((DBPObjectWithLazyDescription) entity).getDescription(monitor);
             } catch (DBException e) {
-                log.warn("Unable to load lazy description when filling ERDEntity from object", e);
+                log.warn("Unable to load lazy description for entity '" + entity.getName() + "'", e);
             }
         }
         if (settings.getVisibility() != ERDAttributeVisibility.NONE) {

--- a/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDContentProviderDefault.java
+++ b/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDContentProviderDefault.java
@@ -70,7 +70,7 @@ public class ERDContentProviderDefault implements ERDContentProvider {
             try {
                 ((DBPObjectWithLazyDescription) entity).getDescription(monitor);
             } catch (DBException e) {
-                log.warn("Unable to load lazy description when filling ERDEntity from object");
+                log.warn("Unable to load lazy description when filling ERDEntity from object", e);
             }
         }
         if (settings.getVisibility() != ERDAttributeVisibility.NONE) {
@@ -125,7 +125,7 @@ public class ERDContentProviderDefault implements ERDContentProvider {
                         try {
                             ((DBPObjectWithLazyDescription) attribute).getDescription(monitor);
                         } catch (DBException e) {
-                            log.warn("Unable to load lazy description for attribute '" + attribute.getName() + "'");
+                            log.warn("Unable to load lazy description for attribute '" + attribute.getName() + "'", e);
                         }
                     }
                     boolean inPrimaryKey = idColumns != null && idColumns.contains(attribute);

--- a/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDContentProviderDefault.java
+++ b/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDContentProviderDefault.java
@@ -37,8 +37,6 @@ public class ERDContentProviderDefault implements ERDContentProvider {
 
     private static final Log log = Log.getLog(ERDContentProviderDefault.class);
 
-    private static final boolean READ_LAZY_DESCRIPTIONS = false;
-
     private final Map<String, Object> attributes = new HashMap<>();
 
     public ERDContentProviderDefault() {
@@ -68,7 +66,7 @@ public class ERDContentProviderDefault implements ERDContentProvider {
         @NotNull ERDAttributeSettings settings
     ) {
         DBSEntity entity = erdEntity.getObject();
-        if (READ_LAZY_DESCRIPTIONS && entity instanceof DBPObjectWithLazyDescription) {
+        if (entity instanceof DBPObjectWithLazyDescription) {
             try {
                 ((DBPObjectWithLazyDescription) entity).getDescription(monitor);
             } catch (DBException e) {
@@ -122,6 +120,13 @@ public class ERDContentProviderDefault implements ERDContentProvider {
                             break;
                         default:
                             break;
+                    }
+                    if (attribute instanceof DBPObjectWithLazyDescription) {
+                        try {
+                            ((DBPObjectWithLazyDescription) attribute).getDescription(monitor);
+                        } catch (DBException e) {
+                            log.warn("Unable to load lazy description for attribute '" + attribute.getName() + "'");
+                        }
                     }
                     boolean inPrimaryKey = idColumns != null && idColumns.contains(attribute);
                     ERDEntityAttribute c1 = new ERDEntityAttribute(attribute, inPrimaryKey);


### PR DESCRIPTION
## Summary
- Remove the `READ_LAZY_DESCRIPTIONS = false` guard that prevented lazy description preloading in `ERDContentProviderDefault`
- Enable unconditional lazy loading for both entity and attribute descriptions so ERD diagrams can display comments
- Include stack traces and entity/attribute names in warning logs for debugging failed loads

## Test plan
- [x] Verify entity comments appear in ERD diagrams after opening
- [x] Verify attribute comments appear in ERD diagrams
- [x] Verify warning logs include entity name and stack trace on load failure
- [ ] No regression in ERD diagram loading performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)