### PR TITLE
dbeaver/pro#8509 Remove dots from dbvr help desctiptions

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.cli/src/org/jkiss/dbeaver/model/cli/command/AbstractTopLevelCommand.java
+++ b/plugins/org.jkiss.dbeaver.model.cli/src/org/jkiss/dbeaver/model/cli/command/AbstractTopLevelCommand.java
@@ -34,13 +34,13 @@ public abstract class AbstractTopLevelCommand extends CLIAbstractCommand impleme
     public static final String TRACE_LOGS_OPTION = "--trace-logs";
 
     @CommandLine.Option(names = {"-dump"},
-        description = "Print instance thread dump.")
+        description = "Print instance thread dump")
     private boolean dump;
 
 
     @CommandLine.Option(
         names = {"-h", "-help", HELP_OPTION},
-        description = "Show this help message and exit.",
+        description = "Show this help message and exit",
         usageHelp = true,
         scope = CommandLine.ScopeType.INHERIT
     )
@@ -48,20 +48,20 @@ public abstract class AbstractTopLevelCommand extends CLIAbstractCommand impleme
 
     @CommandLine.Option(
         names = {"-V", "--version"},
-        description = "Print version information and exit.",
+        description = "Print version information and exit",
         versionHelp = true,
         scope = CommandLine.ScopeType.INHERIT
     )
     private boolean version;
 
     @CommandLine.Option(names = {DEBUG_LOGS_OPTION},
-        description = "Enable debug logging.",
+        description = "Enable debug logging",
         scope = CommandLine.ScopeType.INHERIT
     )
     private boolean debugLogs;
 
     @CommandLine.Option(names = {TRACE_LOGS_OPTION},
-        description = "Enable trace logging.",
+        description = "Enable trace logging",
         scope = CommandLine.ScopeType.INHERIT,
         hidden = true
     )

--- a/plugins/org.jkiss.dbeaver.model.cli/src/org/jkiss/dbeaver/model/cli/command/ListNetworkHandlersParameterHandler.java
+++ b/plugins/org.jkiss.dbeaver.model.cli/src/org/jkiss/dbeaver/model/cli/command/ListNetworkHandlersParameterHandler.java
@@ -31,7 +31,7 @@ import picocli.CommandLine;
 
 import java.util.*;
 
-@CommandLine.Command(name = "network-handlers", description = "List available database network handlers.")
+@CommandLine.Command(name = "network-handlers", description = "List available database network handlers")
 
 public class ListNetworkHandlersParameterHandler extends CLIAbstractSubcommand {
     @NotNull


### PR DESCRIPTION
Also removed`.` from the network-handlers command
<img width="656" height="351" alt="image" src="https://github.com/user-attachments/assets/55b1271a-d600-433a-ae01-f616c16d31ce" />
