### PR TITLE
Dbeaver/pro#6618 packages visualize procedure name when reviewing source

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/plugin.xml
@@ -210,6 +210,7 @@
             <objectType name="org.jkiss.dbeaver.ext.oracle.model.OracleTableIndex"/>
             <objectType name="org.jkiss.dbeaver.ext.oracle.model.OracleSequence"/>
             <objectType name="org.jkiss.dbeaver.ext.oracle.model.OracleTablespace"/>
+            <objectType name="org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged"/>
         </editor>
         <editor
                 id="org.jkiss.dbeaver.ext.oracle.ui.editors.SchedulerJobLogEditor"

--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/actions/PackageNavigateHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/actions/PackageNavigateHandler.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2025 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.eclipse.ui.handlers.HandlerUtil;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
-import org.jkiss.dbeaver.ext.oracle.model.OraclePackage;
 import org.jkiss.dbeaver.ext.oracle.model.OracleProcedureArgument;
 import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
@@ -63,8 +62,7 @@ public class PackageNavigateHandler extends AbstractHandler //implements IElemen
     {
         final OracleProcedurePackaged procedure = getSelectedProcedure(event);
         if (procedure != null) {
-            OraclePackage procPackage = procedure.getParentObject();
-            IEditorPart entityEditor = NavigatorHandlerObjectOpen.openEntityEditor(procPackage);
+            IEditorPart entityEditor = NavigatorHandlerObjectOpen.openEntityEditor(procedure);
             if (entityEditor instanceof EntityEditor) {
                 ((EntityEditor) entityEditor).switchFolder("source.definition");
                 SQLEditorBase sqlEditor = entityEditor.getAdapter(SQLEditorBase.class);

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedureBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedureBase.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ public abstract class OracleProcedureBase<PARENT extends DBSObjectContainer> ext
 
     public abstract OracleSchema getSchema();
 
+    @Nullable
     public abstract Integer getOverloadNumber();
 
     @Nullable

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
@@ -18,6 +18,7 @@ package org.jkiss.dbeaver.ext.oracle.model;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.oracle.model.util.ProcedureBodyExtractor;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
 import org.jkiss.dbeaver.model.DBPScriptObject;
 import org.jkiss.dbeaver.model.DBPUniqueObject;
@@ -29,9 +30,6 @@ import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
 
 import java.sql.ResultSet;
 import java.util.Map;
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * GenericProcedure
@@ -40,8 +38,7 @@ public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> 
 {
     private Integer overload;
 
-    @NotNull
-    private final String parentPackageName;
+    private String procedureDefinition;
 
     public OracleProcedurePackaged(
         @NotNull OraclePackage ownerPackage,
@@ -52,7 +49,6 @@ public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> 
             JDBCUtils.safeGetString(dbResult, "PROCEDURE_NAME"),
             0l,
             DBSProcedureType.valueOf(JDBCUtils.safeGetString(dbResult, "PROCEDURE_TYPE")));
-        parentPackageName = defineParentPackageName(dbResult, ownerPackage);
     }
 
     @NotNull
@@ -92,36 +88,15 @@ public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> 
     @NotNull
     @Override
     public String getObjectDefinitionText(@NotNull DBRProgressMonitor monitor, @NotNull Map<String, Object> options) throws DBException {
-        return parent.getExtendedDefinitionText(monitor);
-    }
-
-    @NotNull
-    private static String defineParentPackageName(@NotNull ResultSet dbResult, @NotNull OraclePackage ownerPackage) {
-        return Objects.requireNonNullElse(
-            JDBCUtils.safeGetString(dbResult, "OBJECT_NAME"),
-            ownerPackage.getName()
-        );
-    }
-
-    private String extractSource(@NotNull String typeText, @NotNull String parentPackageBodyDefinition) {
-        Pattern procStartToken = Pattern.compile(typeText + " " + getUniqueName(), Pattern.CASE_INSENSITIVE);
-        Matcher matcherStart = procStartToken.matcher(parentPackageBodyDefinition);
-        if (matcherStart.find()) {
-            int beginDefinition = matcherStart.start();
-            Pattern procEndPattern = Pattern.compile(constructEndRegex(getUniqueName()), Pattern.CASE_INSENSITIVE);
-            Matcher procEndMatcher = procEndPattern.matcher(parentPackageBodyDefinition.substring(matcherStart.end()));
-            if (procEndMatcher.find()) {
-                return parentPackageBodyDefinition.substring(beginDefinition, procEndMatcher.end());
-            } else {
-                Pattern generalEndPattern = Pattern.compile(constructEndRegex(parentPackageName) + "|" + "function\\s+.+");
-            }
+        if (!definitionPresent()) {
+            String packageDefinition = parent.getExtendedDefinitionText(monitor);
+            procedureDefinition = new ProcedureBodyExtractor(this, packageDefinition).extractProcBody();
         }
-        return "-- no procedure definition found";
+        return procedureDefinition;
     }
 
-    @NotNull
-    private String constructEndRegex(@NotNull String objectName) {
-        return "end\\s++" + objectName + ";";
+    private boolean definitionPresent() {
+        return procedureDefinition != null && !procedureDefinition.equals(ProcedureBodyExtractor.NO_DEFINITION_FOUND);
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.ext.oracle.model;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.oracle.model.util.ProcedureBodyExtractor;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
@@ -68,6 +69,7 @@ public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> 
     }
 
     @Override
+    @Nullable
     public Integer getOverloadNumber()
     {
         return overload;

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
@@ -30,6 +30,8 @@ import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
 import java.sql.ResultSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * GenericProcedure
@@ -88,6 +90,7 @@ public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> 
     }
 
     @NotNull
+    @Override
     public String getObjectDefinitionText(@NotNull DBRProgressMonitor monitor, @NotNull Map<String, Object> options) throws DBException {
         return parent.getExtendedDefinitionText(monitor);
     }
@@ -99,4 +102,26 @@ public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> 
             ownerPackage.getName()
         );
     }
+
+    private String extractSource(@NotNull String typeText, @NotNull String parentPackageBodyDefinition) {
+        Pattern procStartToken = Pattern.compile(typeText + " " + getUniqueName(), Pattern.CASE_INSENSITIVE);
+        Matcher matcherStart = procStartToken.matcher(parentPackageBodyDefinition);
+        if (matcherStart.find()) {
+            int beginDefinition = matcherStart.start();
+            Pattern procEndPattern = Pattern.compile(constructEndRegex(getUniqueName()), Pattern.CASE_INSENSITIVE);
+            Matcher procEndMatcher = procEndPattern.matcher(parentPackageBodyDefinition.substring(matcherStart.end()));
+            if (procEndMatcher.find()) {
+                return parentPackageBodyDefinition.substring(beginDefinition, procEndMatcher.end());
+            } else {
+                Pattern generalEndPattern = Pattern.compile(constructEndRegex(parentPackageName) + "|" + "function\\s+.+");
+            }
+        }
+        return "-- no procedure definition found";
+    }
+
+    @NotNull
+    private String constructEndRegex(@NotNull String objectName) {
+        return "end\\s++" + objectName + ";";
+    }
+
 }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
@@ -18,7 +18,10 @@ package org.jkiss.dbeaver.ext.oracle.model;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
-import org.jkiss.dbeaver.model.*;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.DBPScriptObject;
+import org.jkiss.dbeaver.model.DBPUniqueObject;
+import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
@@ -26,23 +29,28 @@ import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
 
 import java.sql.ResultSet;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * GenericProcedure
  */
-public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> implements DBPUniqueObject, DBPScriptObject, DBSObject,
-    DBPScriptObjectExt
+public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> implements DBPUniqueObject, DBPScriptObject, DBSObject
 {
     private Integer overload;
 
+    @NotNull
+    private final String parentPackageName;
+
     public OracleProcedurePackaged(
-        OraclePackage ownerPackage,
-        ResultSet dbResult)
+        @NotNull OraclePackage ownerPackage,
+        @NotNull ResultSet dbResult
+    )
     {
         super(ownerPackage,
             JDBCUtils.safeGetString(dbResult, "PROCEDURE_NAME"),
             0l,
             DBSProcedureType.valueOf(JDBCUtils.safeGetString(dbResult, "PROCEDURE_TYPE")));
+        parentPackageName = defineParentPackageName(dbResult, ownerPackage);
     }
 
     @NotNull
@@ -80,14 +88,15 @@ public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> 
     }
 
     @NotNull
-    @Override
     public String getObjectDefinitionText(@NotNull DBRProgressMonitor monitor, @NotNull Map<String, Object> options) throws DBException {
-        return "test normal definition";
+        return parent.getExtendedDefinitionText(monitor);
     }
 
     @NotNull
-    @Override
-    public String getExtendedDefinitionText(@NotNull DBRProgressMonitor monitor) throws DBException {
-        return "test extended definition";
+    private static String defineParentPackageName(@NotNull ResultSet dbResult, @NotNull OraclePackage ownerPackage) {
+        return Objects.requireNonNullElse(
+            JDBCUtils.safeGetString(dbResult, "OBJECT_NAME"),
+            ownerPackage.getName()
+        );
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedurePackaged.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2025 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,21 @@
 package org.jkiss.dbeaver.ext.oracle.model;
 
 import org.jkiss.code.NotNull;
-import org.jkiss.dbeaver.model.DBPEvaluationContext;
-import org.jkiss.dbeaver.model.DBPUniqueObject;
-import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.*;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
 
 import java.sql.ResultSet;
+import java.util.Map;
 
 /**
  * GenericProcedure
  */
-public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> implements DBPUniqueObject
+public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> implements DBPUniqueObject, DBPScriptObject, DBSObject,
+    DBPScriptObjectExt
 {
     private Integer overload;
 
@@ -76,4 +79,15 @@ public class OracleProcedurePackaged extends OracleProcedureBase<OraclePackage> 
         return overload == null || overload <= 1 ? getName() : getName() + "#" + overload;
     }
 
+    @NotNull
+    @Override
+    public String getObjectDefinitionText(@NotNull DBRProgressMonitor monitor, @NotNull Map<String, Object> options) throws DBException {
+        return "test normal definition";
+    }
+
+    @NotNull
+    @Override
+    public String getExtendedDefinitionText(@NotNull DBRProgressMonitor monitor) throws DBException {
+        return "test extended definition";
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedureStandalone.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleProcedureStandalone.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2025 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.ext.oracle.model;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.oracle.model.source.OracleSourceObject;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
@@ -88,6 +89,7 @@ public class OracleProcedureStandalone extends OracleProcedureBase<OracleSchema>
     }
 
     @Override
+    @Nullable
     public Integer getOverloadNumber()
     {
         return null;

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -51,11 +51,8 @@ public class ProcedureBodyExtractor {
         "LOOP"
     );
 
-
-
     private final OracleProcedurePackaged proc;
     private final String parentPackageBodyDefinition;
-
 
     // must be sorted in asc to exclude properly
     private final List<RegionRange> commentRanges = new ArrayList<>();
@@ -90,7 +87,7 @@ public class ProcedureBodyExtractor {
         String procType = procType();
         if (procType != null) {
             Matcher procStart = Pattern
-                .compile(procType + "\\s+" + proc.getUniqueName(), Pattern.CASE_INSENSITIVE)
+                .compile(procType + "\\s+" + proc.getName(), Pattern.CASE_INSENSITIVE)
                 .matcher(parentPackageBodyDefinition);
             if (procStart.find()) {
                 int functionEndIndex = findProcEnd(procStart.end());

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -74,16 +74,7 @@ public class ProcedureBodyExtractor {
         } else {
             beginMatcher = getBeginMatcher();
             endMatcher = getEndMatcher();
-            boolean isNextEndFound = findFromIndex(endMatcher, startIndex);
-            if (isNextEndFound) {
-                fillBeginStack(startIndex, endMatcher.start());
-                beginStack.poll();
-                return beginStack.isEmpty()
-                    ? endMatcher.end()
-                    : findFunctionEndIndex(endMatcher.end());
-            } else {
-                return -1;
-            }
+            return findFunctionEndIndex(startIndex);
         }
     }
 
@@ -91,7 +82,7 @@ public class ProcedureBodyExtractor {
         Matcher endFunctionWithName = Pattern
             .compile("end\\s*" + proc.getUniqueName() + "[\\s\\n]*;", Pattern.CASE_INSENSITIVE)
             .matcher(parentPackageBodyDefinition);
-        return endFunctionWithName.find(startIndex)
+        return findFromIndex(endFunctionWithName, startIndex)
             ? endFunctionWithName.end()
             : -1;
     }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -1,0 +1,118 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.oracle.model.util;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ProcedureBodyExtractor {
+
+    public static final String NO_DEFINITION_FOUND = "-- no definition found";
+    private final OracleProcedurePackaged proc;
+    private final String parentPackageBodyDefinition;
+
+    private final Deque<Integer> beginStack = new ArrayDeque<>();
+    private final Deque<Integer> endStack = new ArrayDeque<>();
+
+    private Matcher beginMatcher;
+    private Matcher endMatcher;
+
+
+    public ProcedureBodyExtractor(@NotNull OracleProcedurePackaged proc, @NotNull String parentPackageBodyDefinition) {
+        this.proc = proc;
+        this.parentPackageBodyDefinition = parentPackageBodyDefinition;
+    }
+
+
+    public String extractProcBody() {
+        String procType = procType();
+        if (procType != null) {
+            Matcher procStart = Pattern
+                .compile(procType + "\\s+" + proc.getUniqueName(), Pattern.CASE_INSENSITIVE)
+                .matcher(parentPackageBodyDefinition);
+            if (procStart.find()) {
+                int functionEndIndex = findProcEnd(procStart);
+                return functionEndIndex >= 0
+                    ? parentPackageBodyDefinition.substring(procStart.start(), functionEndIndex)
+                    : parentPackageBodyDefinition.substring(procStart.start());
+            }
+        }
+        return NO_DEFINITION_FOUND;
+    }
+
+    private int findProcEnd(@NotNull Matcher procStart) {
+        int functionEndIndex = tryFindProcEnd(procStart.end());
+        if (functionEndIndex >= 0) {
+            return functionEndIndex;
+        } else {
+            beginStack.addFirst(procStart.end());
+            beginMatcher = getBeginMatcher();
+            endMatcher = getEndMatcher();
+            fillStacks();
+            Integer endIndex = endStack.getLast();
+            return endStack.getLast() != null ? endIndex : -1;
+        }
+    }
+
+    private int tryFindProcEnd(int startIndex) {
+        Matcher endFunctionWithName = Pattern
+            .compile("end\\s*" + proc.getUniqueName() + "[\\s\\n]*;", Pattern.CASE_INSENSITIVE)
+            .matcher(parentPackageBodyDefinition);
+        return endFunctionWithName.find(startIndex)
+            ? endFunctionWithName.end()
+            : -1;
+    }
+
+    private void fillStacks() {
+        if (endMatcher.find(beginStack.peek())) {
+            endStack.addFirst(endMatcher.end());
+            boolean isBeginFound = beginMatcher.find(endMatcher.end());
+            if (isBeginFound && beginMatcher.end() < endMatcher.start()) {
+                beginStack.addFirst(beginMatcher.end());
+                fillStacks();
+            }
+        }
+    }
+
+    private Matcher getBeginMatcher() {
+        return Pattern
+            .compile("begin", Pattern.CASE_INSENSITIVE)
+            .matcher(parentPackageBodyDefinition);
+    }
+
+    private Matcher getEndMatcher() {
+        return Pattern
+            .compile("end\\s*.*;", Pattern.CASE_INSENSITIVE)
+            .matcher(parentPackageBodyDefinition);
+    }
+
+    @Nullable
+    private String procType() {
+        return switch (proc.getProcedureType()) {
+            case PROCEDURE -> "procedure";
+            case FUNCTION -> "function";
+            default -> null;
+        };
+    }
+
+}

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -23,9 +23,9 @@ import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class ProcedureBodyExtractor {
 
@@ -43,11 +43,9 @@ public class ProcedureBodyExtractor {
     private final String parentPackageBodyDefinition;
 
     private final Deque<Integer> beginStack = new ArrayDeque<>();
-    private final Deque<Integer> endStack = new ArrayDeque<>();
 
     private Matcher beginMatcher;
     private Matcher endMatcher;
-
 
     public ProcedureBodyExtractor(@NotNull OracleProcedurePackaged proc, @NotNull String parentPackageBodyDefinition) {
         this.proc = proc;
@@ -72,20 +70,26 @@ public class ProcedureBodyExtractor {
     }
 
     private int findProcEnd(int startIndex) {
-        int functionEndIndex = tryFindProcEnd(startIndex);
+        int functionEndIndex = tryFindLabeledProcEnd(startIndex);
         if (functionEndIndex >= 0) {
             return functionEndIndex;
         } else {
-            beginStack.addFirst(startIndex);
             beginMatcher = getBeginMatcher();
             endMatcher = getEndMatcher();
-            fillStacks();
-            Integer endIndex = endStack.peek();
-            return endIndex != null ? endIndex : -1;
+            boolean isNextEndFound = findFromIndex(endMatcher, startIndex);
+            if (isNextEndFound) {
+                fillBeginStack(startIndex, endMatcher.start());
+                beginStack.poll();
+                return beginStack.isEmpty()
+                    ? endMatcher.end()
+                    : findFunctionEndIndex(endMatcher.end());
+            } else {
+                return -1;
+            }
         }
     }
 
-    private int tryFindProcEnd(int startIndex) {
+    private int tryFindLabeledProcEnd(int startIndex) {
         Matcher endFunctionWithName = Pattern
             .compile("end\\s*" + proc.getUniqueName() + "[\\s\\n]*;", Pattern.CASE_INSENSITIVE)
             .matcher(parentPackageBodyDefinition);
@@ -94,19 +98,23 @@ public class ProcedureBodyExtractor {
             : -1;
     }
 
-    private void fillStacks() {
-        Integer lastBegin = beginStack.peek();
-        if (lastBegin != null) {
-            Integer lastEnd = Objects.requireNonNullElse(endStack.peek(), lastBegin);
-            boolean isNextEndFound = findFromIndex(endMatcher, lastEnd);
-            if (isNextEndFound && endMatcher.start() > lastBegin) {
-                endStack.addFirst(endMatcher.end());
-                boolean isNextBeginFound = findFromIndex(beginMatcher, lastBegin);
-                if (isNextBeginFound) {
-                    beginStack.addFirst(beginMatcher.end());
-                    fillStacks();
-                }
-            }
+    private int findFunctionEndIndex(int startSearch) {
+        boolean isNextEndFound = findFromIndex(endMatcher, startSearch);
+        if (isNextEndFound) {
+            fillBeginStack(startSearch, endMatcher.start());
+            beginStack.poll();
+            return beginStack.isEmpty()
+                ? endMatcher.end()
+                : findFunctionEndIndex(endMatcher.end());
+        } else {
+            return -1;
+        }
+    }
+
+    private void fillBeginStack(int fromIndex, int toIndex) {
+        beginMatcher.region(fromIndex, toIndex);
+        while (beginMatcher.find()) {
+            beginStack.push(beginMatcher.end());
         }
     }
 
@@ -117,13 +125,18 @@ public class ProcedureBodyExtractor {
 
     private Matcher getBeginMatcher() {
         return Pattern
-            .compile(String.join("|", possibleBeginCases), Pattern.CASE_INSENSITIVE)
+            .compile(
+                possibleBeginCases.stream()
+                    .map(token -> "(?<!END\\s+)" + token)
+                    .collect(Collectors.joining("|")),
+                Pattern.CASE_INSENSITIVE
+            )
             .matcher(parentPackageBodyDefinition);
     }
 
     private Matcher getEndMatcher() {
         return Pattern
-            .compile("end[\\s\\n]*;", Pattern.CASE_INSENSITIVE)
+            .compile("END[\\s]*.*;", Pattern.CASE_INSENSITIVE)
             .matcher(parentPackageBodyDefinition);
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -20,7 +20,10 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -29,15 +32,17 @@ public class ProcedureBodyExtractor {
 
     public static final String NO_DEFINITION_FOUND = "-- no definition found";
     private static final List<String> possibleBeginCases = List.of(
-        "begin",
+        "BEGIN",
         "IF",
         "CASE",
         "LOOP"
     );
 
     private static final List<String> commentPatterns = List.of(
-        "--.*\n"
+        "--.*\n",
+        "/\\*[\\s\\S]*?\\*/"
     );
+    private static final String END_PATTERN = "\\b(END\\s+.*|END\\s*);";
 
     private final OracleProcedurePackaged proc;
     private final String parentPackageBodyDefinition;
@@ -45,7 +50,7 @@ public class ProcedureBodyExtractor {
     private final Deque<Integer> beginStack = new ArrayDeque<>();
 
     // must be sorted in asc to exclude properly
-    private final PriorityQueue<RegionRange> commentRanges = new PriorityQueue<>();
+    private final List<RegionRange> commentRanges = new ArrayList<>();
 
     private Matcher beginMatcher;
     private Matcher endMatcher;
@@ -89,9 +94,12 @@ public class ProcedureBodyExtractor {
             .compile(String.join("|", commentPatterns))
             .matcher(parentPackageBodyDefinition);
         while (commentsMatcher.find()) {
-            RegionRange prevRange = commentRanges.peek();
-            if (prevRange == null || commentsMatcher.start() >= prevRange.endExclusive()) {
-                commentRanges.add(new RegionRange(commentsMatcher.start(), commentsMatcher.end() + 1));
+            RegionRange prevRange = commentRanges.isEmpty() ? null : commentRanges.getLast();
+            if (prevRange != null && commentsMatcher.start() < prevRange.endExclusive()) {
+                commentRanges.removeLast();
+                commentRanges.add(new RegionRange(prevRange.startInclusive(), commentsMatcher.end()));
+            } else {
+                commentRanges.add(new RegionRange(commentsMatcher.start(), commentsMatcher.end()));
             }
         }
     }
@@ -173,7 +181,7 @@ public class ProcedureBodyExtractor {
 
     private Matcher getEndMatcher() {
         return Pattern
-            .compile("END\\s+.*;", Pattern.CASE_INSENSITIVE)
+            .compile(END_PATTERN, Pattern.CASE_INSENSITIVE)
             .matcher(parentPackageBodyDefinition);
     }
 
@@ -187,16 +195,9 @@ public class ProcedureBodyExtractor {
     }
 
 
-    private record RegionRange(int startInclusive, int endExclusive) implements Comparable<RegionRange> {
-
+    private record RegionRange(int startInclusive, int endExclusive) {
         public boolean isInsideRange(int index) {
-            return index > startInclusive && index < endExclusive;
-        }
-
-        @Override
-        public int compareTo(@NotNull RegionRange o) {
-            int diff = this.startInclusive - o.startInclusive;
-            return diff != 0 ? diff : this.endExclusive - o.endExclusive;
+            return index >= startInclusive && index < endExclusive;
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -84,7 +84,7 @@ public class ProcedureBodyExtractor {
         String procType = procType();
         if (procType != null) {
             Matcher procStart = Pattern
-                .compile(procType + "\\s+" + proc.getName(), Pattern.CASE_INSENSITIVE)
+                .compile(procType + "\\s+" + Pattern.quote(proc.getName()), Pattern.CASE_INSENSITIVE)
                 .matcher(parentPackageBodyDefinition);
             int numberOfOverloadsBefore = Objects.requireNonNullElse(proc.getOverloadNumber(), 1) - 1;
             if (findNthMatchInRange(procStart, 0, parentPackageBodyDefinition.length(), numberOfOverloadsBefore)) {

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -20,10 +20,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -89,7 +86,8 @@ public class ProcedureBodyExtractor {
             Matcher procStart = Pattern
                 .compile(procType + "\\s+" + proc.getName(), Pattern.CASE_INSENSITIVE)
                 .matcher(parentPackageBodyDefinition);
-            if (procStart.find()) {
+            int numberOfOverloadsBefore = Objects.requireNonNullElse(proc.getOverloadNumber(), 1) - 1;
+            if (findInRangeTimesX(procStart, 0, parentPackageBodyDefinition.length(), numberOfOverloadsBefore)) {
                 int functionEndIndex = findProcEnd(procStart.end());
                 return functionEndIndex >= 0
                     ? parentPackageBodyDefinition.substring(procStart.start(), functionEndIndex)
@@ -113,7 +111,7 @@ public class ProcedureBodyExtractor {
 
     private int tryFindLabeledProcEnd(int startIndex) {
         Matcher endFunctionWithName = Pattern
-            .compile("\\bend\\s+" + proc.getUniqueName() + "\\s*;", Pattern.CASE_INSENSITIVE)
+            .compile("\\bEND\\s+" + proc.getName() + "\\s*;", Pattern.CASE_INSENSITIVE)
             .matcher(parentPackageBodyDefinition);
         return findFromIndex(endFunctionWithName, startIndex)
             ? endFunctionWithName.end()
@@ -125,11 +123,18 @@ public class ProcedureBodyExtractor {
     }
 
     private boolean findInRange(@NotNull Matcher matcher, int startIndex, int endIndexExclusive) {
+        return findInRangeTimesX(matcher, startIndex, endIndexExclusive, 0);
+    }
+
+    private boolean findInRangeTimesX(@NotNull Matcher matcher, int startIndex, int endIndexExclusive, int numberOfOccurrencesToSkip) {
         var searchableRegions = defineSearchableRanges(startIndex, endIndexExclusive);
+        int numberOfFoundBefore = 0;
         for (RegionRange region : searchableRegions) {
             matcher.region(region.startInclusive(), region.endExclusive());
-            if (matcher.find()) {
-                return true;
+            while (matcher.find()) {
+                if (++numberOfFoundBefore > numberOfOccurrencesToSkip) {
+                    return true;
+                }
             }
         }
         return false;
@@ -196,6 +201,7 @@ public class ProcedureBodyExtractor {
     }
 
     private class EndProcedureFinder {
+
         private final Deque<Integer> beginStack = new ArrayDeque<>();
 
         private final int procedureStartIndex;

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -31,6 +31,19 @@ import java.util.stream.Collectors;
 public class ProcedureBodyExtractor {
 
     public static final String NO_DEFINITION_FOUND = "-- no definition found";
+
+    private static final List<String> commentPatterns = List.of(
+        "--.*\n",
+        "/\\*[\\s\\S]*?\\*/"
+    );
+
+    private static final String END_PATTERN = "\\b(END\\s+.*|END\\s*);";
+
+    private static final List<String> nestedProcedureStartCases = List.of(
+        "PROCEDURE",
+        "FUNCTION"
+    );
+
     private static final List<String> possibleBeginCases = List.of(
         "BEGIN",
         "IF",
@@ -38,22 +51,18 @@ public class ProcedureBodyExtractor {
         "LOOP"
     );
 
-    private static final List<String> commentPatterns = List.of(
-        "--.*\n",
-        "/\\*[\\s\\S]*?\\*/"
-    );
-    private static final String END_PATTERN = "\\b(END\\s+.*|END\\s*);";
+
 
     private final OracleProcedurePackaged proc;
     private final String parentPackageBodyDefinition;
 
-    private final Deque<Integer> beginStack = new ArrayDeque<>();
 
     // must be sorted in asc to exclude properly
     private final List<RegionRange> commentRanges = new ArrayList<>();
 
     private Matcher beginMatcher;
     private Matcher endMatcher;
+    private Matcher nestedProcedureMatcher;
 
     public ProcedureBodyExtractor(@NotNull OracleProcedurePackaged proc, @NotNull String parentPackageBodyDefinition) {
         this.proc = proc;
@@ -61,6 +70,21 @@ public class ProcedureBodyExtractor {
         defineCommentRegions();
     }
 
+
+    private void defineCommentRegions() {
+        Matcher commentsMatcher = Pattern
+            .compile(String.join("|", commentPatterns))
+            .matcher(parentPackageBodyDefinition);
+        while (commentsMatcher.find()) {
+            RegionRange prevRange = commentRanges.isEmpty() ? null : commentRanges.getLast();
+            if (prevRange != null && commentsMatcher.start() < prevRange.endExclusive()) {
+                commentRanges.removeLast();
+                commentRanges.add(new RegionRange(prevRange.startInclusive(), commentsMatcher.end()));
+            } else {
+                commentRanges.add(new RegionRange(commentsMatcher.start(), commentsMatcher.end()));
+            }
+        }
+    }
 
     public String extractProcBody() {
         String procType = procType();
@@ -85,59 +109,26 @@ public class ProcedureBodyExtractor {
         } else {
             beginMatcher = getBeginMatcher();
             endMatcher = getEndMatcher();
-            return findFunctionEndIndex(startIndex);
-        }
-    }
-
-    private void defineCommentRegions() {
-        Matcher commentsMatcher = Pattern
-            .compile(String.join("|", commentPatterns))
-            .matcher(parentPackageBodyDefinition);
-        while (commentsMatcher.find()) {
-            RegionRange prevRange = commentRanges.isEmpty() ? null : commentRanges.getLast();
-            if (prevRange != null && commentsMatcher.start() < prevRange.endExclusive()) {
-                commentRanges.removeLast();
-                commentRanges.add(new RegionRange(prevRange.startInclusive(), commentsMatcher.end()));
-            } else {
-                commentRanges.add(new RegionRange(commentsMatcher.start(), commentsMatcher.end()));
-            }
+            nestedProcedureMatcher = getNestedProcedureMatcher();
+            return new EndProcedureFinder(startIndex).findProcedureEndIndex();
         }
     }
 
     private int tryFindLabeledProcEnd(int startIndex) {
         Matcher endFunctionWithName = Pattern
-            .compile("end\\s*" + proc.getUniqueName() + "[\\s\\n]*;", Pattern.CASE_INSENSITIVE)
+            .compile("\\bend\\s+" + proc.getUniqueName() + "\\s*;", Pattern.CASE_INSENSITIVE)
             .matcher(parentPackageBodyDefinition);
         return findFromIndex(endFunctionWithName, startIndex)
             ? endFunctionWithName.end()
             : -1;
     }
 
-    private int findFunctionEndIndex(int startSearch) {
-        boolean isNextEndFound = findFromIndex(endMatcher, startSearch);
-        if (isNextEndFound) {
-            fillBeginStack(startSearch, endMatcher.start());
-            beginStack.poll();
-            return beginStack.isEmpty()
-                ? endMatcher.end()
-                : findFunctionEndIndex(endMatcher.end());
-        } else {
-            return -1;
-        }
-    }
-
-    private void fillBeginStack(int fromIndex, int toIndex) {
-        var searchableRegions = defineSearchableRanges(fromIndex, toIndex);
-        for (RegionRange region : searchableRegions) {
-            beginMatcher.region(region.startInclusive(), region.endExclusive());
-            while (beginMatcher.find()) {
-                beginStack.push(beginMatcher.end());
-            }
-        }
-    }
-
     private boolean findFromIndex(@NotNull Matcher matcher, int startIndex) {
-        var searchableRegions = defineSearchableRanges(startIndex, parentPackageBodyDefinition.length());
+        return findInRange(matcher, startIndex, parentPackageBodyDefinition.length());
+    }
+
+    private boolean findInRange(@NotNull Matcher matcher, int startIndex, int endIndexExclusive) {
+        var searchableRegions = defineSearchableRanges(startIndex, endIndexExclusive);
         for (RegionRange region : searchableRegions) {
             matcher.region(region.startInclusive(), region.endExclusive());
             if (matcher.find()) {
@@ -185,6 +176,12 @@ public class ProcedureBodyExtractor {
             .matcher(parentPackageBodyDefinition);
     }
 
+    private Matcher getNestedProcedureMatcher() {
+        return Pattern
+            .compile(String.join("|", nestedProcedureStartCases))
+            .matcher(parentPackageBodyDefinition);
+    }
+
     @Nullable
     private String procType() {
         return switch (proc.getProcedureType()) {
@@ -201,4 +198,48 @@ public class ProcedureBodyExtractor {
         }
     }
 
+    private class EndProcedureFinder {
+        private final Deque<Integer> beginStack = new ArrayDeque<>();
+
+        private final int procedureStartIndex;
+
+        public EndProcedureFinder(int procedureStartIndex) {
+            this.procedureStartIndex = procedureStartIndex;
+        }
+
+        public int findProcedureEndIndex() {
+            return findProcedureEndIndex(procedureStartIndex);
+        }
+
+        private int findProcedureEndIndex(int startSearch) {
+            boolean isNextEndFound = findFromIndex(endMatcher, startSearch);
+            if (isNextEndFound) {
+                boolean isNestedProcedureFound = findInRange(nestedProcedureMatcher, startSearch, endMatcher.start());
+                if (isNestedProcedureFound) {
+                    fillBeginStack(startSearch, nestedProcedureMatcher.start());
+                    int nestedProcEnd = new EndProcedureFinder(nestedProcedureMatcher.end()).findProcedureEndIndex();
+                    if (nestedProcEnd < 0) {
+                        return nestedProcEnd;
+                    }
+                    return findProcedureEndIndex(nestedProcEnd);
+                }
+                fillBeginStack(startSearch, endMatcher.start());
+                beginStack.poll();
+                return beginStack.isEmpty()
+                    ? endMatcher.end()
+                    : findProcedureEndIndex(endMatcher.end());
+            }
+            return -1;
+        }
+
+        private void fillBeginStack(int fromIndex, int toIndex) {
+            var searchableRegions = defineSearchableRanges(fromIndex, toIndex);
+            for (RegionRange region : searchableRegions) {
+                beginMatcher.region(region.startInclusive(), region.endExclusive());
+                while (beginMatcher.find()) {
+                    beginStack.push(beginMatcher.end());
+                }
+            }
+        }
+    }
 }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -34,9 +34,7 @@ public class ProcedureBodyExtractor {
         "begin",
         "IF",
         "CASE",
-        "LOOP",
-        "FOR",
-        "WHILE"
+        "LOOP"
     );
 
     private final OracleProcedurePackaged proc;

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -20,9 +20,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -37,10 +35,17 @@ public class ProcedureBodyExtractor {
         "LOOP"
     );
 
+    private static final List<String> commentPatterns = List.of(
+        "--.*\n"
+    );
+
     private final OracleProcedurePackaged proc;
     private final String parentPackageBodyDefinition;
 
     private final Deque<Integer> beginStack = new ArrayDeque<>();
+
+    // must be sorted in asc to exclude properly
+    private final PriorityQueue<RegionRange> commentRanges = new PriorityQueue<>();
 
     private Matcher beginMatcher;
     private Matcher endMatcher;
@@ -48,6 +53,7 @@ public class ProcedureBodyExtractor {
     public ProcedureBodyExtractor(@NotNull OracleProcedurePackaged proc, @NotNull String parentPackageBodyDefinition) {
         this.proc = proc;
         this.parentPackageBodyDefinition = parentPackageBodyDefinition;
+        defineCommentRegions();
     }
 
 
@@ -78,6 +84,18 @@ public class ProcedureBodyExtractor {
         }
     }
 
+    private void defineCommentRegions() {
+        Matcher commentsMatcher = Pattern
+            .compile(String.join("|", commentPatterns))
+            .matcher(parentPackageBodyDefinition);
+        while (commentsMatcher.find()) {
+            RegionRange prevRange = commentRanges.peek();
+            if (prevRange == null || commentsMatcher.start() >= prevRange.endExclusive()) {
+                commentRanges.add(new RegionRange(commentsMatcher.start(), commentsMatcher.end() + 1));
+            }
+        }
+    }
+
     private int tryFindLabeledProcEnd(int startIndex) {
         Matcher endFunctionWithName = Pattern
             .compile("end\\s*" + proc.getUniqueName() + "[\\s\\n]*;", Pattern.CASE_INSENSITIVE)
@@ -101,15 +119,45 @@ public class ProcedureBodyExtractor {
     }
 
     private void fillBeginStack(int fromIndex, int toIndex) {
-        beginMatcher.region(fromIndex, toIndex);
-        while (beginMatcher.find()) {
-            beginStack.push(beginMatcher.end());
+        var searchableRegions = defineSearchableRanges(fromIndex, toIndex);
+        for (RegionRange region : searchableRegions) {
+            beginMatcher.region(region.startInclusive(), region.endExclusive());
+            while (beginMatcher.find()) {
+                beginStack.push(beginMatcher.end());
+            }
         }
     }
 
-    private boolean findFromIndex(@NotNull Matcher matcher, int index) {
-        matcher.region(index, parentPackageBodyDefinition.length());
-        return matcher.find();
+    private boolean findFromIndex(@NotNull Matcher matcher, int startIndex) {
+        var searchableRegions = defineSearchableRanges(startIndex, parentPackageBodyDefinition.length());
+        for (RegionRange region : searchableRegions) {
+            matcher.region(region.startInclusive(), region.endExclusive());
+            if (matcher.find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @NotNull
+    private List<RegionRange> defineSearchableRanges(int startIndex, int endIndexExclusive) {
+        List<RegionRange> searchableRegions = new ArrayList<>();
+        RegionRange rightPart = new RegionRange(startIndex, endIndexExclusive);
+        for (RegionRange commentRange : commentRanges) {
+            boolean isStartInside = rightPart.isInsideRange(commentRange.startInclusive());
+            boolean isEndInside = rightPart.isInsideRange(commentRange.endExclusive());
+            if (isStartInside) {
+                searchableRegions.add(new RegionRange(rightPart.startInclusive(), commentRange.startInclusive()));
+                if (!isEndInside) {
+                    return searchableRegions;
+                }
+            }
+            if (isEndInside) {
+                rightPart = new RegionRange(commentRange.endExclusive(), rightPart.endExclusive());
+            }
+        }
+        searchableRegions.add(rightPart);
+        return searchableRegions;
     }
 
     private Matcher getBeginMatcher() {
@@ -125,7 +173,7 @@ public class ProcedureBodyExtractor {
 
     private Matcher getEndMatcher() {
         return Pattern
-            .compile("END[\\s]*.*;", Pattern.CASE_INSENSITIVE)
+            .compile("END\\s+.*;", Pattern.CASE_INSENSITIVE)
             .matcher(parentPackageBodyDefinition);
     }
 
@@ -136,6 +184,20 @@ public class ProcedureBodyExtractor {
             case FUNCTION -> "function";
             default -> null;
         };
+    }
+
+
+    private record RegionRange(int startInclusive, int endExclusive) implements Comparable<RegionRange> {
+
+        public boolean isInsideRange(int index) {
+            return index > startInclusive && index < endExclusive;
+        }
+
+        @Override
+        public int compareTo(@NotNull RegionRange o) {
+            int diff = this.startInclusive - o.startInclusive;
+            return diff != 0 ? diff : this.endExclusive - o.endExclusive;
+        }
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -23,6 +23,7 @@ import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,7 +33,10 @@ public class ProcedureBodyExtractor {
     private static final List<String> possibleBeginCases = List.of(
         "begin",
         "IF",
-        "CASE"
+        "CASE",
+        "LOOP",
+        "FOR",
+        "WHILE"
     );
 
     private final OracleProcedurePackaged proc;
@@ -58,7 +62,7 @@ public class ProcedureBodyExtractor {
                 .compile(procType + "\\s+" + proc.getUniqueName(), Pattern.CASE_INSENSITIVE)
                 .matcher(parentPackageBodyDefinition);
             if (procStart.find()) {
-                int functionEndIndex = findProcEnd(procStart);
+                int functionEndIndex = findProcEnd(procStart.end());
                 return functionEndIndex >= 0
                     ? parentPackageBodyDefinition.substring(procStart.start(), functionEndIndex)
                     : parentPackageBodyDefinition.substring(procStart.start());
@@ -67,17 +71,17 @@ public class ProcedureBodyExtractor {
         return NO_DEFINITION_FOUND;
     }
 
-    private int findProcEnd(@NotNull Matcher procStart) {
-        int functionEndIndex = tryFindProcEnd(procStart.end());
+    private int findProcEnd(int startIndex) {
+        int functionEndIndex = tryFindProcEnd(startIndex);
         if (functionEndIndex >= 0) {
             return functionEndIndex;
         } else {
-            beginStack.addFirst(procStart.end());
+            beginStack.addFirst(startIndex);
             beginMatcher = getBeginMatcher();
             endMatcher = getEndMatcher();
             fillStacks();
-            Integer endIndex = endStack.getLast();
-            return endStack.getLast() != null ? endIndex : -1;
+            Integer endIndex = endStack.peek();
+            return endIndex != null ? endIndex : -1;
         }
     }
 
@@ -92,14 +96,23 @@ public class ProcedureBodyExtractor {
 
     private void fillStacks() {
         Integer lastBegin = beginStack.peek();
-        if (lastBegin != null && endMatcher.find(lastBegin)) {
-            endStack.addFirst(endMatcher.end());
-            boolean isNextBeginFound = beginMatcher.find(lastBegin);
-            if (isNextBeginFound && beginMatcher.end() < endMatcher.start()) {
-                beginStack.addFirst(beginMatcher.end());
-                fillStacks();
+        if (lastBegin != null) {
+            Integer lastEnd = Objects.requireNonNullElse(endStack.peek(), lastBegin);
+            boolean isNextEndFound = findFromIndex(endMatcher, lastEnd);
+            if (isNextEndFound && endMatcher.start() > lastBegin) {
+                endStack.addFirst(endMatcher.end());
+                boolean isNextBeginFound = findFromIndex(beginMatcher, lastBegin);
+                if (isNextBeginFound) {
+                    beginStack.addFirst(beginMatcher.end());
+                    fillStacks();
+                }
             }
         }
+    }
+
+    private boolean findFromIndex(@NotNull Matcher matcher, int index) {
+        matcher.region(index, parentPackageBodyDefinition.length());
+        return matcher.find();
     }
 
     private Matcher getBeginMatcher() {

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -87,7 +87,7 @@ public class ProcedureBodyExtractor {
                 .compile(procType + "\\s+" + proc.getName(), Pattern.CASE_INSENSITIVE)
                 .matcher(parentPackageBodyDefinition);
             int numberOfOverloadsBefore = Objects.requireNonNullElse(proc.getOverloadNumber(), 1) - 1;
-            if (findInRangeTimesX(procStart, 0, parentPackageBodyDefinition.length(), numberOfOverloadsBefore)) {
+            if (findNthMatchInRange(procStart, 0, parentPackageBodyDefinition.length(), numberOfOverloadsBefore)) {
                 int functionEndIndex = findProcEnd(procStart.end());
                 return functionEndIndex >= 0
                     ? parentPackageBodyDefinition.substring(procStart.start(), functionEndIndex)
@@ -123,16 +123,16 @@ public class ProcedureBodyExtractor {
     }
 
     private boolean findInRange(@NotNull Matcher matcher, int startIndex, int endIndexExclusive) {
-        return findInRangeTimesX(matcher, startIndex, endIndexExclusive, 0);
+        return findNthMatchInRange(matcher, startIndex, endIndexExclusive, 0);
     }
 
-    private boolean findInRangeTimesX(@NotNull Matcher matcher, int startIndex, int endIndexExclusive, int numberOfOccurrencesToSkip) {
+    private boolean findNthMatchInRange(@NotNull Matcher matcher, int startIndex, int endIndexExclusive, int occurrencesToSkip) {
         var searchableRegions = defineSearchableRanges(startIndex, endIndexExclusive);
-        int numberOfFoundBefore = 0;
+        int matchesFound = 0;
         for (RegionRange region : searchableRegions) {
             matcher.region(region.startInclusive(), region.endExclusive());
             while (matcher.find()) {
-                if (++numberOfFoundBefore > numberOfOccurrencesToSkip) {
+                if (++matchesFound > occurrencesToSkip) {
                     return true;
                 }
             }

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractor.java
@@ -22,12 +22,19 @@ import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ProcedureBodyExtractor {
 
     public static final String NO_DEFINITION_FOUND = "-- no definition found";
+    private static final List<String> possibleBeginCases = List.of(
+        "begin",
+        "IF",
+        "CASE"
+    );
+
     private final OracleProcedurePackaged proc;
     private final String parentPackageBodyDefinition;
 
@@ -84,10 +91,11 @@ public class ProcedureBodyExtractor {
     }
 
     private void fillStacks() {
-        if (endMatcher.find(beginStack.peek())) {
+        Integer lastBegin = beginStack.peek();
+        if (lastBegin != null && endMatcher.find(lastBegin)) {
             endStack.addFirst(endMatcher.end());
-            boolean isBeginFound = beginMatcher.find(endMatcher.end());
-            if (isBeginFound && beginMatcher.end() < endMatcher.start()) {
+            boolean isNextBeginFound = beginMatcher.find(lastBegin);
+            if (isNextBeginFound && beginMatcher.end() < endMatcher.start()) {
                 beginStack.addFirst(beginMatcher.end());
                 fillStacks();
             }
@@ -96,13 +104,13 @@ public class ProcedureBodyExtractor {
 
     private Matcher getBeginMatcher() {
         return Pattern
-            .compile("begin", Pattern.CASE_INSENSITIVE)
+            .compile(String.join("|", possibleBeginCases), Pattern.CASE_INSENSITIVE)
             .matcher(parentPackageBodyDefinition);
     }
 
     private Matcher getEndMatcher() {
         return Pattern
-            .compile("end\\s*.*;", Pattern.CASE_INSENSITIVE)
+            .compile("end[\\s\\n]*;", Pattern.CASE_INSENSITIVE)
             .matcher(parentPackageBodyDefinition);
     }
 

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureBodyExtractorTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProcedureFunctionExtractorTest {
+public class ProcedureBodyExtractorTest {
 
     private static final String packageDefinitionTemplate = """
         CREATE OR REPLACE PACKAGE BODY TEST_PACKAGE AS
@@ -561,16 +561,16 @@ public class ProcedureFunctionExtractorTest {
     }
 
     @Test
-    public void overloadedFucntionsTest() {
+    public void overloadedFunctionsTest() {
         // given
-        String packageDefinitionWillAllOverloadedFucntions =
+        String packageDefinitionWillAllOverloadedFunctions =
             packageDefinitionTemplate
                 .formatted(String.join("\n\n", List.of(overloadedFunc1.procBody, overloadedFunc2.procBody, overloadedFunc3.procBody)));
 
         // then
-        assertBodyFound(overloadedFunc1, packageDefinitionWillAllOverloadedFucntions);
-        assertBodyFound(overloadedFunc2, packageDefinitionWillAllOverloadedFucntions);
-        assertBodyFound(overloadedFunc3, packageDefinitionWillAllOverloadedFucntions);
+        assertBodyFound(overloadedFunc1, packageDefinitionWillAllOverloadedFunctions);
+        assertBodyFound(overloadedFunc2, packageDefinitionWillAllOverloadedFunctions);
+        assertBodyFound(overloadedFunc3, packageDefinitionWillAllOverloadedFunctions);
     }
 
     @Test

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.ext.oracle.model.util;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
 import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
 import org.junit.Test;
@@ -75,6 +76,33 @@ public class ProcedureFunctionExtractorTest {
     }
 
     @Test
+    public void functionStartInOneLineCommentLineIsIgnoredTest() {
+        // given
+        String funcBodyWithCommentFalseStart = "--PROCEDURE simple_proc IS\n" + simpleNoArgsProc.procBody;
+        ProcedureBodyExtractor extractor = new ProcedureBodyExtractor(
+            simpleNoArgsProc.procedure,
+            packageDefinitionTemplate.formatted(funcBodyWithCommentFalseStart)
+        );
+        // then
+        assertEquals(simpleNoArgsProc.procBody, extractor.extractProcBody());
+    }
+
+    @Test
+    public void functionStartInMultiLineCommentLineIsIgnoredTest() {
+        // given
+        String funcBodyWithCommentFalseStart = """
+            /*PROCEDURE simple_proc IS;
+            PROCEDURE simple_proc IS;
+            PROCEDURE simple_proc IS;*/""" + simpleNoArgsProc.procBody;
+        ProcedureBodyExtractor extractor = new ProcedureBodyExtractor(
+            simpleNoArgsProc.procedure,
+            packageDefinitionTemplate.formatted(funcBodyWithCommentFalseStart)
+        );
+        // then
+        assertEquals(simpleNoArgsProc.procBody, extractor.extractProcBody());
+    }
+
+    @Test
     public void endIfTest() {
         assertBodyFound(ifEndIf);
     }
@@ -128,6 +156,32 @@ public class ProcedureFunctionExtractorTest {
     }
 
     @Test
+    public void overloadedProcsTest() {
+        // given
+        String packageDefinitionWillAllOverloadedProcs =
+            packageDefinitionTemplate
+                .formatted(String.join("\n\n", List.of(overloadedProc1.procBody, overloadedProc2.procBody, overloadedProc3.procBody)));
+
+        // then
+        assertBodyFound(overloadedProc1, packageDefinitionWillAllOverloadedProcs);
+        assertBodyFound(overloadedProc2, packageDefinitionWillAllOverloadedProcs);
+        assertBodyFound(overloadedProc3, packageDefinitionWillAllOverloadedProcs);
+    }
+
+    @Test
+    public void overloadedFucntionsTest() {
+        // given
+        String packageDefinitionWillAllOverloadedFucntions =
+            packageDefinitionTemplate
+                .formatted(String.join("\n\n", List.of(overloadedFunc1.procBody, overloadedFunc2.procBody, overloadedFunc3.procBody)));
+
+        // then
+        assertBodyFound(overloadedFunc1, packageDefinitionWillAllOverloadedFucntions);
+        assertBodyFound(overloadedFunc2, packageDefinitionWillAllOverloadedFucntions);
+        assertBodyFound(overloadedFunc3, packageDefinitionWillAllOverloadedFucntions);
+    }
+
+    @Test
     public void allProceduresBodyExtractTest() {
         // given
         List<ProcTestCase> allTestCases = new ArrayList<>();
@@ -167,24 +221,42 @@ public class ProcedureFunctionExtractorTest {
         List<ProcTestCase> reversedAllCases = new ArrayList<>(allTestCases);
         Collections.reverse(reversedAllCases);
 
+        // can be tested only in straight order, since overload number works sequentially
+        List<ProcTestCase> overloadedCases = List.of(
+            overloadedProc1,
+            overloadedProc2,
+            overloadedProc3,
+
+            overloadedFunc1,
+            overloadedFunc2,
+            overloadedFunc3
+        );
+        allTestCases.addAll(overloadedCases);
 
         String allProcs = allTestCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n\n"));
         String reversedAllProcs = reversedAllCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n\n"));
+
         String packageBody = packageDefinitionTemplate.formatted(allProcs);
         String reversedPackageBody = packageDefinitionTemplate.formatted(reversedAllProcs);
 
         // then
         for (ProcTestCase procToSearch : allTestCases) {
             ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(procToSearch.procedure, packageBody);
-            ProcedureBodyExtractor procedureBodyExtractorReversed = new ProcedureBodyExtractor(procToSearch.procedure, reversedPackageBody);
             assertEquals(procToSearch.procBody, procedureBodyExtractor.extractProcBody());
+        }
+
+        for (ProcTestCase procToSearch : reversedAllCases) {
+            ProcedureBodyExtractor procedureBodyExtractorReversed = new ProcedureBodyExtractor(procToSearch.procedure, reversedPackageBody);
             assertEquals(procToSearch.procBody, procedureBodyExtractorReversed.extractProcBody());
         }
     }
 
     private void assertBodyFound(@NotNull ProcTestCase testCase) {
-        String packageDefinition = constructPackageBody(testCase);
-        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(testCase.procedure, packageDefinition);
+        assertBodyFound(testCase, constructPackageBody(testCase));
+    }
+
+    private void assertBodyFound(@NotNull ProcTestCase testCase, @NotNull String packageBodyDefinition) {
+        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(testCase.procedure, packageBodyDefinition);
         // then
         assertEquals(testCase.procBody, procedureBodyExtractor.extractProcBody());
     }
@@ -523,20 +595,99 @@ public class ProcedureFunctionExtractorTest {
              END;"""
     );
 
+    // overloads
+    private final String overLoadProcName = "overloaded_proc";
+    private final ProcTestCase overloadedProc1 = new ProcTestCase(
+        overLoadProcName, DBSProcedureType.PROCEDURE,
+        """
+            PROCEDURE overloaded_proc(p_id NUMBER) IS
+              BEGIN
+                DBMS_OUTPUT.PUT_LINE('Single parameter: ' || p_id);
+              END;""",
+        1
+    );
+
+    private final ProcTestCase overloadedProc2 = new ProcTestCase(
+        overLoadProcName, DBSProcedureType.PROCEDURE,
+        """
+            PROCEDURE overloaded_proc(p_id NUMBER, p_name VARCHAR2) IS
+            BEGIN
+             DBMS_OUTPUT.PUT_LINE('Two parameters: ' || p_id || ', ' || p_name);
+            END;""",
+        2
+    );
+
+    private final ProcTestCase overloadedProc3 = new ProcTestCase(
+        overLoadProcName, DBSProcedureType.PROCEDURE,
+        """
+            
+            PROCEDURE overloaded_proc(p_flag CHAR) IS
+            BEGIN
+             DBMS_OUTPUT.PUT_LINE('Flag parameter: ' || p_flag);
+            END;""",
+        3
+    );
+
+    private final String overLoadFuncName = "overloaded_func";
+    private final ProcTestCase overloadedFunc1 = new ProcTestCase(
+        overLoadFuncName, DBSProcedureType.FUNCTION,
+        """
+            FUNCTION overloaded_func(p_id NUMBER) RETURN VARCHAR2 IS
+            BEGIN
+              RETURN 'Single parameter: ' || p_id;
+            END;""",
+        1
+    );
+
+    private final ProcTestCase overloadedFunc2 = new ProcTestCase(
+        overLoadFuncName, DBSProcedureType.FUNCTION,
+        """
+            FUNCTION overloaded_func(p_id NUMBER, p_name VARCHAR2) RETURN VARCHAR2 IS
+            BEGIN
+             RETURN 'Two parameters: ' || p_id || ', ' || p_name;
+            END;""",
+        2
+    );
+
+    private final ProcTestCase overloadedFunc3 = new ProcTestCase(
+        overLoadFuncName, DBSProcedureType.FUNCTION,
+        """
+            FUNCTION overloaded_func(p_flag CHAR) RETURN VARCHAR2 IS
+            BEGIN
+             RETURN 'Flag parameter: ' || p_flag;
+            END;""",
+        3
+    );
+
+
     private class ProcTestCase {
         private final OracleProcedurePackaged procedure;
         private final String procBody;
 
         public ProcTestCase(@NotNull String name, @NotNull DBSProcedureType procType, @NotNull String procBody) {
-            this.procedure = getProcedure(procType, name);
-            this.procBody = procBody;
+            this(name, procType, procBody, null);
+        }
+
+        public ProcTestCase(
+            @NotNull String name,
+            @NotNull DBSProcedureType procType,
+            @NotNull String procBody,
+            @Nullable Integer overloadNumber
+        ) {
+            this.procedure = getProcedure(procType, name, overloadNumber);
+            this.procBody = procBody.trim();
         }
 
         @NotNull
-        private OracleProcedurePackaged getProcedure(@NotNull DBSProcedureType procType, @NotNull String procName) {
+        private OracleProcedurePackaged getProcedure(
+            @NotNull DBSProcedureType procType,
+            @NotNull String procName,
+            @Nullable Integer overloadNumber
+        ) {
             OracleProcedurePackaged mockProc = mock(OracleProcedurePackaged.class);
             when(mockProc.getProcedureType()).thenReturn(procType);
             when(mockProc.getName()).thenReturn(procName);
+            when(mockProc.getOverloadNumber()).thenReturn(overloadNumber);
             return mockProc;
         }
     }

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 
 public class ProcedureFunctionExtractorTest {
 
-    private final String packageDefinitionTemplate = """
+    private static final String packageDefinitionTemplate = """
         CREATE OR REPLACE PACKAGE BODY TEST_PACKAGE AS
         %s
         END TEST_PACKAGE;""";
@@ -362,7 +362,7 @@ public class ProcedureFunctionExtractorTest {
     );
 
     // overloads
-    private final String overLoadProcName = "overloaded_proc";
+    private static final String overLoadProcName = "overloaded_proc";
     private final ProcTestCase overloadedProc1 = new ProcTestCase(
         overLoadProcName, DBSProcedureType.PROCEDURE,
         """
@@ -394,7 +394,7 @@ public class ProcedureFunctionExtractorTest {
         3
     );
 
-    private final String overLoadFuncName = "overloaded_func";
+    private static final String overLoadFuncName = "overloaded_func";
     private final ProcTestCase overloadedFunc1 = new ProcTestCase(
         overLoadFuncName, DBSProcedureType.FUNCTION,
         """

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -49,11 +49,22 @@ public class ProcedureFunctionExtractorTest {
     }
 
     @Test
+    public void endIfTest() {
+        assertBodyFound(ifEndIf);
+    }
+
+    @Test
+    public void caseEndTest() {
+        assertBodyFound(caseEndCase);
+    }
+
+    @Test
     public void allProceduresBodyExtractTest() {
         // given
         List<ProcTestCase> allTestCases = new ArrayList<>();
         allTestCases.add(simpleNoArgsProc);
         allTestCases.add(simpleNoArgsNoEndProc);
+        allTestCases.add(ifEndIf);
         Collections.shuffle(allTestCases);
 
         String allProcs = allTestCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n"));
@@ -99,6 +110,105 @@ public class ProcedureFunctionExtractorTest {
           NULL;
         END;"""
     );
+
+    private final ProcTestCase ifEndIf = new ProcTestCase(
+        "if_end_if", DBSProcedureType.PROCEDURE, """
+        PROCEDURE if_end_if IS
+        BEGIN
+          IF 1=1 THEN
+            NULL;
+          END IF;
+        END ;"""
+    );
+
+    private final ProcTestCase caseEndCase = new ProcTestCase(
+        "case_end_case", DBSProcedureType.PROCEDURE, """
+        PROCEDURE case_end_case IS
+        BEGIN
+          CASE 1
+            WHEN 1 THEN NULL;
+          END CASE;
+        END ;"""
+    );
+
+    private final ProcTestCase loopEndLoop = new ProcTestCase(
+        "loop_end_loop", DBSProcedureType.PROCEDURE, """
+        PROCEDURE loop_end_loop IS
+        BEGIN
+          LOOP
+            NULL;
+            EXIT;
+          END LOOP;
+        END ;"""
+    );
+
+    private final ProcTestCase forLoopEndLoop = new ProcTestCase(
+        "for_loop_end_loop", DBSProcedureType.PROCEDURE, """
+        PROCEDURE for_loop_end_loop IS
+        BEGIN
+          FOR i IN 1..1 LOOP
+            NULL;
+          END LOOP;
+        END ;"""
+    );
+
+    private final ProcTestCase whileLoopEndLoop = new ProcTestCase(
+        "while_loop_end_loop", DBSProcedureType.PROCEDURE, """
+        PROCEDURE while_loop_end_loop IS
+        BEGIN
+          DECLARE
+            i NUMBER := 0;
+          BEGIN
+            WHILE i < 1 LOOP
+              NULL;
+              i := i + 1;
+            END LOOP;
+          END;
+        END ;"""
+    );
+
+    private final ProcTestCase declareEnd = new ProcTestCase(
+        "declare_end", DBSProcedureType.PROCEDURE, """
+        PROCEDURE declare_end IS
+        BEGIN
+          DECLARE
+            l_var NUMBER;
+          BEGIN
+            l_var := 42;
+          END;
+        END ;"""
+    );
+
+    private final ProcTestCase nestedProcEnd = new ProcTestCase(
+        "nested_proc_end", DBSProcedureType.PROCEDURE, """
+        PROCEDURE nested_proc_end IS
+        BEGIN
+          DECLARE
+            PROCEDURE nested_proc IS
+            BEGIN
+              NULL;
+            END nested_proc;
+          BEGIN
+            nested_proc;
+          END;
+        END ;"""
+    );
+
+    private final ProcTestCase nestedFuncEnd = new ProcTestCase(
+        "nested_func_end", DBSProcedureType.PROCEDURE, """
+        PROCEDURE nested_func_end IS
+        BEGIN
+          DECLARE
+            FUNCTION nested_func RETURN NUMBER IS
+            BEGIN
+              RETURN 42;
+            END nested_func;
+          BEGIN
+            NULL;
+          END;
+        END ;"""
+    );
+
 
     private class ProcTestCase {
         private final String name;

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -536,7 +536,7 @@ public class ProcedureFunctionExtractorTest {
         private OracleProcedurePackaged getProcedure(@NotNull DBSProcedureType procType, @NotNull String procName) {
             OracleProcedurePackaged mockProc = mock(OracleProcedurePackaged.class);
             when(mockProc.getProcedureType()).thenReturn(procType);
-            when(mockProc.getUniqueName()).thenReturn(procName);
+            when(mockProc.getName()).thenReturn(procName);
             return mockProc;
         }
     }

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -43,9 +43,20 @@ public class ProcedureFunctionExtractorTest {
     }
 
     @Test
-    public void simpleProcTest() {
+    public void simpleProcFuncTest() {
         assertBodyFound(simpleNoArgsProc);
         assertBodyFound(simpleNoArgsNoEndProc);
+        assertBodyFound(procWithParams);
+
+        assertBodyFound(simpleFunc);
+        assertBodyFound(simpleNoArgsNoEndProc);
+        assertBodyFound(funcWithParams);
+    }
+
+    @Test
+    public void noBeginTest() {
+        assertBodyFound(procNoBegin);
+        assertBodyFound(funcNoBegin);
     }
 
     @Test
@@ -59,12 +70,65 @@ public class ProcedureFunctionExtractorTest {
     }
 
     @Test
+    public void loopsTest() {
+        assertBodyFound(loopEndLoop);
+        assertBodyFound(forLoopEndLoop);
+    }
+
+    @Test
+    public void nestedBeginTest() {
+        assertBodyFound(tripleNestedBegins);
+    }
+
+    @Test
+    public void openClosedNestedBeginsTest() {
+        assertBodyFound(openClosedBeginsInsideMain);
+    }
+
+    @Test
+    public void combinedNestedBegins() {
+        assertBodyFound(combinedNestedBegins);
+    }
+
+    @Test
+    public void whileTest() {
+        assertBodyFound(whileLoopEndLoop);
+    }
+
+    @Test
+    public void declareTest() {
+        assertBodyFound(declareEnd);
+    }
+
+    @Test
     public void allProceduresBodyExtractTest() {
         // given
         List<ProcTestCase> allTestCases = new ArrayList<>();
         allTestCases.add(simpleNoArgsProc);
         allTestCases.add(simpleNoArgsNoEndProc);
+        allTestCases.add(procNoBegin);
+        allTestCases.add(procWithParams);
+
+        allTestCases.add(simpleFunc);
+        allTestCases.add(simpleFuncNoEnd);
+        allTestCases.add(funcNoBegin);
+        allTestCases.add(funcWithParams);
+
         allTestCases.add(ifEndIf);
+        allTestCases.add(caseEndCase);
+
+        allTestCases.add(forLoopEndLoop);
+        allTestCases.add(loopEndLoop);
+
+        allTestCases.add(tripleNestedBegins);
+        allTestCases.add(openClosedBeginsInsideMain);
+        allTestCases.add(combinedNestedBegins);
+
+        allTestCases.add(whileLoopEndLoop);
+
+        allTestCases.add(declareEnd);
+
+        // not sure if needed to shuffle
         Collections.shuffle(allTestCases);
 
         String allProcs = allTestCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n"));
@@ -95,6 +159,7 @@ public class ProcedureFunctionExtractorTest {
         END TEST_PACKAGE;""";
 
     private final ProcTestCase unknownProc = new ProcTestCase("unknown", DBSProcedureType.UNKNOWN, "-- Procedure Body");
+
     private final ProcTestCase simpleNoArgsProc = new ProcTestCase(
         "simple_proc", DBSProcedureType.PROCEDURE, """
         PROCEDURE simple_proc IS
@@ -109,6 +174,66 @@ public class ProcedureFunctionExtractorTest {
         BEGIN
           NULL;
         END;"""
+    );
+
+    private final ProcTestCase procWithParams = new ProcTestCase(
+        "proc_with_params",
+        DBSProcedureType.PROCEDURE,
+        """
+            PROCEDURE proc_with_params(
+               p_id    IN     NUMBER,
+               p_name  IN OUT VARCHAR2,
+               p_flag  OUT    NUMBER
+             ) IS
+             BEGIN
+               DBMS_OUTPUT.PUT_LINE('proc_with_params');
+             END proc_with_params;"""
+    );
+
+    private final ProcTestCase procNoBegin = new ProcTestCase(
+        "proc_no_begin", DBSProcedureType.PROCEDURE, """
+        PROCEDURE proc_no_begin IS
+          l_var NUMBER := 42;
+          l_msg VARCHAR2(100);
+        END;"""
+    );
+
+
+    private final ProcTestCase simpleFunc = new ProcTestCase(
+        "simple_func", DBSProcedureType.FUNCTION, """
+        FUNCTION simple_func RETURN NUMBER IS
+          l_var NUMBER := 42;
+        BEGIN
+          RETURN l_var;
+        END simple_func;"""
+    );
+
+    private final ProcTestCase simpleFuncNoEnd = new ProcTestCase(
+        "func_no_end", DBSProcedureType.FUNCTION, """
+        FUNCTION func_no_end RETURN NUMBER IS
+          l_var NUMBER := 42;
+        BEGIN
+          RETURN l_var;
+        END ;"""
+    );
+
+    private final ProcTestCase funcNoBegin = new ProcTestCase(
+        "func_no_begin", DBSProcedureType.FUNCTION, """
+        FUNCTION func_no_begin RETURN NUMBER IS
+          l_var NUMBER := 42;
+          l_msg VARCHAR2(100);
+        END;"""
+    );
+
+    private final ProcTestCase funcWithParams = new ProcTestCase(
+        "func_with_params",
+        DBSProcedureType.FUNCTION,
+        """
+            FUNCTION func_with_params(p_qty IN NUMBER, p_price IN NUMBER DEFAULT 1)\s
+              RETURN NUMBER IS
+            BEGIN
+              RETURN p_qty * p_price;
+            END;"""
     );
 
     private final ProcTestCase ifEndIf = new ProcTestCase(
@@ -152,6 +277,53 @@ public class ProcedureFunctionExtractorTest {
         END ;"""
     );
 
+    private final ProcTestCase tripleNestedBegins = new ProcTestCase(
+        "triple_nested_begins", DBSProcedureType.PROCEDURE, """
+        PROCEDURE triple_nested_begins IS
+        BEGIN                    -- #1 Outer BEGIN
+          BEGIN                  -- #2 Middle BEGIN
+            BEGIN                -- #3 Inner BEGIN
+              NULL;
+            END;                 -- Closes #3
+          END;                   -- Closes #2
+        END;"""
+    );
+
+    private final ProcTestCase openClosedBeginsInsideMain = new ProcTestCase(
+        "two_nested_inside_main", DBSProcedureType.PROCEDURE, """
+        PROCEDURE two_nested_inside_main IS
+        BEGIN                       -- Main BEGIN
+          BEGIN                     -- Nested #1
+            NULL;
+          END;                      -- Closes nested #1
+          BEGIN                     -- Nested #2  
+            NULL;
+          END;                      -- Closes nested #2
+        END;"""
+    );
+
+    private final ProcTestCase combinedNestedBegins = new ProcTestCase(
+        "combined_nested_begins", DBSProcedureType.PROCEDURE, """
+        PROCEDURE combined_nested_begins IS
+        BEGIN                          -- Main BEGIN #1
+          BEGIN                        -- Triple nest #1
+            BEGIN                      -- Triple nest #2
+              BEGIN                    -- Triple nest #3
+                NULL;
+              END;                     -- Closes triple #3
+            END;                       -- Closes triple #2
+          END;                         -- Closes triple #1
+        
+          BEGIN                        -- Inside main #1
+            NULL;
+          END;                         -- Closes inside #1
+          BEGIN                        -- Inside main #2
+            NULL;
+          END;                         -- Closes inside #2
+        END;"""
+    );
+
+
     private final ProcTestCase whileLoopEndLoop = new ProcTestCase(
         "while_loop_end_loop", DBSProcedureType.PROCEDURE, """
         PROCEDURE while_loop_end_loop IS
@@ -194,19 +366,22 @@ public class ProcedureFunctionExtractorTest {
         END ;"""
     );
 
-    private final ProcTestCase nestedFuncEnd = new ProcTestCase(
-        "nested_func_end", DBSProcedureType.PROCEDURE, """
-        PROCEDURE nested_func_end IS
-        BEGIN
-          DECLARE
-            FUNCTION nested_func RETURN NUMBER IS
-            BEGIN
-              RETURN 42;
-            END nested_func;
+    private final ProcTestCase procWithNested = new ProcTestCase(
+        "outer_proc", DBSProcedureType.PROCEDURE, """
+        PROCEDURE outer_proc IS
+          PROCEDURE inner_proc_labeled IS
+          BEGIN
+            NULL;
+          END inner_proc;
+          PROCEDURE inner_proc_labeled IS
           BEGIN
             NULL;
           END;
-        END ;"""
+        
+        BEGIN
+          inner_proc;
+          inner_proc_labeled;
+        END;"""
     );
 
 

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -34,10 +34,19 @@ public class ProcedureFunctionExtractorTest {
 
 
     @Test
-    public void notFoundDefinitionTest() {
+    public void unknownFunctionType() {
         // given
         String notEmptyPackageDefinition = constructPackageBody(simpleNoArgsProc);
         ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(unknownProc.procedure, notEmptyPackageDefinition);
+        // then
+        assertEquals(ProcedureBodyExtractor.NO_DEFINITION_FOUND, procedureBodyExtractor.extractProcBody());
+    }
+
+    @Test
+    public void notFoundDefinitionTest() {
+        // given
+        String notEmptyPackageDefinition = constructPackageBody(noNameMatch);
+        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(noNameMatch.procedure, notEmptyPackageDefinition);
         // then
         assertEquals(ProcedureBodyExtractor.NO_DEFINITION_FOUND, procedureBodyExtractor.extractProcBody());
     }
@@ -113,6 +122,18 @@ public class ProcedureFunctionExtractorTest {
     }
 
     @Test
+    public void nestedProcedures() {
+        assertBodyFound(tripleNestedProc);
+        assertBodyFound(outerBeginEndInner);
+    }
+
+    @Test
+    public void nestedFunctions() {
+        assertBodyFound(tripleNestedFunc);
+        assertBodyFound(outerBeginEndInnerFunc);
+    }
+
+    @Test
     public void allProceduresBodyExtractTest() {
         // given
         List<ProcTestCase> allTestCases = new ArrayList<>();
@@ -145,6 +166,12 @@ public class ProcedureFunctionExtractorTest {
 
         allTestCases.add(declareEnd);
 
+        allTestCases.add(tripleNestedProc);
+        allTestCases.add(outerBeginEndInner);
+
+        allTestCases.add(tripleNestedFunc);
+        allTestCases.add(outerBeginEndInnerFunc);
+
         // not sure if needed to shuffle
         Collections.shuffle(allTestCases);
 
@@ -175,7 +202,21 @@ public class ProcedureFunctionExtractorTest {
         %s
         END TEST_PACKAGE;""";
 
-    private final ProcTestCase unknownProc = new ProcTestCase("unknown", DBSProcedureType.UNKNOWN, "-- Procedure Body");
+    private final ProcTestCase unknownProc = new ProcTestCase(
+        "unknown", DBSProcedureType.UNKNOWN, """
+        PROCEDURE unknown IS
+        BEGIN
+          NULL;
+        END unknown;"""
+    );
+
+    private final ProcTestCase noNameMatch = new ProcTestCase(
+        "no_name_match", DBSProcedureType.PROCEDURE, """
+        PROCEDURE unknown IS
+        BEGIN
+          NULL;
+        END unknown;"""
+    );
 
     private final ProcTestCase simpleNoArgsProc = new ProcTestCase(
         "simple_proc", DBSProcedureType.PROCEDURE, """
@@ -417,39 +458,88 @@ public class ProcedureFunctionExtractorTest {
         END ;"""
     );
 
-    private final ProcTestCase nestedProcEnd = new ProcTestCase(
+    private final ProcTestCase tripleNestedProc = new ProcTestCase(
         "nested_proc_end", DBSProcedureType.PROCEDURE, """
         PROCEDURE nested_proc_end IS
         BEGIN
           DECLARE
-            PROCEDURE nested_proc IS
+            PROCEDURE nested_proc_1 IS
+              PROCEDURE nested_proc_2 IS
+                PROCEDURE nested_proc_3 IS
+                BEGIN
+                  NULL;
+                END ;
+              BEGIN
+                nested_proc_3;
+              END ;
             BEGIN
-              NULL;
-            END nested_proc;
+              nested_proc_2;
+            END;
           BEGIN
-            nested_proc;
+            nested_proc_1;
           END;
-        END ;"""
-    );
-
-    private final ProcTestCase procWithNested = new ProcTestCase(
-        "outer_proc", DBSProcedureType.PROCEDURE, """
-        PROCEDURE outer_proc IS
-          PROCEDURE inner_proc_labeled IS
-          BEGIN
-            NULL;
-          END inner_proc;
-          PROCEDURE inner_proc_unlabeled IS
-          BEGIN
-            NULL;
-          END;
-        
-        BEGIN
-          inner_proc;
-          inner_proc_labeled;
         END;"""
     );
 
+    private final ProcTestCase outerBeginEndInner = new ProcTestCase(
+        "outer_proc", DBSProcedureType.PROCEDURE, """
+        PROCEDURE outer_proc IS
+               PROCEDURE inner_proc_labeled IS
+               BEGIN
+                 NULL;
+               END inner_proc_labeled;
+               PROCEDURE inner_proc_unlabeled IS
+               BEGIN
+                 NULL;
+               END;
+        
+             BEGIN
+               inner_proc_unlabeled ;
+               inner_proc_labeled;
+             END;;"""
+    );
+
+    private final ProcTestCase tripleNestedFunc = new ProcTestCase(
+        "nested_func_end", DBSProcedureType.FUNCTION, """
+        FUNCTION nested_func_end RETURN NUMBER IS
+        BEGIN
+          DECLARE
+            FUNCTION nested_func_1 RETURN NUMBER IS
+              FUNCTION nested_func_2 RETURN NUMBER IS
+                FUNCTION nested_func_3 RETURN NUMBER IS
+                BEGIN
+                  RETURN 1;
+                END;
+              BEGIN
+                RETURN nested_func_3;
+              END;
+            BEGIN
+              RETURN nested_func_2;
+            END;
+          BEGIN
+            RETURN nested_func_1;
+          END;
+        END;"""
+    );
+
+
+    private final ProcTestCase outerBeginEndInnerFunc = new ProcTestCase(
+        "outer_func", DBSProcedureType.FUNCTION, """
+        FUNCTION outer_func RETURN NUMBER IS
+               FUNCTION inner_func_labeled RETURN NUMBER IS
+               BEGIN
+                 RETURN 1;
+               END inner_func_labeled;
+        
+               FUNCTION inner_func_unlabeled RETURN NUMBER IS
+               BEGIN
+                 RETURN 2;
+               END;
+        
+             BEGIN
+               RETURN inner_func_unlabeled + inner_func_labeled;
+             END;"""
+    );
 
     private class ProcTestCase {
         private final OracleProcedurePackaged procedure;

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -45,10 +45,14 @@ public class ProcedureFunctionExtractorTest {
     @Test
     public void simpleProcFuncTest() {
         assertBodyFound(simpleNoArgsProc);
+        assertBodyFound(simpleFunc);
+    }
+
+    @Test
+    public void simpleProcFuncNoLabeledEndTest() {
         assertBodyFound(simpleNoArgsNoEndProc);
         assertBodyFound(procWithParams);
 
-        assertBodyFound(simpleFunc);
         assertBodyFound(simpleNoArgsNoEndProc);
         assertBodyFound(funcWithParams);
     }
@@ -131,7 +135,7 @@ public class ProcedureFunctionExtractorTest {
         // not sure if needed to shuffle
         Collections.shuffle(allTestCases);
 
-        String allProcs = allTestCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n"));
+        String allProcs = allTestCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n\n"));
         String packageBody = packageDefinitionTemplate.formatted(allProcs);
         // then
         for (ProcTestCase testCase : allTestCases) {
@@ -386,12 +390,10 @@ public class ProcedureFunctionExtractorTest {
 
 
     private class ProcTestCase {
-        private final String name;
         private final OracleProcedurePackaged procedure;
         private final String procBody;
 
         public ProcTestCase(@NotNull String name, @NotNull DBSProcedureType procType, @NotNull String procBody) {
-            this.name = name;
             this.procedure = getProcedure(procType, name);
             this.procBody = procBody;
         }

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -64,6 +64,12 @@ public class ProcedureFunctionExtractorTest {
     }
 
     @Test
+    public void commentsTest() {
+        assertBodyFound(oneLineComments);
+        assertBodyFound(multiLineComments);
+    }
+
+    @Test
     public void endIfTest() {
         assertBodyFound(ifEndIf);
     }
@@ -117,6 +123,9 @@ public class ProcedureFunctionExtractorTest {
         allTestCases.add(simpleFuncNoEnd);
         allTestCases.add(funcNoBegin);
         allTestCases.add(funcWithParams);
+
+        allTestCases.add(oneLineComments);
+        allTestCases.add(multiLineComments);
 
         allTestCases.add(ifEndIf);
         allTestCases.add(caseEndCase);
@@ -240,6 +249,32 @@ public class ProcedureFunctionExtractorTest {
             END;"""
     );
 
+    private final ProcTestCase oneLineComments = new ProcTestCase(
+        "proc_with_comment",
+        DBSProcedureType.FUNCTION, """
+        FUNCTION proc_with_comment RETURN NUMBER IS
+        -- extra BEGIN 
+        --more BEGIN
+          l_var NUMBER := 42; --some end; and another begin loop
+          l_msg VARCHAR2(100);
+          --END proc_with_comment;
+        END;"""
+    );
+
+    private final ProcTestCase multiLineComments = new ProcTestCase(
+        "proc_with_multiline_comment",
+        DBSProcedureType.FUNCTION, """
+        FUNCTION proc_with_multiline_comment RETURN NUMBER IS
+        /* extra BEGIN 
+         more BEGIN
+         */
+          l_var NUMBER := 42; --some end; and another begin loop
+          /* l_msg VARCHAR2(100);
+          END proc_with_multiline_comment; */
+          /*END proc_with_multiline_comment;*/
+        END;"""
+    );
+
     private final ProcTestCase ifEndIf = new ProcTestCase(
         "if_end_if", DBSProcedureType.PROCEDURE, """
         PROCEDURE if_end_if IS
@@ -284,9 +319,9 @@ public class ProcedureFunctionExtractorTest {
     private final ProcTestCase tripleNestedBegins = new ProcTestCase(
         "triple_nested_begins", DBSProcedureType.PROCEDURE, """
         PROCEDURE triple_nested_begins IS
-        BEGIN                    -- #1 Outer BEGIN
-          BEGIN                  -- #2 Middle BEGIN
-            BEGIN                -- #3 Inner BEGIN
+        BEGIN                    -- #1 
+          BEGIN                  -- #2 
+            BEGIN                -- #3 
               NULL;
             END;                 -- Closes #3
           END;                   -- Closes #2
@@ -296,7 +331,7 @@ public class ProcedureFunctionExtractorTest {
     private final ProcTestCase openClosedBeginsInsideMain = new ProcTestCase(
         "two_nested_inside_main", DBSProcedureType.PROCEDURE, """
         PROCEDURE two_nested_inside_main IS
-        BEGIN                       -- Main BEGIN
+        BEGIN                       --
           BEGIN                     -- Nested #1
             NULL;
           END;                      -- Closes nested #1
@@ -309,7 +344,7 @@ public class ProcedureFunctionExtractorTest {
     private final ProcTestCase combinedNestedBegins = new ProcTestCase(
         "combined_nested_begins", DBSProcedureType.PROCEDURE, """
         PROCEDURE combined_nested_begins IS
-        BEGIN                          -- Main BEGIN #1
+        BEGIN                          -- Main  #1
           BEGIN                        -- Triple nest #1
             BEGIN                      -- Triple nest #2
               BEGIN                    -- Triple nest #3

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -62,14 +62,8 @@ public class ProcedureFunctionExtractorTest {
         assertBodyFound(simpleNoArgsNoEndProc);
         assertBodyFound(procWithParams);
 
-        assertBodyFound(simpleNoArgsNoEndProc);
+        assertBodyFound(simpleFuncNoEnd);
         assertBodyFound(funcWithParams);
-    }
-
-    @Test
-    public void noBeginTest() {
-        assertBodyFound(procNoBegin);
-        assertBodyFound(funcNoBegin);
     }
 
     @Test
@@ -139,12 +133,10 @@ public class ProcedureFunctionExtractorTest {
         List<ProcTestCase> allTestCases = new ArrayList<>();
         allTestCases.add(simpleNoArgsProc);
         allTestCases.add(simpleNoArgsNoEndProc);
-        allTestCases.add(procNoBegin);
         allTestCases.add(procWithParams);
 
         allTestCases.add(simpleFunc);
         allTestCases.add(simpleFuncNoEnd);
-        allTestCases.add(funcNoBegin);
         allTestCases.add(funcWithParams);
 
         allTestCases.add(simpleOneLineComment);
@@ -249,14 +241,6 @@ public class ProcedureFunctionExtractorTest {
              END proc_with_params;"""
     );
 
-    private final ProcTestCase procNoBegin = new ProcTestCase(
-        "proc_no_begin", DBSProcedureType.PROCEDURE, """
-        PROCEDURE proc_no_begin IS
-          l_var NUMBER := 42;
-          l_msg VARCHAR2(100);
-        END;"""
-    );
-
 
     private final ProcTestCase simpleFunc = new ProcTestCase(
         "simple_func", DBSProcedureType.FUNCTION, """
@@ -274,14 +258,6 @@ public class ProcedureFunctionExtractorTest {
         BEGIN
           RETURN l_var;
         END ;"""
-    );
-
-    private final ProcTestCase funcNoBegin = new ProcTestCase(
-        "func_no_begin", DBSProcedureType.FUNCTION, """
-        FUNCTION func_no_begin RETURN NUMBER IS
-          l_var NUMBER := 42;
-          l_msg VARCHAR2(100);
-        END;"""
     );
 
     private final ProcTestCase funcWithParams = new ProcTestCase(
@@ -496,7 +472,7 @@ public class ProcedureFunctionExtractorTest {
              BEGIN
                inner_proc_unlabeled ;
                inner_proc_labeled;
-             END;;"""
+             END;"""
     );
 
     private final ProcTestCase tripleNestedFunc = new ProcTestCase(

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -33,240 +33,6 @@ import static org.mockito.Mockito.when;
 
 public class ProcedureFunctionExtractorTest {
 
-
-    @Test
-    public void unknownFunctionType() {
-        // given
-        String notEmptyPackageDefinition = constructPackageBody(simpleNoArgsProc);
-        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(unknownProc.procedure, notEmptyPackageDefinition);
-        // then
-        assertEquals(ProcedureBodyExtractor.NO_DEFINITION_FOUND, procedureBodyExtractor.extractProcBody());
-    }
-
-    @Test
-    public void notFoundDefinitionTest() {
-        // given
-        String notEmptyPackageDefinition = constructPackageBody(noNameMatch);
-        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(noNameMatch.procedure, notEmptyPackageDefinition);
-        // then
-        assertEquals(ProcedureBodyExtractor.NO_DEFINITION_FOUND, procedureBodyExtractor.extractProcBody());
-    }
-
-    @Test
-    public void simpleProcFuncTest() {
-        assertBodyFound(simpleNoArgsProc);
-        assertBodyFound(simpleFunc);
-    }
-
-    @Test
-    public void simpleProcFuncNoLabeledEndTest() {
-        assertBodyFound(simpleNoArgsNoEndProc);
-        assertBodyFound(procWithParams);
-
-        assertBodyFound(simpleFuncNoEnd);
-        assertBodyFound(funcWithParams);
-    }
-
-    @Test
-    public void commentsTest() {
-        assertBodyFound(simpleOneLineComment);
-        assertBodyFound(oneLineComments);
-        assertBodyFound(simpleMultiLineComment);
-        assertBodyFound(multiLineComments);
-    }
-
-    @Test
-    public void functionStartInOneLineCommentLineIsIgnoredTest() {
-        // given
-        String funcBodyWithCommentFalseStart = "--PROCEDURE simple_proc IS\n" + simpleNoArgsProc.procBody;
-        ProcedureBodyExtractor extractor = new ProcedureBodyExtractor(
-            simpleNoArgsProc.procedure,
-            packageDefinitionTemplate.formatted(funcBodyWithCommentFalseStart)
-        );
-        // then
-        assertEquals(simpleNoArgsProc.procBody, extractor.extractProcBody());
-    }
-
-    @Test
-    public void functionStartInMultiLineCommentLineIsIgnoredTest() {
-        // given
-        String funcBodyWithCommentFalseStart = """
-            /*PROCEDURE simple_proc IS;
-            PROCEDURE simple_proc IS;
-            PROCEDURE simple_proc IS;*/""" + simpleNoArgsProc.procBody;
-        ProcedureBodyExtractor extractor = new ProcedureBodyExtractor(
-            simpleNoArgsProc.procedure,
-            packageDefinitionTemplate.formatted(funcBodyWithCommentFalseStart)
-        );
-        // then
-        assertEquals(simpleNoArgsProc.procBody, extractor.extractProcBody());
-    }
-
-    @Test
-    public void endIfTest() {
-        assertBodyFound(ifEndIf);
-    }
-
-    @Test
-    public void caseEndTest() {
-        assertBodyFound(caseEndCase);
-    }
-
-    @Test
-    public void loopsTest() {
-        assertBodyFound(loopEndLoop);
-        assertBodyFound(forLoopEndLoop);
-    }
-
-    @Test
-    public void nestedBeginTest() {
-        assertBodyFound(tripleNestedBegins);
-    }
-
-    @Test
-    public void openClosedNestedBeginsTest() {
-        assertBodyFound(openClosedBeginsInsideMain);
-    }
-
-    @Test
-    public void combinedNestedBegins() {
-        assertBodyFound(combinedNestedBegins);
-    }
-
-    @Test
-    public void whileTest() {
-        assertBodyFound(whileLoopEndLoop);
-    }
-
-    @Test
-    public void declareTest() {
-        assertBodyFound(declareEnd);
-    }
-
-    @Test
-    public void nestedProcedures() {
-        assertBodyFound(tripleNestedProc);
-        assertBodyFound(outerBeginEndInner);
-    }
-
-    @Test
-    public void nestedFunctions() {
-        assertBodyFound(tripleNestedFunc);
-        assertBodyFound(outerBeginEndInnerFunc);
-    }
-
-    @Test
-    public void overloadedProcsTest() {
-        // given
-        String packageDefinitionWillAllOverloadedProcs =
-            packageDefinitionTemplate
-                .formatted(String.join("\n\n", List.of(overloadedProc1.procBody, overloadedProc2.procBody, overloadedProc3.procBody)));
-
-        // then
-        assertBodyFound(overloadedProc1, packageDefinitionWillAllOverloadedProcs);
-        assertBodyFound(overloadedProc2, packageDefinitionWillAllOverloadedProcs);
-        assertBodyFound(overloadedProc3, packageDefinitionWillAllOverloadedProcs);
-    }
-
-    @Test
-    public void overloadedFucntionsTest() {
-        // given
-        String packageDefinitionWillAllOverloadedFucntions =
-            packageDefinitionTemplate
-                .formatted(String.join("\n\n", List.of(overloadedFunc1.procBody, overloadedFunc2.procBody, overloadedFunc3.procBody)));
-
-        // then
-        assertBodyFound(overloadedFunc1, packageDefinitionWillAllOverloadedFucntions);
-        assertBodyFound(overloadedFunc2, packageDefinitionWillAllOverloadedFucntions);
-        assertBodyFound(overloadedFunc3, packageDefinitionWillAllOverloadedFucntions);
-    }
-
-    @Test
-    public void allProceduresBodyExtractTest() {
-        // given
-        List<ProcTestCase> allTestCases = new ArrayList<>();
-        allTestCases.add(simpleNoArgsProc);
-        allTestCases.add(simpleNoArgsNoEndProc);
-        allTestCases.add(procWithParams);
-
-        allTestCases.add(simpleFunc);
-        allTestCases.add(simpleFuncNoEnd);
-        allTestCases.add(funcWithParams);
-
-        allTestCases.add(simpleOneLineComment);
-        allTestCases.add(oneLineComments);
-        allTestCases.add(simpleMultiLineComment);
-        allTestCases.add(multiLineComments);
-
-        allTestCases.add(ifEndIf);
-        allTestCases.add(caseEndCase);
-
-        allTestCases.add(forLoopEndLoop);
-        allTestCases.add(loopEndLoop);
-
-        allTestCases.add(tripleNestedBegins);
-        allTestCases.add(openClosedBeginsInsideMain);
-        allTestCases.add(combinedNestedBegins);
-
-        allTestCases.add(whileLoopEndLoop);
-
-        allTestCases.add(declareEnd);
-
-        allTestCases.add(tripleNestedProc);
-        allTestCases.add(outerBeginEndInner);
-
-        allTestCases.add(tripleNestedFunc);
-        allTestCases.add(outerBeginEndInnerFunc);
-
-        List<ProcTestCase> reversedAllCases = new ArrayList<>(allTestCases);
-        Collections.reverse(reversedAllCases);
-
-        // can be tested only in straight order, since overload number works sequentially
-        List<ProcTestCase> overloadedCases = List.of(
-            overloadedProc1,
-            overloadedProc2,
-            overloadedProc3,
-
-            overloadedFunc1,
-            overloadedFunc2,
-            overloadedFunc3
-        );
-        allTestCases.addAll(overloadedCases);
-
-        String allProcs = allTestCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n\n"));
-        String reversedAllProcs = reversedAllCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n\n"));
-
-        String packageBody = packageDefinitionTemplate.formatted(allProcs);
-        String reversedPackageBody = packageDefinitionTemplate.formatted(reversedAllProcs);
-
-        // then
-        for (ProcTestCase procToSearch : allTestCases) {
-            ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(procToSearch.procedure, packageBody);
-            assertEquals(procToSearch.procBody, procedureBodyExtractor.extractProcBody());
-        }
-
-        for (ProcTestCase procToSearch : reversedAllCases) {
-            ProcedureBodyExtractor procedureBodyExtractorReversed = new ProcedureBodyExtractor(procToSearch.procedure, reversedPackageBody);
-            assertEquals(procToSearch.procBody, procedureBodyExtractorReversed.extractProcBody());
-        }
-    }
-
-    private void assertBodyFound(@NotNull ProcTestCase testCase) {
-        assertBodyFound(testCase, constructPackageBody(testCase));
-    }
-
-    private void assertBodyFound(@NotNull ProcTestCase testCase, @NotNull String packageBodyDefinition) {
-        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(testCase.procedure, packageBodyDefinition);
-        // then
-        assertEquals(testCase.procBody, procedureBodyExtractor.extractProcBody());
-    }
-
-    private String constructPackageBody(@NotNull ProcTestCase testCase) {
-        return packageDefinitionTemplate
-            .formatted(testCase.procBody);
-    }
-
-
     private final String packageDefinitionTemplate = """
         CREATE OR REPLACE PACKAGE BODY TEST_PACKAGE AS
         %s
@@ -658,6 +424,239 @@ public class ProcedureFunctionExtractorTest {
             END;""",
         3
     );
+
+
+    @Test
+    public void unknownFunctionType() {
+        // given
+        String notEmptyPackageDefinition = constructPackageBody(simpleNoArgsProc);
+        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(unknownProc.procedure, notEmptyPackageDefinition);
+        // then
+        assertEquals(ProcedureBodyExtractor.NO_DEFINITION_FOUND, procedureBodyExtractor.extractProcBody());
+    }
+
+    @Test
+    public void notFoundDefinitionTest() {
+        // given
+        String notEmptyPackageDefinition = constructPackageBody(noNameMatch);
+        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(noNameMatch.procedure, notEmptyPackageDefinition);
+        // then
+        assertEquals(ProcedureBodyExtractor.NO_DEFINITION_FOUND, procedureBodyExtractor.extractProcBody());
+    }
+
+    @Test
+    public void simpleProcFuncTest() {
+        assertBodyFound(simpleNoArgsProc);
+        assertBodyFound(simpleFunc);
+    }
+
+    @Test
+    public void simpleProcFuncNoLabeledEndTest() {
+        assertBodyFound(simpleNoArgsNoEndProc);
+        assertBodyFound(procWithParams);
+
+        assertBodyFound(simpleFuncNoEnd);
+        assertBodyFound(funcWithParams);
+    }
+
+    @Test
+    public void commentsTest() {
+        assertBodyFound(simpleOneLineComment);
+        assertBodyFound(oneLineComments);
+        assertBodyFound(simpleMultiLineComment);
+        assertBodyFound(multiLineComments);
+    }
+
+    @Test
+    public void functionStartInOneLineCommentLineIsIgnoredTest() {
+        // given
+        String funcBodyWithCommentFalseStart = "--PROCEDURE simple_proc IS\n" + simpleNoArgsProc.procBody;
+        ProcedureBodyExtractor extractor = new ProcedureBodyExtractor(
+            simpleNoArgsProc.procedure,
+            packageDefinitionTemplate.formatted(funcBodyWithCommentFalseStart)
+        );
+        // then
+        assertEquals(simpleNoArgsProc.procBody, extractor.extractProcBody());
+    }
+
+    @Test
+    public void functionStartInMultiLineCommentLineIsIgnoredTest() {
+        // given
+        String funcBodyWithCommentFalseStart = """
+            /*PROCEDURE simple_proc IS;
+            PROCEDURE simple_proc IS;
+            PROCEDURE simple_proc IS;*/""" + simpleNoArgsProc.procBody;
+        ProcedureBodyExtractor extractor = new ProcedureBodyExtractor(
+            simpleNoArgsProc.procedure,
+            packageDefinitionTemplate.formatted(funcBodyWithCommentFalseStart)
+        );
+        // then
+        assertEquals(simpleNoArgsProc.procBody, extractor.extractProcBody());
+    }
+
+    @Test
+    public void endIfTest() {
+        assertBodyFound(ifEndIf);
+    }
+
+    @Test
+    public void caseEndTest() {
+        assertBodyFound(caseEndCase);
+    }
+
+    @Test
+    public void loopsTest() {
+        assertBodyFound(loopEndLoop);
+        assertBodyFound(forLoopEndLoop);
+    }
+
+    @Test
+    public void nestedBeginTest() {
+        assertBodyFound(tripleNestedBegins);
+    }
+
+    @Test
+    public void openClosedNestedBeginsTest() {
+        assertBodyFound(openClosedBeginsInsideMain);
+    }
+
+    @Test
+    public void combinedNestedBegins() {
+        assertBodyFound(combinedNestedBegins);
+    }
+
+    @Test
+    public void whileTest() {
+        assertBodyFound(whileLoopEndLoop);
+    }
+
+    @Test
+    public void declareTest() {
+        assertBodyFound(declareEnd);
+    }
+
+    @Test
+    public void nestedProcedures() {
+        assertBodyFound(tripleNestedProc);
+        assertBodyFound(outerBeginEndInner);
+    }
+
+    @Test
+    public void nestedFunctions() {
+        assertBodyFound(tripleNestedFunc);
+        assertBodyFound(outerBeginEndInnerFunc);
+    }
+
+    @Test
+    public void overloadedProcsTest() {
+        // given
+        String packageDefinitionWillAllOverloadedProcs =
+            packageDefinitionTemplate
+                .formatted(String.join("\n\n", List.of(overloadedProc1.procBody, overloadedProc2.procBody, overloadedProc3.procBody)));
+
+        // then
+        assertBodyFound(overloadedProc1, packageDefinitionWillAllOverloadedProcs);
+        assertBodyFound(overloadedProc2, packageDefinitionWillAllOverloadedProcs);
+        assertBodyFound(overloadedProc3, packageDefinitionWillAllOverloadedProcs);
+    }
+
+    @Test
+    public void overloadedFucntionsTest() {
+        // given
+        String packageDefinitionWillAllOverloadedFucntions =
+            packageDefinitionTemplate
+                .formatted(String.join("\n\n", List.of(overloadedFunc1.procBody, overloadedFunc2.procBody, overloadedFunc3.procBody)));
+
+        // then
+        assertBodyFound(overloadedFunc1, packageDefinitionWillAllOverloadedFucntions);
+        assertBodyFound(overloadedFunc2, packageDefinitionWillAllOverloadedFucntions);
+        assertBodyFound(overloadedFunc3, packageDefinitionWillAllOverloadedFucntions);
+    }
+
+    @Test
+    public void allProceduresBodyExtractTest() {
+        // given
+        List<ProcTestCase> allTestCases = new ArrayList<>();
+        allTestCases.add(simpleNoArgsProc);
+        allTestCases.add(simpleNoArgsNoEndProc);
+        allTestCases.add(procWithParams);
+
+        allTestCases.add(simpleFunc);
+        allTestCases.add(simpleFuncNoEnd);
+        allTestCases.add(funcWithParams);
+
+        allTestCases.add(simpleOneLineComment);
+        allTestCases.add(oneLineComments);
+        allTestCases.add(simpleMultiLineComment);
+        allTestCases.add(multiLineComments);
+
+        allTestCases.add(ifEndIf);
+        allTestCases.add(caseEndCase);
+
+        allTestCases.add(forLoopEndLoop);
+        allTestCases.add(loopEndLoop);
+
+        allTestCases.add(tripleNestedBegins);
+        allTestCases.add(openClosedBeginsInsideMain);
+        allTestCases.add(combinedNestedBegins);
+
+        allTestCases.add(whileLoopEndLoop);
+
+        allTestCases.add(declareEnd);
+
+        allTestCases.add(tripleNestedProc);
+        allTestCases.add(outerBeginEndInner);
+
+        allTestCases.add(tripleNestedFunc);
+        allTestCases.add(outerBeginEndInnerFunc);
+
+        List<ProcTestCase> reversedAllCases = new ArrayList<>(allTestCases);
+        Collections.reverse(reversedAllCases);
+
+        // can be tested only in straight order, since overload number works sequentially
+        List<ProcTestCase> overloadedCases = List.of(
+            overloadedProc1,
+            overloadedProc2,
+            overloadedProc3,
+
+            overloadedFunc1,
+            overloadedFunc2,
+            overloadedFunc3
+        );
+        allTestCases.addAll(overloadedCases);
+
+        String allProcs = allTestCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n\n"));
+        String reversedAllProcs = reversedAllCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n\n"));
+
+        String packageBody = packageDefinitionTemplate.formatted(allProcs);
+        String reversedPackageBody = packageDefinitionTemplate.formatted(reversedAllProcs);
+
+        // then
+        for (ProcTestCase procToSearch : allTestCases) {
+            ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(procToSearch.procedure, packageBody);
+            assertEquals(procToSearch.procBody, procedureBodyExtractor.extractProcBody());
+        }
+
+        for (ProcTestCase procToSearch : reversedAllCases) {
+            ProcedureBodyExtractor procedureBodyExtractorReversed = new ProcedureBodyExtractor(procToSearch.procedure, reversedPackageBody);
+            assertEquals(procToSearch.procBody, procedureBodyExtractorReversed.extractProcBody());
+        }
+    }
+
+    private void assertBodyFound(@NotNull ProcTestCase testCase) {
+        assertBodyFound(testCase, constructPackageBody(testCase));
+    }
+
+    private void assertBodyFound(@NotNull ProcTestCase testCase, @NotNull String packageBodyDefinition) {
+        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(testCase.procedure, packageBodyDefinition);
+        // then
+        assertEquals(testCase.procBody, procedureBodyExtractor.extractProcBody());
+    }
+
+    private String constructPackageBody(@NotNull ProcTestCase testCase) {
+        return packageDefinitionTemplate
+            .formatted(testCase.procBody);
+    }
 
 
     private class ProcTestCase {

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -67,6 +67,7 @@ public class ProcedureFunctionExtractorTest {
     public void commentsTest() {
         assertBodyFound(simpleOneLineComment);
         assertBodyFound(oneLineComments);
+        assertBodyFound(simpleMultiLineComment);
         assertBodyFound(multiLineComments);
     }
 
@@ -127,6 +128,7 @@ public class ProcedureFunctionExtractorTest {
 
         allTestCases.add(simpleOneLineComment);
         allTestCases.add(oneLineComments);
+        allTestCases.add(simpleMultiLineComment);
         allTestCases.add(multiLineComments);
 
         allTestCases.add(ifEndIf);
@@ -188,6 +190,7 @@ public class ProcedureFunctionExtractorTest {
         PROCEDURE simple_no_end_proc IS
         BEGIN
           NULL;
+          print("false_end;end_false;")
         END;"""
     );
 
@@ -273,6 +276,18 @@ public class ProcedureFunctionExtractorTest {
         END;"""
     );
 
+    private final ProcTestCase simpleMultiLineComment = new ProcTestCase(
+        "simple_with_multiline_comment",
+        DBSProcedureType.FUNCTION, """
+        FUNCTION simple_with_multiline_comment RETURN NUMBER IS
+          l_var NUMBER := 42; --some end; and another begin loop
+          /*END proc_with_multiline_comment;*/
+          /*END simple_with_multiline_comment;
+          END simple_with_multiline_comment;
+          */
+        END;"""
+    );
+
     private final ProcTestCase multiLineComments = new ProcTestCase(
         "proc_with_multiline_comment",
         DBSProcedureType.FUNCTION, """
@@ -343,7 +358,7 @@ public class ProcedureFunctionExtractorTest {
     private final ProcTestCase openClosedBeginsInsideMain = new ProcTestCase(
         "two_nested_inside_main", DBSProcedureType.PROCEDURE, """
         PROCEDURE two_nested_inside_main IS
-        BEGIN                       --
+        BEGIN                       -- first BEGIN
           BEGIN                     -- Nested #1
             NULL;
           END;                      -- Closes nested #1
@@ -356,7 +371,7 @@ public class ProcedureFunctionExtractorTest {
     private final ProcTestCase combinedNestedBegins = new ProcTestCase(
         "combined_nested_begins", DBSProcedureType.PROCEDURE, """
         PROCEDURE combined_nested_begins IS
-        BEGIN                          -- Main  #1
+        BEGIN                          -- Main  #1 BEGIN
           BEGIN                        -- Triple nest #1
             BEGIN                      -- Triple nest #2
               BEGIN                    -- Triple nest #3
@@ -424,7 +439,7 @@ public class ProcedureFunctionExtractorTest {
           BEGIN
             NULL;
           END inner_proc;
-          PROCEDURE inner_proc_labeled IS
+          PROCEDURE inner_proc_unlabeled IS
           BEGIN
             NULL;
           END;

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -65,6 +65,7 @@ public class ProcedureFunctionExtractorTest {
 
     @Test
     public void commentsTest() {
+        assertBodyFound(simpleOneLineComment);
         assertBodyFound(oneLineComments);
         assertBodyFound(multiLineComments);
     }
@@ -124,6 +125,7 @@ public class ProcedureFunctionExtractorTest {
         allTestCases.add(funcNoBegin);
         allTestCases.add(funcWithParams);
 
+        allTestCases.add(simpleOneLineComment);
         allTestCases.add(oneLineComments);
         allTestCases.add(multiLineComments);
 
@@ -249,6 +251,16 @@ public class ProcedureFunctionExtractorTest {
             END;"""
     );
 
+    private final ProcTestCase simpleOneLineComment = new ProcTestCase(
+        "proc_with_simple_comment",
+        DBSProcedureType.FUNCTION, """
+        FUNCTION proc_with_simple_comment RETURN NUMBER IS
+          l_var NUMBER := 42;
+          l_msg VARCHAR2(100);
+          --END proc_with_simple_comment;
+        END;"""
+    );
+
     private final ProcTestCase oneLineComments = new ProcTestCase(
         "proc_with_comment",
         DBSProcedureType.FUNCTION, """
@@ -256,7 +268,7 @@ public class ProcedureFunctionExtractorTest {
         -- extra BEGIN 
         --more BEGIN
           l_var NUMBER := 42; --some end; and another begin loop
-          l_msg VARCHAR2(100);
+          l_msg --sudden inline comment -- included comment VARCHAR2(100);
           --END proc_with_comment;
         END;"""
     );

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -1,0 +1,122 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.oracle.model.util;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
+import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ProcedureFunctionExtractorTest {
+
+
+    @Test
+    public void notFoundDefinitionTest() {
+        // given
+        String notEmptyPackageDefinition = constructPackageBody(simpleNoArgsProc);
+        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(unknownProc.procedure, notEmptyPackageDefinition);
+        // then
+        assertEquals(ProcedureBodyExtractor.NO_DEFINITION_FOUND, procedureBodyExtractor.extractProcBody());
+    }
+
+    @Test
+    public void simpleProcTest() {
+        assertBodyFound(simpleNoArgsProc);
+        assertBodyFound(simpleNoArgsNoEndProc);
+    }
+
+    @Test
+    public void allProceduresBodyExtractTest() {
+        // given
+        List<ProcTestCase> allTestCases = new ArrayList<>();
+        allTestCases.add(simpleNoArgsProc);
+        allTestCases.add(simpleNoArgsNoEndProc);
+        Collections.shuffle(allTestCases);
+
+        String allProcs = allTestCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n"));
+        String packageBody = packageDefinitionTemplate.formatted(allProcs);
+        // then
+        for (ProcTestCase testCase : allTestCases) {
+            ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(testCase.procedure, packageBody);
+            assertEquals(testCase.procBody, procedureBodyExtractor.extractProcBody());
+        }
+    }
+
+    private void assertBodyFound(@NotNull ProcTestCase testCase) {
+        String packageDefinition = constructPackageBody(testCase);
+        ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(testCase.procedure, packageDefinition);
+        // then
+        assertEquals(testCase.procBody, procedureBodyExtractor.extractProcBody());
+    }
+
+    private String constructPackageBody(@NotNull ProcTestCase testCase) {
+        return packageDefinitionTemplate
+            .formatted(testCase.procBody);
+    }
+
+
+    private final String packageDefinitionTemplate = """
+        CREATE OR REPLACE PACKAGE BODY TEST_PACKAGE AS
+        %s
+        END TEST_PACKAGE;""";
+
+    private final ProcTestCase unknownProc = new ProcTestCase("unknown", DBSProcedureType.UNKNOWN, "-- Procedure Body");
+    private final ProcTestCase simpleNoArgsProc = new ProcTestCase(
+        "simple_proc", DBSProcedureType.PROCEDURE, """
+        PROCEDURE simple_proc IS
+        BEGIN
+          NULL;
+        END simple_proc;"""
+    );
+
+    private final ProcTestCase simpleNoArgsNoEndProc = new ProcTestCase(
+        "simple_no_end_proc", DBSProcedureType.PROCEDURE, """
+        PROCEDURE simple_no_end_proc IS
+        BEGIN
+          NULL;
+        END;"""
+    );
+
+    private class ProcTestCase {
+        private final String name;
+        private final OracleProcedurePackaged procedure;
+        private final String procBody;
+
+        public ProcTestCase(@NotNull String name, @NotNull DBSProcedureType procType, @NotNull String procBody) {
+            this.name = name;
+            this.procedure = getProcedure(procType, name);
+            this.procBody = procBody;
+        }
+
+        @NotNull
+        private OracleProcedurePackaged getProcedure(@NotNull DBSProcedureType procType, @NotNull String procName) {
+            OracleProcedurePackaged mockProc = mock(OracleProcedurePackaged.class);
+            when(mockProc.getProcedureType()).thenReturn(procType);
+            when(mockProc.getUniqueName()).thenReturn(procName);
+            return mockProc;
+        }
+    }
+}

--- a/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
+++ b/test/org.jkiss.dbeaver.ext.oracle.test/src/org/jkiss/dbeaver/ext/oracle/model/util/ProcedureFunctionExtractorTest.java
@@ -164,15 +164,21 @@ public class ProcedureFunctionExtractorTest {
         allTestCases.add(tripleNestedFunc);
         allTestCases.add(outerBeginEndInnerFunc);
 
-        // not sure if needed to shuffle
-        Collections.shuffle(allTestCases);
+        List<ProcTestCase> reversedAllCases = new ArrayList<>(allTestCases);
+        Collections.reverse(reversedAllCases);
+
 
         String allProcs = allTestCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n\n"));
+        String reversedAllProcs = reversedAllCases.stream().map(ptc -> ptc.procBody).collect(Collectors.joining("\n\n"));
         String packageBody = packageDefinitionTemplate.formatted(allProcs);
+        String reversedPackageBody = packageDefinitionTemplate.formatted(reversedAllProcs);
+
         // then
-        for (ProcTestCase testCase : allTestCases) {
-            ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(testCase.procedure, packageBody);
-            assertEquals(testCase.procBody, procedureBodyExtractor.extractProcBody());
+        for (ProcTestCase procToSearch : allTestCases) {
+            ProcedureBodyExtractor procedureBodyExtractor = new ProcedureBodyExtractor(procToSearch.procedure, packageBody);
+            ProcedureBodyExtractor procedureBodyExtractorReversed = new ProcedureBodyExtractor(procToSearch.procedure, reversedPackageBody);
+            assertEquals(procToSearch.procBody, procedureBodyExtractor.extractProcBody());
+            assertEquals(procToSearch.procBody, procedureBodyExtractorReversed.extractProcBody());
         }
     }
 


### PR DESCRIPTION
closes dbeaver/pro#6618
_For reviewers:_ 700 lines are just test case

Basically, we should parse the whole package definition not more than three times O(n):
1. comments exclusion
2. finding proc start
3. finding proc labeled end (only if start found, and starting from proc start index)
if labaled end not found
4. Finding proc end recursively. Every time we parse from the last found end instance index

Simplified parcer algo:
```mermaid
flowchart TD

A[Start] --> B[defineCommentRegions]

B --> C[extractProcBody]

C --> D{procType exists?}

D -- No --> E[Return NO_DEFINITION_FOUND]

D -- Yes --> F[Find procedure start using regex]

F --> G{Nth overload found?}

G -- No --> E

G -- Yes --> H[Call findProcEnd]

H --> I{END procName found?}

I -- Yes --> J[Return substring until END procName]

I -- No --> K[Initialize matchers: BEGIN END NESTED]

K --> L[Call EndProcedureFinder]

L --> M{End index found?}

M -- Yes --> N[Return substring until end index]

M -- No --> O[Return substring until end of package]

```

**EndProcedureFinder** algorithm

```mermaid
flowchart TD

A[Start search] --> B[Find next END]

B --> C{END found?}

C -- No --> D[Return -1]

C -- Yes --> E[Check nested procedure before END]

E --> F{Nested procedure found?}

F -- Yes --> G[Push BEGIN tokens before nested procedure]
G --> H[Recursively find nested procedure end]
H --> A

F -- No --> I[Push BEGIN tokens before END]
I --> J[Pop one BEGIN]

J --> K{Stack empty?}

K -- Yes --> L[Return END position]

K -- No --> A
```

