### PR TITLE
#37181 Add TDengineMetaModel to fix special character handling in dat…

### DIFF
--- a/features/org.jkiss.dbeaver.db.feature/feature.xml
+++ b/features/org.jkiss.dbeaver.db.feature/feature.xml
@@ -36,6 +36,7 @@
    <plugin id="org.jkiss.dbeaver.ext.iotdb" version="0.0.0" />
    <plugin id="org.jkiss.dbeaver.ext.netezza" version="0.0.0" />
    <plugin id="org.jkiss.dbeaver.ext.oceanbase" version="0.0.0" />
+   <plugin id="org.jkiss.dbeaver.ext.tdengine" version="0.0.0" />
    <plugin id="org.jkiss.dbeaver.ext.tidb" version="0.0.0" />
    <plugin id="org.jkiss.dbeaver.ext.phoenix" version="0.0.0" />
    <plugin id="org.jkiss.dbeaver.ext.snowflake" version="0.0.0"/>

--- a/plugins/org.jkiss.dbeaver.ext.tdengine/META-INF/MANIFEST.MF
+++ b/plugins/org.jkiss.dbeaver.ext.tdengine/META-INF/MANIFEST.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-Name: DBeaver TDengine Model
+Bundle-SymbolicName: org.jkiss.dbeaver.ext.tdengine;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Release-Date: 20260310
+Bundle-Vendor: DBeaver Corp
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Bundle-ActivationPolicy: lazy
+Require-Bundle: org.jkiss.dbeaver.model,
+ org.jkiss.dbeaver.ext.generic;visibility:=reexport
+Export-Package: org.jkiss.dbeaver.ext.tdengine.model
+Automatic-Module-Name: org.jkiss.dbeaver.ext.tdengine

--- a/plugins/org.jkiss.dbeaver.ext.tdengine/build.properties
+++ b/plugins/org.jkiss.dbeaver.ext.tdengine/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/plugins/org.jkiss.dbeaver.ext.tdengine/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.tdengine/plugin.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.2"?>
+
+<plugin>
+
+    <extension point="org.jkiss.dbeaver.generic.meta">
+        <meta
+            id="tdengine"
+            class="org.jkiss.dbeaver.ext.tdengine.model.TDengineMetaModel"
+            driverClass="com.taosdata.jdbc.ws.WebSocketDriver"/>
+    </extension>
+
+</plugin>

--- a/plugins/org.jkiss.dbeaver.ext.tdengine/pom.xml
+++ b/plugins/org.jkiss.dbeaver.ext.tdengine/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jkiss.dbeaver</groupId>
+    <artifactId>plugins</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  <artifactId>org.jkiss.dbeaver.ext.tdengine</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/plugins/org.jkiss.dbeaver.ext.tdengine/src/org/jkiss/dbeaver/ext/tdengine/model/TDengineMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.tdengine/src/org/jkiss/dbeaver/ext/tdengine/model/TDengineMetaModel.java
@@ -1,0 +1,67 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.tdengine.model;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.ext.generic.model.GenericStructContainer;
+import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
+import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaModel;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
+import org.jkiss.utils.CommonUtils;
+
+import java.sql.SQLException;
+
+/**
+ * TDengineMetaModel
+ */
+public class TDengineMetaModel extends GenericMetaModel {
+
+    public TDengineMetaModel() {
+        super();
+    }
+
+    @Override
+    public JDBCStatement prepareTableLoadStatement(
+        @NotNull JDBCSession session,
+        @NotNull GenericStructContainer owner,
+        @Nullable GenericTableBase table,
+        @Nullable String tableName
+    ) throws SQLException {
+        // Use information_schema.ins_tables with parameterized query
+        // This avoids the backtick escaping issue with special characters in database names
+        StringBuilder sql = new StringBuilder();
+        sql.append("SELECT table_name AS TABLE_NAME, type AS TABLE_TYPE, table_comment AS REMARKS ");
+        sql.append("FROM information_schema.ins_tables ");
+        sql.append("WHERE db_name = ?");
+
+        if (table != null || CommonUtils.isNotEmpty(tableName)) {
+            sql.append(" AND table_name = ?");
+        }
+
+        JDBCPreparedStatement dbStat = session.prepareStatement(sql.toString());
+        dbStat.setString(1, owner.getCatalog() != null ? owner.getCatalog().getName() : owner.getName());
+
+        if (table != null || CommonUtils.isNotEmpty(tableName)) {
+            dbStat.setString(2, table != null ? table.getName() : tableName);
+        }
+
+        return dbStat;
+    }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -76,6 +76,7 @@
         <module>org.jkiss.dbeaver.ext.tidb</module>
         <module>org.jkiss.dbeaver.ext.trino</module>
         <module>org.jkiss.dbeaver.ext.denodo</module>
+        <module>org.jkiss.dbeaver.ext.tdengine</module>
         <module>org.jkiss.dbeaver.ext.altibase</module>
         <module>org.jkiss.dbeaver.ext.gaussdb</module>
         


### PR DESCRIPTION
## Summary
Fix TDengine metadata loading for database names containing `-`.

related #37181 

## What changed
- add a TDengine-specific metadata model
- replace the generic table metadata path with a parameterized query against `information_schema.ins_tables`

## Result
Databases such as `my-db` can now be opened successfully.

## Before
![Image](https://github.com/user-attachments/assets/086c24ae-f708-459a-b234-892230b0fe6e)

## After
![Image](https://github.com/user-attachments/assets/4fbc3a60-f641-4b42-9b0b-d218d2e8bdeb)

## Note
While testing, I also found a separate metadata-loading issue in another path (PK / ERD / constraints), but I left it out of this PR to keep the scope focused.