### PR TITLE
#40474 Add ORDER BY clause when loading columns

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaMetaModel.java
@@ -125,7 +125,11 @@ public class VerticaMetaModel extends GenericMetaModel implements DBCQueryTransf
         if (forTable != null) {
             ddl.append("AND col.table_name=? ");
         }
-        ddl.append("\nORDER BY " + (forTable != null ? "table_name," : "") + "ordinal_position");
+        ddl.append("\nORDER BY ");
+        if (forTable != null) {
+            ddl.append("table_name,");
+        }
+        ddl.append("ordinal_position");
         JDBCPreparedStatement dbStat = session.prepareStatement(ddl.toString());
         if (forTable != null) {
             dbStat.setString(1, forTable.getSchema().getName());

--- a/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaMetaModel.java
@@ -125,6 +125,7 @@ public class VerticaMetaModel extends GenericMetaModel implements DBCQueryTransf
         if (forTable != null) {
             ddl.append("AND col.table_name=? ");
         }
+        ddl.append("\nORDER BY schema_name, table_name, ordinal_position");
         JDBCPreparedStatement dbStat = session.prepareStatement(ddl.toString());
         if (forTable != null) {
             dbStat.setString(1, forTable.getSchema().getName());

--- a/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.vertica/src/org/jkiss/dbeaver/ext/vertica/model/VerticaMetaModel.java
@@ -125,7 +125,7 @@ public class VerticaMetaModel extends GenericMetaModel implements DBCQueryTransf
         if (forTable != null) {
             ddl.append("AND col.table_name=? ");
         }
-        ddl.append("\nORDER BY schema_name, table_name, ordinal_position");
+        ddl.append("\nORDER BY " + (forTable != null ? "table_name," : "") + "ordinal_position");
         JDBCPreparedStatement dbStat = session.prepareStatement(ddl.toString());
         if (forTable != null) {
             dbStat.setString(1, forTable.getSchema().getName());


### PR DESCRIPTION
Add ORDER BY clause to fix columns displayed order and columns order in INSERT,... genereted queries

before:
<img width="794" height="167" alt="before" src="https://github.com/user-attachments/assets/22967177-bee5-4dbe-bff3-23a66893ab18" />

after:
<img width="791" height="162" alt="after" src="https://github.com/user-attachments/assets/d18bcf2a-2a46-4e70-8849-93e14067e8bd" />
