### PR TITLE
Fix: column completion not working after WHERE clause in legacy SQL

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
@@ -293,6 +293,7 @@ public class SQLCompletionAnalyzer implements DBRRunnableParametrized<DBRProgres
                 }
             } else if (!isInLiteral) {
                 DBSObject rootObject = null;
+                List<DBSObject> rootObjects = null;
                 if (queryType == SQLCompletionRequest.QueryType.COLUMN && dataSource instanceof DBSObjectContainer) {
                     // Part of column name
                     // Try to get from active object
@@ -321,26 +322,36 @@ public class SQLCompletionAnalyzer implements DBRRunnableParametrized<DBRProgres
                         tableAlias = divPos == -1 ? null : wordPart.substring(0, divPos);
                     }
                     if (tableAlias == null && !CommonUtils.isEmpty(wordPart)) {
-                        // May be an incomplete table alias. Try to find such table
-                        rootObject = getTableFromAlias(sc, wordPart);
-                        if (rootObject != null) {
-                            // Found alias - no proposals
-                            searchFinished = true;
-                            return;
+                        // May be an incomplete table alias or column name prefix.
+                        // Instead of stopping here, fall through to show columns from all tables.
+                        // This fixes the case where wordPart matches a table name (e.g. "mem" matches "MEM_Head")
+                        // but the user is actually trying to type a column name like "memo_no".
+                    }
+                    if (tableAlias == null) {
+                        // Use root dataSource (not sc) to resolve fully-qualified table names
+                        // (e.g. db_backoffice.dbo.MEM_Head) that may belong to a different catalog
+                        // than the currently active database (sc). This mirrors what the emptyWord
+                        // branch does at line 222.
+                        rootObjects = getTableListFromAlias((DBSObjectContainer) dataSource, null);
+                    } else {
+                        // Use root dataSource (not sc) to resolve cross-database aliases
+                        rootObject = getTableFromAlias((DBSObjectContainer) dataSource, tableAlias);
+                        if (rootObject == null) {
+                            // Maybe alias is a table name
+                            String[] allNames = SQLUtils.splitFullIdentifier(
+                                tableAlias,
+                                sqlDialect.getCatalogSeparator(),
+                                sqlDialect.getIdentifierQuoteStrings(),
+                                false);
+                            rootObject = SQLSearchUtils.findObjectByFQN(monitor, (DBSObjectContainer) dataSource, request, Arrays.asList(allNames));
                         }
                     }
-                    rootObject = getTableFromAlias(sc, tableAlias);
-                    if (rootObject == null && tableAlias != null) {
-                        // Maybe alias ss a table name
-                        String[] allNames = SQLUtils.splitFullIdentifier(
-                            tableAlias,
-                            sqlDialect.getCatalogSeparator(),
-                            sqlDialect.getIdentifierQuoteStrings(),
-                            false);
-                        rootObject = SQLSearchUtils.findObjectByFQN(monitor, sc, request, Arrays.asList(allNames));
-                    }
                 }
-                if (rootObject != null) {
+                if (rootObjects != null && !rootObjects.isEmpty()) {
+                    for (DBSObject obj : rootObjects) {
+                        makeProposalsFromChildren(obj, wordPart, false, parameters);
+                    }
+                } else if (rootObject != null) {
                     makeProposalsFromChildren(rootObject, wordPart, false, parameters);
                 } else {
                     // Get root object or objects from active database (if any)


### PR DESCRIPTION
Problem:

In the Legacy SQL completion engine, column suggestions were not shown when typing a partial column name after WHERE, or when using a table alias followed by . (e.g. h.), especially when the table is referenced with a fully-qualified name across databases (e.g. db_backoffice.dbo.MEM_Head).
<img width="578" height="174" alt="image" src="https://github.com/user-attachments/assets/0cb5652c-4de1-4081-81e4-b181888112a6" />
<img width="535" height="123" alt="image" src="https://github.com/user-attachments/assets/72fcb7b6-2740-4524-8b79-47f3ba9e0030" />
<img width="531" height="75" alt="image" src="https://github.com/user-attachments/assets/dbb88475-e915-4b25-9595-88a72d1c5e4c" />

Root cause:

In 

SQLCompletionAnalyzer.java
, the non-empty wordPart branch called 

getTableListFromAlias()
 and 

getTableFromAlias()
 with sc — the currently active/selected database container. When the table in the query belongs to a different catalog than the active one, the lookup returned nothing, causing the completion to fall through with no proposals.

Fix:

Changed the calls to use the root dataSource instead of sc, consistent with the emptyWord branch which already worked correctly. Also removed an early-return that aborted proposals when a partial wordPart matched a table name instead of a column prefix.

Test cases:

SELECT * FROM db_name.dbo.Table1 WHERE col → shows matching columns ✅
SELECT * FROM db_name.dbo.Table1 t WHERE t. → shows all columns ✅