### PR TITLE
perf: fix slow navigator and editing for large MySQL databases (64K+ tables)

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLCatalog.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLCatalog.java
@@ -330,12 +330,7 @@ public class MySQLCatalog implements
 
     @Association
     public Collection<MySQLTable> getTables(DBRProgressMonitor monitor) throws DBException {
-        List<MySQLTable> tables = getTableCache().getTypedObjects(monitor, this, MySQLTable.class);
-        if (getDataSource().readKeysWithColumns()) {
-            // Read constraints with columns
-            uniqueKeyCache.getAllObjects(monitor, this);
-        }
-        return tables;
+        return getTableCache().getTypedObjects(monitor, this, MySQLTable.class);
     }
 
     public MySQLTable getTable(DBRProgressMonitor monitor, String name)

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTable.java
@@ -30,6 +30,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCObjectCache;
 import org.jkiss.dbeaver.model.meta.*;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
 import org.jkiss.dbeaver.model.struct.*;
 import org.jkiss.dbeaver.model.struct.cache.DBSObjectCache;
 import org.jkiss.dbeaver.model.struct.cache.SimpleObjectCache;
@@ -315,6 +316,10 @@ public class MySQLTable extends MySQLTableBase
     public Collection<MySQLTableConstraint> getConstraints(@NotNull DBRProgressMonitor monitor)
         throws DBException
     {
+        if (monitor.isForceCacheUsage()) {
+            getContainer().uniqueKeyCache.getObjects(
+                new VoidProgressMonitor(), getContainer(), this);
+        }
         List<MySQLTableConstraint> constraintObjects = getContainer().uniqueKeyCache.getObjects(monitor, getContainer(), this);
         if (getDataSource().supportsCheckConstraints()) {
             List<MySQLTableConstraint> checkConstraintObjects = getContainer().checkConstraintCache.getObjects(monitor, getContainer(), this);

--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTableBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/model/MySQLTableBase.java
@@ -30,6 +30,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCStructCache;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTable;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTableColumn;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSEntity;
 import org.jkiss.dbeaver.model.struct.DBSEntityAttribute;
 import org.jkiss.dbeaver.model.struct.DBSObject;
@@ -122,6 +123,10 @@ public abstract class MySQLTableBase extends JDBCTable<MySQLDataSource, MySQLCat
     public MySQLTableColumn getAttribute(@NotNull DBRProgressMonitor monitor, @NotNull String attributeName)
         throws DBException
     {
+        if (monitor.isForceCacheUsage()) {
+            getContainer().getTableCache().getChild(
+                new VoidProgressMonitor(), getContainer(), this, attributeName);
+        }
         return getContainer().getTableCache().getChild(monitor, getContainer(), this, attributeName);
     }
 

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRuleManager.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRuleManager.java
@@ -173,7 +173,11 @@ public class SQLRuleManager {
             boolean hasDoubleQuoteRule = false;
             if (!ArrayUtils.isEmpty(identifierQuoteStrings)) {
                 for (String[] quotes : identifierQuoteStrings) {
-                    rules.add(new MultiLineRule(quotes[0], quotes[1], quotedToken, escapeChar, breaksOnEOF));
+                    // Do not use string escape character for identifier quotes.
+                    // Identifiers (e.g. backticks in MySQL) use doubling for escaping, not backslash.
+                    // Using backslash causes the rule to consume past the closing quote,
+                    // breaking bracket tracking and statement delimiter detection.
+                    rules.add(new MultiLineRule(quotes[0], quotes[1], quotedToken, (char) 0, breaksOnEOF));
                     if (quotes[1].equals(SQLConstants.STR_QUOTE_DOUBLE) && quotes[0].equals(quotes[1])) {
                         hasDoubleQuoteRule = true;
                     }

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/database/DatabaseNavigatorContentProvider.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/database/DatabaseNavigatorContentProvider.java
@@ -32,6 +32,7 @@ import org.jkiss.utils.CommonUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * DatabaseNavigatorContentProvider
@@ -156,7 +157,29 @@ public class DatabaseNavigatorContentProvider implements IStructuredContentProvi
         );
 
         boolean searchBarIsActive = isSearchBarActive(children);
-        if (parent.isFiltered() || maxFetchSize < children.length) {
+
+        // When the search bar is active, pre-filter children before applying pagination.
+        // Without this, matching items can be hidden behind "More..." nodes in large lists
+        // because the SWT PatternFilter runs after pagination truncation.
+        DBNNode[] displayChildren = children;
+        if (searchBarIsActive && navigatorTree != null) {
+            String filterText = navigatorTree.getFilterText();
+            if (filterText != null) {
+                List<DBNNode> filtered = new ArrayList<>();
+                for (DBNNode child : children) {
+                    String name = child.getName();
+                    if (name != null && name.toLowerCase(Locale.ROOT).contains(filterText)) {
+                        filtered.add(child);
+                        if (filtered.size() >= maxFetchSize) {
+                            break;
+                        }
+                    }
+                }
+                displayChildren = filtered.toArray(new DBNNode[0]);
+            }
+        }
+
+        if (parent.isFiltered() || maxFetchSize < displayChildren.length) {
             final List<Object> nodes = new ArrayList<>(maxFetchSize);
 
             if (parent.isFiltered()) {
@@ -167,20 +190,20 @@ public class DatabaseNavigatorContentProvider implements IStructuredContentProvi
                 }
             }
 
-            if (maxFetchSize < children.length) {
-                nodes.addAll(List.of(children).subList(0, maxFetchSize));
-                nodes.add(new TreeNodeLazyExpander(parent, children, maxFetchSize));
+            if (maxFetchSize < displayChildren.length) {
+                nodes.addAll(List.of(displayChildren).subList(0, maxFetchSize));
+                nodes.add(new TreeNodeLazyExpander(parent, displayChildren, maxFetchSize));
             } else {
-                nodes.addAll(List.of(children));
+                nodes.addAll(List.of(displayChildren));
             }
 
             return nodes.toArray();
-        } else if (children.length == 0) {
+        } else if (displayChildren.length == 0) {
             return EMPTY_CHILDREN;
         } else if (searchBarIsActive) {
             final List<Object> nodes = new ArrayList<>();
             nodes.add(new TreeNodeSearch(parent));
-            nodes.addAll(List.of(children));
+            nodes.addAll(List.of(displayChildren));
             return nodes.toArray();
         } else {
             return children;

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/database/DatabaseNavigatorTree.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/database/DatabaseNavigatorTree.java
@@ -68,6 +68,7 @@ import org.jkiss.utils.CommonUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 public class DatabaseNavigatorTree extends Composite implements INavigatorListener {
@@ -422,6 +423,25 @@ public class DatabaseNavigatorTree extends Composite implements INavigatorListen
 
     public boolean isMatchingNeeded(@NotNull Object element) {
         return treeFilter != null && treeFilter.isMatchingNeeded(element);
+    }
+
+    /**
+     * Returns the current filter text in lowercase for fast pre-filtering,
+     * or null if the filter is empty.
+     */
+    @Nullable
+    public String getFilterText() {
+        Display display = Display.getCurrent();
+        if (display == null) {
+            return null;
+        }
+        if (filterControl != null && !filterControl.isDisposed()) {
+            String text = filterControl.getText();
+            if (text != null && !text.isEmpty()) {
+                return text.trim().toLowerCase(Locale.ROOT);
+            }
+        }
+        return null;
     }
 
     public void resetFilter() {


### PR DESCRIPTION
## Summary

DBeaver is almost unusable with MySQL/MariaDB databases containing very large numbers of tables (e.g. 64K+ tables in WordPress multisite). This PR addresses three root causes:

- **Remove bulk constraint loading from `getTables()`** - previously loaded all unique key constraints for every table on each navigator expansion. Now constraints load lazily per-table when actually needed for editing.
- **Lazy per-table column and constraint loading for data editor** - the data editor uses `LocalCacheProgressMonitor` (force-cache mode) which skips database loads. Since bulk preloading is removed, `getAttribute()` and `getConstraints()` now trigger a real per-table load when the cache is empty, so the editor can resolve columns and primary keys correctly.
- **Pre-filter navigator children before pagination** - the search bar filter was applied after the pagination cutoff, so matching items in large lists could be hidden behind "More..." nodes. Now filters all children with fast `String.contains()` before pagination truncation.
- **Fix identifier quote escape character** - identifier quote rules (e.g. backticks in MySQL) incorrectly used the string escape character (backslash), which could cause the tokenizer to consume past the closing quote, breaking bracket tracking and delimiter detection.

## Test plan

- [ ] Connect to a MySQL/MariaDB database with 1000+ tables
- [ ] Expand Tables node - should load without long delay
- [ ] Use navigator search bar to filter tables - matching items should appear regardless of list size
- [ ] Open a table's Data tab and verify editing works (primary key detected, no "Table metadata not found")
- [ ] Run a SQL script with backtick-quoted identifiers in DATE_ADD() etc. - statements should split correctly on `;`
- [ ] Verify normal-sized databases still work as expected


**Recommended settings for large databases:** 
- In Preferences > User Interface > Navigator, uncheck "Show statistics info". 
- In Edit Connection > Metadata (or Preferences > Connections > Metadata), check "Do not read tables information in SQL and data editors". These skip `SHOW TABLE STATUS` queries that load engine type, row count, collation, and data sizes on every table interaction. Combined with the lazy loading changes in this PR, this eliminates all unnecessary metadata overhead.