### PR TITLE
Fix #39264: Eagerly load table/column comments in ERD to fix lazy loading

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDEntity.java
+++ b/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDEntity.java
@@ -190,7 +190,7 @@ public class ERDEntity extends ERDElement<DBSEntity> {
             attributes.clear();
         }
         try {
-            diagram.getContentProvider().fillEntityFromObject(new VoidProgressMonitor(), diagram, Collections.emptyList(), this);
+            diagram.getContentProvider().fillEntityFromObject(diagram.getMonitor() != null ? diagram.getMonitor() : new VoidProgressMonitor(), diagram, Collections.emptyList(), this);
         } catch (DBCException e) {
             log.debug("Can't reload attributes", e);
         }

--- a/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDEntityAttribute.java
+++ b/plugins/org.jkiss.dbeaver.model.erd/src/org/jkiss/dbeaver/model/erd/ERDEntityAttribute.java
@@ -24,6 +24,7 @@ import org.jkiss.dbeaver.model.DBPImage;
 import org.jkiss.dbeaver.model.DBValueFormatting;
 import org.jkiss.dbeaver.model.data.json.JSONUtils;
 import org.jkiss.dbeaver.model.struct.DBSEntityAttribute;
+import org.jkiss.dbeaver.model.DBPObjectWithLazyDescription;
 import org.jkiss.utils.CommonUtils;
 
 import java.util.LinkedHashMap;
@@ -132,8 +133,11 @@ public class ERDEntityAttribute extends ERDObject<DBSEntityAttribute> {
             if (!CommonUtils.isEmpty(entityAttribute.getDefaultValue())) {
                 attrMap.put("defaultValue", entityAttribute.getDefaultValue());
             }
-            if (!CommonUtils.isEmpty(entityAttribute.getDescription())) {
-                attrMap.put("description", entityAttribute.getDescription());
+            String description = entityAttribute instanceof DBPObjectWithLazyDescription
+                ? ((DBPObjectWithLazyDescription) entityAttribute).getDescription(context.getMonitor())
+                : entityAttribute.getDescription();
+            if (!CommonUtils.isEmpty(description)) {
+                attrMap.put("description", description);
             }
         }
         if (this.isChecked()) {


### PR DESCRIPTION
When an ER Diagram opens, table and column comments are blank even though they exist in the database. Pressing Refresh makes them appear, confirming the cause is lazy loading. Two bugs were found: in ERDEntity.java line 193, reloadAttributes() was calling fillEntityFromObject() with a new VoidProgressMonitor(), a fake monitor that cannot trigger any real DB fetch; and in ERDEntityAttribute.java line 135, getDescription() was called without a monitor, which returns null for objects implementing DBPObjectWithLazyDescription. The fix replaces VoidProgressMonitor with a diagram.getMonitor() (falling back to void if null) in ERDEntity.java, and checks for DBPObjectWithLazyDescription in ERDEntityAttribute.java to pass context.getMonitor() so a real DB fetch is triggered. Note: the devel branch has a pre-existing unrelated build failure in model.sql (LSM API mismatch) — our changed files compile cleanly when their dependency chain is available.