### PR TITLE
#40592 Fix DuckDB geometry display for 1.5+

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.duckdb/src/org/jkiss/dbeaver/ext/duckdb/model/DuckDBDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.duckdb/src/org/jkiss/dbeaver/ext/duckdb/model/DuckDBDataSource.java
@@ -21,7 +21,9 @@ import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaModel;
 import org.jkiss.dbeaver.model.DBPDataKind;
+import org.jkiss.dbeaver.model.DBPDataSourceInfo;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCDatabaseMetaData;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCExecutionContext;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCRemoteInstance;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
@@ -43,6 +45,11 @@ public class DuckDBDataSource extends GenericDataSource {
             case DuckDBConstants.TYPE_GEOMETRY -> DBPDataKind.OBJECT;
             default -> super.resolveDataKind(typeName, valueType);
         };
+    }
+
+    @Override
+    protected DBPDataSourceInfo createDataSourceInfo(DBRProgressMonitor monitor, @NotNull JDBCDatabaseMetaData metaData) {
+        return new DuckDBDataSourceInfo(getContainer().getDriver(), metaData);
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.duckdb/src/org/jkiss/dbeaver/ext/duckdb/model/DuckDBDataSourceInfo.java
+++ b/plugins/org.jkiss.dbeaver.ext.duckdb/src/org/jkiss/dbeaver/ext/duckdb/model/DuckDBDataSourceInfo.java
@@ -1,0 +1,55 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.duckdb.model;
+
+import org.jkiss.dbeaver.ext.generic.model.GenericDataSourceInfo;
+import org.jkiss.dbeaver.model.connection.DBPDriver;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCDatabaseMetaData;
+import org.osgi.framework.Version;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DuckDBDataSourceInfo extends GenericDataSourceInfo {
+    private static final Pattern DATABASE_VERSION_PATTERN = Pattern.compile("^\\D*(\\d+)\\.(\\d+)(?:\\.(\\d+))?.*$");
+
+    private final Version databaseVersion;
+
+    public DuckDBDataSourceInfo(DBPDriver driver, JDBCDatabaseMetaData metaData) {
+        super(driver, metaData);
+        this.databaseVersion = resolveDatabaseVersion();
+    }
+
+    @Override
+    public Version getDatabaseVersion() {
+        return databaseVersion;
+    }
+
+    private Version resolveDatabaseVersion() {
+        var productVersion = getDatabaseProductVersion();
+        if (productVersion != null) {
+            Matcher matcher = DATABASE_VERSION_PATTERN.matcher(productVersion);
+            if (matcher.matches()) {
+                int major = Integer.parseInt(matcher.group(1));
+                int minor = Integer.parseInt(matcher.group(2));
+                int micro = matcher.group(3) == null ? 0 : Integer.parseInt(matcher.group(3));
+                return new Version(major, minor, micro);
+            }
+        }
+        return super.getDatabaseVersion();
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.duckdb/src/org/jkiss/dbeaver/ext/duckdb/model/data/DuckDBGeometryValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.duckdb/src/org/jkiss/dbeaver/ext/duckdb/model/data/DuckDBGeometryValueHandler.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.ext.duckdb.model.data;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.data.gis.handlers.GISGeometryValueHandler;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.DBCSession;
@@ -24,6 +25,7 @@ import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.osgi.framework.Version;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -31,6 +33,7 @@ import java.sql.SQLException;
 
 public class DuckDBGeometryValueHandler extends GISGeometryValueHandler {
     public static final DuckDBGeometryValueHandler INSTANCE = new DuckDBGeometryValueHandler();
+    private static final Version STANDARD_WKB_STORAGE_VERSION = new Version(1, 5, 0);
 
     @Override
     protected Object fetchColumnValue(
@@ -48,6 +51,10 @@ public class DuckDBGeometryValueHandler extends GISGeometryValueHandler {
 
     @Override
     protected Geometry convertGeometryFromBinaryFormat(DBCSession session, byte[] object) throws DBCException {
+        if (session != null && isStandardWkbStorage(session)) {
+            return super.convertGeometryFromBinaryFormat(session, object);
+        }
+
         try {
             var buffer = ByteBuffer.wrap(object).order(ByteOrder.LITTLE_ENDIAN);
             var factory = new GeometryFactory(new PrecisionModel());
@@ -55,5 +62,10 @@ public class DuckDBGeometryValueHandler extends GISGeometryValueHandler {
         } catch (Exception e) {
             return super.convertGeometryFromBinaryFormat(session, object);
         }
+    }
+
+    private boolean isStandardWkbStorage(@NotNull DBCSession session) {
+        Version version = session.getDataSource().getInfo().getDatabaseVersion();
+        return version != null && version.compareTo(STANDARD_WKB_STORAGE_VERSION) >= 0;
     }
 }


### PR DESCRIPTION
## Root Cause

DuckDB 1.5 moved `GEOMETRY` into core and switched geometry storage to standard little-endian WKB:
https://duckdb.org/2026/03/09/announcing-duckdb-150

DuckDB JDBC metadata also reports structured database version information unreliably for this purpose, so routing based on `getDatabaseMajorVersion()` / `getDatabaseMinorVersion()` is not sufficient.


## Fix
This change routes DuckDB geometry decoding by the actual database product version string:

- DuckDB 1.5+ uses standard WKB decoding
- older DuckDB versions keep using the legacy DuckDB geometry decoder

This preserves compatibility with pre-1.5 DuckDB versions while correctly handling the new built-in `GEOMETRY` storage in DuckDB 1.5+.
