### PR TITLE
dbeaver/dbeaver#40607: fix revert functionality to open procedure

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/plugin.xml
@@ -210,7 +210,6 @@
             <objectType name="org.jkiss.dbeaver.ext.oracle.model.OracleTableIndex"/>
             <objectType name="org.jkiss.dbeaver.ext.oracle.model.OracleSequence"/>
             <objectType name="org.jkiss.dbeaver.ext.oracle.model.OracleTablespace"/>
-            <objectType name="org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged"/>
         </editor>
         <editor
                 id="org.jkiss.dbeaver.ext.oracle.ui.editors.SchedulerJobLogEditor"

--- a/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/actions/PackageNavigateHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle.ui/src/org/jkiss/dbeaver/ext/oracle/ui/actions/PackageNavigateHandler.java
@@ -32,6 +32,7 @@ import org.eclipse.ui.handlers.HandlerUtil;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ext.oracle.model.OraclePackage;
 import org.jkiss.dbeaver.ext.oracle.model.OracleProcedureArgument;
 import org.jkiss.dbeaver.ext.oracle.model.OracleProcedurePackaged;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
@@ -62,7 +63,8 @@ public class PackageNavigateHandler extends AbstractHandler //implements IElemen
     {
         final OracleProcedurePackaged procedure = getSelectedProcedure(event);
         if (procedure != null) {
-            IEditorPart entityEditor = NavigatorHandlerObjectOpen.openEntityEditor(procedure);
+            OraclePackage procPackage = procedure.getParentObject();
+            IEditorPart entityEditor = NavigatorHandlerObjectOpen.openEntityEditor(procPackage);
             if (entityEditor instanceof EntityEditor) {
                 ((EntityEditor) entityEditor).switchFolder("source.definition");
                 SQLEditorBase sqlEditor = entityEditor.getAdapter(SQLEditorBase.class);


### PR DESCRIPTION
dbeaver/dbeaver#40607: old functionality restored.
For now, didn't revert many changes made in https://github.com/dbeaver/dbeaver/pull/40473, even though this functionality is now unused. 
Reason is since some of them might be useful in: https://github.com/dbeaver/pro/issues/8719

