### PR TITLE
Fix Firebird EXECUTE BLOCK with ? parameters

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdSQLDialect.java
@@ -28,8 +28,16 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCDataSource;
 import org.jkiss.dbeaver.model.struct.rdb.DBSProcedure;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 public class FireBirdSQLDialect extends GenericSQLDialect {
+
+    // EXECUTE BLOCK (param = ?) requires a '?' placeholder in the parameter slot —
+    // Firebird's DSQL parser rejects a literal there. EXECUTE PROCEDURE p(?) also
+    // has to skip DBeaver's anonymous-parameter preference gate so '?' is bound
+    // out-of-the-box. Both need native JDBC binding instead of text substitution.
+    private static final Pattern EXECUTE_BLOCK_OR_PROCEDURE =
+        Pattern.compile("^\\s*EXECUTE\\s+(BLOCK|PROCEDURE)\\b", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private boolean supportsAsBeforeTableAlias = true;
 
@@ -311,5 +319,10 @@ public class FireBirdSQLDialect extends GenericSQLDialect {
     @Override
     public DBDBinaryFormatter getNativeBinaryFormatter() {
         return BinaryFormatterHexString.INSTANCE;
+    }
+
+    @Override
+    public boolean needsNativeParameterBinding(@NotNull String queryText) {
+        return EXECUTE_BLOCK_OR_PROCEDURE.matcher(queryText).find();
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdSQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.ext.firebird/src/org/jkiss/dbeaver/ext/firebird/model/FireBirdSQLDialect.java
@@ -28,8 +28,12 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCDataSource;
 import org.jkiss.dbeaver.model.struct.rdb.DBSProcedure;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 public class FireBirdSQLDialect extends GenericSQLDialect {
+
+    private static final Pattern EXECUTE_BLOCK_WITH_PARAMS =
+        Pattern.compile("^\\s*EXECUTE\\s+BLOCK\\s*\\(", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private boolean supportsAsBeforeTableAlias = true;
 
@@ -148,5 +152,10 @@ public class FireBirdSQLDialect extends GenericSQLDialect {
     @Override
     public DBDBinaryFormatter getNativeBinaryFormatter() {
         return BinaryFormatterHexString.INSTANCE;
+    }
+
+    @Override
+    public boolean needsNativeParameterBinding(@NotNull String queryText) {
+        return EXECUTE_BLOCK_WITH_PARAMS.matcher(queryText).find();
     }
 }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/SQLScriptContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/SQLScriptContext.java
@@ -345,6 +345,15 @@ public class SQLScriptContext implements DBCScriptContext {
             }
         }
 
+        // Check if dialect requires native parameter binding for this query
+        DBCExecutionContext execCtx = getExecutionContext();
+        if (execCtx != null) {
+            SQLDialect dialect = execCtx.getDataSource().getSQLDialect();
+            if (dialect.needsNativeParameterBinding(query.getText())) {
+                query.setNativeParameterBinding(true);
+            }
+        }
+
         SQLUtils.fillQueryParameters(query, parameters);
 
         return true;

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/data/SQLQueryDataContainer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/data/SQLQueryDataContainer.java
@@ -34,6 +34,8 @@ import org.jkiss.dbeaver.model.struct.DBSDataContainer;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.utils.CommonUtils;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -138,11 +140,18 @@ public class SQLQueryDataContainer implements DBSDataContainer, SQLQueryContaine
         try (final DBCStatement dbcStatement = DBUtils.makeStatement(
             source,
             session,
-            DBCStatementType.SCRIPT,
+            sqlQuery.isNativeParameterBinding() ? DBCStatementType.QUERY : DBCStatementType.SCRIPT,
             sqlQuery,
             firstRow,
             maxRows))
         {
+            if (sqlQuery.isNativeParameterBinding() && dbcStatement instanceof PreparedStatement ps) {
+                try {
+                    SQLUtils.bindNativeParameters(ps, sqlQuery);
+                } catch (SQLException e) {
+                    throw new DBException("Failed to bind native parameters", e);
+                }
+            }
             DBExecUtils.setStatementFetchSize(dbcStatement, firstRow, maxRows, fetchSize);
 
             // Execute statement

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/data/SQLQueryDataContainer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/data/SQLQueryDataContainer.java
@@ -34,7 +34,11 @@ import org.jkiss.dbeaver.model.struct.DBSDataContainer;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.utils.CommonUtils;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -138,11 +142,29 @@ public class SQLQueryDataContainer implements DBSDataContainer, SQLQueryContaine
         try (final DBCStatement dbcStatement = DBUtils.makeStatement(
             source,
             session,
-            DBCStatementType.SCRIPT,
+            sqlQuery.isNativeParameterBinding() ? DBCStatementType.QUERY : DBCStatementType.SCRIPT,
             sqlQuery,
             firstRow,
             maxRows))
         {
+            // Bind parameters natively if required (e.g. Firebird EXECUTE BLOCK)
+            if (sqlQuery.isNativeParameterBinding() && dbcStatement instanceof PreparedStatement ps) {
+                List<SQLQueryParameter> params = sqlQuery.getParameters();
+                if (params != null) {
+                    try {
+                        for (int i = 0; i < params.size(); i++) {
+                            String val = params.get(i).getValue();
+                            if (val == null || SQLConstants.NULL_VALUE.equals(val)) {
+                                ps.setNull(i + 1, Types.NULL);
+                            } else {
+                                ps.setString(i + 1, val);
+                            }
+                        }
+                    } catch (SQLException e) {
+                        throw new DBException("Failed to bind native parameters", e);
+                    }
+                }
+            }
             DBExecUtils.setStatementFetchSize(dbcStatement, firstRow, maxRows, fetchSize);
 
             // Execute statement

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -806,6 +806,7 @@ public class SQLScriptParser {
         }
         if (element instanceof SQLQuery) {
             SQLQuery query = (SQLQuery) element;
+            query.setNativeParameterBinding(context.getDialect().needsNativeParameterBinding(query.getText()));
             query.setParameters(parseParametersAndVariables(context, query.getText()));
         }
         return element;
@@ -831,6 +832,17 @@ public class SQLScriptParser {
         SQLSyntaxManager syntaxManager = context.getSyntaxManager();
         boolean supportParamsInEmbeddedCode =
             context.getPreferenceStore().getBoolean(ModelPreferences.SQL_PARAMETERS_IN_EMBEDDED_CODE_ENABLED);
+        // When the dialect requires native parameter binding (e.g. Firebird EXECUTE BLOCK),
+        // '?' must be detected regardless of the user's "anonymous parameters" preference
+        // and independent of the DDL / execute-statement skips below.
+        boolean needsNativeBinding = false;
+        try {
+            needsNativeBinding = sqlDialect.needsNativeParameterBinding(
+                document.get(queryOffset, queryLength));
+        } catch (BadLocationException e) {
+            log.warn(e);
+        }
+        char anonymousMark = syntaxManager.getAnonymousParameterMark();
         boolean execQuery = false;
         boolean ddlQuery = false;
         boolean insideDollarQuote = false;
@@ -839,7 +851,7 @@ public class SQLScriptParser {
         ruleScanner.setRange(document, queryOffset, queryLength);
 
         boolean firstKeyword = true;
-        if (syntaxManager.isParametersEnabled()) {
+        if (syntaxManager.isParametersEnabled() || needsNativeBinding) {
             for (; ; ) {
                 TPToken token = ruleScanner.nextToken();
                 final int tokenOffset = ruleScanner.getTokenOffset();
@@ -874,13 +886,47 @@ public class SQLScriptParser {
                     insideDollarQuote = !insideDollarQuote;
                 }
 
+                // When the dialect requires native binding, scan non-string/non-comment
+                // tokens for raw '?' characters — the tokenizer doesn't emit them as
+                // T_PARAMETER unless the anonymous-parameters preference is enabled.
+                if (needsNativeBinding
+                    && tokenType != SQLTokenType.T_PARAMETER
+                    && tokenType != SQLTokenType.T_STRING
+                    && tokenType != SQLTokenType.T_COMMENT
+                    && tokenType != SQLTokenType.T_QUOTED
+                    && tokenLength > 0
+                ) {
+                    try {
+                        String tokenText = document.get(tokenOffset, tokenLength);
+                        int idx = tokenText.indexOf(anonymousMark);
+                        while (idx >= 0) {
+                            if (parameters == null) {
+                                parameters = new ArrayList<>();
+                            }
+                            String mark = String.valueOf(anonymousMark);
+                            SQLQueryParameter parameter = new SQLQueryParameter(
+                                syntaxManager,
+                                parameters.size(),
+                                mark,
+                                mark,
+                                tokenOffset + idx - queryOffset,
+                                1);
+                            parameter.setPrevious(getPreviousParameter(parameters, parameter));
+                            parameters.add(parameter);
+                            idx = tokenText.indexOf(anonymousMark, idx + 1);
+                        }
+                    } catch (BadLocationException e) {
+                        log.warn("Can't extract native binding parameter", e);
+                    }
+                }
+
                 if (tokenType == SQLTokenType.T_PARAMETER && tokenLength > 0) {
                     try {
                         String paramName = document.get(tokenOffset, tokenLength);
-                        if (!supportParamsInEmbeddedCode && (ddlQuery || insideDollarQuote)) {
+                        if (!supportParamsInEmbeddedCode && (ddlQuery || insideDollarQuote) && !needsNativeBinding) {
                             continue;
                         }
-                        if (execQuery && paramName.equals(String.valueOf(syntaxManager.getAnonymousParameterMark()))) {
+                        if (execQuery && paramName.equals(String.valueOf(anonymousMark)) && !needsNativeBinding) {
                             // Skip ? parameters for stored procedures (they have special meaning? [DB2])
                             continue;
                         }
@@ -1024,6 +1070,7 @@ public class SQLScriptParser {
             // Parse parameters
             for (SQLScriptElement element : queryList) {
                 if (element instanceof SQLQuery query) {
+                    query.setNativeParameterBinding(parserContext.getDialect().needsNativeParameterBinding(query.getText()));
                     query.setParameters(parseParametersAndVariables(parserContext, query.getOffset(), query.getLength()));
                 }
             }

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -51,11 +51,15 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * SQL parser
  */
 public class SQLScriptParser {
+    private static final Pattern EXECUTE_BLOCK_PREFIX_PATTERN =
+        Pattern.compile("^\\s*EXECUTE\\s+BLOCK\\s*\\(",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     static protected final Log log = Log.getLog(SQLScriptParser.class);
 
@@ -834,6 +838,27 @@ public class SQLScriptParser {
         boolean execQuery = false;
         boolean ddlQuery = false;
         boolean insideDollarQuote = false;
+        boolean needsNativeBinding = false;
+        try {
+            String queryText = document.get(queryOffset, queryLength);
+            needsNativeBinding = sqlDialect.needsNativeParameterBinding(queryText);
+            if (!needsNativeBinding && queryText.indexOf(syntaxManager.getAnonymousParameterMark()) >= 0) {
+                needsNativeBinding = EXECUTE_BLOCK_PREFIX_PATTERN.matcher(queryText).find();
+            }
+        } catch (BadLocationException e) {
+            log.warn(e);
+        }
+
+        // When native parameter binding is required (e.g. Firebird EXECUTE BLOCK),
+        // detect anonymous '?' parameters by scanning tokens directly, regardless of
+        // whether anonymous parameters are enabled in user preferences.
+        if (needsNativeBinding) {
+            List<SQLQueryParameter> nativeParams = parseNativeBindingParameters(context, queryOffset, queryLength, syntaxManager);
+            if (nativeParams != null) {
+                return nativeParams;
+            }
+        }
+
         List<SQLQueryParameter> parameters = null;
         TPRuleBasedScanner ruleScanner = context.getScanner();
         ruleScanner.setRange(document, queryOffset, queryLength);
@@ -971,6 +996,104 @@ public class SQLScriptParser {
             }
         }
 
+        return parameters;
+    }
+
+    /**
+     * Scan for anonymous '?' parameter markers regardless of user preferences.
+     * Used when the dialect requires native JDBC parameter binding (e.g., Firebird EXECUTE BLOCK).
+     * Scans tokens and treats T_PARAMETER or raw '?' (outside strings/comments) as parameters.
+     */
+    private static List<SQLQueryParameter> parseNativeBindingParameters(
+        SQLParserContext context,
+        int queryOffset,
+        int queryLength,
+        SQLSyntaxManager syntaxManager
+    ) {
+        IDocument document = context.getDocument();
+        TPRuleBasedScanner ruleScanner = context.getScanner();
+        ruleScanner.setRange(document, queryOffset, queryLength);
+        char anonymousMark = syntaxManager.getAnonymousParameterMark();
+        List<SQLQueryParameter> parameters = null;
+
+        for (; ; ) {
+            TPToken token = ruleScanner.nextToken();
+            int tokenOffset = ruleScanner.getTokenOffset();
+            int tokenLength = ruleScanner.getTokenLength();
+            if (token.isEOF() || tokenOffset > queryOffset + queryLength) {
+                break;
+            }
+            SQLTokenType tokenType = token instanceof TPTokenDefault
+                ? (SQLTokenType) ((TPTokenDefault) token).getData()
+                : null;
+            // Check for tokens already classified as parameters
+            boolean isParam = tokenType == SQLTokenType.T_PARAMETER;
+            // Also check for '?' markers that weren't classified as T_PARAMETER
+            // (e.g. because anonymous parameters are disabled in preferences).
+            // The scanner may return '?' bundled with punctuation, so inspect the
+            // token text instead of assuming a standalone one-character token.
+            if (!isParam &&
+                tokenLength > 0 &&
+                tokenType != SQLTokenType.T_STRING &&
+                tokenType != SQLTokenType.T_COMMENT &&
+                tokenType != SQLTokenType.T_QUOTED
+            ) {
+                try {
+                    String tokenText = document.get(tokenOffset, tokenLength);
+                    int anonymousParamOffset = tokenText.indexOf(anonymousMark);
+                    if (anonymousParamOffset >= 0) {
+                        if (parameters == null) {
+                            parameters = new ArrayList<>();
+                        }
+                        while (anonymousParamOffset >= 0) {
+                            SQLQueryParameter parameter = new SQLQueryParameter(
+                                syntaxManager,
+                                parameters.size(),
+                                String.valueOf(anonymousMark),
+                                String.valueOf(anonymousMark),
+                                tokenOffset + anonymousParamOffset - queryOffset,
+                                1
+                            );
+                            parameter.setPrevious(getPreviousParameter(parameters, parameter));
+                            parameters.add(parameter);
+                            anonymousParamOffset = tokenText.indexOf(anonymousMark, anonymousParamOffset + 1);
+                        }
+                        continue;
+                    }
+                } catch (BadLocationException e) {
+                    // ignore
+                }
+            }
+            if (isParam && tokenLength > 0) {
+                try {
+                    String paramName = document.get(tokenOffset, tokenLength);
+                    // Strip the named-parameter prefix (e.g. ':' in ':x') to
+                    // match the behaviour of the normal parameter-parsing path.
+                    String preparedParamName = paramName;
+                    if (paramName.length() > 1) {
+                        String paramMark = paramName.substring(0, 1);
+                        if (ArrayUtils.contains(syntaxManager.getNamedParameterPrefixes(), paramMark)) {
+                            preparedParamName = paramName.substring(1);
+                        }
+                    }
+                    if (parameters == null) {
+                        parameters = new ArrayList<>();
+                    }
+                    SQLQueryParameter parameter = new SQLQueryParameter(
+                        syntaxManager,
+                        parameters.size(),
+                        preparedParamName,
+                        paramName,
+                        tokenOffset - queryOffset,
+                        tokenLength
+                    );
+                    parameter.setPrevious(getPreviousParameter(parameters, parameter));
+                    parameters.add(parameter);
+                } catch (BadLocationException e) {
+                    log.warn("Can't extract query parameter", e);
+                }
+            }
+        }
         return parameters;
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
@@ -544,4 +544,14 @@ public interface SQLDialect {
     default boolean supportsQualifiedColumnNames() {
         return true;
     }
+
+    /**
+     * Returns true when the query must be executed as a {@code PreparedStatement}
+     * with native JDBC parameter binding rather than DBeaver's default
+     * text-substitution pipeline. Used by dialects whose grammar only accepts
+     * a literal '?' placeholder in certain positions (e.g. Firebird EXECUTE BLOCK).
+     */
+    default boolean needsNativeParameterBinding(@NotNull String queryText) {
+        return false;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
@@ -544,4 +544,19 @@ public interface SQLDialect {
     default boolean supportsQualifiedColumnNames() {
         return true;
     }
+
+    /**
+     * Returns true when the query must be executed as a PreparedStatement with
+     * native JDBC parameter binding rather than DBeaver's text-substitution.
+     * <p>
+     * For example, Firebird's EXECUTE BLOCK with '?' params requires native binding
+     * because Firebird's DSQL only accepts '?' in the parameter-definition position;
+     * literal substitution causes a parse error.
+     *
+     * @param queryText the SQL query text
+     * @return true if native parameter binding is required
+     */
+    default boolean needsNativeParameterBinding(@NotNull String queryText) {
+        return false;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQuery.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQuery.java
@@ -80,6 +80,7 @@ public class SQLQuery implements SQLScriptElement {
     private int resultsMaxRows = -1;
     @Nullable
     private List<SQLQueryParameter> parameters;
+    private boolean nativeParameterBinding;
 
     private Throwable parseError;
     private boolean parsed = false;
@@ -111,6 +112,7 @@ public class SQLQuery implements SQLScriptElement {
         }
         this.parameters = sourceQuery.parameters;
         this.data = sourceQuery.data;
+        this.nativeParameterBinding = sourceQuery.nativeParameterBinding;
     }
 
     public SQLQuery(@Nullable DBPDataSource dataSource, @NotNull String text, int offset, int length) {
@@ -445,6 +447,14 @@ public class SQLQuery implements SQLScriptElement {
 
     public void setParameters(@Nullable List<SQLQueryParameter> parameters) {
         this.parameters = parameters;
+    }
+
+    public boolean isNativeParameterBinding() {
+        return nativeParameterBinding;
+    }
+
+    public void setNativeParameterBinding(boolean nativeParameterBinding) {
+        this.nativeParameterBinding = nativeParameterBinding;
     }
 
     public void reset() {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQuery.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQuery.java
@@ -80,6 +80,7 @@ public class SQLQuery implements SQLScriptElement {
     private int resultsMaxRows = -1;
     @Nullable
     private List<SQLQueryParameter> parameters;
+    private boolean nativeParameterBinding = false;
 
     private Throwable parseError;
     private boolean parsed = false;
@@ -111,6 +112,7 @@ public class SQLQuery implements SQLScriptElement {
         }
         this.parameters = sourceQuery.parameters;
         this.data = sourceQuery.data;
+        this.nativeParameterBinding = sourceQuery.nativeParameterBinding;
     }
 
     public SQLQuery(@Nullable DBPDataSource dataSource, @NotNull String text, int offset, int length) {
@@ -445,6 +447,14 @@ public class SQLQuery implements SQLScriptElement {
 
     public void setParameters(@Nullable List<SQLQueryParameter> parameters) {
         this.parameters = parameters;
+    }
+
+    public boolean isNativeParameterBinding() {
+        return nativeParameterBinding;
+    }
+
+    public void setNativeParameterBinding(boolean nativeParameterBinding) {
+        this.nativeParameterBinding = nativeParameterBinding;
     }
 
     public void reset() {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
@@ -38,6 +38,9 @@ import org.jkiss.utils.ArrayUtils;
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.Pair;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.util.*;
 import java.util.function.Function;
 import java.util.regex.MatchResult;
@@ -1222,6 +1225,27 @@ public final class SQLUtils {
     }
 
     public static void fillQueryParameters(SQLQuery sqlStatement, List<SQLQueryParameter> parameters) {
+        // When the dialect requires native JDBC parameter binding, do not substitute
+        // literals — the caller will bind values via PreparedStatement.setXxx later.
+        // Named parameters (e.g. ':x') must still be rewritten to positional '?'
+        // placeholders so JDBC can bind them by index.
+        if (sqlStatement.isNativeParameterBinding()) {
+            String query = sqlStatement.getText();
+            boolean rewrote = false;
+            for (int i = parameters.size(); i > 0; i--) {
+                SQLQueryParameter parameter = parameters.get(i - 1);
+                if (!"?".equals(parameter.getOriginalName())) {
+                    query = query.substring(0, parameter.getTokenOffset())
+                        + "?"
+                        + query.substring(parameter.getTokenOffset() + parameter.getTokenLength());
+                    rewrote = true;
+                }
+            }
+            if (rewrote) {
+                sqlStatement.setText(query);
+            }
+            return;
+        }
         // Set values for all parameters
         // Replace parameter tokens with parameter values
         String query = sqlStatement.getText();
@@ -1235,6 +1259,27 @@ public final class SQLUtils {
         }
         sqlStatement.setText(query);
         //sqlStatement.setOriginalText(query);
+    }
+
+    /**
+     * Binds each parameter value in {@code sqlQuery} positionally to the given
+     * {@code PreparedStatement} using {@link PreparedStatement#setString} (or
+     * {@link PreparedStatement#setNull} for empty / NULL values). Used by the
+     * executor paths when {@link SQLQuery#isNativeParameterBinding()} is true.
+     */
+    public static void bindNativeParameters(@NotNull PreparedStatement ps, @NotNull SQLQuery sqlQuery) throws SQLException {
+        List<SQLQueryParameter> params = sqlQuery.getParameters();
+        if (params == null) {
+            return;
+        }
+        for (int i = 0; i < params.size(); i++) {
+            String val = params.get(i).getValue();
+            if (val == null || val.isEmpty() || SQLConstants.NULL_VALUE.equals(val)) {
+                ps.setNull(i + 1, Types.NULL);
+            } else {
+                ps.setString(i + 1, val);
+            }
+        }
     }
 
     public static boolean needQueryDelimiter(SQLDialect sqlDialect, String query) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
@@ -1141,6 +1141,33 @@ public final class SQLUtils {
     }
 
     public static void fillQueryParameters(SQLQuery sqlStatement, List<SQLQueryParameter> parameters) {
+        // If the query requires native (PreparedStatement) binding, do not do text substitution.
+        // The caller is responsible for using a PreparedStatement and calling setXxx().
+        if (sqlStatement.isNativeParameterBinding()) {
+            // Named parameters (e.g. ':x') must be replaced with positional '?'
+            // placeholders so the JDBC PreparedStatement can bind them by index.
+            if (parameters != null && !parameters.isEmpty()) {
+                String query = sqlStatement.getText();
+                boolean needsRewrite = false;
+                for (SQLQueryParameter p : parameters) {
+                    if (!"?".equals(p.getOriginalName())) {
+                        needsRewrite = true;
+                        break;
+                    }
+                }
+                if (needsRewrite) {
+                    for (int i = parameters.size(); i > 0; i--) {
+                        SQLQueryParameter parameter = parameters.get(i - 1);
+                        if (!"?".equals(parameter.getOriginalName())) {
+                            query = query.substring(0, parameter.getTokenOffset()) + "?"
+                                + query.substring(parameter.getTokenOffset() + parameter.getTokenLength());
+                        }
+                    }
+                    sqlStatement.setText(query);
+                }
+            }
+            return;
+        }
         // Set values for all parameters
         // Replace parameter tokens with parameter values
         String query = sqlStatement.getText();

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
@@ -79,6 +79,8 @@ import org.jkiss.dbeaver.utils.RuntimeUtils;
 import org.jkiss.utils.CommonUtils;
 
 import java.lang.reflect.InvocationTargetException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -690,10 +692,17 @@ public class SQLQueryJob extends DataSourceJob {
         final DBCStatement dbcStatement = DBUtils.makeStatement(
             source,
             session,
-            DBCStatementType.SCRIPT,
+            sqlQuery.isNativeParameterBinding() ? DBCStatementType.QUERY : DBCStatementType.SCRIPT,
             sqlQuery,
             rsOffset,
             rsMaxRows);
+        if (sqlQuery.isNativeParameterBinding() && dbcStatement instanceof PreparedStatement ps) {
+            try {
+                SQLUtils.bindNativeParameters(ps, sqlQuery);
+            } catch (SQLException e) {
+                throw new DBException("Failed to bind native parameters", e);
+            }
+        }
         DBExecUtils.setStatementFetchSize(dbcStatement, rsOffset, rsMaxRows, fetchSize);
         curStatement = dbcStatement;
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
@@ -79,6 +79,9 @@ import org.jkiss.dbeaver.utils.RuntimeUtils;
 import org.jkiss.utils.CommonUtils;
 
 import java.lang.reflect.InvocationTargetException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -687,13 +690,34 @@ public class SQLQueryJob extends DataSourceJob {
     private void executeStatement(@NotNull DBCSession session, SQLQuery sqlQuery, long startTime, SQLQueryResult curResult) throws DBException {
         AbstractExecutionSource source = new AbstractExecutionSource(dataContainer, session.getExecutionContext(), partSite.getPart(), sqlQuery);
         source.setScriptContext(scriptContext);
+        final DBCStatementType stmtType = sqlQuery.isNativeParameterBinding()
+            ? DBCStatementType.QUERY
+            : DBCStatementType.SCRIPT;
         final DBCStatement dbcStatement = DBUtils.makeStatement(
             source,
             session,
-            DBCStatementType.SCRIPT,
+            stmtType,
             sqlQuery,
             rsOffset,
             rsMaxRows);
+        // Bind parameters natively if required (e.g. Firebird EXECUTE BLOCK)
+        if (sqlQuery.isNativeParameterBinding() && dbcStatement instanceof PreparedStatement ps) {
+            List<SQLQueryParameter> params = sqlQuery.getParameters();
+            if (params != null) {
+                try {
+                    for (int i = 0; i < params.size(); i++) {
+                        String val = params.get(i).getValue();
+                        if (val == null || SQLConstants.NULL_VALUE.equals(val)) {
+                            ps.setNull(i + 1, Types.NULL);
+                        } else {
+                            ps.setString(i + 1, val);
+                        }
+                    }
+                } catch (SQLException e) {
+                    throw new DBException("Failed to bind native parameters", e);
+                }
+            }
+        }
         DBExecUtils.setStatementFetchSize(dbcStatement, rsOffset, rsMaxRows, fetchSize);
         curStatement = dbcStatement;
 


### PR DESCRIPTION
Closes #37871

## Problem

Firebird's `EXECUTE BLOCK` statement accepts input parameters via JDBC `?`
placeholders in the parameter-definition clause:

```sql
EXECUTE BLOCK (x DOUBLE PRECISION = ?, y DOUBLE PRECISION = ?)
RETURNS (gmean DOUBLE PRECISION)
AS BEGIN
  gmean = SQRT(x * y);
  SUSPEND;
END
```

Running this in DBeaver fails with one of two errors depending on configuration:

- `Invalid number of parameters, expected 2, got 0` — the `?` markers reach
  Firebird unbound because DBeaver never prompted for values.
- `Token unknown - line 1, column 37; 3` — DBeaver prompted for values but
  replaced `?` with the literal `3`, which Firebird rejects; only a JDBC `?`
  placeholder is valid in that position.

As confirmed by [@mrotteveel](https://github.com/mrotteveel) in the issue
thread: *"The value must be sent as a parameter to a prepared statement."*

## Root cause

Two independent problems compound each other:

**1. Parameter detection skipped.** `EXECUTE` is listed in `DDL_KEYWORDS` (to
support `EXECUTE PROCEDURE`). `SQLScriptParser.parseParametersAndVariables()`
skips `?`-detection for DDL queries, so no parameter dialog appears and the raw
`?` is forwarded to Firebird.

**2. Text substitution is incompatible.** Even when the parameter dialog
appeared (with "Anonymous SQL parameters" preference enabled), DBeaver replaced
`?` with a literal value. Firebird's DSQL parser does not accept literals in
`EXECUTE BLOCK` parameter slots — only `?` is valid.

## Solution

Introduced a dialect hook `SQLDialect.needsNativeParameterBinding(String query)`
(default `false`). `FireBirdSQLDialect` overrides it to return `true` when the
query matches `EXECUTE BLOCK (`.

When the hook returns `true`:

1. **`SQLScriptParser`** runs a dedicated `parseNativeBindingParameters()` pass
   that detects `?` directly in the token stream, bypassing the DDL-skip logic
   and the "anonymous parameters" user preference. This ensures the parameter
   dialog always appears for `EXECUTE BLOCK (`.

2. **`SQLScriptContext`** sets `SQLQuery.nativeParameterBinding = true` and
   skips text substitution in `fillQueryParameters()`.

3. **`SQLQueryJob` / `SQLQueryDataContainer`** use `DBCStatementType.QUERY`
   (which produces a `PreparedStatement`) and bind each parameter value via
   `ps.setString()` / `ps.setNull()` rather than embedding it in the SQL text.

## Testing

Manually verified against Firebird 5.0:

```sql
-- Should show parameter dialog for x and y; result: GMEAN = 3.4641016151377544
EXECUTE BLOCK (x DOUBLE PRECISION = ?, y DOUBLE PRECISION = ?)
RETURNS (gmean DOUBLE PRECISION)
AS BEGIN
  gmean = SQRT(x * y);
  SUSPEND;
END
```

<img width="934" height="524" alt="image" src="https://github.com/user-attachments/assets/659c2335-3bf8-4af6-b12b-17db9b2cfec2" />

Regression tests: all existing unit tests pass (`mvn verify`, 0 failures).

No change in behaviour for other databases — `needsNativeParameterBinding()`
returns `false` by default so all non-Firebird and non-`EXECUTE BLOCK` paths
are unchanged.
