### PR TITLE
Firebird: Handle COMMIT/ROLLBACK via transaction manager API in script execution

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/execute/SQLQueryJob.java
@@ -485,6 +485,14 @@ public class SQLQueryJob extends DataSourceJob {
     private boolean executeSingleElement(@NotNull DBCSession session, boolean fireEvents, SQLQuery sqlQuery) {
         lastError = null;
 
+        // Handle transaction control statements (COMMIT/ROLLBACK) via transaction manager API
+        // instead of executing them as raw SQL statements
+        if (sqlQuery.getType() == SQLQueryType.COMMIT || sqlQuery.getType() == SQLQueryType.ROLLBACK) {
+            statistics.addStatementsCount();
+            lastGoodQuery = sqlQuery;
+            return true;
+        }
+
         if (!skipConfirmation && getDataSourceContainer().getConnectionConfiguration().getConnectionType().isConfirmExecute()) {
             // Validate all transactional queries
             if (!SQLSemanticProcessor.isSelectQuery(session.getDataSource().getSQLDialect(), sqlQuery.getText())) {


### PR DESCRIPTION
## Problem

When executing SQL scripts via Alt+X (Execute SQL Script), COMMIT and ROLLBACK statements are sent as raw SQL to the database. This causes failures on databases where the JDBC driver manages transactions exclusively through the JDBC API rather than accepting raw transaction control SQL.

For example, for the following SQL
```sql
See attached pictures. They show the execution result of DBeaver "Execute SQL Script" command (`Alt-X`) for the following script on a Firebird database:
```sql
RECREATE TABLE TEST_SECTION9 (
    ID INTEGER NOT NULL,
    NAME VARCHAR(100),
    CATEGORY VARCHAR(50),
    AMOUNT DECIMAL(12,2),
    CREATED_AT TIMESTAMP,
    BIN_VALUE BIGINT,
    CONSTRAINT PK_TEST_SECTION9 PRIMARY KEY (ID)
);

COMMIT;

INSERT INTO TEST_SECTION9 (ID, NAME, CATEGORY, AMOUNT, CREATED_AT, BIN_VALUE) VALUES
    (1, 'Alice', 'A', 10.00, CURRENT_TIMESTAMP, 1);
INSERT INTO TEST_SECTION9 (ID, NAME, CATEGORY, AMOUNT, CREATED_AT, BIN_VALUE) VALUES
    (2, 'Bob', 'A', 15.00, CURRENT_TIMESTAMP, 2);
INSERT INTO TEST_SECTION9 (ID, NAME, CATEGORY, AMOUNT, CREATED_AT, BIN_VALUE) VALUES
    (3, 'Carol', 'B', 7.50, CURRENT_TIMESTAMP, 4);
INSERT INTO TEST_SECTION9 (ID, NAME, CATEGORY, AMOUNT, CREATED_AT, BIN_VALUE) VALUES
    (4, 'Dave', 'B', 22.00, CURRENT_TIMESTAMP, 8);

COMMIT;
```

Firebird fails with:
```
SQL Error [335544332] [08003]: invalid transaction handle (expecting explicit transaction start)
```

in both **auto-commit** and **manual commit** modes.

## Root Cause

In `SQLQueryJob.executeSingleElement()`, the `ExecuteStatement()` method sends COMMIT/ROLLBACK as raw SQL before the existing `handleTransactionStatements()` logic can handle them via the transaction manager API. The raw SQL execution fails for databases like Firebird, so the transaction manager handling is never reached.

## Fix

Intercept COMMIT/ROLLBACK statements at the beginning of `ExecuteSingleElement()` and return early, delegating transaction handling to the existing `handleTransactionStatements()` call in the script execution loop. This correctly:
- **Auto-commit mode**: Ignores the statement (it is a no-op)
- **Manual commit mode**: Commits/rolls back via `DBCTransactionManager` API

## Testing

- All existing unit tests pass (`cd test && mvn clean verify`)
- Tested with Firebird database in both auto-commit and manual commit modes

This PR was generated with AI (GitHub Copilot), supervised and tested by @fdcastel.