### PR TITLE
fix: ClassCastException when executing SQL script natively without a database selected (#40687)

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/handlers/SQLEditorHandlerExecute.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/handlers/SQLEditorHandlerExecute.java
@@ -104,7 +104,10 @@ public class SQLEditorHandlerExecute extends AbstractHandler {
                         }
                         DBSObject object = executionContext.getDefaultCatalog();
                         if (object == null) {
-                            object = editor.getDataSource();
+                            object = executionContext.getDefaultSchema();
+                        }
+                        if (object == null) {
+                            throw new DBException("No database selected. Please select a database before executing a script natively");
                         }
                         if (editor.getGlobalScriptContext().getSourceFile() != null) {
                             nativeExecutor.execute(object, editor.getGlobalScriptContext().getSourceFile());

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerExec.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorHandlerExec.java
@@ -85,17 +85,17 @@ public class NavigatorHandlerExec extends AbstractHandler {
                         container.connect(monitor, true, false);
                     }
                     DBPDataSource dataSource = container.getDataSource();
-                    DBSObject launchObject = dataSource;
+                    DBSObject launchObject = null;
                     if (catalog != null) {
                         if (dataSource instanceof DBSObjectContainer) {
                             if (DBSCatalog.class.isAssignableFrom(((DBSObjectContainer) dataSource).getPrimaryChildType(monitor))) {
                                 Collection<? extends DBSObject> children = ((DBSObjectContainer) dataSource).getChildren(monitor);
-                                DBSObject foundCatalog = DBUtils.findObject(children, catalog);
-                                if (foundCatalog != null) {
-                                    launchObject = foundCatalog;
-                                }
+                                launchObject = DBUtils.findObject(children, catalog);
                             }
                         }
+                    }
+                    if (launchObject == null) {
+                        throw new DBException("No database selected. Please select a database before executing a script natively");
                     }
                     SQLNativeExecutorDescriptor executorDescriptor = SQLNativeExecutorRegistry.getInstance()
                         .getExecutorDescriptor(container);


### PR DESCRIPTION
## Summary
- Fix `ClassCastException` (`MySQLDataSource` cannot be cast to `MySQLCatalog`) when executing SQL scripts natively without a database selected
- Both `SQLEditorHandlerExecute` and `NavigatorHandlerExec` now validate that a database/catalog is selected before proceeding, throwing a descriptive error instead of crashing

## Details
When no database was selected, `SQLEditorHandlerExecute` fell back to `editor.getDataSource()`, which returns a `MySQLDataSource` — not a `MySQLCatalog`. This caused a `ClassCastException` downstream. Similarly, `NavigatorHandlerExec` defaulted `launchObject` to the `dataSource` instance, leading to the same type mismatch.

Now both handlers use `null` as the default and throw `DBException("No database selected. Please select a database before executing a script natively")` if no schema/catalog is resolved.

Fixes #40687
