### PR TITLE
#40372 Skip redundant save dialog when executing DROP queries

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/QueryProcessor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/QueryProcessor.java
@@ -260,6 +260,10 @@ abstract class QueryProcessor implements SQLResultsConsumer, ISmartTransactionMa
                     curJob = job;
                     ResultSetViewer rsv = resultsContainer.getResultSetController();
                     if (rsv != null) {
+                        // Discard pending edits when the query will destroy the underlying data
+                        if (rsv.isDirty() && containsDropQuery(queries)) {
+                            rsv.rejectChanges();
+                        }
                         rsv.resetDataFilter(false);
                         rsv.resetHistory();
                         rsv.refresh();
@@ -274,6 +278,15 @@ abstract class QueryProcessor implements SQLResultsConsumer, ISmartTransactionMa
             }
         }
         return true;
+    }
+
+    private boolean containsDropQuery(@NotNull List<SQLScriptElement> queries) {
+        for (SQLScriptElement element : queries) {
+            if (element instanceof SQLQuery sqlQuery && sqlQuery.isDropDangerous()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void processDataExport(SQLScriptContext scriptContext, List<SQLScriptElement> queries) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/QueryProcessor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/QueryProcessor.java
@@ -260,12 +260,9 @@ abstract class QueryProcessor implements SQLResultsConsumer, ISmartTransactionMa
                     curJob = job;
                     ResultSetViewer rsv = resultsContainer.getResultSetController();
                     if (rsv != null) {
-                        // Discard pending edits when the query will destroy the underlying data
-                        if (rsv.isDirty() && containsDropQuery(queries)) {
-                            rsv.rejectChanges();
-                        }
                         rsv.resetDataFilter(false);
                         rsv.resetHistory();
+                        // Dirty result sets will prompt to save via checkForChanges inside refresh
                         rsv.refresh();
                     }
                 } else {
@@ -278,15 +275,6 @@ abstract class QueryProcessor implements SQLResultsConsumer, ISmartTransactionMa
             }
         }
         return true;
-    }
-
-    private boolean containsDropQuery(@NotNull List<SQLScriptElement> queries) {
-        for (SQLScriptElement element : queries) {
-            if (element instanceof SQLQuery sqlQuery && sqlQuery.isDropDangerous()) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void processDataExport(SQLScriptContext scriptContext, List<SQLScriptElement> queries) {


### PR DESCRIPTION
## Summary

When executing a DROP TABLE query while the result set has unsaved edits, DBeaver shows a redundant "Save result set edit" dialog after the drop confirmation.
Saving edits to a table that is about to be dropped makes no sense.

## Changes

Discard pending result set edits before refreshing the viewer when the query contains a DROP statement.
This skips the unnecessary save prompt while keeping the normal behavior for all other queries.

## Test plan

- [X] Execute SELECT, edit a cell, then run DROP TABLE - only drop confirmation dialog should appear
- [X] Execute SELECT, edit a cell, then run another SELECT - save dialog should still appear
- [X] Execute SELECT without edits, then run DROP TABLE - no extra dialogs

Fixes #40372
