### PR TITLE
#40757 Fix PostgreSQL TIME 24:00:00 display

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreConstants.java
@@ -120,6 +120,7 @@ public class PostgreConstants {
     public static final String TYPE_TIMESTAMP = "timestamp";
     public static final String TYPE_TIMETZ = "timetz";
     public static final String TYPE_TIMESTAMPTZ = "timestamptz";
+    public static final String TIME_END_OF_DAY = "24:00:00";
     public static final String TYPE_XML = "xml";
     public static final String TYPE_BOOLEAN = "boolean";
     public static final String TYPE_BYTEA = "bytea";

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreDateTimeValueHandler.java
@@ -85,6 +85,15 @@ public class PostgreDateTimeValueHandler extends JDBCDateTimeValueHandler {
                 try {
                     return jdbc.getObject(index + 1, OffsetTime.class);
                 } catch (SQLException e) {
+                    try {
+                        String rawString = jdbc.getString(index + 1);
+                        // PostgreSQL accepts 24:00:00 for TIME, but java.sql.Time can't display it distinctly from 00:00:00.
+                        if (PostgreConstants.TIME_END_OF_DAY.equals(rawString)) {
+                            return PostgreConstants.TIME_END_OF_DAY;
+                        }
+                    } catch (SQLException e1) {
+                        log.debug("Exception caught when reading PostgreSQL time value as string", e1);
+                    }
                     log.debug("Exception caught when fetching time value", e);
                 }
             }


### PR DESCRIPTION
Closes: #40757 

test, Use the following SQL:

```sql
drop table if exists test_time_2400;
create table test_time_2400 (
    id int primary key,
    t time(0)
);

insert into test_time_2400(id, t) values (1, '0000');
insert into test_time_2400(id, t) values (2, '2400');

select id, t from test_time_2400;
```

Test environment：

<img width="420" height="240" alt="image" src="https://github.com/user-attachments/assets/aeacc245-9d56-41e5-91f6-8f8a125a2090" />


before fix:
<img width="302" height="198" alt="image" src="https://github.com/user-attachments/assets/bc715b26-c156-417f-aef0-aa5c16eb36c1" />


After fix:

<img width="270" height="181" alt="image" src="https://github.com/user-attachments/assets/838c97a8-4092-41a4-83f1-f188eb3ce7ab" />

pgAdmin:

<img width="360" height="225" alt="image" src="https://github.com/user-attachments/assets/eca6f0e2-bcdc-42fc-8d2d-532b8284f656" />
