### PR TITLE
Check connection before showing execution plan

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -2657,6 +2657,13 @@ public class SQLEditor extends SQLEditorBase implements
             explainPlanFromQuery(planner, sqlQuery);
             showOutputPanel(true);
         } else {
+            if (getExecutionContext() == null) {
+                DBWorkbench.getPlatformUI().showError(
+                    ModelMessages.error_not_connected_to_database,
+                    ModelMessages.error_not_connected_to_database
+                );
+                return;
+            }
             ExplainPlanViewer planView = getPlanView(sqlQuery, planner);
 
             if (planView != null) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorPropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorPropertyTester.java
@@ -86,7 +86,7 @@ public class SQLEditorPropertyTester extends PropertyTester {
             }
             case PROP_CAN_EXECUTE_NATIVE: {
                 try {
-                    if (editor.getExecutionContext() == null) {
+                    if (!hasConnection) {
                         return false;
                     }
                     SQLNativeExecutorDescriptor executorDescriptor =

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorPropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorPropertyTester.java
@@ -73,7 +73,7 @@ public class SQLEditorPropertyTester extends PropertyTester {
         if (editorControl == null) {
             return false;
         }
-        boolean hasConnection = editor.getDataSourceContainer() != null;
+        boolean hasConnection = editor.getExecutionContext() != null;
         switch (property) {
             case PROP_CAN_EXECUTE: {
                 var descriptor = editor.getActivePresentationDescriptor();
@@ -86,7 +86,7 @@ public class SQLEditorPropertyTester extends PropertyTester {
             }
             case PROP_CAN_EXECUTE_NATIVE: {
                 try {
-                    if (editor.getDataSourceContainer() == null) {
+                    if (editor.getExecutionContext() == null) {
                         return false;
                     }
                     SQLNativeExecutorDescriptor executorDescriptor =

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorPropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorPropertyTester.java
@@ -86,7 +86,7 @@ public class SQLEditorPropertyTester extends PropertyTester {
             }
             case PROP_CAN_EXECUTE_NATIVE: {
                 try {
-                    if (!hasConnection) {
+                    if (editor.getExecutionContext() == null) {
                         return false;
                     }
                     SQLNativeExecutorDescriptor executorDescriptor =


### PR DESCRIPTION
Execution plan viewer was attempting to show a plan even when there's no active connection. Added a null check on getExecutionContext() to show an error and return early instead.