### PR TITLE
#40900 SQL: guard delimiter bounds check so single-token scripts don't crash transformers

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLUtils.java
@@ -1242,10 +1242,10 @@ public final class SQLUtils {
         for (String delimiter : scriptDelimiters) {
             if (!delimiter.isEmpty()) {
                 if (Character.isLetterOrDigit(delimiter.charAt(0))) {
-                    if (query.toUpperCase().endsWith(delimiter.toUpperCase())) {
-                        if (!Character.isLetterOrDigit(query.charAt(query.length() - delimiter.length() - 1))) {
-                            return true;
-                        }
+                    if (query.toUpperCase().endsWith(delimiter.toUpperCase())
+                        && isDelimiterStandalone(query, delimiter))
+                    {
+                        return true;
                     }
                 } else {
                     return !query.endsWith(delimiter);
@@ -1261,10 +1261,10 @@ public final class SQLUtils {
             if (!delimiter.isEmpty() && query.contains(delimiter)) {
                 String queryWithoutDelimiter = query.substring(0, query.lastIndexOf(delimiter));
                 if (Character.isLetterOrDigit(delimiter.charAt(0))) {
-                    if (query.toUpperCase().endsWith(delimiter.toUpperCase())) {
-                        if (!Character.isLetterOrDigit(query.charAt(query.length() - delimiter.length() - 1))) {
-                            return queryWithoutDelimiter;
-                        }
+                    if (query.toUpperCase().endsWith(delimiter.toUpperCase())
+                        && isDelimiterStandalone(query, delimiter))
+                    {
+                        return queryWithoutDelimiter;
                     }
                 } else if (query.endsWith(delimiter)) {
                     return queryWithoutDelimiter;
@@ -1272,6 +1272,24 @@ public final class SQLUtils {
             }
         }
         return query;
+    }
+
+    /**
+     * Checks that the character immediately preceding the trailing delimiter in
+     * {@code query} is not a letter or digit — i.e. the delimiter is tokenised
+     * as its own SQL token and is not a tail of a bigger identifier.
+     *
+     * <p>If the query is exactly the delimiter (no preceding character), the
+     * delimiter is considered standalone and this method returns {@code true}.
+     * Without this guard, callers computed {@code query.charAt(query.length() -
+     * delimiter.length() - 1)} which evaluates to {@code charAt(-1)} in the
+     * query-equals-delimiter case and threw {@link StringIndexOutOfBoundsException}
+     * — crashing the query transformer for single-token scripts such as a bare
+     * {@code GO} against SQL Server.
+     */
+    private static boolean isDelimiterStandalone(String query, String delimiter) {
+        int precedingIndex = query.length() - delimiter.length() - 1;
+        return precedingIndex < 0 || !Character.isLetterOrDigit(query.charAt(precedingIndex));
     }
 
     public static String getDefaultScriptDelimiter(SQLDialect sqlDialect) {


### PR DESCRIPTION
```
`SQLUtils.needQueryDelimiter` and `SQLUtils.removeQueryDelimiter` both
computed `query.charAt(query.length() - delimiter.length() - 1)` to
check that the trailing delimiter is a standalone SQL token. When the
entire query equals the delimiter — e.g. a bare `GO` against SQL
Server — the computed index is `-1` and the call throws
`StringIndexOutOfBoundsException`.

`removeQueryDelimiter` is invoked from `QueryTransformerLimit.addLimit`
and `GenericSourceViewEditor`, so the crash reaches the Auto-Limit
rewrite codepath and the stored-routine "View Source" editor: the
script silently fails with a cryptic `Index -1 out of bounds` entry in
the log instead of producing a result.

## Fix

Extract `isDelimiterStandalone(query, delimiter)` which returns `true`
when there is no preceding character (delimiter IS the whole query —
no identifier could surround it), or when the preceding character is
not a letter or digit. Route both call sites through it so the bounds
check can never dereference a negative index.

## Reproduction (pre-fix)

1. Connect to any SQL Server instance.
2. Execute the single statement `GO` as a script.
3. Log shows `StringIndexOutOfBoundsException: Index -1 out of bounds
   for length 2` from `SQLUtils.needQueryDelimiter` (or from
   `QueryTransformerLimit` with Auto-Limit enabled).

After the fix, the transformer returns cleanly (`removeQueryDelimiter`
yields `""` — delimiter stripped — and `needQueryDelimiter` reports
`true` since the delimiter is present and standalone), and the outer
execution pipeline continues without throwing.
```