### PR TITLE
#40901 SQL: Fold case with explicit locale so case-insensitive lookups work on Turkish JVMs

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/QueryTransformerLimit.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/QueryTransformerLimit.java
@@ -24,6 +24,7 @@ import org.jkiss.dbeaver.model.sql.SQLQuery;
 import org.jkiss.dbeaver.model.sql.SQLQueryType;
 import org.jkiss.dbeaver.model.sql.SQLUtils;
 
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
@@ -65,7 +66,12 @@ public class QueryTransformerLimit implements DBCQueryTransformer {
     @Override
     public String transformQueryString(SQLQuery query) throws DBCException {
         String newQuery;
-        String testQuery = query.getText().toUpperCase().trim();
+        // Use an explicit locale so the ASCII keyword list in NON_LIMIT_QUERY_PATTERN
+        // matches regardless of the JVM default locale. In Turkish/Azeri locales plain
+        // toUpperCase() folds a lowercase "limit" to "LİMİT" (with a combining dot above),
+        // which does not match the ASCII pattern literal "LIMIT" - Auto-Limit then
+        // appends a second LIMIT clause and the driver rejects the rewritten query.
+        String testQuery = query.getText().toUpperCase(Locale.ENGLISH).trim();
         SQLDialect dialect = SQLUtils.getDialectFromDataSource(query.getDataSource());
         boolean plainSelect = query.isPlainSelect();
         if (!plainSelect && query.getType() == SQLQueryType.UNKNOWN) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/cache/AbstractObjectCache.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/cache/AbstractObjectCache.java
@@ -90,7 +90,9 @@ public abstract class AbstractObjectCache<OWNER extends DBSObject, OBJECT extend
     @Override
     public OBJECT getCachedObject(@Nullable String name) {
         synchronized (cacheSync) {
-            return objectList == null || name == null ? null : getObjectMap().get(caseSensitive ? name : name.toUpperCase());
+            return objectList == null || name == null
+                ? null
+                : getObjectMap().get(caseSensitive ? name : name.toUpperCase(Locale.ENGLISH));
         }
     }
 
@@ -304,7 +306,12 @@ public abstract class AbstractObjectCache<OWNER extends DBSObject, OBJECT extend
             return null;
         }
         if (!caseSensitive) {
-            return name.toUpperCase();
+            // Use an explicit locale (matches renameObject above) so the case-folded
+            // map key is stable. With the JVM default locale, a Turkish/Azeri JVM
+            // folds "items" to "İTEMS" while a later getCachedObject("ITEMS") folds
+            // to "ITEMS" - the keys do not match and the cache misses every table,
+            // column or schema whose name contains i/I.
+            return name.toUpperCase(Locale.ENGLISH);
         }
         return name;
     }

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/struct/cache/AbstractObjectCacheLocaleTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/struct/cache/AbstractObjectCacheLocaleTest.java
@@ -1,0 +1,152 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.struct.cache;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collection;
+import java.util.Locale;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Regression coverage for case-insensitive object lookup in
+ * {@link AbstractObjectCache} under non-English JVM default locales.
+ *
+ * Turkish/Azeri/Lithuanian locales fold ASCII letters differently from
+ * {@link Locale#ENGLISH}: {@code "items".toUpperCase(tr_TR)} is {@code "İTEMS"}
+ * (LATIN CAPITAL LETTER I WITH DOT ABOVE), not ASCII {@code "ITEMS"}. Before
+ * the fix, both {@link AbstractObjectCache#getCachedObject(String)} and
+ * {@code getObjectName} folded names with the JVM default locale, so a table
+ * stored under the cached name {@code "items"} could no longer be located by
+ * a lookup with the name {@code "ITEMS"} on a Turkish JVM - the two folded
+ * keys are {@code "İTEMS"} and {@code "ITEMS"} and the map returned
+ * {@code null}.
+ */
+public class AbstractObjectCacheLocaleTest extends DBeaverUnitTest {
+
+    private static final Locale TURKISH = Locale.forLanguageTag("tr-TR");
+
+    private static Locale originalDefaultLocale;
+
+    @BeforeClass
+    public static void setTurkishDefaultLocale() {
+        originalDefaultLocale = Locale.getDefault();
+        Locale.setDefault(TURKISH);
+    }
+
+    @AfterClass
+    public static void restoreDefaultLocale() {
+        Locale.setDefault(originalDefaultLocale);
+    }
+
+    /**
+     * Concrete cache used purely as a test harness over the abstract base.
+     */
+    private static final class TestObjectCache extends AbstractObjectCache<DBSObject, DBSObject> {
+        @NotNull
+        @Override
+        public Collection<DBSObject> getAllObjects(@NotNull DBRProgressMonitor monitor, @Nullable DBSObject owner)
+            throws DBException
+        {
+            return getCachedObjects();
+        }
+    }
+
+    private static DBSObject namedObject(@NotNull String name) {
+        DBSObject obj = Mockito.mock(DBSObject.class);
+        Mockito.when(obj.getName()).thenReturn(name);
+        return obj;
+    }
+
+    /**
+     * DB stores "items"; caller asks for "ITEMS". Pre-fix this lookup returned null
+     * on a Turkish JVM because the two folds were "İTEMS" vs "ITEMS".
+     */
+    @Test
+    public void getCachedObject_caseInsensitive_findsLowercaseEntryViaUppercaseKey_underTurkishLocale() {
+        TestObjectCache cache = new TestObjectCache();
+        cache.setCaseSensitive(false);
+        DBSObject items = namedObject("items");
+        cache.cacheObject(items);
+
+        assertSame(
+            "Case-insensitive lookup under Turkish locale must find a cached lowercase name via an uppercase key",
+            items,
+            cache.getCachedObject("ITEMS")
+        );
+    }
+
+    @Test
+    public void getCachedObject_caseInsensitive_findsUppercaseEntryViaLowercaseKey_underTurkishLocale() {
+        TestObjectCache cache = new TestObjectCache();
+        cache.setCaseSensitive(false);
+        DBSObject items = namedObject("ITEMS");
+        cache.cacheObject(items);
+
+        assertSame(
+            "Case-insensitive lookup under Turkish locale must find a cached uppercase name via a lowercase key",
+            items,
+            cache.getCachedObject("items")
+        );
+    }
+
+    /**
+     * Case-sensitive lookups must keep their existing exact-match semantics
+     * regardless of the JVM default locale - the fix only touches the
+     * !caseSensitive code path.
+     */
+    @Test
+    public void getCachedObject_caseSensitive_requiresExactMatch_underTurkishLocale() {
+        TestObjectCache cache = new TestObjectCache();
+        // caseSensitive defaults to true; do not toggle it.
+        DBSObject items = namedObject("items");
+        cache.cacheObject(items);
+
+        assertSame(items, cache.getCachedObject("items"));
+        assertNull(
+            "Case-sensitive lookup must not collapse case under any locale",
+            cache.getCachedObject("ITEMS")
+        );
+    }
+
+    /**
+     * Identifiers with no i/I are unaffected by the Turkish-locale fold;
+     * pinned here to catch any future regression in the ASCII path.
+     */
+    @Test
+    public void getCachedObject_caseInsensitive_asciiOnlyNames_stillResolve_underTurkishLocale() {
+        TestObjectCache cache = new TestObjectCache();
+        cache.setCaseSensitive(false);
+        DBSObject orders = namedObject("orders");
+        cache.cacheObject(orders);
+
+        assertSame(orders, cache.getCachedObject("ORDERS"));
+        assertSame(orders, cache.getCachedObject("Orders"));
+        assertSame(orders, cache.getCachedObject("orders"));
+    }
+}


### PR DESCRIPTION
```
## Reproduction (pre-fix)

### Cache miss (Bug 1)

- Launch DBeaver on a JVM with `-Duser.language=tr -Duser.country=TR`.
- Connect to any case-insensitive metadata provider (Oracle, Postgres, etc).
- Open a table named `items` in the Database Navigator.
- Internal cache lookups via `getCachedObject("ITEMS")` miss on every
  column expansion or right-click action — DBeaver re-queries the DB
  each time (visible in the SQL log).

### Double-LIMIT rewrite (Bug 2)

- Same Turkish JVM.
- SQL editor → Preferences → "Auto-Limit" on, default limit 200.
- Run `select 1 limit 10`.
- DBeaver rewrites to `select 1 limit 10\nLIMIT 200\n` and the driver
  rejects the double LIMIT with a syntax error.

After this PR both scenarios succeed regardless of the JVM default
locale.
```