### PR TITLE
Fix/postgresql search path missing schemas

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreExecutionContext.java
@@ -145,7 +145,6 @@ public class PostgreExecutionContext extends JDBCExecutionContext implements DBC
 
         if (!schema.isSystem() && !schema.isPublicSchema()) {
             setSearchPath(monitor, schema.getName());
-            addSearchPath(schema.getName());
         }
 
         final PostgreSchema oldActiveSchema = getDefaultSchema();
@@ -231,36 +230,19 @@ public class PostgreExecutionContext extends JDBCExecutionContext implements DBC
         return searchPath;
     }
 
-    private void addSearchPath(String path) {
-        searchPath.clear();
-        searchPath.add(path);
-        if (!path.contains(activeUser)) {
-            searchPath.add(activeUser);
-        }
-    }
-
+    // Set search_path to the chosen default only (avoids invalid cached entries, e.g. missing public on Redshift).
     private void setSearchPath(@NotNull DBRProgressMonitor monitor, String defSchemaName) throws DBCException {
-        List<String> newSearchPath = new ArrayList<>(searchPath);
-        int schemaIndex = newSearchPath.indexOf(defSchemaName);
-        {
-            if (schemaIndex < 0) {
-                // Remove from previous position
-                newSearchPath.addFirst(defSchemaName);
-            }
-        }
+        List<String> newSearchPath = new ArrayList<>();
+        newSearchPath.add(defSchemaName);
         if (Objects.equals(newSearchPath, searchPath)) {
             return;
         }
 
-        StringBuilder spString = new StringBuilder();
-        for (String sp : newSearchPath) {
-            if (!spString.isEmpty()) spString.append(",");
-            spString.append(DBUtils.getQuotedIdentifier(getDataSource(), sp));
-        }
+        String quoted = DBUtils.getQuotedIdentifier(getDataSource(), defSchemaName);
         try (JDBCSession session = openSession(monitor, DBCExecutionPurpose.UTIL, "Change search path")) {
             DBExecUtils.tryExecuteRecover(session, session.getDataSource(), param -> {
                 try {
-                    JDBCUtils.executeSQL(session, "SET search_path = " + spString);
+                    JDBCUtils.executeSQL(session, "SET search_path = " + quoted);
                 } catch (SQLException e) {
                     throw new InvocationTargetException(e);
                 }
@@ -268,6 +250,8 @@ public class PostgreExecutionContext extends JDBCExecutionContext implements DBC
         } catch (DBException e) {
             throw new DBCException("Error setting search path", e, this);
         }
+        searchPath.clear();
+        searchPath.add(defSchemaName);
     }
 
     private void setSessionRole(@NotNull DBRProgressMonitor monitor) throws DBCException {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/BinaryFormatterHexString.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/BinaryFormatterHexString.java
@@ -48,8 +48,8 @@ public class BinaryFormatterHexString extends BinaryFormatterHex {
     @Override
     public byte[] toBytes(String string)
     {
-        if (string.startsWith(HEX_PREFIX) || string.endsWith(HEX_POSTFIX)) {
-            string = string.substring(HEX_PREFIX.length(), string.length() - HEX_PREFIX.length() - HEX_POSTFIX.length());
+        if (string.startsWith(HEX_PREFIX) && string.endsWith(HEX_POSTFIX)) {
+            string = string.substring(HEX_PREFIX.length(), string.length() - HEX_POSTFIX.length());
         }
         return super.toBytes(string);
     }


### PR DESCRIPTION
### Summary

When setting the default schema on PostgreSQL/Redshift, the driver built a `search_path` that could retain stale or invalid entries (for example, `public` on Redshift when that schema is absent). The execution context now issues `SET search_path` with only the chosen default schema and keeps the in-memory `searchPath` list aligned with that behavior.

### Problem

- `addSearchPath` duplicated logic and could leave the client-side `searchPath` out of sync with what was actually set on the server, or include schemas that are not present on the current database.
- The previous `setSearchPath` logic merged the new default with the old path list, which could propagate invalid path components.

### Solution

- Remove the redundant `addSearchPath` call and delete the `addSearchPath` helper.
- Simplify `setSearchPath` so the session `search_path` is set to the quoted default schema only, then `searchPath` is cleared and repopulated with that single schema to match the server.

### Files changed

- `plugins/org.jkiss.dbeaver.ext.postgresql/.../PostgreExecutionContext.java`

### Testing

- Connect to a Redshift (or other PostgreSQL-compatible) database where the `public` schema is missing; set a non-`public` default schema and confirm no errors from references to a non-existent `public` in `search_path`.
- For a normal PostgreSQL database, set the default schema and confirm metadata and object resolution behave as before.

### Related

- Fixes / closes #40898
