### PR TITLE
#38044 Skip null and empty driver properties when opening a JDBC connection

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCDataSource.java
+++ b/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCDataSource.java
@@ -355,13 +355,37 @@ public abstract class JDBCDataSource extends AbstractDataSource
             // Use driver properties
             final Map<String, Object> driverProperties = container.getDriver().getConnectionProperties();
             for (Map.Entry<String, Object> prop : driverProperties.entrySet()) {
-                connectProps.setProperty(prop.getKey(), CommonUtils.toString(prop.getValue()));
+                copyConnectionProperty(connectProps, prop.getKey(), prop.getValue());
             }
         }
 
         for (Map.Entry<String, String> prop : connectionInfo.getProperties().entrySet()) {
-            connectProps.setProperty(CommonUtils.toString(prop.getKey()), CommonUtils.toString(prop.getValue()));
+            copyConnectionProperty(connectProps, prop.getKey(), prop.getValue());
         }
+    }
+
+    /**
+     * Copy a single driver / connection property into the JDBC {@code Properties} bag,
+     * skipping null or empty values.
+     *
+     * <p>Null values arrive when the user has cleared a property in the Driver Properties
+     * tab (a property reset is stored as a null in {@code customConnectionProperties}).
+     * Empty strings arrive when the user has saved an empty text value. Forwarding either
+     * to the JDBC driver as an empty PRAGMA value causes drivers like SQLite to reject the
+     * connection with {@code SQLITE_ERROR: SQL error or missing database (incomplete
+     * input)}. The right semantic for a cleared property is "do not send", which the
+     * driver then treats as "use the built-in default". See dbeaver/dbeaver#38044.</p>
+     */
+    static void copyConnectionProperty(@NotNull Properties target, @Nullable Object key, @Nullable Object value) {
+        if (key == null || value == null) {
+            return;
+        }
+        String stringKey = CommonUtils.toString(key);
+        String stringValue = CommonUtils.toString(value);
+        if (stringKey.isEmpty() || stringValue.isEmpty()) {
+            return;
+        }
+        target.setProperty(stringKey, stringValue);
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/driver/DriverDescriptor.java
@@ -1185,7 +1185,19 @@ public class DriverDescriptor extends AbstractDescriptor implements DBPDriver {
 
     public void setConnectionProperties(@NotNull Map<String, Object> parameters) {
         customConnectionProperties.clear();
-        customConnectionProperties.putAll(parameters);
+        // Reject null values: a null entry survives `clear() + putAll(...)` and is later
+        // forwarded as an empty string to the JDBC driver in
+        // JDBCDataSource.fillConnectionProperties (CommonUtils.toString(null) -> ""),
+        // which some drivers (e.g. SQLite) reject with a cryptic
+        // "[SQLITE_ERROR] SQL error or missing database (incomplete input)" when applying
+        // the empty PRAGMA at connection time. Resetting a property to null in the
+        // Driver Properties tab must mean "do not send this property", not "send empty".
+        // See dbeaver/dbeaver#38044.
+        for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+            if (entry.getValue() != null) {
+                customConnectionProperties.put(entry.getKey(), entry.getValue());
+            }
+        }
     }
 
     @NotNull

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCDataSourcePropertiesTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/impl/jdbc/JDBCDataSourcePropertiesTest.java
@@ -1,0 +1,128 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.impl.jdbc;
+
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Regression tests for dbeaver/dbeaver#38044 — resetting a driver property
+ * to null in the Driver Properties tab caused a connection failure
+ * because {@code JDBCDataSource.fillConnectionProperties} forwarded the
+ * cleared value to the JDBC driver as an empty string. SQLite (and other
+ * drivers that interpret an empty PRAGMA literally) responded with
+ * {@code SQLITE_ERROR: SQL error or missing database (incomplete input)}.
+ */
+public class JDBCDataSourcePropertiesTest extends DBeaverUnitTest {
+
+    @Test
+    public void copyNonEmptyValuePropagatesToJdbcProperties() {
+        Properties target = new Properties();
+
+        JDBCDataSource.copyConnectionProperty(target, "currentSchema", "myschema");
+
+        assertEquals("myschema", target.getProperty("currentSchema"));
+    }
+
+    @Test
+    public void copyNullValueIsSkipped() {
+        Properties target = new Properties();
+        // Bug #38044: a property cleared by the user is stored as a null value;
+        // forwarding it as `setProperty(key, "")` made SQLite reject the connection
+        // with `(incomplete input)` while applying an empty PRAGMA.
+        JDBCDataSource.copyConnectionProperty(target, "encoding", null);
+
+        assertFalse(
+            "null value must not produce an empty-string entry in the JDBC Properties bag",
+            target.containsKey("encoding"));
+        assertNull(target.getProperty("encoding"));
+    }
+
+    @Test
+    public void copyEmptyStringValueIsSkipped() {
+        Properties target = new Properties();
+        // Same shape as the null case: an empty-string text widget should mean
+        // "do not send this property", not "send empty".
+        JDBCDataSource.copyConnectionProperty(target, "encoding", "");
+
+        assertFalse(target.containsKey("encoding"));
+    }
+
+    @Test
+    public void copyNullKeyIsSkipped() {
+        Properties target = new Properties();
+        JDBCDataSource.copyConnectionProperty(target, null, "anything");
+
+        assertEquals("the target Properties must remain empty", 0, target.size());
+    }
+
+    @Test
+    public void copyEmptyKeyIsSkipped() {
+        Properties target = new Properties();
+        JDBCDataSource.copyConnectionProperty(target, "", "anything");
+
+        assertEquals(0, target.size());
+    }
+
+    @Test
+    public void copyNumericValueIsStringified() {
+        Properties target = new Properties();
+        JDBCDataSource.copyConnectionProperty(target, "loginTimeout", 30);
+
+        assertEquals("30", target.getProperty("loginTimeout"));
+    }
+
+    @Test
+    public void copyBooleanValueIsStringified() {
+        Properties target = new Properties();
+        JDBCDataSource.copyConnectionProperty(target, "ssl", Boolean.TRUE);
+
+        assertEquals("true", target.getProperty("ssl"));
+    }
+
+    @Test
+    public void copyOverridesExistingPropertyWhenValuePresent() {
+        Properties target = new Properties();
+        target.setProperty("encoding", "UTF-8");
+
+        JDBCDataSource.copyConnectionProperty(target, "encoding", "UTF-16");
+
+        assertEquals("UTF-16", target.getProperty("encoding"));
+    }
+
+    @Test
+    public void copyDoesNotRemoveExistingPropertyWhenNullArrives() {
+        // The helper is additive only — when the loop encounters a null/cleared
+        // entry it must leave the target untouched, so a previously-copied
+        // property from internal datasource defaults survives.
+        Properties target = new Properties();
+        target.setProperty("encoding", "UTF-8");
+
+        JDBCDataSource.copyConnectionProperty(target, "encoding", null);
+
+        assertEquals(
+            "previously-set properties must survive a subsequent null entry",
+            "UTF-8",
+            target.getProperty("encoding"));
+    }
+}


### PR DESCRIPTION
## Summary

Resetting a driver property to null in the Driver Properties tab made
the next connection attempt fail. SQLite reported the failure clearly
as `[SQLITE_ERROR] SQL error or missing database (incomplete input)`,
because DBeaver was forwarding `Properties[key]=""` to the driver.

Root cause: `DriverDescriptor.setConnectionProperties` did
`customConnectionProperties.clear() + putAll(parameters)`. When the
property source merges its `originalValues` (which retain a null
sentinel after the user resets a row) with `propValues`, the merged
map contains an explicit `key -> null` entry. `HashMap.putAll` keeps
that null. `JDBCDataSource.fillConnectionProperties` then turned it
into the empty string via `CommonUtils.toString(null)` and applied it
as a PRAGMA at connection time.

Fix:

- `DriverDescriptor.setConnectionProperties` now skips entries whose
  value is null, so the cleared row no longer survives the bulk save
  and is no longer serialised to disk.
- `JDBCDataSource.fillConnectionProperties` now routes both loops
  through `copyConnectionProperty(target, key, value)`, a new
  package-visible helper that skips null or empty keys/values. This
  is defence-in-depth for any other caller path that produces a null,
  and gives the fix a small unit-testable seam.

## Related Issues

Closes #38044.

## Reproduction (pre-fix)

1. Open any driver with properties (e.g. SQLite).
2. Driver Properties tab → change any null property to a valid value.
3. Save.
4. Reopen the dialog, change the same property back to null.
5. Save and try to open a connection.

Pre-fix: connection fails with
`[SQLITE_ERROR] SQL error or missing database (incomplete input)`
(or the equivalent error from any other driver that rejects empty
PRAGMA values).

Post-fix: the property is no longer sent at all, the driver uses its
built-in default, and the connection succeeds.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Testing

- [x] `JDBCDataSourcePropertiesTest` added (9 JUnit cases pinning
      `copyConnectionProperty` semantics including the null-value
      regression guard for #38044, additive semantics, and
      stringification of non-string values).
- [x] Manually traced the path
      `PropertySourceCustom.getPropertyValues` →
      `DriverDescriptor.setConnectionProperties` →
      `JDBCDataSource.fillConnectionProperties` and confirmed that
      after the fix neither the storage map nor the JDBC `Properties`
      bag retain the cleared key.

