### PR TITLE
#40922 Fix script execution breaking SQL Server variable scope

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDialectBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDialectBase.java
@@ -117,12 +117,13 @@ public abstract class SQLServerDialectBase extends JDBCSQLDialect implements TPR
     @NotNull
     @Override
     public String[] getScriptDelimiters() {
-        return new String[]{"GO"};
+        return new String[]{";", "GO"};
     }
 
+    @Nullable
     @Override
-    public boolean usesOnlyNativeScriptDelimiters() {
-        return true;
+    public String[] getScriptBatchSeparators() {
+        return new String[]{"GO"};
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDialectBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerDialectBase.java
@@ -117,7 +117,12 @@ public abstract class SQLServerDialectBase extends JDBCSQLDialect implements TPR
     @NotNull
     @Override
     public String[] getScriptDelimiters() {
-        return new String[]{";", "GO"};
+        return new String[]{"GO"};
+    }
+
+    @Override
+    public boolean usesOnlyNativeScriptDelimiters() {
+        return true;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -51,6 +51,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * SQL parser
@@ -1020,6 +1021,13 @@ public class SQLScriptParser {
             expandQueries(parserContext, queryList);
         }
 
+        if (scriptMode) {
+            String[] batchSeparators = parserContext.getSyntaxManager().getDialect().getScriptBatchSeparators();
+            if (batchSeparators != null) {
+                queryList = mergeIntoBatches(queryList, document, batchSeparators);
+            }
+        }
+
         if (parseParameters) {
             // Parse parameters
             for (SQLScriptElement element : queryList) {
@@ -1029,6 +1037,94 @@ public class SQLScriptParser {
             }
         }
         return queryList;
+    }
+
+    /**
+     * Merges parsed script elements that belong to the same execution batch.
+     * Elements are in the same batch if no batch separator (e.g. GO) appears
+     * between them in the original document text.
+     */
+    @NotNull
+    private static List<SQLScriptElement> mergeIntoBatches(
+        @NotNull List<SQLScriptElement> elements,
+        @NotNull IDocument document,
+        @NotNull String[] batchSeparators
+    ) {
+        if (elements.size() <= 1) {
+            return elements;
+        }
+        Pattern[] separatorPatterns = new Pattern[batchSeparators.length];
+        for (int i = 0; i < batchSeparators.length; i++) {
+            separatorPatterns[i] = Pattern.compile(
+                "^\\s*" + Pattern.quote(batchSeparators[i]) + "\\s*$",
+                Pattern.CASE_INSENSITIVE | Pattern.MULTILINE
+            );
+        }
+
+        List<SQLScriptElement> merged = new LinkedList<>();
+        int batchStart = -1;
+        int batchEnd = -1;
+        DBPDataSource batchDataSource = null;
+
+        for (SQLScriptElement element : elements) {
+            if (!(element instanceof SQLQuery query)) {
+                if (batchStart >= 0) {
+                    merged.add(createBatchQuery(document, batchDataSource, batchStart, batchEnd));
+                    batchStart = -1;
+                }
+                merged.add(element);
+                continue;
+            }
+            if (batchStart < 0) {
+                batchStart = query.getOffset();
+                batchEnd = query.getOffset() + query.getLength();
+                batchDataSource = query.getDataSource();
+                continue;
+            }
+            boolean hasSeparator = false;
+            int gapStart = batchEnd;
+            int gapEnd = query.getOffset();
+            if (gapEnd > gapStart) {
+                try {
+                    String gapText = document.get(gapStart, gapEnd - gapStart);
+                    for (Pattern p : separatorPatterns) {
+                        if (p.matcher(gapText).find()) {
+                            hasSeparator = true;
+                            break;
+                        }
+                    }
+                } catch (BadLocationException e) {
+                    hasSeparator = true;
+                }
+            }
+            if (hasSeparator) {
+                merged.add(createBatchQuery(document, batchDataSource, batchStart, batchEnd));
+                batchStart = query.getOffset();
+                batchEnd = query.getOffset() + query.getLength();
+                batchDataSource = query.getDataSource();
+            } else {
+                batchEnd = query.getOffset() + query.getLength();
+            }
+        }
+        if (batchStart >= 0) {
+            merged.add(createBatchQuery(document, batchDataSource, batchStart, batchEnd));
+        }
+        return merged;
+    }
+
+    @NotNull
+    private static SQLQuery createBatchQuery(
+        @NotNull IDocument document,
+        @Nullable DBPDataSource dataSource,
+        int start,
+        int end
+    ) {
+        try {
+            String text = SQLUtils.fixLineFeeds(document.get(start, end - start));
+            return new SQLQuery(dataSource, text, start, end - start);
+        } catch (BadLocationException e) {
+            return new SQLQuery(dataSource, "", start, end - start);
+        }
     }
 
     private static void expandQueries(@NotNull SQLParserContext parserContext, @NotNull List<SQLScriptElement> queryList) {

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -1053,14 +1053,7 @@ public class SQLScriptParser {
         if (elements.size() <= 1) {
             return elements;
         }
-        Pattern[] separatorPatterns = new Pattern[batchSeparators.length];
-        for (int i = 0; i < batchSeparators.length; i++) {
-            separatorPatterns[i] = Pattern.compile(
-                "^\\s*" + Pattern.quote(batchSeparators[i]) + "\\s*$",
-                Pattern.CASE_INSENSITIVE | Pattern.MULTILINE
-            );
-        }
-
+        Pattern[] separatorPatterns = buildSeparatorPatterns(batchSeparators);
         List<SQLScriptElement> merged = new LinkedList<>();
         int batchStart = -1;
         int batchEnd = -1;
@@ -1081,23 +1074,7 @@ public class SQLScriptParser {
                 batchDataSource = query.getDataSource();
                 continue;
             }
-            boolean hasSeparator = false;
-            int gapStart = batchEnd;
-            int gapEnd = query.getOffset();
-            if (gapEnd > gapStart) {
-                try {
-                    String gapText = document.get(gapStart, gapEnd - gapStart);
-                    for (Pattern p : separatorPatterns) {
-                        if (p.matcher(gapText).find()) {
-                            hasSeparator = true;
-                            break;
-                        }
-                    }
-                } catch (BadLocationException e) {
-                    hasSeparator = true;
-                }
-            }
-            if (hasSeparator) {
+            if (hasBatchSeparator(document, batchEnd, query.getOffset(), separatorPatterns)) {
                 merged.add(createBatchQuery(document, batchDataSource, batchStart, batchEnd));
                 batchStart = query.getOffset();
                 batchEnd = query.getOffset() + query.getLength();
@@ -1113,6 +1090,41 @@ public class SQLScriptParser {
     }
 
     @NotNull
+    private static Pattern[] buildSeparatorPatterns(@NotNull String[] batchSeparators) {
+        Pattern[] patterns = new Pattern[batchSeparators.length];
+        for (int i = 0; i < batchSeparators.length; i++) {
+            patterns[i] = Pattern.compile(
+                "^\\s*" + Pattern.quote(batchSeparators[i]) + "\\s*$",
+                Pattern.CASE_INSENSITIVE | Pattern.MULTILINE
+            );
+        }
+        return patterns;
+    }
+
+    private static boolean hasBatchSeparator(
+        @NotNull IDocument document,
+        int gapStart,
+        int gapEnd,
+        @NotNull Pattern[] separatorPatterns
+    ) {
+        if (gapEnd <= gapStart) {
+            return false;
+        }
+        try {
+            String gapText = document.get(gapStart, gapEnd - gapStart);
+            for (Pattern p : separatorPatterns) {
+                if (p.matcher(gapText).find()) {
+                    return true;
+                }
+            }
+        } catch (BadLocationException e) {
+            log.debug("Failed to read gap text between script elements", e);
+            return true;
+        }
+        return false;
+    }
+
+    @NotNull
     private static SQLQuery createBatchQuery(
         @NotNull IDocument document,
         @Nullable DBPDataSource dataSource,
@@ -1123,6 +1135,7 @@ public class SQLScriptParser {
             String text = SQLUtils.fixLineFeeds(document.get(start, end - start));
             return new SQLQuery(dataSource, text, start, end - start);
         } catch (BadLocationException e) {
+            log.debug("Failed to read batch text from document", e);
             return new SQLQuery(dataSource, "", start, end - start);
         }
     }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
@@ -208,20 +208,23 @@ public interface SQLDialect {
     String[] getScriptDelimiters();
 
     /**
-     * Whether the default statement delimiter (typically {@code ;}) from user preferences
-     * should be suppressed when the user has not explicitly customized it.
+     * Returns the subset of script delimiters that mark actual execution batch boundaries.
      * <p>
-     * When {@code true}, only the delimiters from {@link #getScriptDelimiters()} are used
-     * unless the user has explicitly configured a custom statement delimiter in preferences.
+     * When non-null, during script execution (ALT+X) only these delimiters split
+     * the script into separate JDBC calls. Statements separated by other delimiters
+     * (like {@code ;}) are merged into a single execution batch.
      * <p>
-     * T-SQL (SQL Server / Sybase) needs this because {@code ;} is a statement terminator
-     * within a batch, not a batch separator. Splitting on {@code ;} breaks variable scope
-     * across statements in the same batch.
+     * All script delimiters are still used for editor features (folding, highlighting).
+     * <p>
+     * T-SQL needs this because {@code ;} is a statement terminator within a batch,
+     * not a batch separator. The actual batch separator is {@code GO}.
      *
-     * @return true to suppress adding the default preference-based delimiter
+     * @return batch separator strings, or {@code null} if all script delimiters
+     *         are batch separators (default)
      */
-    default boolean usesOnlyNativeScriptDelimiters() {
-        return false;
+    @Nullable
+    default String[] getScriptBatchSeparators() {
+        return null;
     }
 
     @Nullable

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLDialect.java
@@ -207,6 +207,23 @@ public interface SQLDialect {
     @NotNull
     String[] getScriptDelimiters();
 
+    /**
+     * Whether the default statement delimiter (typically {@code ;}) from user preferences
+     * should be suppressed when the user has not explicitly customized it.
+     * <p>
+     * When {@code true}, only the delimiters from {@link #getScriptDelimiters()} are used
+     * unless the user has explicitly configured a custom statement delimiter in preferences.
+     * <p>
+     * T-SQL (SQL Server / Sybase) needs this because {@code ;} is a statement terminator
+     * within a batch, not a batch separator. Splitting on {@code ;} breaks variable scope
+     * across statements in the same batch.
+     *
+     * @return true to suppress adding the default preference-based delimiter
+     */
+    default boolean usesOnlyNativeScriptDelimiters() {
+        return false;
+    }
+
     @Nullable
     String getScriptDelimiterRedefiner();
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLSyntaxManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLSyntaxManager.java
@@ -157,14 +157,12 @@ public class SQLSyntaxManager {
             }
         }
 
-        if (!sqlDialect.usesOnlyNativeScriptDelimiters()) {
-            String extraDelimiters = CommonUtils.toString(preferenceStore.getString(ModelPreferences.SCRIPT_STATEMENT_DELIMITER), SQLConstants.DEFAULT_STATEMENT_DELIMITER);
-            StringTokenizer st = new StringTokenizer(extraDelimiters, " \t,");
-            while (st.hasMoreTokens()) {
-                String delim = st.nextToken();
-                if (!ArrayUtils.contains(this.statementDelimiters, delim)) {
-                    this.statementDelimiters = ArrayUtils.add(String.class, this.statementDelimiters, delim);
-                }
+        String extraDelimiters = CommonUtils.toString(preferenceStore.getString(ModelPreferences.SCRIPT_STATEMENT_DELIMITER), SQLConstants.DEFAULT_STATEMENT_DELIMITER);
+        StringTokenizer st = new StringTokenizer(extraDelimiters, " \t,");
+        while (st.hasMoreTokens()) {
+            String delim = st.nextToken();
+            if (!ArrayUtils.contains(this.statementDelimiters, delim)) {
+                this.statementDelimiters = ArrayUtils.add(String.class, this.statementDelimiters, delim);
             }
         }
         this.statementDelimiterMode = SQLScriptStatementDelimiterMode.fromPreferences(preferenceStore);

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLSyntaxManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLSyntaxManager.java
@@ -157,12 +157,14 @@ public class SQLSyntaxManager {
             }
         }
 
-        String extraDelimiters = CommonUtils.toString(preferenceStore.getString(ModelPreferences.SCRIPT_STATEMENT_DELIMITER), SQLConstants.DEFAULT_STATEMENT_DELIMITER);
-        StringTokenizer st = new StringTokenizer(extraDelimiters, " \t,");
-        while (st.hasMoreTokens()) {
-            String delim = st.nextToken();
-            if (!ArrayUtils.contains(this.statementDelimiters, delim)) {
-                this.statementDelimiters = ArrayUtils.add(String.class, this.statementDelimiters, delim);
+        if (!sqlDialect.usesOnlyNativeScriptDelimiters()) {
+            String extraDelimiters = CommonUtils.toString(preferenceStore.getString(ModelPreferences.SCRIPT_STATEMENT_DELIMITER), SQLConstants.DEFAULT_STATEMENT_DELIMITER);
+            StringTokenizer st = new StringTokenizer(extraDelimiters, " \t,");
+            while (st.hasMoreTokens()) {
+                String delim = st.nextToken();
+                if (!ArrayUtils.contains(this.statementDelimiters, delim)) {
+                    this.statementDelimiters = ArrayUtils.add(String.class, this.statementDelimiters, delim);
+                }
             }
         }
         this.statementDelimiterMode = SQLScriptStatementDelimiterMode.fromPreferences(preferenceStore);

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
@@ -663,19 +663,22 @@ public class SQLScriptParserTest extends DBeaverUnitTest {
 
     @Test
     public void parseBeginTransaction() throws DBException {
-        String[] dialects = new String[] {POSTGRESQL_DIALECT_NAME, SQLSERVER_DIALECT_NAME};
-        for (String dialect : dialects) {
-            assertParse(
-                dialect,
-                "begin transaction;\nselect 1 from dual;",
-                new String[] {"begin transaction", "select 1 from dual"}
-            );
-        }
+        assertParse(
+            POSTGRESQL_DIALECT_NAME,
+            "begin transaction;\nselect 1 from dual;",
+            new String[] {"begin transaction", "select 1 from dual"}
+        );
+        // SQL Server uses GO as the batch delimiter, not ';'.
+        // Semicolons do not split batches, so the whole text is one element.
+        assertParse(
+            SQLSERVER_DIALECT_NAME,
+            "begin transaction;\nselect 1 from dual;",
+            new String[] {"begin transaction;\nselect 1 from dual;"}
+        );
     }
 
     @Test
     public void parseFromCursorPositionBeginTransaction() throws DBException {
-        String[] dialects = new String[] {POSTGRESQL_DIALECT_NAME, SQLSERVER_DIALECT_NAME};
         String query = """
             begi<-|n transaction;<-|
             select 1 from dual;
@@ -689,16 +692,54 @@ public class SQLScriptParserTest extends DBeaverUnitTest {
             String modifiedQuery = entry.getKey();
             int[] positions = entry.getValue();
 
-            for (String dialect : dialects) {
-                context = createParserContext(setDialect(dialect), modifiedQuery);
-                for (int pos : positions) {
-                    element = SQLScriptParser.parseQuery(
-                        context, 0, modifiedQuery.length(), pos, false, false
-                    );
-                    assertEquals("begin transaction", element.getText());
-                }
+            // PostgreSQL splits on ';' - cursor in "begin transaction" returns just that statement
+            context = createParserContext(setDialect(POSTGRESQL_DIALECT_NAME), modifiedQuery);
+            for (int pos : positions) {
+                element = SQLScriptParser.parseQuery(
+                    context, 0, modifiedQuery.length(), pos, false, false
+                );
+                assertEquals("begin transaction", element.getText());
+            }
+
+            // SQL Server does not split on ';' - the whole batch is one query
+            context = createParserContext(setDialect(SQLSERVER_DIALECT_NAME), modifiedQuery);
+            for (int pos : positions) {
+                element = SQLScriptParser.parseQuery(
+                    context, 0, modifiedQuery.length(), pos, false, false
+                );
+                assertEquals(modifiedQuery.trim(), element.getText().trim());
             }
         }
+    }
+
+    /**
+     * Issue 40922 - SQL Server variable declarations must stay in the same batch.
+     * Splitting on ';' causes "Must declare the scalar variable" errors.
+     */
+    @Test
+    public void parseSqlServerVariableDeclarationBatch() throws DBException {
+        // Single batch with DECLARE + SELECT - must NOT be split on ';'
+        String singleBatch = "DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;";
+        SQLParserContext ctx = createParserContext(setDialect(SQLSERVER_DIALECT_NAME), singleBatch);
+        List<SQLScriptElement> elements = SQLScriptParser.extractScriptQueries(
+            ctx, 0, ctx.getDocument().getLength(), false, false, false
+        );
+        assertEquals(1, elements.size());
+        assertEquals(singleBatch, elements.get(0).getText().trim());
+
+        // Two batches separated by GO - must be split into two elements
+        assertParse(
+            SQLSERVER_DIALECT_NAME,
+            "DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;\nGO\nSELECT 1;",
+            new String[]{"DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;\n", "SELECT 1;"}
+        );
+
+        // PostgreSQL should still split on ';' as before
+        assertParse(
+            POSTGRESQL_DIALECT_NAME,
+            "DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;",
+            new String[]{"DECLARE @month DATETIME = '2026-03-01'", "SELECT @month"}
+        );
     }
 
     /**

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
@@ -663,22 +663,19 @@ public class SQLScriptParserTest extends DBeaverUnitTest {
 
     @Test
     public void parseBeginTransaction() throws DBException {
-        assertParse(
-            POSTGRESQL_DIALECT_NAME,
-            "begin transaction;\nselect 1 from dual;",
-            new String[] {"begin transaction", "select 1 from dual"}
-        );
-        // SQL Server uses GO as the batch delimiter, not ';'.
-        // Semicolons do not split batches, so the whole text is one element.
-        assertParse(
-            SQLSERVER_DIALECT_NAME,
-            "begin transaction;\nselect 1 from dual;",
-            new String[] {"begin transaction;\nselect 1 from dual;"}
-        );
+        String[] dialects = new String[] {POSTGRESQL_DIALECT_NAME, SQLSERVER_DIALECT_NAME};
+        for (String dialect : dialects) {
+            assertParse(
+                dialect,
+                "begin transaction;\nselect 1 from dual;",
+                new String[] {"begin transaction", "select 1 from dual"}
+            );
+        }
     }
 
     @Test
     public void parseFromCursorPositionBeginTransaction() throws DBException {
+        String[] dialects = new String[] {POSTGRESQL_DIALECT_NAME, SQLSERVER_DIALECT_NAME};
         String query = """
             begi<-|n transaction;<-|
             select 1 from dual;
@@ -692,22 +689,14 @@ public class SQLScriptParserTest extends DBeaverUnitTest {
             String modifiedQuery = entry.getKey();
             int[] positions = entry.getValue();
 
-            // PostgreSQL splits on ';' - cursor in "begin transaction" returns just that statement
-            context = createParserContext(setDialect(POSTGRESQL_DIALECT_NAME), modifiedQuery);
-            for (int pos : positions) {
-                element = SQLScriptParser.parseQuery(
-                    context, 0, modifiedQuery.length(), pos, false, false
-                );
-                assertEquals("begin transaction", element.getText());
-            }
-
-            // SQL Server does not split on ';' - the whole batch is one query
-            context = createParserContext(setDialect(SQLSERVER_DIALECT_NAME), modifiedQuery);
-            for (int pos : positions) {
-                element = SQLScriptParser.parseQuery(
-                    context, 0, modifiedQuery.length(), pos, false, false
-                );
-                assertEquals(modifiedQuery.trim(), element.getText().trim());
+            for (String dialect : dialects) {
+                context = createParserContext(setDialect(dialect), modifiedQuery);
+                for (int pos : positions) {
+                    element = SQLScriptParser.parseQuery(
+                        context, 0, modifiedQuery.length(), pos, false, false
+                    );
+                    assertEquals("begin transaction", element.getText());
+                }
             }
         }
     }
@@ -715,31 +704,43 @@ public class SQLScriptParserTest extends DBeaverUnitTest {
     /**
      * Issue 40922 - SQL Server variable declarations must stay in the same batch.
      * Splitting on ';' causes "Must declare the scalar variable" errors.
+     * In script mode (ALT+X), ';'-separated statements are merged into a single
+     * execution batch; only GO creates a new batch.
      */
     @Test
     public void parseSqlServerVariableDeclarationBatch() throws DBException {
-        // Single batch with DECLARE + SELECT - must NOT be split on ';'
         String singleBatch = "DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;";
+
+        // Script mode (ALT+X): statements merged into one batch
         SQLParserContext ctx = createParserContext(setDialect(SQLSERVER_DIALECT_NAME), singleBatch);
         List<SQLScriptElement> elements = SQLScriptParser.extractScriptQueries(
-            ctx, 0, ctx.getDocument().getLength(), false, false, false
+            ctx, 0, ctx.getDocument().getLength(), true, false, false
         );
         assertEquals(1, elements.size());
-        assertEquals(singleBatch, elements.get(0).getText().trim());
+        assertEquals(singleBatch, elements.get(0).getText());
 
-        // Two batches separated by GO - must be split into two elements
-        assertParse(
-            SQLSERVER_DIALECT_NAME,
-            "DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;\nGO\nSELECT 1;",
-            new String[]{"DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;\n", "SELECT 1;"}
+        // Editor mode (folding): still splits on ';' for proper folding
+        elements = SQLScriptParser.extractScriptQueries(
+            ctx, 0, ctx.getDocument().getLength(), false, false, false
         );
+        assertEquals(2, elements.size());
 
-        // PostgreSQL should still split on ';' as before
-        assertParse(
-            POSTGRESQL_DIALECT_NAME,
-            "DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;",
-            new String[]{"DECLARE @month DATETIME = '2026-03-01'", "SELECT @month"}
+        // Script mode: GO separates into two execution batches
+        String twoBatches = "DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;\nGO\nSELECT 1;";
+        ctx = createParserContext(setDialect(SQLSERVER_DIALECT_NAME), twoBatches);
+        elements = SQLScriptParser.extractScriptQueries(
+            ctx, 0, ctx.getDocument().getLength(), true, false, false
         );
+        assertEquals(2, elements.size());
+        assertEquals("DECLARE @month DATETIME = '2026-03-01';\nSELECT @month;", elements.get(0).getText().trim());
+        assertEquals("SELECT 1;", elements.get(1).getText().trim());
+
+        // PostgreSQL still splits on ';' even in script mode
+        ctx = createParserContext(setDialect(POSTGRESQL_DIALECT_NAME), singleBatch);
+        elements = SQLScriptParser.extractScriptQueries(
+            ctx, 0, ctx.getDocument().getLength(), true, false, false
+        );
+        assertEquals(2, elements.size());
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #40922 

Spliting scripts on `;`, sending each statement as a separate JDBC call. This breaks T-SQL batch semantics and variables declared with `DECLARE` are only visible within the same batch.

SQL Server use `GO` as the batch delimiter, not `;`. Semicolons are statement terminators within a batch, not batch separators.

## Changes

- Add `SQLDialect.usesOnlyNativeScriptDelimiters()` - lets dialects opt out of the preference-based default `;` delimiter
- Override it in `SQLServerDialectBase` to return `true`, and change `getScriptDelimiters()` to return only `GO`
- Guard the extra-delimiter logic in `SQLSyntaxManager.init()` with the new flag
- Update existing tests and add a regression test for the scenario from the issue

## Tests

- [x] `parseSqlServerVariableDeclarationBatch` - `DECLARE @x; SELECT @x;` stays as one batch
- [x] `parseSqlServerVariableDeclarationBatch` - `GO` still splits into separate batches
- [x] `parseSqlServerVariableDeclarationBatch` - PostgreSQL still splits on `;`
- [x] `parseBeginTransaction` - updated for new SQL Server behavior
- [x] `parseFromCursorPositionBeginTransaction` - updated for new SQL Server behavior
