### PR TITLE
#40914 Support {{name}} SQL script parameters

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQueryParameter.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/sql/SQLQueryParameter.java
@@ -27,8 +27,14 @@ public class SQLQueryParameter {
 
     public static final String VARIABLE_NAME_GROUP_NAME = "pn";
 
-    private static final Pattern VARIABLE_PATTERN_SIMPLE = Pattern.compile("\\$\\{(?<pn>[a-z0-9_.\"]+)\\}", Pattern.CASE_INSENSITIVE);
-    private static final Pattern VARIABLE_PATTERN_FULL = Pattern.compile("\\$P?!?\\{(?<pn>[a-z0-9_.\"]+)\\}", Pattern.CASE_INSENSITIVE);
+    private static final Pattern VARIABLE_PATTERN_SIMPLE = Pattern.compile(
+        "(?:\\$\\{|\\{\\{)(?<pn>[a-z0-9_.\"]+)(?:\\}|\\}\\})",
+        Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern VARIABLE_PATTERN_FULL = Pattern.compile(
+        "(?:\\$P?!?\\{|\\$\\{|\\{\\{)(?<pn>[a-z0-9_.\"]+)(?:\\}|\\}\\})",
+        Pattern.CASE_INSENSITIVE
+    );
     //private static final Pattern VARIABLE_PATTERN_QUOTED = Pattern.compile("\\$\\{(?<pn>\"[a-z0-9_.]+)\"\\}}", Pattern.CASE_INSENSITIVE);
 
 
@@ -141,6 +147,9 @@ public class SQLQueryParameter {
         }
         if (pattern.startsWith("${") && pattern.endsWith("}")) {
             return pattern.substring(2, pattern.length() - 1);
+        }
+        if (pattern.startsWith("{{") && pattern.endsWith("}}")) {
+            return pattern.substring(2, pattern.length() - 2);
         }
 
         return pattern;

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserGenericsTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserGenericsTest.java
@@ -351,6 +351,21 @@ public class SQLScriptParserGenericsTest extends DBeaverUnitTest {
     }
 
     @Test
+    public void parseDoubleCurlyVariables() throws DBException {
+        List<String> inputParamNames = List.of("term", "school", "AbC");
+        StringJoiner joiner = new StringJoiner(", ", "select ", " from dual");
+        inputParamNames.stream().forEach(p -> joiner.add("{{" + p + "}}"));
+        String query = joiner.toString();
+        SQLParserContext context = createParserContext(setDialect("snowflake"), query);
+        List<SQLQueryParameter> params = SQLScriptParser.parseParametersAndVariables(context, 0, query.length());
+        List<String> actualParamNames = new ArrayList<String>();
+        for (SQLQueryParameter sqlQueryParameter : params) {
+            actualParamNames.add(sqlQueryParameter.getName());
+        }
+        Assert.assertEquals(List.of("term", "school", "AbC"), actualParamNames);
+    }
+
+    @Test
     public void parseParameterFromSetCommand() throws DBException {
         List<String> varNames = List.of("aBc", "\"aBc\"", "\"a@c=\"");
         ArrayList<String> expectedCommandsText = new ArrayList<>();


### PR DESCRIPTION
Closes #40914

## Summary
- add `{{name}}` support to SQL variable detection patterns
- extend variable stripping logic to normalize `{{name}}` to `name`
- add parser test coverage for double-curly variables

## Test plan
- [x] Add unit test for parsing `{{term}}` style variables
- [x] Ensure existing `${name}` and `$P{name}` patterns still parse
- [ ] Run full SQL parser test suite in CI

Made with [Cursor](https://cursor.com)