### PR TITLE
#40920 Preserve newly-created object in navigator on parent-node refresh

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNDatabaseNode.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNDatabaseNode.java
@@ -764,6 +764,14 @@ public abstract class DBNDatabaseNode extends DBNNode implements DBNLazyNode, DB
                     // Wrong type
                     continue;
                 }
+                if (isNonPersistedChild(oldChild)) {
+                    // Preserve newly-created (non-persisted) child across refresh.
+                    // Its underlying DBSObject isn't visible to the database query yet,
+                    // so the matching loop above can't find it. Disposing it would close
+                    // the in-progress entity editor and lose the user's work (#40920).
+                    toList.add(oldChild);
+                    continue;
+                }
                 boolean found = false;
                 for (Object childItem : itemList) {
                     if (childItem instanceof DBSObject && equalObjects(oldChild.getObject(), (DBSObject) childItem)) {
@@ -778,6 +786,13 @@ public abstract class DBNDatabaseNode extends DBNNode implements DBNLazyNode, DB
             }
         }
         return true;
+    }
+
+    // Preserve in-progress (non-persisted) children across a parent-node refresh: the
+    // database query can't see them yet, but the user's open editor depends on them.
+    private static boolean isNonPersistedChild(@NotNull DBNDatabaseNode child) {
+        DBSObject object = child.getObject();
+        return object != null && !object.isPersisted();
     }
 
     @Nullable


### PR DESCRIPTION
Closes #40920

### Problem

When the user starts creating a new object (table, sequence, FK, index, etc.)
and then refreshes a parent tree node before saving, the navigator drops the in-progress object and the entity editor closes — losing the user's edits.

The new object is wrapped in a `DBNDatabaseItem` whose underlying `DBSObject`  returns `isPersisted() == false`. On refresh, `DBNDatabaseNode.loadTreeItems()` re-queries the children from the database, which can't see the unpersisted
object yet. The matching loop fails to pair it with anything in the fresh result set, so the cleanup loop calls `DBNUtils.disposeNode(...)` on it. That fires a removal event, which closes any editor whose input was that node.

There is already a precedent guard against this in `NavigatorHandlerRefresh.execute()`: when the user explicitly refreshes the editor's own node, it short-circuits with "Do not refresh non-persistent objects". The same principle was missing one level deeper, in the parent-node cleanup path.

### Fix

In `DBNDatabaseNode.loadTreeItems()`, before disposing an old child that isn't present in the freshly-fetched item list, check whether its underlying `DBSObject` is non-persisted. If so, preserve it in the new child list. The cross-cutting check is extracted into a small `isNonPersistedChild` helper for readability and to mirror the surrounding `equalObjects` helper style.

### Verification

Manual repro on a generic JDBC connection (steps from the issue):

1. Right-click a schema → Create New Table → entity editor opens for the new   non-persisted table.
2. Right-click the parent schema → Refresh.

- **Before this change:** editor closes, new object disappears from the tree.
- **After this change:** editor stays open, new object remains in the tree.
  Saving then refreshing then continues to work correctly (no duplicate node);
  closing the editor without saving correctly removes the unpersisted node.

Same result for sequence/index/FK creation, which all flow through the same `loadTreeItems` cleanup path.
