### PR TITLE
#41021 Group multi-object delete commands into a single undo batch

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/edit/DBECommandContext.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/edit/DBECommandContext.java
@@ -69,6 +69,13 @@ public interface DBECommandContext extends DBPContextProvider {
 
     //void addCommandBatch(List<DBECommand> commands, DBECommandReflector reflector, boolean execute);
 
+    default int getCommandCount() {
+        return 0;
+    }
+
+    default void linkLastCommands(int count) {
+    }
+
     void removeCommand(@NotNull DBECommand<?> command);
 
     void updateCommand(@NotNull DBECommand<?> command, @Nullable DBECommandReflector commandReflector);

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/edit/AbstractCommandContext.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/edit/AbstractCommandContext.java
@@ -333,6 +333,29 @@ public abstract class AbstractCommandContext implements DBECommandContext {
         }
     }
 
+    @Override
+    public int getCommandCount() {
+        synchronized (commands) {
+            return commands.size();
+        }
+    }
+
+    @Override
+    public void linkLastCommands(int count) {
+        if (count < 2) {
+            return;
+        }
+        synchronized (commands) {
+            int size = commands.size();
+            if (size < count) {
+                return;
+            }
+            for (int i = size - 1; i > size - count; i--) {
+                commands.get(i).linkedCommand = commands.get(i - 1);
+            }
+        }
+    }
+
     @NotNull
     @Override
     public Collection<? extends DBECommand<?>> getUndoCommands()

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/edit/AbstractObjectManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/edit/AbstractObjectManager.java
@@ -49,10 +49,22 @@ public abstract class AbstractObjectManager<OBJECT_TYPE extends DBSObject> imple
         }
         protected void cacheModelObject(OBJECT_TYPE object)
         {
+            cacheModelObject(object, -1);
+        }
+        protected void cacheModelObject(OBJECT_TYPE object, int index)
+        {
             DBSObjectCache<? extends DBSObject, OBJECT_TYPE> cache = objectMaker.getObjectsCache(object);
             if (cache != null) {
-                cache.cacheObject(object);
+                cache.cacheObject(object, index);
             }
+        }
+        protected int getModelObjectIndex(OBJECT_TYPE object)
+        {
+            DBSObjectCache<? extends DBSObject, OBJECT_TYPE> cache = objectMaker.getObjectsCache(object);
+            if (cache != null) {
+                return cache.getCachedObjects().indexOf(object);
+            }
+            return -1;
         }
         protected void removeModelObject(OBJECT_TYPE object)
         {
@@ -89,6 +101,8 @@ public abstract class AbstractObjectManager<OBJECT_TYPE extends DBSObject> imple
     }
 
     public static class DeleteObjectReflector<OBJECT_TYPE extends DBSObject> extends AbstractObjectReflector<OBJECT_TYPE> {
+        private int savedIndex = -1;
+
         public DeleteObjectReflector(DBEObjectMaker<OBJECT_TYPE, ? extends DBSObject> objectMaker)
         {
             super(objectMaker);
@@ -97,6 +111,7 @@ public abstract class AbstractObjectManager<OBJECT_TYPE extends DBSObject> imple
         @Override
         public void redoCommand(@NotNull DBECommand<OBJECT_TYPE> command)
         {
+            savedIndex = getModelObjectIndex(command.getObject());
             DBUtils.fireObjectRemove(command.getObject());
             removeModelObject(command.getObject());
         }
@@ -104,7 +119,7 @@ public abstract class AbstractObjectManager<OBJECT_TYPE extends DBSObject> imple
         @Override
         public void undoCommand(@NotNull DBECommand<OBJECT_TYPE> command)
         {
-            cacheModelObject(command.getObject());
+            cacheModelObject(command.getObject(), savedIndex);
             Map<String, Object> options = null;
             if (command instanceof DBECommandWithOptions) {
                 options = ((DBECommandWithOptions) command).getOptions();

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/cache/AbstractObjectCache.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/cache/AbstractObjectCache.java
@@ -102,12 +102,21 @@ public abstract class AbstractObjectCache<OWNER extends DBSObject, OBJECT extend
 
     @Override
     public void cacheObject(@NotNull OBJECT object) {
+        cacheObject(object, -1);
+    }
+
+    @Override
+    public void cacheObject(@NotNull OBJECT object, int index) {
         synchronized (cacheSync) {
             if (this.objectList == null) {
                 this.objectList = new ArrayList<>();
             }
             detectCaseSensitivity(object);
-            this.objectList.add(object);
+            if (index < 0 || index >= this.objectList.size()) {
+                this.objectList.add(object);
+            } else {
+                this.objectList.add(index, object);
+            }
             if (this.objectMap != null) {
                 String name = getObjectName(object);
                 if (checkDuplicateName(name, object)) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/cache/DBSObjectCache.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/struct/cache/DBSObjectCache.java
@@ -56,6 +56,10 @@ public interface DBSObjectCache<OWNER extends DBSObject, OBJECT extends DBSObjec
      */
     void cacheObject(@NotNull OBJECT object);
 
+    default void cacheObject(@NotNull OBJECT object, int index) {
+        cacheObject(object);
+    }
+
     /**
      * Sets new cache contents. setCache(getCachedObjects()) will reset named cache.
      * Set fullyCache flag to true.

--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorObjectsDeleter.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorObjectsDeleter.java
@@ -83,6 +83,8 @@ public class NavigatorObjectsDeleter {
     private final Set<Option> enabledOptions = new HashSet<>();
     private boolean deleteWarningShowed;
 
+    private final Map<DBECommandContext, Integer> batchStartCommandCounts = new IdentityHashMap<>();
+
     private NavigatorObjectsDeleter(IWorkbenchWindow window, List<?> selection, boolean selectedFromNavigator, boolean supportsShowViewScript,
                                     boolean supportsDeleteContents, Set<Option> supportedOptions) {
         this.window = window;
@@ -169,7 +171,7 @@ public class NavigatorObjectsDeleter {
             UIUtils.runInProgressService(dbrMonitor -> {
                 dbrMonitor.beginTask("Delete objects", selection.size());
                 try {
-                    for (Object obj: selection) {
+                    for (Object obj : selection) {
                         if (dbrMonitor.isCanceled()) {
                             break;
                         }
@@ -268,10 +270,19 @@ public class NavigatorObjectsDeleter {
                 // and execute command within it
             }
             Map<String, Object> deleteOptions = collectObjectMakerOptionsMap(object, objectMaker);
-            objectMaker.deleteObject(commandTarget.getContext(), node.getObject(), deleteOptions);
-            if (commandTarget.getEditor() == null && commandTarget.getContext() != null) {
+            DBECommandContext deleteContext = commandTarget.getContext();
+            Integer batchStart = (deleteContext == null) ? null
+                : batchStartCommandCounts.computeIfAbsent(deleteContext, DBECommandContext::getCommandCount);
+            objectMaker.deleteObject(deleteContext, node.getObject(), deleteOptions);
+            if (batchStart != null) {
+                int chainSize = deleteContext.getCommandCount() - batchStart;
+                if (chainSize > 1) {
+                    deleteContext.linkLastCommands(chainSize);
+                }
+            }
+            if (commandTarget.getEditor() == null && deleteContext != null) {
                 // Persist object deletion - only if there is no host editor and we have a command context
-                final NavigatorHandlerObjectBase.ObjectSaver deleter = new NavigatorHandlerObjectBase.ObjectSaver(commandTarget.getContext(), deleteOptions);
+                final NavigatorHandlerObjectBase.ObjectSaver deleter = new NavigatorHandlerObjectBase.ObjectSaver(deleteContext, deleteOptions);
                 tasksToExecute.add(deleter);
             }
             if (commandTarget.getEditor() != null && selectedFromNavigator && !deleteWarningShowed) {


### PR DESCRIPTION
## Summary

When the user selects several objects in the database navigator and presses Delete (for example 10 columns at once on a table), each object delete becomes its own undo entry. As a result, restoring all of them requires pressing Ctrl+Z N times instead of a single Ctrl+Z, even though the user issued the deletion as a single action.

This change groups every command queued during one navigator multi-delete into a single undo batch, so one Ctrl+Z restores the whole selection at once. The framework already supports batched undo through `CommandInfo.linkedCommand`, but `NavigatorObjectsDeleter` was not threading the link between successive deletes.

## What changed

- `org.jkiss.dbeaver.model/.../DBECommandContext.java`: two new default-no-op interface methods, `getCommandCount()` and `linkLastCommands(int count)`. Default implementations keep all existing implementers (e.g. `SimpleCommandContext`, `TestCommandContext`) compiling without changes.
- `org.jkiss.dbeaver.model/.../impl/edit/AbstractCommandContext.java`: real implementations. `getCommandCount` returns the size of the internal command list. `linkLastCommands(N)` chains `commands[size-N..size-1]` together via `linkedCommand`, which is what the existing `undoCommand()` walks during a batch undo.
- `org.jkiss.dbeaver.ui.navigator/.../actions/NavigatorObjectsDeleter.java`: track per-context starting count in an `IdentityHashMap`, snapshot it the first time a context is touched, then after each `objectMaker.deleteObject(...)` call `linkLastCommands(diff)` on that context. The chain grows monotonically, idempotent re-applies of earlier links are harmless.

## Test plan

1. Open or create any database connection with editable tables (SQLite is fine, no server required).
2. In a SQL editor: `CREATE TABLE foo (a INT, b INT, c INT, d INT, e INT, f INT, g INT, h INT, i INT, j INT);` and refresh the navigator.
3. Expand `foo` -> Columns. Multi-select 10 columns (Ctrl+click).
4. Right-click -> Delete -> confirm.
5. The columns are now marked for deletion. Press Ctrl+Z.

   Before this PR: only one column is restored. You must press Ctrl+Z 10 times to restore everything.

   After this PR: a single Ctrl+Z restores all 10 columns.

6. Press Ctrl+Y once after step 5 -> all 10 deletions are re-applied as a batch (existing redo logic also walks the `linkedCommand` chain).
7. Sanity check on a single delete: delete one column on its own, Ctrl+Z restores it. No regression.
8. Cross-context safety: select objects from two different connections in the navigator, multi-delete them. Each context is linked independently via the per-context `IdentityHashMap`; undo on one connection's editor is independent.

## Notes

- No `Closes #...` link yet -- I'll report this as a fresh issue and link it once the PR title is right. Happy to amend the PR description with the issue number once filed.
- `DBECommandContext` is implemented by a small number of classes. Default no-op implementations on the new methods mean only the `AbstractCommandContext` path actually batches; alternate implementations stay unchanged.
- The bug is observable in any database (PostgreSQL, MySQL, etc.) since the fix is at the navigator/framework layer, not in any DB-specific manager.


Closes #41021 