### PR TITLE
dbeaver/dbeaver#40987 temporary use java.security from DBeaver version 26.0.3 (corresponds to Java 21.0.8)

### DIFF
--- a/plugins/org.jkiss.dbeaver.launcher/src/org/jkiss/dbeaver/launcher/DBeaverLauncher.java
+++ b/plugins/org.jkiss.dbeaver.launcher/src/org/jkiss/dbeaver/launcher/DBeaverLauncher.java
@@ -398,7 +398,7 @@ public class DBeaverLauncher {
      */
     private static void patchJavaSecurity(String[] args) {
         // We need a way to disable this using a Java property just in case
-        if (!Boolean.parseBoolean(System.getProperty("dbeaver.security.enableLegacyAlgorithms", "true"))) {
+        if (!Boolean.parseBoolean(System.getProperty("dbeaver.security.enableLegacyAlgorithms", "false"))) {
             return;
         }
         // Let's detect a desktop DBeaver or dbvr using their product ID


### PR DESCRIPTION
Closes dbeaver/dbeaver#40987.