### PR TITLE
#40779 Fix Oracle ORA-00911 on CREATE VIEW with trailing CASE...END

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParser.java
@@ -133,6 +133,7 @@ public class SQLScriptParser {
         int lastTokenLineFeeds = 0;
         SQLTokenType prevNotEmptyTokenType = SQLTokenType.T_UNKNOWN;
         String firstKeyword = null, lastKeyword = null;
+        boolean endClosedCaseBlock = false;
         for (; ; ) {
             TPToken token = ruleScanner.nextToken();
             int tokenOffset = ruleScanner.getTokenOffset();
@@ -228,12 +229,19 @@ public class SQLScriptParser {
                         }
                     }
                     curBlock = new ScriptBlockInfo(curBlock, false);
+                    curBlock.beginToken = document.get(tokenOffset, tokenLength);
                     hasBlocks = true;
                 } else if (tokenType == SQLTokenType.T_BLOCK_END) {
                     if (curBlock != null) {
                         if (curBlock.togglePattern != null) {
                             log.trace("SQLScriptParser: blocks structure recognition inconsistency - trying to leave toggled block on non-togging token");
                         } else {
+                            // CASE...END is an expression, not a control block. Don't let
+                            // its END be treated as a statement-block terminator that
+                            // forces appending the trailing delimiter (issue 40779).
+                            if (SQLConstants.KEYWORD_CASE.equalsIgnoreCase(curBlock.beginToken)) {
+                                endClosedCaseBlock = true;
+                            }
                             curBlock = curBlock.parent;
                         }
                     }
@@ -255,8 +263,15 @@ public class SQLScriptParser {
 
                 if (tokenLength > 0 && !token.isWhitespace()) {
                     switch (tokenType) {
-                        case T_BLOCK_BEGIN:
                         case T_BLOCK_END:
+                            if (endClosedCaseBlock) {
+                                // Skip lastKeyword overwrite — END here closed a CASE
+                                // expression, not a real block, so it must not influence
+                                // the block-end-based delimiter retention logic.
+                                break;
+                            }
+                            // fall through
+                        case T_BLOCK_BEGIN:
                         case T_BLOCK_TOGGLE:
                         case T_BLOCK_HEADER:
                         case T_KEYWORD:
@@ -268,6 +283,7 @@ public class SQLScriptParser {
                             break;
                     }
                 }
+                endClosedCaseBlock = false;
 
                 if (isPredicateEvaluationEnabled && !token.isEOF() && newTokenCaptured) {
                     newTokenCaptured = false;
@@ -1125,6 +1141,7 @@ public class SQLScriptParser {
         final String togglePattern;
         boolean isHeader; // block started by DECLARE, FUNCTION, etc
         boolean isPredicateHeaderBlock;
+        String beginToken;
 
         ScriptBlockInfo(ScriptBlockInfo parent, boolean isHeader) {
             this.parent = parent;

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/parser/SQLScriptParserTest.java
@@ -532,6 +532,35 @@ public class SQLScriptParserTest extends DBeaverUnitTest {
         assertParse(ORACLE_DIALECT_NAME, statements);
     }
 
+    /**
+     * Issue 40779.
+     * CREATE VIEW with trailing CASE...END must not retain the
+     * statement delimiter — Oracle JDBC rejects ';' with ORA-00911.
+     */
+    @Test
+    public void parseOracleCreateViewWithCaseEnd() throws DBException {
+        String query =
+            "CREATE OR REPLACE view VM_TEST as(\n" +
+            "\tSELECT C,Q\n" +
+            "\tFROM (\n" +
+            "\t\tSELECT 1 AS C,0 AS Q FROM dual\n" +
+            "\t) A WHERE CASE WHEN C = 1 THEN Q ELSE 1 END <> 0\n" +
+            ");";
+        SQLParserContext context = createParserContext(setDialect(ORACLE_DIALECT_NAME), query);
+        // scriptMode=true matches editor behaviour (Execute SQL Script).
+        List<SQLScriptElement> elements = SQLScriptParser.extractScriptQueries(
+            context, 0, context.getDocument().getLength(), true, false, false);
+        String text = elements.get(0).getText();
+        assertEquals(
+            "CREATE OR REPLACE view VM_TEST as(\n" +
+            "\tSELECT C,Q\n" +
+            "\tFROM (\n" +
+            "\t\tSELECT 1 AS C,0 AS Q FROM dual\n" +
+            "\t) A WHERE CASE WHEN C = 1 THEN Q ELSE 1 END <> 0\n" +
+            ")",
+            text);
+    }
+
     @Test
     public void parseCurrentControlCommandsCursorHead() throws DBException {
         String query = """


### PR DESCRIPTION
## Summary

Fixes #40779 — Oracle returns `ORA-00911: invalid character` when running `CREATE OR REPLACE VIEW` whose body ends with a `CASE ... END` expression.

## Root cause

`SQLScriptParser.parseQueryImpl` tokenizes the bare `END` of a `CASE` expression as `T_BLOCK_END`, identical to the `END` that closes a real PL/SQL block. The token's text overwrites `lastKeyword` to `"END"`. When the trailing `;` is reached, `needsDelimiterAfterBlock("CREATE", "END", oracle)` returns `true` because:

- Oracle dialect has `isDelimiterAfterBlock() == true`
- `lastKeyword == "END"`
- `firstKeyword == "CREATE"` — present in `getDDLKeywords()`

The delimiter is therefore re-appended to the extracted query text. Oracle JDBC rejects the trailing `;` with `ORA-00911`.

## Fix

Track the opening token of every block in `ScriptBlockInfo.beginToken`. When a `T_BLOCK_END` pops a block whose `beginToken` is `CASE`, set a local flag and skip the `lastKeyword = "END"` overwrite. The block-end delimiter retention path then only fires for genuine PL/SQL blocks (`BEGIN`, `LOOP`, `IF`, ...), which is the intended behaviour.

`CASE` statement form (`END CASE`) inside `BEGIN..END` is unaffected — the outer `BEGIN..END` still terminates with a normal `END` token and triggers delimiter retention as before.

## Reproduction

```sql
CREATE OR REPLACE VIEW VM_TEST AS (
  SELECT C, Q
  FROM (SELECT 1 AS C, 0 AS Q FROM dual) A
  WHERE CASE WHEN C = 1 THEN Q ELSE 1 END <> 0
);
