### PR TITLE
dbeaver/dbeaver#40759 Fix UI freeze on multi-object delete

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorObjectsDeleter.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/actions/NavigatorObjectsDeleter.java
@@ -275,13 +275,13 @@ public class NavigatorObjectsDeleter {
                 tasksToExecute.add(deleter);
             }
             if (commandTarget.getEditor() != null && selectedFromNavigator && !deleteWarningShowed) {
+                deleteWarningShowed = true;
                 UIUtils.getActiveWorkbenchWindow().getActivePage().activate(commandTarget.getEditor());
                 DBWorkbench.getPlatformUI().showMessageBox(
                     UINavigatorMessages.actions_navigator_persist_delete_in_the_editor_title,
                     NLS.bind(UINavigatorMessages.actions_navigator_persist_delete_in_the_editor_message, commandTarget.getEditor().getTitle()),
                     false
                 );
-                deleteWarningShowed = true;
             }
         } catch (Throwable e) {
             DBWorkbench.getPlatformUI().showError(


### PR DESCRIPTION
Closes #40759

## Summary

When deleting multiple objects (e.g. 5+ table columns at once on MariaDB), the UI froze because N "Change is not persisted" warning dialogs were spawned — one per selected object — and the underlying error from MariaDB rejecting the drop-all-columns statement ended up hidden behind them.

Reproduce video and full bug report are in the linked issue: #40759

## Root cause

In `NavigatorObjectsDeleter.deleteDatabaseNode()`, the guard flag `deleteWarningShowed` was set **after** `showMessageBox()` returned. SWT modal dialogs keep pumping events while open, so each pending `asyncExec` delete saw the flag still unset and opened its own dialog — stacking N dialogs and freezing the UI.

## Fix

Move the `deleteWarningShowed = true` assignment to **before** the dialog call so the next queued delete sees the flag already set and skips the warning. Only one dialog now appears regardless of selection size.

## Test plan

- [x] Create a table with 5+ columns on MariaDB, persist
- [x] Reopen, select all columns, Delete → only one warning dialog, UI responsive
- [x] Verify single-object delete still shows the warning once
