### PR TITLE
#40732 Fix exasol union all/order by in sql views query

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolViewCache.java
+++ b/plugins/org.jkiss.dbeaver.ext.exasol/src/org/jkiss/dbeaver/ext/exasol/model/cache/ExasolViewCache.java
@@ -124,7 +124,7 @@ public class ExasolViewCache extends JDBCStructCache<ExasolSchema, ExasolView, E
 			"WHERE table_schem = '%s' ";
 
 	private static final String SQL_VIEWS = "/*snapshot execution*/ select OWNER,OBJECT_ID,TABLE_CAT,TABLE_SCHEM,TABLE_NAME as COLUMN_TABLE,TABLE_TYPE,REMARKS,TYPE_CAT,TYPE_SCHEM,TYPE_NAME,SELF_REFERENCING_COL_NAME,REF_GENERATION from \"$ODBCJDBC\".ALL_TABLES WHERE TABLE_SCHEM = '%s' and TABLE_TYPE = 'VIEW' " +
-            " union all select 'SYS',-1,' ',SCHEMA_name, object_name as column_table, object_type,object_comment,null, null,null,null,null from EXA_SYSCAT where SCHEMA_NAME = '%s' order by TABLE_NAME";
+            " union all select 'SYS',-1,' ',SCHEMA_name, object_name as column_table, object_type,object_comment,null, null,null,null,null from EXA_SYSCAT where SCHEMA_NAME = '%s' order by COLUMN_TABLE";
 
     public ExasolViewCache() {
         super("COLUMN_TABLE");


### PR DESCRIPTION
Closes #40732 

  - Replace `ORDER BY TABLE_NAME` with `ORDER BY COLUMN_TABLE` in the views metadata query.                                                                       
  - In the `UNION ALL`, `ORDER BY` applies to the whole union and must reference an output column. `TABLE_NAME` was only valid due to a legacy Exasol behavior that no longer works on 2025.2.x / 2026.1.0. 