### PR TITLE
#40753 Fix silent hex data truncation in BinaryFormatterHexString.toBytes

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/BinaryFormatterHexString.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/data/formatters/BinaryFormatterHexString.java
@@ -54,8 +54,8 @@ public class BinaryFormatterHexString extends BinaryFormatterHex {
     @Override
     public byte[] toBytes(@NotNull String string)
     {
-        if (string.startsWith(HEX_PREFIX) || string.endsWith(HEX_POSTFIX)) {
-            string = string.substring(HEX_PREFIX.length(), string.length() - HEX_PREFIX.length() - HEX_POSTFIX.length());
+        if (string.startsWith(HEX_PREFIX) && string.endsWith(HEX_POSTFIX)) {
+            string = string.substring(HEX_PREFIX.length(), string.length() - HEX_POSTFIX.length());
         }
         return super.toBytes(string);
     }


### PR DESCRIPTION
## Summary

`BinaryFormatterHexString.toBytes` strips the `x'…'` wrappers from a hex literal but had two bugs that combined to silently truncate valid input. For the reporter's `x'1234ABCD'` example the parser dropped the trailing `CD` and returned `1234AB` with no error.

## Fix

Two small changes on the same two lines (`plugins/org.jkiss.dbeaver.model/.../BinaryFormatterHexString.java:57-58`):

1. **Use `&&` instead of `||` in the strip guard.** The branch only makes sense when both the prefix and the suffix are present. With `||`, a string with only the prefix or only the suffix entered the strip branch and produced corrupted (or shorter) output instead of being passed through unchanged for the parent class to reject.
2. **Drop the spurious `HEX_PREFIX.length()` from the substring's end index.** The prefix is at the *front*, so subtracting its length from the end is wrong by exactly that many characters. Removing it makes the substring end at `string.length() - HEX_POSTFIX.length()`, which is the position of the closing `'`.

The fix keeps the diff minimal — two operator/argument changes on lines 57-58, no new control flow, no helper extraction.

```java
// before
if (string.startsWith(HEX_PREFIX) || string.endsWith(HEX_POSTFIX)) {
    string = string.substring(HEX_PREFIX.length(), string.length() - HEX_PREFIX.length() - HEX_POSTFIX.length());
}

// after
if (string.startsWith(HEX_PREFIX) && string.endsWith(HEX_POSTFIX)) {
    string = string.substring(HEX_PREFIX.length(), string.length() - HEX_POSTFIX.length());
}
```

## Reproduction

Following the reporter's example:

| Input | `string.length()` | Old `substring(2, len-2-1)` | New `substring(2, len-1)` |
|---|---|---|---|
| `x'1234ABCD'` | 11 | `substring(2, 8)` → `1234AB` (silent loss of `CD`) | `substring(2, 10)` → `1234ABCD` ✅ |
| `x'1234'` | 7 | `substring(2, 4)` → `12` (silent loss of `34`) | `substring(2, 6)` → `1234` ✅ |
| `x''` | 3 | `substring(2, 0)` → `StringIndexOutOfBoundsException` | `substring(2, 2)` → `""` ✅ |
| `x'1234` (malformed, no closing `'`) | 6 | `substring(2, 3)` → `1` (silent corruption) | guard is false → string falls through unchanged so the parent parser reports the real error ✅ |
| `1234ABCD` (bare hex, no wrappers) | 8 | guard false → unchanged ✅ | guard false → unchanged ✅ |

The sister class `BinaryFormatterHexNative` uses a separate code path (`substring(2)` after a case-insensitive `0x`/`0X` prefix check) and is not affected.
