### PR TITLE
#19226 Localize Switch presentation and DDL-from-ResultSet generator labels in SQL Editor

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/OSGI-INF/l10n/bundle.properties
@@ -112,6 +112,8 @@ command.org.jkiss.dbeaver.ui.editors.sql.show.variables.name=Show SQL variables
 command.org.jkiss.dbeaver.ui.editors.sql.show.variables.description=Show active SQL variables
 command.org.jkiss.dbeaver.ui.editors.sql.toggle.extraPanel.name=Show panels in result tabs
 command.org.jkiss.dbeaver.ui.editors.sql.toggle.extraPanel.description=Show panels in result tabs instead of SQL editor pane
+command.org.jkiss.dbeaver.ui.editors.sql.switch.presentation.name=Switch presentation to
+command.org.jkiss.dbeaver.ui.editors.sql.switch.presentation.description=Switch SQL editor presentation
 command.org.jkiss.dbeaver.ui.editors.sql.multipleResultsPerTab.name= Show multiple results in a single tab
 command.org.jkiss.dbeaver.ui.editors.sql.multipleResultsPerTab.description=Show each result set in a separate tab or on one scrollable tab
 command.org.jkiss.dbeaver.ui.editors.sql.toggle.result.panel.name=Toggle results panel
@@ -270,3 +272,5 @@ scriptEditorPropertyPage.name = SQL Editor behavior
 
 org.jkiss.dbeaver.toolBarConfiguration.sqlEditor.side.top = SQL Editor top toolbar
 org.jkiss.dbeaver.toolBarConfiguration.sqlEditor.side.bottom = SQL Editor bottom toolbar
+
+generator.org.jkiss.dbeaver.ui.editors.sql.ddlByResultSet.description = CREATE table

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
@@ -256,7 +256,7 @@
         <command id="org.jkiss.dbeaver.ui.editors.sql.show.outline" name="%command.org.jkiss.dbeaver.ui.editors.sql.show.outline.name" description="%command.org.jkiss.dbeaver.ui.editors.sql.show.outline.description" categoryId="org.jkiss.dbeaver.core.sql"/>
         <command id="org.jkiss.dbeaver.ui.editors.sql.show.variables" name="%command.org.jkiss.dbeaver.ui.editors.sql.show.variables.name" description="%command.org.jkiss.dbeaver.ui.editors.sql.show.variables.description" categoryId="org.jkiss.dbeaver.core.sql"/>
         <command id="org.jkiss.dbeaver.ui.editors.sql.toggle.extraPanels" name="%command.org.jkiss.dbeaver.ui.editors.sql.toggle.extraPanel.name" description="%command.org.jkiss.dbeaver.ui.editors.sql.toggle.extraPanel.description" categoryId="org.jkiss.dbeaver.core.sql"/>
-        <command id="org.jkiss.dbeaver.ui.editors.sql.switch.presentation" name="Switch presentation to" description="Switch SQL editor presentation" categoryId="org.jkiss.dbeaver.core.sql">
+        <command id="org.jkiss.dbeaver.ui.editors.sql.switch.presentation" name="%command.org.jkiss.dbeaver.ui.editors.sql.switch.presentation.name" description="%command.org.jkiss.dbeaver.ui.editors.sql.switch.presentation.description" categoryId="org.jkiss.dbeaver.core.sql">
             <commandParameter
                     id="presentationId"
                     name="Presentation"
@@ -1610,7 +1610,7 @@
     </extension>
 
     <extension point="org.jkiss.dbeaver.sqlGenerator">
-        <generator id="ddlByResultSet" class="org.jkiss.dbeaver.ui.editors.sql.generator.SQLGeneratorDDLFromResultSet" label="CREATE" description="CREATE table" order="6">
+        <generator id="ddlByResultSet" class="org.jkiss.dbeaver.ui.editors.sql.generator.SQLGeneratorDDLFromResultSet" label="CREATE" description="%generator.org.jkiss.dbeaver.ui.editors.sql.ddlByResultSet.description" order="6">
             <objectType name="org.jkiss.dbeaver.ui.controls.resultset.IResultSetController"/>
         </generator>
     </extension>


### PR DESCRIPTION
## Summary

Fix two SQL Editor command labels that were hard-coded English in
`plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml` instead of being
referenced from the localization bundle, addressing part of #19226.

The previously hard-coded labels are user-visible — they appear in
the Eclipse command palette, in keyboard shortcut preferences, and in
the SQL Generator menu — and so they remained untranslated for every
non-English UI language that the bundle already ships
(`bundle_de.properties`, `bundle_es.properties`, `bundle_fr.properties`,
`bundle_it.properties`, `bundle_ja.properties`, `bundle_ko.properties`,
`bundle_pt_BR.properties`, `bundle_ru.properties`, `bundle_zh.properties`,
etc.).

## Fix

Replace the hard-coded `name`/`description` attribute strings with `%key`
references and add the matching English entries to the source
`OSGI-INF/l10n/bundle.properties`. Translators can then provide locale
overrides through the existing per-language bundles via DBeaver's normal
localization flow ([wiki](https://github.com/dbeaver/dbeaver/wiki/Localization)).

Two affected commands in `plugin.xml`:

```diff
- <command id="org.jkiss.dbeaver.ui.editors.sql.switch.presentation"
-          name="Switch presentation to"
-          description="Switch SQL editor presentation"
+ <command id="org.jkiss.dbeaver.ui.editors.sql.switch.presentation"
+          name="%command.org.jkiss.dbeaver.ui.editors.sql.switch.presentation.name"
+          description="%command.org.jkiss.dbeaver.ui.editors.sql.switch.presentation.description"
           categoryId="org.jkiss.dbeaver.core.sql">

- <generator id="ddlByResultSet"
-            label="CREATE" description="CREATE table" order="6">
+ <generator id="ddlByResultSet"
+            label="CREATE"
+            description="%generator.org.jkiss.dbeaver.ui.editors.sql.ddlByResultSet.description"
+            order="6">
```

Three new entries in `OSGI-INF/l10n/bundle.properties`:

```properties
command.org.jkiss.dbeaver.ui.editors.sql.switch.presentation.name=Switch presentation to
command.org.jkiss.dbeaver.ui.editors.sql.switch.presentation.description=Switch SQL editor presentation

generator.org.jkiss.dbeaver.ui.editors.sql.ddlByResultSet.description=CREATE table
```

The new keys follow the existing `command.org.jkiss.dbeaver.ui.editors.sql...` naming pattern used by every adjacent SQL Editor command in the same bundle.

## Reproduction

1. Switch the DBeaver UI language to any non-English locale that the SQL Editor bundle supports (e.g. German via `bundle_de.properties`).
2. Open `Window` → `Preferences` → `General` → `Keys` and search for `Switch presentation`.
3. Before this PR: the command appears as `Switch presentation to` in English regardless of UI locale.
4. After this PR: the command resolves through the bundle and can be translated per-locale.

The same is observable for the SQL Generator's `CREATE table` description in the right-click `Generate SQL` submenu.

## Closes

Part of #19226.
