### PR TITLE
feat: add MiniMax provider support (default model: M3)

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.model.ai/plugin.xml
@@ -22,6 +22,11 @@
             properties="org.jkiss.dbeaver.model.ai.engine.copilot.CopilotProperties"
             supportsFunctions="false"
             fallbacks="copilot-pro"/>
+        <completionEngine id="minimax"
+            label="MiniMax"
+            class="org.jkiss.dbeaver.model.ai.engine.minimax.MiniMaxEngine"
+            properties="org.jkiss.dbeaver.model.ai.engine.minimax.MiniMaxProperties"
+            supportsFunctions="false"/>
     </extension>
 
     <extension point="com.dbeaver.ai.assistant">

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxConstants.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxConstants.java
@@ -23,7 +23,7 @@ public class MiniMaxConstants {
     public static final String MINIMAX_ENGINE = "minimax"; //$NON-NLS-1$
     public static final String MINIMAX_ENDPOINT = "https://api.minimax.io/v1/"; //$NON-NLS-1$
     public static final String MINIMAX_API_TOKEN = "minimax.token"; //$NON-NLS-1$
-    public static final String DEFAULT_MODEL = "MiniMax-M2.7"; //$NON-NLS-1$
+    public static final String DEFAULT_MODEL = "MiniMax-M3"; //$NON-NLS-1$
     public static final double DEFAULT_TEMPERATURE = 1.0;
 
     private MiniMaxConstants() {

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxConstants.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxConstants.java
@@ -1,0 +1,31 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.engine.minimax;
+
+/**
+ * MiniMax AI engine constants
+ */
+public class MiniMaxConstants {
+    public static final String MINIMAX_ENGINE = "minimax"; //$NON-NLS-1$
+    public static final String MINIMAX_ENDPOINT = "https://api.minimax.io/v1/"; //$NON-NLS-1$
+    public static final String MINIMAX_API_TOKEN = "minimax.token"; //$NON-NLS-1$
+    public static final String DEFAULT_MODEL = "MiniMax-M2.7"; //$NON-NLS-1$
+    public static final double DEFAULT_TEMPERATURE = 1.0;
+
+    private MiniMaxConstants() {
+    }
+}

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxEngine.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxEngine.java
@@ -1,0 +1,105 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.engine.minimax;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.ai.engine.*;
+import org.jkiss.dbeaver.model.ai.engine.openai.OpenAIClient;
+import org.jkiss.dbeaver.model.ai.engine.openai.OpenAIClientLegacy;
+import org.jkiss.dbeaver.model.ai.engine.openai.OpenAIEngine;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * MiniMax AI engine. Uses the OpenAI-compatible chat completions API.
+ */
+public class MiniMaxEngine extends OpenAIEngine<MiniMaxProperties> {
+
+    public MiniMaxEngine(@NotNull MiniMaxProperties properties) {
+        super(properties);
+    }
+
+    @NotNull
+    @Override
+    public List<AIModel> getModels(@NotNull DBRProgressMonitor monitor) throws DBException {
+        return new ArrayList<>(MiniMaxModels.KNOWN_MODELS.values());
+    }
+
+    @Override
+    public int getContextWindowSize(@NotNull DBRProgressMonitor monitor) throws DBException {
+        Integer contextWindowSize = properties.getContextWindowSize();
+        if (contextWindowSize != null) {
+            return contextWindowSize;
+        }
+        // Default context window size for MiniMax models
+        return 204_800;
+    }
+
+    @NotNull
+    @Override
+    protected OpenAIClient createClient() throws DBException {
+        String token = properties.getToken();
+        if (token == null || token.isEmpty()) {
+            throw new DBException("MiniMax API token is not set"); //$NON-NLS-1$
+        }
+        String baseUrl = properties.getBaseUrl();
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            baseUrl = MiniMaxConstants.MINIMAX_ENDPOINT;
+        }
+        // MiniMax uses OpenAI-compatible chat/completions API (legacy format)
+        return OpenAIClientLegacy.createClient(baseUrl, token);
+    }
+
+    @Nullable
+    @Override
+    protected String model() throws DBException {
+        String model = properties.getModel();
+        if (model == null || model.isEmpty()) {
+            return MiniMaxConstants.DEFAULT_MODEL;
+        }
+        return model;
+    }
+
+    @Override
+    protected double temperature() throws DBException {
+        return MiniMaxProperties.clampTemperature(properties.getTemperature());
+    }
+
+    /**
+     * MiniMax uses the legacy chat/completions API which does not support
+     * the OpenAI Responses API streaming format. Fall back to a synchronous
+     * request and emit the result as a single chunk.
+     */
+    @Override
+    public void requestCompletionStream(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull AIEngineRequest request,
+        @NotNull AIEngineResponseConsumer listener
+    ) throws DBException {
+        AIEngineResponse response = requestCompletion(monitor, request);
+        List<String> variants = response.getVariants();
+        if (variants != null && !variants.isEmpty()) {
+            listener.nextChunk(new AIEngineResponseChunk(variants));
+        }
+        listener.usage(response.getUsage());
+        listener.completeBlock();
+    }
+}

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxEngine.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxEngine.java
@@ -49,8 +49,8 @@ public class MiniMaxEngine extends OpenAIEngine<MiniMaxProperties> {
         if (contextWindowSize != null) {
             return contextWindowSize;
         }
-        // Default context window size for MiniMax models
-        return 204_800;
+        // Default context window size for MiniMax models (M3 = 512K)
+        return 512_000;
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxModels.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxModels.java
@@ -1,0 +1,56 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.engine.minimax;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.model.ai.engine.AIModel;
+import org.jkiss.dbeaver.model.ai.engine.AIModelFeature;
+import org.jkiss.dbeaver.model.ai.utils.AIUtils;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Known MiniMax models
+ */
+public final class MiniMaxModels {
+
+    private MiniMaxModels() {
+    }
+
+    public static final Map<String, AIModel> KNOWN_MODELS = AIUtils.modelMap(
+        new AIModel(
+            "MiniMax-M2.7", //$NON-NLS-1$
+            204_800,
+            Set.of(AIModelFeature.CHAT, AIModelFeature.STREAMING),
+            MiniMaxConstants.DEFAULT_TEMPERATURE
+        ),
+        new AIModel(
+            "MiniMax-M2.7-highspeed", //$NON-NLS-1$
+            204_800,
+            Set.of(AIModelFeature.CHAT, AIModelFeature.STREAMING),
+            MiniMaxConstants.DEFAULT_TEMPERATURE
+        )
+    );
+
+    @NotNull
+    public static Optional<AIModel> getModelByName(@Nullable String modelName) {
+        return AIUtils.getModelByName(KNOWN_MODELS, modelName);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxModels.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxModels.java
@@ -36,6 +36,12 @@ public final class MiniMaxModels {
 
     public static final Map<String, AIModel> KNOWN_MODELS = AIUtils.modelMap(
         new AIModel(
+            "MiniMax-M3", //$NON-NLS-1$
+            512_000,
+            Set.of(AIModelFeature.CHAT, AIModelFeature.STREAMING),
+            MiniMaxConstants.DEFAULT_TEMPERATURE
+        ),
+        new AIModel(
             "MiniMax-M2.7", //$NON-NLS-1$
             204_800,
             Set.of(AIModelFeature.CHAT, AIModelFeature.STREAMING),

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxProperties.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxProperties.java
@@ -1,0 +1,185 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.engine.minimax;
+
+import com.google.gson.annotations.SerializedName;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.ai.engine.AIModel;
+import org.jkiss.dbeaver.model.ai.engine.openai.OpenAIBaseProperties;
+import org.jkiss.dbeaver.model.ai.utils.AIUtils;
+import org.jkiss.dbeaver.model.meta.Property;
+import org.jkiss.dbeaver.model.meta.SecureProperty;
+import org.jkiss.dbeaver.model.secret.DBSSecretController;
+import org.jkiss.utils.CommonUtils;
+
+/**
+ * MiniMax engine configuration properties
+ */
+public class MiniMaxProperties implements OpenAIBaseProperties {
+
+    private static final String MINIMAX_BASE_URL = "minimax.base_url"; //$NON-NLS-1$
+    private static final String MINIMAX_TOKEN = "minimax.token"; //$NON-NLS-1$
+    private static final String MINIMAX_MODEL = "minimax.model"; //$NON-NLS-1$
+    private static final String MINIMAX_CONTEXT_WINDOW_SIZE = "minimax.contextWindowSize"; //$NON-NLS-1$
+    private static final String MINIMAX_TEMPERATURE = "minimax.model.temperature"; //$NON-NLS-1$
+    private static final String MINIMAX_LOG_QUERY = "minimax.log.query"; //$NON-NLS-1$
+
+    @Nullable
+    @SerializedName(MINIMAX_BASE_URL)
+    private String baseUrl;
+
+    @Nullable
+    @SecureProperty
+    @SerializedName(MINIMAX_TOKEN)
+    private String token;
+
+    @Nullable
+    @SerializedName(MINIMAX_MODEL)
+    private String model;
+
+    @Nullable
+    @SerializedName(MINIMAX_CONTEXT_WINDOW_SIZE)
+    private Integer contextWindowSize;
+
+    @SerializedName(MINIMAX_TEMPERATURE)
+    private Double temperature;
+
+    @SerializedName(MINIMAX_LOG_QUERY)
+    private Boolean loggingEnabled;
+
+    @NotNull
+    @Override
+    @Property(order = 2, required = true)
+    public String getBaseUrl() {
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            return MiniMaxConstants.MINIMAX_ENDPOINT;
+        }
+        return baseUrl;
+    }
+
+    public void setBaseUrl(@Nullable String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    @Nullable
+    @Override
+    @Property(order = 1, password = true, required = true)
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(@Nullable String token) {
+        this.token = token;
+    }
+
+    @Override
+    public boolean isLegacyApi() {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    @Property(order = 3)
+    public String getModel() {
+        if (model != null && !model.isEmpty()) {
+            return model;
+        }
+        return MiniMaxConstants.DEFAULT_MODEL;
+    }
+
+    public void setModel(@Nullable String model) {
+        this.model = model;
+    }
+
+    @Override
+    @Property(order = 4)
+    public double getTemperature() {
+        if (temperature != null
+            && Double.isFinite(temperature)
+            && temperature != AIUtils.DEFAULT_TEMPERATURE
+        ) {
+            return clampTemperature(temperature);
+        }
+        return MiniMaxConstants.DEFAULT_TEMPERATURE;
+    }
+
+    public void setTemperature(double temperature) {
+        this.temperature = AIUtils.normalizeTemperature(temperature);
+    }
+
+    @Override
+    @Property(order = 5)
+    public boolean isLoggingEnabled() {
+        if (loggingEnabled != null) {
+            return loggingEnabled;
+        }
+        return false;
+    }
+
+    public void setLoggingEnabled(boolean loggingEnabled) {
+        this.loggingEnabled = loggingEnabled;
+    }
+
+    @Nullable
+    @Override
+    @Property(order = 6)
+    public Integer getContextWindowSize() {
+        if (contextWindowSize != null) {
+            return contextWindowSize;
+        }
+        return MiniMaxModels.getModelByName(getModel())
+            .map(AIModel::contextWindowSize)
+            .orElse(null);
+    }
+
+    public void setContextWindowSize(@Nullable Integer contextWindowSize) {
+        this.contextWindowSize = contextWindowSize;
+    }
+
+    @Override
+    public void resolveSecrets() throws DBException {
+        token = AIUtils.getSecretValueOrDefault(
+            MiniMaxConstants.MINIMAX_API_TOKEN, token
+        );
+    }
+
+    @Override
+    public void saveSecrets() throws DBException {
+        if (token != null) {
+            DBSSecretController.getGlobalSecretController()
+                .setPrivateSecretValue(MiniMaxConstants.MINIMAX_API_TOKEN, token);
+        }
+    }
+
+    @Override
+    public boolean isValidConfiguration() {
+        return !CommonUtils.isEmpty(getToken());
+    }
+
+    /**
+     * Clamps temperature to the MiniMax valid range (0.0, 1.0].
+     * MiniMax does not accept temperature = 0.
+     */
+    static double clampTemperature(double temperature) {
+        if (temperature <= 0.0) {
+            return MiniMaxConstants.DEFAULT_TEMPERATURE;
+        }
+        return Math.min(temperature, 1.0);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.ai/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.ai/plugin.xml
@@ -5,6 +5,7 @@
     <extension point="org.jkiss.dbeaver.ui.propertyConfigurator">
         <propertyConfigurator class="org.jkiss.dbeaver.model.ai.engine.openai.OpenAIEngine" uiClass="org.jkiss.dbeaver.ui.ai.engine.openai.OpenAiConfigurator"/>
         <propertyConfigurator class="org.jkiss.dbeaver.model.ai.engine.copilot.CopilotCompletionEngine" uiClass="org.jkiss.dbeaver.ui.ai.engine.copilot.CopilotConfigurator"/>
+        <propertyConfigurator class="org.jkiss.dbeaver.model.ai.engine.minimax.MiniMaxEngine" uiClass="org.jkiss.dbeaver.ui.ai.engine.minimax.MiniMaxConfigurator"/>
     </extension>
 
     <extension point="org.eclipse.core.runtime.preferences">

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/minimax/MiniMaxConfigurator.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/engine/minimax/MiniMaxConfigurator.java
@@ -1,0 +1,255 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.ai.engine.minimax;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Text;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.ai.engine.AIEngineProperties;
+import org.jkiss.dbeaver.model.ai.engine.AIModel;
+import org.jkiss.dbeaver.model.ai.engine.AIModelFeature;
+import org.jkiss.dbeaver.model.ai.engine.minimax.MiniMaxConstants;
+import org.jkiss.dbeaver.model.ai.engine.minimax.MiniMaxModels;
+import org.jkiss.dbeaver.model.ai.engine.minimax.MiniMaxProperties;
+import org.jkiss.dbeaver.model.ai.registry.AIEngineDescriptor;
+import org.jkiss.dbeaver.ui.UIUtils;
+import org.jkiss.dbeaver.ui.ai.internal.AIUIMessages;
+import org.jkiss.dbeaver.ui.ai.model.ContextWindowSizeField;
+import org.jkiss.dbeaver.ui.ai.model.ModelSelectorField;
+import org.jkiss.dbeaver.ui.ai.preferences.AIIObjectPropertyConfigurator;
+import org.jkiss.utils.CommonUtils;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * UI configurator for the MiniMax AI engine
+ */
+public class MiniMaxConfigurator
+    implements AIIObjectPropertyConfigurator<AIEngineDescriptor, MiniMaxProperties> {
+
+    private static final String API_KEY_URL =
+        "https://platform.minimax.io/user-center/basic-information/interface-key"; //$NON-NLS-1$
+
+    private Text tokenText;
+    private Text baseUrlText;
+    private Text temperatureText;
+    private ModelSelectorField modelSelectorField;
+    private ContextWindowSizeField contextWindowSizeField;
+    private Button logQueryCheck;
+
+    private String baseUrl = MiniMaxConstants.MINIMAX_ENDPOINT;
+    private volatile String token = ""; //$NON-NLS-1$
+    private String temperature = "1.0"; //$NON-NLS-1$
+    private boolean logQuery = false;
+
+    @Override
+    public void createControl(
+        @NotNull Composite parent,
+        AIEngineDescriptor object,
+        @NotNull Runnable propertyChangeListener
+    ) {
+        Composite composite = UIUtils.createComposite(parent, 3);
+        composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+        createConnectionParameters(composite);
+        createModelParameters(composite);
+        createBaseUrlParameter(composite);
+        createAdditionalSettings(composite);
+    }
+
+    @Override
+    public void loadSettings(@NotNull MiniMaxProperties configuration) {
+        baseUrl = CommonUtils.toString(configuration.getBaseUrl());
+        if (baseUrl.isEmpty()) {
+            baseUrl = MiniMaxConstants.MINIMAX_ENDPOINT;
+        }
+        token = CommonUtils.toString(configuration.getToken());
+        modelSelectorField.setSelectedModel(
+            CommonUtils.toString(configuration.getModel(), MiniMaxConstants.DEFAULT_MODEL)
+        );
+        temperature = CommonUtils.toString(
+            configuration.getTemperature(),
+            String.valueOf(MiniMaxConstants.DEFAULT_TEMPERATURE)
+        );
+        logQuery = CommonUtils.toBoolean(configuration.isLoggingEnabled());
+        contextWindowSizeField.setValue(configuration.getContextWindowSize());
+
+        applySettings();
+    }
+
+    @Override
+    public void saveSettings(@NotNull MiniMaxProperties configuration) {
+        configuration.setBaseUrl(baseUrl);
+        configuration.setToken(token);
+        configuration.setModel(modelSelectorField.getSelectedModel());
+        configuration.setContextWindowSize(contextWindowSizeField.getValue());
+        configuration.setTemperature(CommonUtils.toDouble(temperature));
+        configuration.setLoggingEnabled(logQuery);
+    }
+
+    @Override
+    public void resetSettings(@NotNull MiniMaxProperties configuration) {
+    }
+
+    @Override
+    public boolean isComplete() {
+        return tokenText != null
+            && !tokenText.getText().isEmpty()
+            && contextWindowSizeField.isComplete();
+    }
+
+    @Override
+    public Optional<AIEngineProperties> getCurrentProperties() {
+        MiniMaxProperties propertiesCopy = new MiniMaxProperties();
+        propertiesCopy.setBaseUrl(baseUrl);
+        propertiesCopy.setToken(token);
+        propertiesCopy.setModel(modelSelectorField.getSelectedModel());
+        propertiesCopy.setContextWindowSize(contextWindowSizeField.getValue());
+        propertiesCopy.setTemperature(CommonUtils.toDouble(temperature));
+        propertiesCopy.setLoggingEnabled(logQuery);
+        return Optional.of(propertiesCopy);
+    }
+
+    private void createConnectionParameters(@NotNull Composite parent) {
+        tokenText = UIUtils.createLabelText(
+            parent,
+            AIUIMessages.gpt_preference_page_selector_token,
+            "", //$NON-NLS-1$
+            SWT.BORDER | SWT.PASSWORD
+        );
+        GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+        gd.widthHint = 150;
+        tokenText.setLayoutData(gd);
+        tokenText.addModifyListener(e -> token = tokenText.getText());
+        tokenText.setMessage(AIUIMessages.openai_configurator_token_placeholder);
+
+        Link link = UIUtils.createLink(
+            parent,
+            NLS.bind(AIUIMessages.gpt_preference_page_token_info, API_KEY_URL),
+            new SelectionAdapter() {
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    UIUtils.openWebBrowser(API_KEY_URL);
+                }
+            }
+        );
+        GridData linkGd = new GridData(GridData.FILL_HORIZONTAL);
+        linkGd.horizontalSpan = 3;
+        link.setLayoutData(linkGd);
+    }
+
+    private void createModelParameters(@NotNull Composite parent) {
+        // MiniMax models are fixed, no need to fetch from API
+        ModelSelectorField.ModelListProvider modelListProvider =
+            (monitor, forceRefresh) -> MiniMaxModels.KNOWN_MODELS.values().stream()
+                .filter(it -> it.features().contains(AIModelFeature.CHAT))
+                .map(AIModel::name)
+                .toList();
+
+        modelSelectorField = ModelSelectorField.builder()
+            .withParent(parent)
+            .withGridData(new GridData(GridData.FILL_HORIZONTAL))
+            .withModelListSupplier(modelListProvider)
+            .withModifyListener(() ->
+                MiniMaxModels.getModelByName(modelSelectorField.getSelectedModel())
+                    .ifPresentOrElse(
+                        model -> {
+                            contextWindowSizeField.setValue(model.contextWindowSize());
+                            temperatureText.setText(
+                                String.valueOf(model.defaultTemperature())
+                            );
+                        },
+                        () -> {
+                            contextWindowSizeField.setValue(null);
+                            temperatureText.setText(
+                                String.valueOf(MiniMaxConstants.DEFAULT_TEMPERATURE)
+                            );
+                        }
+                    ))
+            .build();
+
+        contextWindowSizeField = ContextWindowSizeField.builder()
+            .withParent(parent)
+            .withGridData(GridDataFactory.fillDefaults().span(2, 1).create())
+            .build();
+
+        temperatureText = UIUtils.createLabelText(
+            parent,
+            AIUIMessages.gpt_preference_page_text_temperature,
+            String.valueOf(MiniMaxConstants.DEFAULT_TEMPERATURE)
+        );
+        temperatureText.addVerifyListener(
+            UIUtils.getNumberVerifyListener(Locale.getDefault())
+        );
+        temperatureText.setLayoutData(
+            GridDataFactory.fillDefaults().span(2, 1).create()
+        );
+        temperatureText.setToolTipText(
+            "Temperature range: (0.0, 1.0]. Default: 1.0" //$NON-NLS-1$
+        );
+        temperatureText.addModifyListener(e -> temperature = temperatureText.getText());
+    }
+
+    private void createBaseUrlParameter(@NotNull Composite parent) {
+        baseUrlText = UIUtils.createLabelText(
+            parent,
+            AIUIMessages.gpt_preference_page_selector_base_url,
+            "" //$NON-NLS-1$
+        );
+        baseUrlText.addModifyListener(e -> baseUrl = baseUrlText.getText());
+        GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+        gd.widthHint = 150;
+        baseUrlText.setLayoutData(gd);
+    }
+
+    private void createAdditionalSettings(@NotNull Composite parent) {
+        logQueryCheck = UIUtils.createCheckbox(
+            parent,
+            AIUIMessages.openai_configurator_log_query_label,
+            AIUIMessages.openai_configurator_log_query_tip,
+            false,
+            2
+        );
+        logQueryCheck.addSelectionListener(
+            SelectionListener.widgetSelectedAdapter(
+                e -> logQuery = logQueryCheck.getSelection()
+            )
+        );
+    }
+
+    private void applySettings() {
+        if (baseUrlText != null) {
+            baseUrlText.setText(baseUrl);
+        }
+        if (tokenText != null) {
+            tokenText.setText(token);
+        }
+        temperatureText.setText(temperature);
+        logQueryCheck.setSelection(logQuery);
+    }
+}

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxModelsTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxModelsTest.java
@@ -1,0 +1,59 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.engine.minimax;
+
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MiniMaxModelsTest extends DBeaverUnitTest {
+
+    @Test
+    public void knownModelsShouldContainExpectedModels() {
+        assertTrue(MiniMaxModels.KNOWN_MODELS.containsKey("MiniMax-M2.7"));
+        assertTrue(MiniMaxModels.KNOWN_MODELS.containsKey("MiniMax-M2.7-highspeed"));
+        assertEquals(2, MiniMaxModels.KNOWN_MODELS.size());
+    }
+
+    @Test
+    public void getModelByNameShouldReturnKnownModel() {
+        var model = MiniMaxModels.getModelByName("MiniMax-M2.7");
+        assertTrue(model.isPresent());
+        assertEquals("MiniMax-M2.7", model.get().name());
+        assertEquals(Integer.valueOf(204_800), model.get().contextWindowSize());
+    }
+
+    @Test
+    public void getModelByNameShouldReturnEmptyForUnknown() {
+        var model = MiniMaxModels.getModelByName("unknown-model");
+        assertFalse(model.isPresent());
+    }
+
+    @Test
+    public void getModelByNameNullShouldReturnEmpty() {
+        var model = MiniMaxModels.getModelByName(null);
+        assertFalse(model.isPresent());
+    }
+
+    @Test
+    public void modelDefaultTemperatureShouldBeOne() {
+        var model = MiniMaxModels.getModelByName("MiniMax-M2.7");
+        assertTrue(model.isPresent());
+        assertEquals(1.0, model.get().defaultTemperature(), 0.001);
+    }
+}

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxModelsTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxModelsTest.java
@@ -25,17 +25,18 @@ public class MiniMaxModelsTest extends DBeaverUnitTest {
 
     @Test
     public void knownModelsShouldContainExpectedModels() {
+        assertTrue(MiniMaxModels.KNOWN_MODELS.containsKey("MiniMax-M3"));
         assertTrue(MiniMaxModels.KNOWN_MODELS.containsKey("MiniMax-M2.7"));
         assertTrue(MiniMaxModels.KNOWN_MODELS.containsKey("MiniMax-M2.7-highspeed"));
-        assertEquals(2, MiniMaxModels.KNOWN_MODELS.size());
+        assertEquals(3, MiniMaxModels.KNOWN_MODELS.size());
     }
 
     @Test
     public void getModelByNameShouldReturnKnownModel() {
-        var model = MiniMaxModels.getModelByName("MiniMax-M2.7");
+        var model = MiniMaxModels.getModelByName("MiniMax-M3");
         assertTrue(model.isPresent());
-        assertEquals("MiniMax-M2.7", model.get().name());
-        assertEquals(Integer.valueOf(204_800), model.get().contextWindowSize());
+        assertEquals("MiniMax-M3", model.get().name());
+        assertEquals(Integer.valueOf(512_000), model.get().contextWindowSize());
     }
 
     @Test
@@ -52,7 +53,7 @@ public class MiniMaxModelsTest extends DBeaverUnitTest {
 
     @Test
     public void modelDefaultTemperatureShouldBeOne() {
-        var model = MiniMaxModels.getModelByName("MiniMax-M2.7");
+        var model = MiniMaxModels.getModelByName("MiniMax-M3");
         assertTrue(model.isPresent());
         assertEquals(1.0, model.get().defaultTemperature(), 0.001);
     }

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxPropertiesTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxPropertiesTest.java
@@ -44,9 +44,10 @@ public class MiniMaxPropertiesTest extends DBeaverUnitTest {
     }
 
     @Test
-    public void defaultModelShouldBeMiniMaxM27() {
+    public void defaultModelShouldBeMiniMaxM3() {
         MiniMaxProperties props = new MiniMaxProperties();
         assertEquals(MiniMaxConstants.DEFAULT_MODEL, props.getModel());
+        assertEquals("MiniMax-M3", props.getModel());
     }
 
     @Test
@@ -112,14 +113,14 @@ public class MiniMaxPropertiesTest extends DBeaverUnitTest {
     @Test
     public void contextWindowSizeShouldDefaultFromModel() {
         MiniMaxProperties props = new MiniMaxProperties();
-        props.setModel("MiniMax-M2.7");
-        assertEquals(Integer.valueOf(204_800), props.getContextWindowSize());
+        props.setModel("MiniMax-M3");
+        assertEquals(Integer.valueOf(512_000), props.getContextWindowSize());
     }
 
     @Test
     public void contextWindowSizeCustomShouldOverrideModel() {
         MiniMaxProperties props = new MiniMaxProperties();
-        props.setModel("MiniMax-M2.7");
+        props.setModel("MiniMax-M3");
         props.setContextWindowSize(100_000);
         assertEquals(Integer.valueOf(100_000), props.getContextWindowSize());
     }

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxPropertiesTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/minimax/MiniMaxPropertiesTest.java
@@ -1,0 +1,126 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.engine.minimax;
+
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MiniMaxPropertiesTest extends DBeaverUnitTest {
+
+    @Test
+    public void defaultBaseUrlShouldBeMiniMaxEndpoint() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        assertEquals(MiniMaxConstants.MINIMAX_ENDPOINT, props.getBaseUrl());
+    }
+
+    @Test
+    public void customBaseUrlShouldBeUsed() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        props.setBaseUrl("https://custom.example.com/v1/");
+        assertEquals("https://custom.example.com/v1/", props.getBaseUrl());
+    }
+
+    @Test
+    public void emptyBaseUrlShouldFallbackToDefault() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        props.setBaseUrl("");
+        assertEquals(MiniMaxConstants.MINIMAX_ENDPOINT, props.getBaseUrl());
+    }
+
+    @Test
+    public void defaultModelShouldBeMiniMaxM27() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        assertEquals(MiniMaxConstants.DEFAULT_MODEL, props.getModel());
+    }
+
+    @Test
+    public void customModelShouldBeUsed() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        props.setModel("MiniMax-M2.7-highspeed");
+        assertEquals("MiniMax-M2.7-highspeed", props.getModel());
+    }
+
+    @Test
+    public void defaultTemperatureShouldBeOne() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        assertEquals(1.0, props.getTemperature(), 0.001);
+    }
+
+    @Test
+    public void isLegacyApiShouldAlwaysBeTrue() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        assertTrue(props.isLegacyApi());
+    }
+
+    @Test
+    public void isValidConfigurationShouldBeFalseWithoutToken() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        assertFalse(props.isValidConfiguration());
+    }
+
+    @Test
+    public void isValidConfigurationShouldBeTrueWithToken() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        props.setToken("test-token");
+        assertTrue(props.isValidConfiguration());
+    }
+
+    @Test
+    public void clampTemperatureZeroShouldReturnDefault() {
+        assertEquals(
+            MiniMaxConstants.DEFAULT_TEMPERATURE,
+            MiniMaxProperties.clampTemperature(0.0),
+            0.001
+        );
+    }
+
+    @Test
+    public void clampTemperatureNegativeShouldReturnDefault() {
+        assertEquals(
+            MiniMaxConstants.DEFAULT_TEMPERATURE,
+            MiniMaxProperties.clampTemperature(-0.5),
+            0.001
+        );
+    }
+
+    @Test
+    public void clampTemperatureAboveOneShouldClampToOne() {
+        assertEquals(1.0, MiniMaxProperties.clampTemperature(1.5), 0.001);
+    }
+
+    @Test
+    public void clampTemperatureValidShouldPassThrough() {
+        assertEquals(0.7, MiniMaxProperties.clampTemperature(0.7), 0.001);
+    }
+
+    @Test
+    public void contextWindowSizeShouldDefaultFromModel() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        props.setModel("MiniMax-M2.7");
+        assertEquals(Integer.valueOf(204_800), props.getContextWindowSize());
+    }
+
+    @Test
+    public void contextWindowSizeCustomShouldOverrideModel() {
+        MiniMaxProperties props = new MiniMaxProperties();
+        props.setModel("MiniMax-M2.7");
+        props.setContextWindowSize(100_000);
+        assertEquals(Integer.valueOf(100_000), props.getContextWindowSize());
+    }
+}


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as a new AI engine provider for DBeaver's AI assistant. MiniMax provides OpenAI-compatible API endpoints, enabling users to use the latest **MiniMax-M3** model (default) along with MiniMax-M2.7 and MiniMax-M2.7-highspeed for AI-powered SQL generation and database queries.

### Models

| Model | Context | Notes |
|------|------|------|
| `MiniMax-M3` | 512K | **Default**; 128K max output |
| `MiniMax-M2.7` | 204K | Alternate |
| `MiniMax-M2.7-highspeed` | 204K | Low-latency variant |

### Changes

- **MiniMaxEngine** — extends `OpenAIEngine` using the legacy chat/completions API format
- **MiniMaxProperties** — engine configuration with MiniMax-specific defaults (base URL: `https://api.minimax.io/v1/`, temperature clamped to `(0.0, 1.0]`, default `1.0`)
- **MiniMaxModels** — fixed model registry with `MiniMax-M3` (512K context, default), `MiniMax-M2.7` (204K), and `MiniMax-M2.7-highspeed`
- **MiniMaxConfigurator** — UI settings panel for API token, base URL, model selection, and temperature
- **Unit tests** — tests for model registry and properties (M3 default, temperature clamping, validation)
- **Plugin registration** — engine registered in `org.jkiss.dbeaver.model.ai/plugin.xml` and UI configurator in `org.jkiss.dbeaver.ui.ai/plugin.xml`

### Architecture

The implementation follows the same patterns as the existing OpenAI and Copilot providers:
- Extends `OpenAIEngine<MiniMaxProperties>` for maximum code reuse
- Uses `OpenAIClientLegacy` (chat/completions endpoint) since MiniMax's OpenAI-compatible API does not support the newer Responses API
- Streaming falls back to synchronous completion + single-chunk emission
- No new Eclipse plugins needed — code is added to existing `org.jkiss.dbeaver.model.ai` and `org.jkiss.dbeaver.ui.ai` plugins

### API Documentation

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo
