### PR TITLE
Expose DDL transaction support for generic drivers

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -158,6 +158,7 @@
                     <property id="use-search-string-escape" label="Escape LIKE masks in search queries" description="Use to access JDBC metadata API. Enabled by default but should be disabled for some (broken) drivers" type="boolean" required="false" defaultValue="false"/>
                 </propertyGroup>
                 <propertyGroup label="DDL" description="DDL generation options">
+                    <property id="supports-ddl-transactions" label="Driver supports DDL transactions" description="Driver supports running DDL statements inside transactions" type="boolean" required="false" defaultValue="true"/>
                     <property id="ddl-drop-column-short" label="Drop column short syntax" description="Use 'ALTER TABLE DROP column-name' instead of standard syntax" type="boolean" required="false" defaultValue="false"/>
                     <property id="ddl-drop-column-brackets" label="Drop column - use brackets" description="Use 'ALTER TABLE DROP (column-name)'" type="boolean" required="false" defaultValue="false"/>
                     <property id="legacy-sql-dialect" label="Use legacy SQL dialect for DDL" description="Use legacy SQL dialect for DDL" type="boolean" required="false" defaultValue="false"/>


### PR DESCRIPTION
## Summary
- add `supports-ddl-transactions` to the generic driver DDL parameter list
- allow custom generic drivers to configure DDL transaction support from the existing driver Parameters tab

Closes #40889

## Tests
- `git diff --check`