### PR TITLE
#41134 Fix fetched rows export with segment extraction

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseProducerPageExtractSettings.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/pages/database/DatabaseProducerPageExtractSettings.java
@@ -224,7 +224,11 @@ public class DatabaseProducerPageExtractSettings extends DataTransferPageNodeSet
         settings.setFetchSize(fetchSize.get());
         getWizard().getSettings().setMaxJobCount(threadCount.get());
         settings.setSegmentSize(segmentSize.get());
-        settings.setExtractType(extractInSegments.get() ? ExtractType.SEGMENTS : ExtractType.SINGLE_QUERY);
+        if (strategy.get() == Strategy.USE_FETCHED_ROWS) {
+            settings.setExtractType(ExtractType.SINGLE_QUERY);
+        } else {
+            settings.setExtractType(extractInSegments.get() ? ExtractType.SEGMENTS : ExtractType.SINGLE_QUERY);
+        }
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/wizard/ConfigureDataExtractionDialog.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/wizard/ConfigureDataExtractionDialog.java
@@ -239,7 +239,11 @@ public class ConfigureDataExtractionDialog extends BaseDialog {
         producerSettings.setFetchSize(fetchSize.get());
         settings.setMaxJobCount(threadCount.get());
         producerSettings.setSegmentSize(segmentSize.get());
-        producerSettings.setExtractType(extractInSegments.get() ? ExtractType.SEGMENTS : ExtractType.SINGLE_QUERY);
+        if (strategy.get() == Strategy.USE_FETCHED_ROWS) {
+            producerSettings.setExtractType(ExtractType.SINGLE_QUERY);
+        } else {
+            producerSettings.setExtractType(extractInSegments.get() ? ExtractType.SEGMENTS : ExtractType.SINGLE_QUERY);
+        }
 
         super.okPressed();
     }

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferProducer.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferProducer.java
@@ -214,6 +214,8 @@ public class DatabaseTransferProducer implements IDataTransferProducer<DatabaseP
             boolean forceDataReadTransactions
                 = Boolean.TRUE.equals(dataSource.getDataSourceFeature(DBPDataSource.FEATURE_LOB_REQUIRE_TRANSACTIONS));
             boolean selectiveExportFromUI = useFetchedRows != null;
+            boolean extractInSegments = useFetchedRows == null &&
+                settings.getExtractType() == DatabaseProducerSettings.ExtractType.SEGMENTS;
 
             DBCExecutionContext context;
             if (dataContainer instanceof DBPContextProvider contextProvider) {
@@ -284,7 +286,7 @@ public class DatabaseTransferProducer implements IDataTransferProducer<DatabaseP
                         monitor.subTask("Read data");
 
                         // Perform export
-                        if (settings.getExtractType() == DatabaseProducerSettings.ExtractType.SINGLE_QUERY) {
+                        if (!extractInSegments) {
                             checkCanceled(monitor);
                             // Just do it in single query
                             producerStatistics.accumulate(dataContainer.readData(transferSource, session, consumer, dataFilter, -1, -1, readFlags, settings.getFetchSize()));


### PR DESCRIPTION
Closes: #41134

Exporting a result set with **Use fetched rows** may never finish if the export task still keeps **Extract in batches** enabled from the same extraction settings page.

## Minimal Reproduction

1. Start DBeaver.
2. Connect to a MySQL database.
3. Create a table with more rows than the batch size. For example:

   ```sql
   create table export_loop_test (
       id int primary key,
       name varchar(50)
   );

   insert into export_loop_test values
   (1, 'row-1'), (2, 'row-2'), (3, 'row-3'), (4, 'row-4'), (5, 'row-5'),
   (6, 'row-6'), (7, 'row-7'), (8, 'row-8'), (9, 'row-9'), (10, 'row-10'),
   (11, 'row-11'), (12, 'row-12'), (13, 'row-13'), (14, 'row-14'), (15, 'row-15'),
   (16, 'row-16'), (17, 'row-17'), (18, 'row-18'), (19, 'row-19'), (20, 'row-20'),
   (21, 'row-21'), (22, 'row-22'), (23, 'row-23'), (24, 'row-24'), (25, 'row-25');
   ```

4. Execute the query in SQL Editor:

   ```sql
   select * from export_loop_test order by id;
   ```

5. Make sure all rows are fetched into the result set grid.
6. Right-click any data cell in the result set grid and choose **Export Data...**.
7. On the **Extraction** page, keep **Query the database** selected.
8. Expand **Advanced**.
9. Enable **Extract in batches** and set the batch size to a value smaller than the fetched row count, for example `10`.
10. On the same page, switch from **Query the database** to **Use fetched rows**.
11. Click **Next** and continue exporting to CSV or clipboard.