### PR TITLE
Clear dirty state when cell value equals original value

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetModel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetModel.java
@@ -507,10 +507,35 @@ public class ResultSetModel implements DBDResultSetModel {
         row.values[rootIndex] = valueToEdit;
 
         if (updateChanges && row.getState() == ResultSetRow.STATE_NORMAL) {
-            changesCount++;
+            if (attr == topAttribute && !attr.getDataKind().isComplex() && !(valueToEdit instanceof DBDValue)) {
+                Object originalValue = row.getChange(topAttribute);
+                if (row.isChanged(topAttribute) && equalCellValues(attr, originalValue, valueToEdit)) {
+                    row.clearChange(topAttribute);
+                    refreshChangeCount();
+                    return true;
+                }
+            }
+            if (isOldHistoricValueAbsent) {
+                changesCount++;
+            }
         }
 
         return true;
+    }
+
+    private static boolean equalCellValues(
+        @NotNull DBDAttributeBinding attr,
+        @Nullable Object value1,
+        @Nullable Object value2
+    ) {
+        if (DBUtils.isNullValue(value1) || DBUtils.isNullValue(value2)) {
+            return DBUtils.compareDataValues(value1, value2) == 0;
+        }
+        Comparator<Object> comparator = attr.getValueHandler().getComparator();
+        if (comparator != null) {
+            return comparator.compare(value1, value2) == 0;
+        }
+        return DBUtils.compareDataValues(value1, value2) == 0;
     }
 
     void resetCellValue(@NotNull DBDAttributeBinding attr, @NotNull ResultSetRow row, @Nullable int[] rowIndexes) {


### PR DESCRIPTION
## Summary

Fixes dbeaver/dbeaver#41146.

This PR clears a pending cell change in the Data Editor when the edited value is changed back to its original value before saving.

## Problem

Currently, if a user edits a cell from `A` to `B` and then edits it back to `A`, the cell/row may still remain dirty and Save/Revert remain enabled, even though there is no effective change.

## Changes

- Compare the pending change's original value with the current new value after a normal root cell update.
- Clear the cell change with `row.clearChange(topAttribute)` when the values are equivalent.
- Refresh the change count after clearing the pending change.
- Use the existing `DBDValueHandler.getComparator()` and `DBUtils.compareDataValues()` instead of string comparison.
- Keep NULL semantics:
  - `NULL -> X -> NULL` clears dirty.
  - `NULL -> ""` remains dirty.
- Keep the fix limited to ordinary root cell updates and avoid complex values, `DBDValue`, new rows, and deleted row flows.
- Increment `changesCount` only when a new pending change is created, avoiding duplicate increments for repeated edits of the same cell.

## Manual testing

- `A -> B`: the cell becomes dirty and Save/Revert are enabled.
- `A -> B -> A`: dirty state is cleared and Save/Revert are disabled when there are no other changes.
- `NULL -> X -> NULL`: dirty state is cleared.
- `NULL -> ""`: the cell remains dirty.
- Multiple edited cells: changing one cell back to its original value only clears that cell's pending change; other pending changes remain.
- Existing save behavior for normal edits still works.