### PR TITLE
dbeaver/pro#9425 Fix datetime editor, handle special datetime values, improve error dialog

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/data/MySQLDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.mysql/src/org/jkiss/dbeaver/ext/mysql/data/MySQLDateTimeValueHandler.java
@@ -144,6 +144,13 @@ public class MySQLDateTimeValueHandler extends JDBCDateTimeValueHandler {
     @NotNull
     @Override
     public String getValueDisplayString(@NotNull DBSTypedObject column, Object value, @NotNull DBDDisplayFormat format) {
+        if (format == DBDDisplayFormat.NATIVE) {
+            if (value == DBDZeroDateValue.INSTANCE) {
+                return "'" + ZERO_DATE_STRING + "'";
+            } else if (value == DBDZeroTimestampValue.INSTANCE) {
+                return "'" + ZERO_TIMESTAMP_STRING + "'";
+            }
+        }
         return super.getValueDisplayString(column, value, format);
     }
 

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreDateTimeValueHandler.java
@@ -20,8 +20,8 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
-import org.jkiss.dbeaver.ext.postgresql.model.data.value.PostgreEndOfDay;
-import org.jkiss.dbeaver.ext.postgresql.model.data.value.PostgreOffsetEndOfDay;
+import org.jkiss.dbeaver.model.data.DBDEndOfDayValue;
+import org.jkiss.dbeaver.model.data.DBDOffsetEndOfDayValue;
 import org.jkiss.dbeaver.model.data.DBDDataFormatter;
 import org.jkiss.dbeaver.model.data.DBDFormatSettings;
 import org.jkiss.dbeaver.model.exec.DBCException;
@@ -107,7 +107,9 @@ public class PostgreDateTimeValueHandler extends JDBCDateTimeValueHandler {
                             // let's do the same
                             if (rawString.startsWith(TIME_END_OF_DAY_STRING)) {
                                 // but instead of OffsetTime.MAX which is '23:59:59.999999999-18:00', we want zone-specific END_OF_DAY
-                                return new PostgreOffsetEndOfDay(ZoneOffset.of(rawString.substring(TIME_END_OF_DAY_STRING.length())));
+                                return DBDOffsetEndOfDayValue.withOffset(
+                                    ZoneOffset.of(rawString.substring(TIME_END_OF_DAY_STRING.length()))
+                                );
                             } else {
                                 return jdbc.getObject(index + 1, OffsetTime.class);
                             }
@@ -117,7 +119,7 @@ public class PostgreDateTimeValueHandler extends JDBCDateTimeValueHandler {
                             // let's do the same as postgresql jdbc driver
                             if (TIME_END_OF_DAY_STRING.equals(rawString)) {
                                 // but instead of LocalTime.MAX which is '23:59:59.999999999' in-the-day, we want zone-less END_OF_DAY
-                                return PostgreEndOfDay.withoutOffset();
+                                return DBDEndOfDayValue.withoutOffset();
                             } else {
                                 return jdbc.getObject(index + 1, LocalTime.class);
                             }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/data/PostgreDateTimeValueHandler.java
@@ -20,10 +20,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
-import org.jkiss.dbeaver.model.data.DBDEndOfDayValue;
-import org.jkiss.dbeaver.model.data.DBDOffsetEndOfDayValue;
-import org.jkiss.dbeaver.model.data.DBDDataFormatter;
-import org.jkiss.dbeaver.model.data.DBDFormatSettings;
+import org.jkiss.dbeaver.model.data.*;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.DBCResultSet;
 import org.jkiss.dbeaver.model.exec.DBCSession;
@@ -146,6 +143,19 @@ public class PostgreDateTimeValueHandler extends JDBCDateTimeValueHandler {
             return;
         }
         super.bindValueObject(session, statement, type, index, value);
+    }
+
+    @NotNull
+    @Override
+    public String getValueDisplayString(@NotNull DBSTypedObject column, Object value, @NotNull DBDDisplayFormat format) {
+        if (format == DBDDisplayFormat.NATIVE) {
+            if (value instanceof DBDOffsetEndOfDayValue endOfDay) {
+                return "'" + TIME_END_OF_DAY_STRING + endOfDay.getOffset() + "'";
+            } else if (value instanceof DBDEndOfDayValue) {
+                return "'" + TIME_END_OF_DAY_STRING + "'";
+            }
+        }
+        return super.getValueDisplayString(column, value, format);
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/data/handlers/JDBCDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/data/handlers/JDBCDateTimeValueHandler.java
@@ -37,10 +37,7 @@ import java.sql.Types;
 import java.text.Format;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
+import java.time.*;
 import java.util.Date;
 
 /**
@@ -236,6 +233,10 @@ public class JDBCDateTimeValueHandler extends DateTimeCustomValueHandler {
             return java.sql.Time.valueOf(localDateTime.toLocalTime());
         } else if (value instanceof LocalTime localTime) {
             return java.sql.Time.valueOf(localTime);
+        } else if (value instanceof OffsetTime offsetTime) {
+            return java.sql.Time.valueOf(offsetTime.toLocalTime());
+        } else if (value instanceof DBDEndOfDayValue) {
+            return java.sql.Time.valueOf(LocalTime.MAX);
         } else if (value == DBDZeroTimestampValue.INSTANCE || value == DBDZeroDateValue.INSTANCE) {
             return new java.sql.Time(0);
         }  else if (value != null) {
@@ -276,6 +277,12 @@ public class JDBCDateTimeValueHandler extends DateTimeCustomValueHandler {
             return Timestamp.valueOf(localDateTime);
         } else if (value instanceof OffsetDateTime offsetDateTime) {
             return Timestamp.valueOf((offsetDateTime.toLocalDateTime()));
+        } else if (value instanceof LocalTime localTime) {
+            return Timestamp.valueOf(localTime.atDate(LocalDate.EPOCH));
+        } else if (value instanceof OffsetTime offsetTime) {
+            return Timestamp.valueOf(offsetTime.toLocalTime().atDate(LocalDate.EPOCH));
+        } else if (value instanceof DBDEndOfDayValue) {
+            return DBDEndOfDayValue.TIMESTAMP;
         } else if (value == DBDZeroTimestampValue.INSTANCE || value == DBDZeroDateValue.INSTANCE) {
             return new Timestamp(0);
         } else if (value != null) {

--- a/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/data/handlers/JDBCDateTimeValueHandler.java
+++ b/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/data/handlers/JDBCDateTimeValueHandler.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.model.impl.jdbc.data.handlers;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.DBConstants;
+import org.jkiss.dbeaver.model.DBPDataKind;
 import org.jkiss.dbeaver.model.data.*;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.DBCResultSet;
@@ -174,10 +175,21 @@ public class JDBCDateTimeValueHandler extends DateTimeCustomValueHandler {
     @Override
     public String getValueDisplayString(@NotNull DBSTypedObject column, Object value, @NotNull DBDDisplayFormat format) {
         if (format == DBDDisplayFormat.NATIVE) {
+            // // Looks like it should have been like this, but this is not for hotfix, because touches everything
+            // value = switch (column.getTypeID()) {
+            //     case Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE -> getTimestampValue(value);
+            //     case Types.TIME, Types.TIME_WITH_TIMEZONE -> getTimeValue(value);
+            //     case Types.DATE -> getDateValue(value);
+            //     default -> value;
+            // };
             if (value instanceof LocalDate localDate) {
                 value = getDateValue(localDate);
             } else if (value instanceof LocalDateTime localDateTime) {
                 value = getTimestampValue(localDateTime);
+            } else if (value instanceof LocalTime localTime) {
+                value = getTimeValue(localTime);
+            } else if (value instanceof OffsetTime offsetTime) {
+                value = getTimeValue(offsetTime);
             }
             if (value instanceof Date) {
                 Format nativeFormat = getNativeValueFormat(column);

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDEndOfDayValue.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDEndOfDayValue.java
@@ -34,10 +34,12 @@ public class DBDEndOfDayValue implements TemporalAccessor {
         LocalDateTime.ofInstant(Instant.ofEpochMilli(Duration.ofHours(24).toMillis()), ZoneId.of(ZoneOffset.UTC.getId()))
     );
 
+    @NotNull
     public static DBDEndOfDayValue withoutOffset() {
         return INSTANCE;
     }
 
+    @NotNull
     public static DBDEndOfDayValue withOffset(@NotNull ZoneOffset offset) {
         return new DBDOffsetEndOfDayValue(offset);
     }
@@ -67,6 +69,7 @@ public class DBDEndOfDayValue implements TemporalAccessor {
         }
     }
 
+    @NotNull
     @Override
     public String toString() {
         return "24:00:00";

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDEndOfDayValue.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDEndOfDayValue.java
@@ -14,37 +14,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jkiss.dbeaver.ext.postgresql.model.data.value;
+package org.jkiss.dbeaver.model.data;
 
 import org.jkiss.code.NotNull;
-import org.jkiss.dbeaver.ext.postgresql.model.data.PostgreDateTimeValueHandler;
 
-import java.time.ZoneOffset;
+import java.sql.Timestamp;
+import java.time.*;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
+import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.Set;
 
-public class PostgreEndOfDay implements TemporalAccessor {
+public class DBDEndOfDayValue implements TemporalAccessor {
 
-    private static final PostgreEndOfDay INSTANCE = new PostgreEndOfDay();
+    private static final DBDEndOfDayValue INSTANCE = new DBDEndOfDayValue();
 
-    public static PostgreEndOfDay withoutOffset() {
+    public static final Timestamp TIMESTAMP = Timestamp.valueOf(
+        LocalDateTime.ofInstant(Instant.ofEpochMilli(Duration.ofHours(24).toMillis()), ZoneId.of(ZoneOffset.UTC.getId()))
+    );
+
+    public static DBDEndOfDayValue withoutOffset() {
         return INSTANCE;
     }
 
-    public static PostgreEndOfDay withOffset(@NotNull ZoneOffset offset) {
-        return new PostgreOffsetEndOfDay(offset);
+    public static DBDEndOfDayValue withOffset(@NotNull ZoneOffset offset) {
+        return new DBDOffsetEndOfDayValue(offset);
     }
 
     private static final Set<TemporalField> fields = Set.of(
         ChronoField.HOUR_OF_DAY,
-        ChronoField.MINUTE_OF_DAY,
+        ChronoField.MINUTE_OF_HOUR,
         ChronoField.SECOND_OF_MINUTE,
-        ChronoField.MILLI_OF_SECOND
+        ChronoField.MILLI_OF_SECOND,
+        ChronoField.NANO_OF_SECOND
     );
 
-    protected PostgreEndOfDay() {
+    protected DBDEndOfDayValue() {
     }
 
     @Override
@@ -54,6 +60,15 @@ public class PostgreEndOfDay implements TemporalAccessor {
 
     @Override
     public long getLong(@NotNull TemporalField field) {
-        return ChronoField.HOUR_OF_DAY.equals(field) ? 24 : 0;
+        if (field.isSupportedBy(this)) {
+            return ChronoField.HOUR_OF_DAY.equals(field) ? 24 : 0;
+        } else {
+            throw new UnsupportedTemporalTypeException("Unsupported field: " + field);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "24:00:00";
     }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDOffsetEndOfDayValue.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDOffsetEndOfDayValue.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jkiss.dbeaver.ext.postgresql.model.data.value;
+package org.jkiss.dbeaver.model.data;
 
 import org.jkiss.code.NotNull;
 
@@ -22,11 +22,11 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalField;
 
-public class PostgreOffsetEndOfDay extends PostgreEndOfDay {
+public class DBDOffsetEndOfDayValue extends DBDEndOfDayValue {
 
     private final ZoneOffset offset;
 
-    public PostgreOffsetEndOfDay(@NotNull ZoneOffset offset) {
+    public DBDOffsetEndOfDayValue(@NotNull ZoneOffset offset) {
         this.offset = offset;
     }
 
@@ -42,5 +42,10 @@ public class PostgreOffsetEndOfDay extends PostgreEndOfDay {
         } else {
             return super.getLong(field);
         }
+    }
+
+    @Override
+    public String toString() {
+        return "24:00:00" + offset;
     }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDOffsetEndOfDayValue.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDOffsetEndOfDayValue.java
@@ -30,6 +30,10 @@ public class DBDOffsetEndOfDayValue extends DBDEndOfDayValue {
         this.offset = offset;
     }
 
+    public ZoneOffset getOffset() {
+        return this.offset;
+    }
+
     @Override
     public boolean isSupported(@NotNull TemporalField field) {
         return super.isSupported(field) || ChronoField.OFFSET_SECONDS.equals(field);

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDOffsetEndOfDayValue.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDOffsetEndOfDayValue.java
@@ -30,6 +30,7 @@ public class DBDOffsetEndOfDayValue extends DBDEndOfDayValue {
         this.offset = offset;
     }
 
+    @NotNull
     public ZoneOffset getOffset() {
         return this.offset;
     }
@@ -48,6 +49,7 @@ public class DBDOffsetEndOfDayValue extends DBDEndOfDayValue {
         }
     }
 
+    @NotNull
     @Override
     public String toString() {
         return "24:00:00" + offset;

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDZeroDateValue.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDZeroDateValue.java
@@ -48,4 +48,9 @@ public class DBDZeroDateValue implements TemporalAccessor {
             throw new UnsupportedTemporalTypeException("Unsupported field: " + field);
         }
     }
+
+    @Override
+    public String toString() {
+        return "0000-00-00";
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDZeroTimestampValue.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDZeroTimestampValue.java
@@ -56,4 +56,9 @@ public class DBDZeroTimestampValue implements TemporalAccessor {
             throw new UnsupportedTemporalTypeException("Unsupported field: " + field);
         }
     }
+
+    @Override
+    public String toString() {
+        return "0000-00-00 00:00:00";
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDZeroTimestampValue.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/data/DBDZeroTimestampValue.java
@@ -57,6 +57,7 @@ public class DBDZeroTimestampValue implements TemporalAccessor {
         }
     }
 
+    @NotNull
     @Override
     public String toString() {
         return "0000-00-00 00:00:00";

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages.properties
@@ -195,7 +195,7 @@ reference_value_editor_define_description_value = Define Description
 reference_value_editor_search_hint_value = Type part of dictionary value to search
 
 dialog_value_view_error_parsing_date_title = Error retrieving date
-dialog_value_view_error_parsing_date_message = Error retrieving date/time information from the value 
+dialog_value_view_error_parsing_date_message = Error retrieving date/time information from the value \n\n {0}
 
 dialog_filter_value_edit_title = Filter by ''{0}''
 dialog_filter_value_edit_label_choose_values = Choose value(s) to filter by

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_pt_BR.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_pt_BR.properties
@@ -455,7 +455,7 @@ dialog_value_view_dialog_error_updating_message = Não é possível atualizar o 
 
 dialog_value_view_dialog_error_updating_title = Erro ao atualizar coluna
 
-dialog_value_view_error_parsing_date_message = Erro ao recuperar informação de data/hora do valor
+dialog_value_view_error_parsing_date_message = Erro ao recuperar informação de data/hora do valor \n\n {0}
 
 dialog_value_view_error_parsing_date_title = Erro ao recuperar data
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_ro.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_ro.properties
@@ -176,7 +176,7 @@ reference_value_editor_define_description_value = Definiţi descrierea
 reference_value_editor_search_hint_value = Introduceţi o parte din valoarea de dicţionar pentru a căuta
 
 dialog_value_view_error_parsing_date_title = Eroare la preluarea datei
-dialog_value_view_error_parsing_date_message = Eroare la preluarea informaţiilor despre dată/ora din valoare
+dialog_value_view_error_parsing_date_message = Eroare la preluarea informaţiilor despre dată/ora din valoare \n\n {0}
 
 dialog_filter_value_edit_title = Filtraţi după "{0}"
 dialog_filter_value_edit_label_choose_values = Alegeţi valoarea (valorile) după care să filtraţi

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_uk.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_uk.properties
@@ -177,7 +177,7 @@ reference_value_editor_define_description_value = Визначити опис
 reference_value_editor_search_hint_value = Введіть частину значення словника для пошуку
 
 dialog_value_view_error_parsing_date_title = Помилка отримання дати
-dialog_value_view_error_parsing_date_message = Помилка отримання інформації про дату/час зі значення
+dialog_value_view_error_parsing_date_message = Помилка отримання інформації про дату/час зі значення \n\n {0}
 
 dialog_filter_value_edit_title = Фільтрувати за ''{0}''
 dialog_filter_value_edit_label_choose_values = Вибрати значення(я) для фільтрації за

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_zh.properties
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/internal/ResultSetMessages_zh.properties
@@ -432,7 +432,7 @@ dialog_value_view_dialog_error_updating_message = 无法更新字段值
 
 dialog_value_view_dialog_error_updating_title = 更新字段出错
 
-dialog_value_view_error_parsing_date_message = 从值检索日期/时间信息时出错
+dialog_value_view_error_parsing_date_message = 从值检索日期/时间信息时出错 \n\n {0}
 
 dialog_value_view_error_parsing_date_title = 检索日期时出错
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/DateTimeInlineEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/DateTimeInlineEditor.java
@@ -127,7 +127,7 @@ public class DateTimeInlineEditor extends BaseValueEditor<Control> {
                 DBWorkbench.getPlatformUI()
                     .showWarningMessageBox(
                         ResultSetMessages.dialog_value_view_error_parsing_date_title,
-                        ResultSetMessages.dialog_value_view_error_parsing_date_message
+                        NLS.bind(ResultSetMessages.dialog_value_view_error_parsing_date_message, exception.getMessage())
                     );
                 DBWorkbench.getPlatform().getPreferenceStore().setValue(ModelPreferences.RESULT_SET_USE_DATETIME_EDITOR, false);
                 this.setChecked(false);

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/DateTimeStandaloneEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/DateTimeStandaloneEditor.java
@@ -17,6 +17,7 @@
 
 package org.jkiss.dbeaver.ui.data.editors;
 
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -125,7 +126,7 @@ public class DateTimeStandaloneEditor extends ValueViewDialog {
             DBWorkbench.getPlatformUI()
                 .showWarningMessageBox(
                     ResultSetMessages.dialog_value_view_error_parsing_date_title,
-                    ResultSetMessages.dialog_value_view_error_parsing_date_message
+                    NLS.bind(ResultSetMessages.dialog_value_view_error_parsing_date_message, e.getMessage())
                 );
         }
     }

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/CustomTimeEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/CustomTimeEditor.java
@@ -24,7 +24,11 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.DBIcon;
+import org.jkiss.dbeaver.model.data.DBDEndOfDayValue;
+import org.jkiss.dbeaver.model.data.DBDZeroDateValue;
+import org.jkiss.dbeaver.model.data.DBDZeroTimestampValue;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 import org.jkiss.dbeaver.model.struct.DBSTypedObjectJDBC;
@@ -36,9 +40,7 @@ import org.jkiss.utils.CommonUtils;
 import java.sql.JDBCType;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.*;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -46,6 +48,9 @@ import java.util.Date;
  * CustomTimeEditor
  */
 public class CustomTimeEditor {
+
+    private static final Log log = Log.getLog(CustomTimeEditor.class);
+
     private final int style;
     private final boolean isPanel;
     private DateTime dateEditor;
@@ -399,12 +404,26 @@ public class CustomTimeEditor {
             return null;
         } else if (value instanceof Date) {
             return (Date) value;
-        } else if (value instanceof Instant) {
-            return Date.from((Instant) value);
-        } else if (value instanceof LocalDateTime) {
-            return Date.from(((LocalDateTime) value).atZone(ZoneId.systemDefault()).toInstant());
+        } else if (value instanceof LocalDate localDate) {
+            return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        } else if (value instanceof Instant instant) {
+            return Date.from(instant);
+        } else if (value instanceof OffsetTime localTime) {
+            return Date.from(localTime.atDate(LocalDate.now()).toInstant());
+        } else if (value instanceof LocalTime localTime) {
+            return Date.from(localTime.atDate(LocalDate.now()).atZone(ZoneId.systemDefault()).toInstant());
+        } else if (value instanceof OffsetDateTime offsetDateTime) {
+            return Date.from(offsetDateTime.toInstant());
+        } else if (value instanceof LocalDateTime localDateTime) {
+            return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        } else if (value instanceof DBDEndOfDayValue) {
+            throw new DBCException("Database-specific end-of-day value cannot be represented with calendar.");
+        } else if (value == DBDZeroTimestampValue.INSTANCE || value == DBDZeroDateValue.INSTANCE) {
+            throw new DBCException("Database-specific zero-date value cannot be represented with calendar.");
         } else {
-            throw new DBCException(value.toString());
+            log.debug("Cannot adapt date and/or time value of the unexpected type " + value.getClass().getName());
+            throw new DBCException("Value of the unsupported type, which cannot be represented with calendar."
+                + "Please report the issue on GitHub https://github.com/dbeaver/dbeaver/issues");
         }
     }
 }


### PR DESCRIPTION
* Fix dbeaver/pro#9425
* Fix filters construction for time values in PostgreSQL and specific values (0000-00-00 00:00:00 in maria and 24:00:00 in PostgreSQL)
<img width="776" height="304" alt="image" src="https://github.com/user-attachments/assets/e72aa96a-f4c2-4c6b-8bef-63822b22a367" />

* Fix 0000-00-00 00:00:00 handling in datetime editor in MariaDB (understandable message)
* Fix 24:00:00 in datetime editor in PostgreSQL (understandable message)
<img width="535" height="170" alt="image" src="https://github.com/user-attachments/assets/e2978ae0-d0aa-498b-898e-bdb2a0dc69f2" />
