### PR TITLE
dbeaver/pro#9412 Mitigate NPE by explicitly loading view's DDL if it's absent

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleViewManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleViewManager.java
@@ -139,7 +139,7 @@ public class OracleViewManager extends SQLTableManager<OracleView, OracleSchema>
         final OracleView view = command.getObject();
         boolean hasComment = command.hasProperty("comment");
         if (!hasComment || command.getProperties().size() > 1) {
-            String viewText = view.getObjectDefinitionText(monitor, options);
+            String viewText = view.getObjectDefinitionText(monitor, options).trim();
             List<SQLScriptElement> sqlScriptElements = SQLScriptParser.parseScript(view.getDataSource(), viewText);
             if (sqlScriptElements.size() > 1) {
                 // In this case we already have and view definition, and view/columns comments

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleViewManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/edit/OracleViewManager.java
@@ -139,7 +139,7 @@ public class OracleViewManager extends SQLTableManager<OracleView, OracleSchema>
         final OracleView view = command.getObject();
         boolean hasComment = command.hasProperty("comment");
         if (!hasComment || command.getProperties().size() > 1) {
-            String viewText = view.getViewText().trim();
+            String viewText = view.getObjectDefinitionText(monitor, options);
             List<SQLScriptElement> sqlScriptElements = SQLScriptParser.parseScript(view.getDataSource(), viewText);
             if (sqlScriptElements.size() > 1) {
                 // In this case we already have and view definition, and view/columns comments

--- a/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleView.java
+++ b/plugins/org.jkiss.dbeaver.ext.oracle/src/org/jkiss/dbeaver/ext/oracle/model/OracleView.java
@@ -193,10 +193,6 @@ public class OracleView extends OracleTableBase implements OracleSourceObject, D
         this.valid = OracleUtils.getObjectStatus(monitor, this, OracleObjectType.VIEW);
     }
 
-    public String getViewText() {
-        return viewText;
-    }
-
     public void setViewText(String viewText) {
         this.viewText = viewText;
     }


### PR DESCRIPTION
It's a blind fix, and I was not able to reproduce the original issue. Ask the issuer for more details.