### PR TITLE
fix: correct singular 'second' pluralization in auto-refresh menu labels

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/autorefresh/AutoRefreshControl.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/controls/autorefresh/AutoRefreshControl.java
@@ -244,8 +244,8 @@ public class AutoRefreshControl {
                         final Integer timeout = presetList.get(i);
                         mi = new MenuItem(schedulerMenu, SWT.PUSH);
                         String text = i == 0 ?
-                            NLS.bind(UIMessages.sql_editor_resultset_filter_panel_menu_refresh_interval, timeout) :
-                            NLS.bind(UIMessages.sql_editor_resultset_filter_panel_menu_refresh_interval_1, timeout);
+                            NLS.bind(timeout == 1 ? UIMessages.sql_editor_resultset_filter_panel_menu_refresh_interval : UIMessages.sql_editor_resultset_filter_panel_menu_refresh_interval_s, timeout) :
+                            NLS.bind(timeout == 1 ? UIMessages.sql_editor_resultset_filter_panel_menu_refresh_interval_1 : UIMessages.sql_editor_resultset_filter_panel_menu_refresh_interval_1_s, timeout);
                         mi.setText(text);
                         if (isAutoRefreshEnabled() && timeout == defaultInterval) {
                             schedulerMenu.setDefaultItem(mi);

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages.java
@@ -48,7 +48,9 @@ public class UIMessages extends NLS {
     public static String sql_editor_resultset_filter_panel_btn_config_refresh;
     public static String sql_editor_resultset_filter_panel_btn_stop_refresh;
     public static String sql_editor_resultset_filter_panel_menu_refresh_interval;
+    public static String sql_editor_resultset_filter_panel_menu_refresh_interval_s;
     public static String sql_editor_resultset_filter_panel_menu_refresh_interval_1;
+    public static String sql_editor_resultset_filter_panel_menu_refresh_interval_1_s;
     public static String sql_editor_resultset_filter_panel_menu_stop;
     public static String sql_editor_resultset_filter_panel_menu_customize;
 

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages.properties
@@ -36,8 +36,10 @@ sql_editor_resultset_filter_panel_btn_stop_refresh = Stop auto-refresh
 sql_editor_resultset_filter_panel_btn_config_refresh = Configure auto-refresh
 sql_editor_resultset_filter_panel_menu_customize = Customize ...
 sql_editor_resultset_filter_panel_menu_stop = Stop
-sql_editor_resultset_filter_panel_menu_refresh_interval = Refresh every {0} seconds
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0} seconds
+sql_editor_resultset_filter_panel_menu_refresh_interval = Refresh every {0} second
+sql_editor_resultset_filter_panel_menu_refresh_interval_s = Refresh every {0} seconds
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0} second
+sql_editor_resultset_filter_panel_menu_refresh_interval_1_s =                 ... {0} seconds
 
 controls_locale_selector_group_locale = Locale
 controls_locale_selector_label_country = Country


### PR DESCRIPTION
This is an independent contribution and is not associated with any hackathon or competition.

## Summary

The auto-refresh interval menu in the SQL editor displays "Refresh every 1 seconds" which is grammatically incorrect. The singular form "second" should be used when the interval is 1.

## Root Cause

The i18n properties only had a single plural form ("{0} seconds") regardless of the numeric value, and the Java code directly substituted the interval value without any singular/plural logic.

## Fix

- Added singular i18n keys (`sql_editor_resultset_filter_panel_menu_refresh_interval` and `sql_editor_resultset_filter_panel_menu_refresh_interval_1_s`) with "second" (singular) text
- Updated `AutoRefreshControl.java` to select between singular and plural keys based on the timeout value

## Testing

- Interval = 1: Displays "Refresh every 1 second" ✓
- Interval = 5: Displays "Refresh every 5 seconds" ✓
- Custom intervals also correctly use singular/plural forms