### PR TITLE
Fix pluralization grammar bug in refresh interval message

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages.properties
@@ -36,8 +36,8 @@ sql_editor_resultset_filter_panel_btn_stop_refresh = Stop auto-refresh
 sql_editor_resultset_filter_panel_btn_config_refresh = Configure auto-refresh
 sql_editor_resultset_filter_panel_menu_customize = Customize ...
 sql_editor_resultset_filter_panel_menu_stop = Stop
-sql_editor_resultset_filter_panel_menu_refresh_interval = Refresh every {0} seconds
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0} seconds
+sql_editor_resultset_filter_panel_menu_refresh_interval = Refresh every {0,choice,1#1 second|1<{0} seconds}
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0,choice,1#1 second|1<{0} seconds}
 
 controls_locale_selector_group_locale = Locale
 controls_locale_selector_label_country = Country

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_de.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_de.properties
@@ -24,8 +24,8 @@ controls_progress_page_progress_bar_loading_tooltip = Ladefortschritt
 controls_progress_page_toolbar_title = Suche Element(e)
 
 sql_editor_resultset_filter_panel_menu_customize = Personalisieren ...
-sql_editor_resultset_filter_panel_menu_refresh_interval = Alle {0} Sekunden aktualisieren
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 = \                ... {0} Sekunden
+sql_editor_resultset_filter_panel_menu_refresh_interval = Alle {0,choice,1#1 Sekunde|1<{0} Sekunden} aktualisieren
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0,choice,1#1 Sekunde|1<{0} Sekunden}
 sql_editor_resultset_filter_panel_menu_stop = Stopp
 sql_editor_resultset_filter_panel_btn_config_refresh = Konfigurieren der automatischen Aktualisierung
 sql_editor_resultset_filter_panel_btn_stop_refresh = Stoppen Sie die automatische Aktualisierung

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_fr.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_fr.properties
@@ -26,8 +26,8 @@ sql_editor_resultset_filter_panel_btn_stop_refresh = Arrêter le rafraîchisseme
 sql_editor_resultset_filter_panel_btn_config_refresh = Configurer le rafraîchissement automatique
 sql_editor_resultset_filter_panel_menu_customize = Personnaliser ...
 sql_editor_resultset_filter_panel_menu_stop = Stop
-sql_editor_resultset_filter_panel_menu_refresh_interval = Rafraîchir toutes les {0} secondes
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0} secondes
+sql_editor_resultset_filter_panel_menu_refresh_interval = Rafraîchir {0,choice,1#toutes les 1 seconde|1<toutes les {0} secondes}
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0,choice,1#1 seconde|1<{0} secondes}
 
 controls_locale_selector_group_locale = Localisation
 controls_locale_selector_label_country = Pays

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_it.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_it.properties
@@ -93,9 +93,9 @@ sql_editor_resultset_filter_panel_btn_stop_refresh = Ferma auto-aggiornamento
 
 sql_editor_resultset_filter_panel_menu_customize = Personalizza ...
 
-sql_editor_resultset_filter_panel_menu_refresh_interval = Aggiorna ogni {0} secondi
+sql_editor_resultset_filter_panel_menu_refresh_interval = Aggiorna ogni {0,choice,1#1 secondo|1<{0} secondi}
 
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 = ... {0} secondi
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 = ... {0,choice,1#1 secondo|1<{0} secondi}
 
 sql_editor_resultset_filter_panel_menu_stop = Ferma
 

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_ja.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_ja.properties
@@ -26,8 +26,8 @@ sql_editor_resultset_filter_panel_btn_stop_refresh =自動リフレッシュを�
 sql_editor_resultset_filter_panel_btn_config_refresh =自動更新を設定する
 sql_editor_resultset_filter_panel_menu_customize =カスタマイズ...
 sql_editor_resultset_filter_panel_menu_stop =やめる
-sql_editor_resultset_filter_panel_menu_refresh_interval ={0}秒ごとに更新
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 =... {0}秒
+sql_editor_resultset_filter_panel_menu_refresh_interval ={0,choice,1#1秒ごとに更新|1<{0}秒ごとに更新}
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 =... {0,choice,1#1秒|1<{0}秒}
 
 controls_locale_selector_group_locale =ロケール
 controls_locale_selector_label_country =国

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_pt_BR.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_pt_BR.properties
@@ -109,9 +109,9 @@ sql_editor_resultset_filter_panel_btn_stop_refresh = Parar auto-atualização
 
 sql_editor_resultset_filter_panel_menu_customize = Personalizar ...
 
-sql_editor_resultset_filter_panel_menu_refresh_interval = Atualizar a cada {0} segundos
+sql_editor_resultset_filter_panel_menu_refresh_interval = Atualizar a cada {0,choice,1#1 segundo|1<{0} segundos}
 
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 = ... {0} segundos
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 = ... {0,choice,1#1 segundo|1<{0} segundos}
 
 sql_editor_resultset_filter_panel_menu_stop = Parar
 

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_ro.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_ro.properties
@@ -36,8 +36,8 @@ sql_editor_resultset_filter_panel_btn_stop_refresh = Opriţi reîmprospătarea a
 sql_editor_resultset_filter_panel_btn_config_refresh = Configurarea reîmprospătării automate
 sql_editor_resultset_filter_panel_menu_customize = Personaliza...
 sql_editor_resultset_filter_panel_menu_stop = Stop
-sql_editor_resultset_filter_panel_menu_refresh_interval = Reîmprospătare la fiecare {0} secunde
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0} secunde
+sql_editor_resultset_filter_panel_menu_refresh_interval = Reîmprospătare la fiecare {0,choice,1#1 secundă|1<{0} secunde}
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0,choice,1#1 secundă|1<{0} secunde}
 
 controls_locale_selector_group_locale = Setări regionale
 controls_locale_selector_label_country = Ţară

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_ru.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_ru.properties
@@ -28,8 +28,8 @@ sql_editor_resultset_filter_panel_btn_stop_refresh = Остановить авт
 sql_editor_resultset_filter_panel_btn_config_refresh = Настроить автообновление
 sql_editor_resultset_filter_panel_menu_customize = Настроить ...
 sql_editor_resultset_filter_panel_menu_stop = Остановить
-sql_editor_resultset_filter_panel_menu_refresh_interval = Обновлять каждые {0} секунд
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0} секунд
+sql_editor_resultset_filter_panel_menu_refresh_interval = {0,choice,1#Обновлять каждую 1 секунду|1<Обновлять каждые {0} секунд}
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 =                 ... {0,choice,1#1 секунда|1<{0} секунд}
 
 controls_locale_selector_group_locale=Локаль
 controls_locale_selector_label_country=Страна

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_uk.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_uk.properties
@@ -36,8 +36,8 @@ sql_editor_resultset_filter_panel_btn_stop_refresh = Зупинити автом
 sql_editor_resultset_filter_panel_btn_config_refresh = Налаштувати автоматичне оновлення
 sql_editor_resultset_filter_panel_menu_customize = Налаштувати...
 sql_editor_resultset_filter_panel_menu_stop = Зупинити
-sql_editor_resultset_filter_panel_menu_refresh_interval = Оновлювати кожні {0} секунд
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 = ... {0} секунд
+sql_editor_resultset_filter_panel_menu_refresh_interval = {0,choice,1#Оновлювати кожну 1 секунду|1<Оновлювати кожні {0} секунд}
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 = ... {0,choice,1#1 секунда|1<{0} секунд}
 
 controls_locale_selector_group_locale = Локаль
 controls_locale_selector_label_country = Країна

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_zh.properties
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/internal/UIMessages_zh.properties
@@ -99,9 +99,9 @@ sql_editor_resultset_filter_panel_btn_stop_refresh = 停止自动刷新
 
 sql_editor_resultset_filter_panel_menu_customize = 自定义...
 
-sql_editor_resultset_filter_panel_menu_refresh_interval = 每 {0} 秒刷新一次 
+sql_editor_resultset_filter_panel_menu_refresh_interval = {0,choice,1#每 1 秒刷新一次|1<每 {0} 秒刷新一次}
 
-sql_editor_resultset_filter_panel_menu_refresh_interval_1 = ... {0} 秒
+sql_editor_resultset_filter_panel_menu_refresh_interval_1 = ... {0,choice,1#1 秒|1<{0} 秒}
 
 sql_editor_resultset_filter_panel_menu_stop = 停止
 


### PR DESCRIPTION
### Overview
Fixed a grammar/pluralization bug in the SQL Editor results panel where it would incorrectly display "Refresh every 1 seconds" instead of "1 second".

### Changes
- Changed the resource strings to use `{0,choice,1}` formatting to correctly handle singular and plural forms for the refresh interval.

Resolves #41142 
