### PR TITLE
dbeaver/dbeaver#41310 Fix macOS native launcher crash

### DIFF
--- a/product/community/pom.xml
+++ b/product/community/pom.xml
@@ -44,6 +44,36 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
+                Fixes dbeaver/dbeaver#41310. The Equinox macOS launcher reads the Info.plist Eclipse array
+                before Java starts; when it is absent, it can SIGSEGV while logging to /dev/console.
+                Keep this plugin after materialize-products so the generated app gets an empty array with no extra args.
+            -->
+            <plugin>
+                <groupId>name.abuchen</groupId>
+                <artifactId>fix-info-plist-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>fix-macos-info-plist</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>fix-info-plist</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <productId>org.jkiss.dbeaver.core.product</productId>
+                    <projectVersion>${qualifiedVersion}</projectVersion>
+                    <appName>DBeaver.app</appName>
+                    <properties>
+                        <property>
+                            <name>Eclipse</name>
+                            <value><![CDATA[<array/>]]></value>
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>target-platform-configuration</artifactId>


### PR DESCRIPTION
Closes dbeaver/dbeaver#41310

Adds a post-processing step for the generated macOS Community app bundle so `Info.plist` keeps an empty `Eclipse` array.

The Equinox macOS launcher reads this key before Java starts. If it is missing during an argument-less launch, the native launcher can crash before DBeaver starts. An empty array keeps the key present without adding launcher arguments.

**For QA team:**
- Check that the generated Community macOS `DBeaver.app/Contents/Info.plist` contains:
  ```xml
  <key>Eclipse</key>
  <array/>
  ```
- Check that DBeaver Community starts from Finder/LaunchServices on macOS without passing extra launcher arguments.
- Check that `CFBundleVersion` and `CFBundleShortVersionString` are unchanged by the plist post-processing step.

**Validation:**
- Verified locally that the plist post-processing writes `<key>Eclipse</key><array/>` and leaves bundle version fields unchanged.
- Verified locally that adding only the empty `Eclipse` array lets the same macOS app continue into DBeaver startup instead of crashing before Java starts.
