### PR TITLE
#41327 Fix IBM DB2 Metadata search

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNModel.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNModel.java
@@ -399,7 +399,10 @@ public class DBNModel {
             for (DBNDatabaseNode child : children) {
                 if (child instanceof DBNDatabaseFolder) {
                     Class<?> itemsClass = ((DBNDatabaseFolder) child).getChildrenClass();
-                    if (itemsClass != null && itemsClass.isAssignableFrom(objectToCache.getClass())) {
+                    // Some folders are only grouping nodes and do not expose a children class (itemsClass == null).
+                    // We still need to traverse them, otherwise getNodeByObject may not reach nested items
+                    // until that branch was expanded manually in the navigator.
+                    if (itemsClass == null || itemsClass.isAssignableFrom(objectToCache.getClass())) {
                         cached = cacheNodeChildren(monitor, child, objectToCache, addFiltered);
                         if (cached) {
                             break;


### PR DESCRIPTION
Fixes #41327

DBNModel.cacheNodeChildren() previously skipped folders where getChildrenClass() returned null, stopping the traversal at purely decorative grouping nodes such as DB2's "applicationObjects" folder. This caused getNodeByObject() to return null for any object nested under such a folder until the user had manually expanded that branch in the navigator tree, making database object search results silently disappear for those objects. Allow recursion into folders without a typed children class so the full navigator path is resolved on demand regardless of tree state.