### PR TITLE
Greenplum 6: avoid OOM when listing schema tables (replace pg_partitions join)

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchema.java
+++ b/plugins/org.jkiss.dbeaver.ext.greenplum/src/org/jkiss/dbeaver/ext/greenplum/model/GreenplumSchema.java
@@ -114,7 +114,7 @@ public class GreenplumSchema extends PostgreSchema {
             boolean supportsRelStorageColumn = dataSource.isServerSupportsRelstorageColumn(session);
             before7version = !dataSource.isGreenplumVersionAtLeast(7, 0);
             String sqlQuery = "SELECT c.oid,c.*,d.description,\n" +
-                (before7version ? "p.partitiontablename,p.partitionboundary as partition_expr," :
+                (before7version ? "case when p.parchildrelid is not null then c.relname else null end as partitiontablename,pg_catalog.pg_get_partition_rule_def(p.oid, true) as partition_expr," :
                     "pg_catalog.pg_get_expr(c.relpartbound, c.oid) as partition_expr, pg_catalog.pg_get_partkeydef(c.oid) as partition_key,") +
                 (hasAccessToExttable ? "CASE WHEN x." + uriLocationColumn + " IS NOT NULL THEN array_to_string(x." + uriLocationColumn +
                     ", ',') ELSE '' END AS urilocation,\n" +
@@ -137,8 +137,7 @@ public class GreenplumSchema extends PostgreSchema {
                 "INNER JOIN pg_catalog.pg_namespace ns\n\ton ns.oid = c.relnamespace\n" +
                 "LEFT OUTER JOIN pg_catalog.pg_description d\n\tON d.objoid=c.oid AND d.objsubid=0\n" +
                 (hasAccessToExttable ? "LEFT OUTER JOIN pg_catalog.pg_exttable x\n\ton x.reloid = c.oid\n" : "") +
-                (before7version ? "LEFT OUTER JOIN pg_catalog.pg_partitions p\n\ton c.relname = p.partitiontablename " +
-                    "and ns.nspname = p.schemaname\n" : "") +
+                    (before7version ? "LEFT OUTER JOIN pg_catalog.pg_partition_rule p\n\ton p.parchildrelid = c.oid\n" : "") +
                 (before7version ? "" : "\nLEFT JOIN pg_catalog.pg_am pa ON pa.oid = c.relam") +
                 "\nWHERE c.relnamespace= ? AND c.relkind not in ('i','c') " +
                 (object == null && objectName == null ? "" : " AND relname=?");


### PR DESCRIPTION
### Summary

Fixes #41280.

Expanding the Tables node of a schema on Greenplum 6 can fail with
`53500 Out of memory: Resource group memory limit reached`. The failure comes
from the metadata lookup query built in
`GreenplumSchema.GreenplumTableCache.prepareLookupStatement` (the
`before7version` branch), not from the table data itself.

### Root cause

The query `LEFT OUTER JOIN`s the `pg_catalog.pg_partitions` view. That view
uses window functions, which prevent the planner from pushing the schema
(`c.relnamespace = ?`) and relation (`relname = ?`) predicates down into it.
As a result Greenplum materializes the full partition set of the entire
database before filtering. On clusters with many partitions and resource
groups enabled this exhausts the group memory limit.

Raising the resource-group limit is not a viable workaround, since it affects
every workload on the cluster.

### Fix

Read the two values the cache actually needs directly from the base catalog
table `pg_catalog.pg_partition_rule`, joined by oid, instead of going through
the `pg_partitions` view:

- `partitiontablename` ← `c.relname` when a matching partition rule exists
- `partition_expr` ← `pg_get_partition_rule_def(p.oid, true)`

This removes the window functions, so the existing schema/relation predicates
push down normally. Output column names are unchanged, `isPartitionTableRow`
keeps working (`partitiontablename` is non-null exactly for partition child
relations), and the join stays `LEFT OUTER`, so non-partitioned tables are
unaffected.

### Testing

Verified on a production Greenplum 6 cluster with resource groups enabled
(DBeaver CE 26.0.5):

- Before: expanding the Tables node fails with the OOM error above.
- After: the same query returns in ~1s and the table list loads normally.
- Spot-checked that partitioned tables still show their child partitions and
  partition expressions.
