### PR TITLE
dbeaver/dbeaver#41222 Add Asia/Saigon for replace

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreConstants.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2025 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,6 +160,8 @@ public class PostgreConstants {
     public static final String DEFAULT_ARRAY_DELIMITER = " ";
     public static final String PG_PASS_HOSTNAME = "overriddenUsername";
     public static final Map<String, String> REPLACING_TIMEZONE = Map.of(
+        "Asia/Saigon", "Asia/Ho_Chi_Minh",
+        "Asia/Ho_Chi_Minh", "Asia/Saigon",
         "Europe/Kyiv", "Europe/Kiev",
         "Europe/Kiev", "Europe/Kyiv",
         "Asia/Calcutta", "Asia/Kolkata",


### PR DESCRIPTION
Closes https://github.com/dbeaver/dbeaver/issues/41222

For testing, connect to the new version of PostgreSQL, I reproduced it with 17.9 and set in the "User Interface" -> "Timezone" Asia/Saigon
<img width="425" height="237" alt="image" src="https://github.com/user-attachments/assets/cdd6c069-29f0-44d0-a132-1917cbd97e9f" />
