### PR TITLE
dbeaver/pro#9610 Fix log output writer logic

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/LogOutputStream.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/LogOutputStream.java
@@ -56,7 +56,6 @@ public class LogOutputStream extends OutputStream {
     private final String logFileName;
     private final String logFileNameExtension;
     private final Predicate<String> logFileNamePattern;
-    private boolean closed;
 
     public LogOutputStream(@NotNull File debugLogFile) throws IOException {
         if (debugLogFile.exists() && !debugLogFile.isFile()) {
@@ -106,18 +105,12 @@ public class LogOutputStream extends OutputStream {
     
     @Override
     public synchronized void write(int b) throws IOException {
-        if (closed) {
-            return;
-        }
         this.getLogFileWriter().write(b);
         this.currentLogSize++;
     }
     
     @Override
     public synchronized void write(byte[] b, int off, int len) throws IOException {
-        if (closed) {
-            return;
-        }
         this.getLogFileWriter().write(b, off, len);
         this.currentLogSize += len;
     }
@@ -135,13 +128,9 @@ public class LogOutputStream extends OutputStream {
             this.currentLogFileOutput.close();
             this.currentLogFileOutput = null;
         }
-        this.closed = true;
     }
 
     private synchronized OutputStream getLogFileWriter() throws IOException {
-        if (closed) {
-            throw new IOException("Log stream was closed");
-        }
         if (this.currentLogFileOutput == null || this.rotateCurrentLogFile(false)) {
             this.currentLogFileOutput = new FileOutputStream(this.currentLogFile, true);
         }


### PR DESCRIPTION
I partially reverted https://github.com/dbeaver/dbeaver/commit/c0883b0a2aab7a855b14810f2f752baff7429011
But left `synchronized` on the `getLogFileWriter` method - it should be enough.

P.S.
The mentioned commit tried to fix the following error from logs:
```
Caused by: java.lang.NullPointerException: Cannot invoke "java.io.OutputStream.write(byte[], int, int)" because the return value of "org.jkiss.dbeaver.LogOutputStream.getLogFileWriter()" is null
	at org.jkiss.dbeaver.LogOutputStream.write(LogOutputStream.java:114)
	at org.jkiss.dbeaver.ui.app.standalone.DBeaverApplication$ProxyPrintStream.write(DBeaverApplication.java:970)
	at java.base/java.io.PrintStream.implWrite(Unknown Source)
	at java.base/java.io.PrintStream.write(Unknown Source)
```
