### PR TITLE
Set AppUserModelID to prevent duplicate taskbar icon (#40782)

### DIFF
--- a/features/org.jkiss.dbeaver.ce.feature/root/readme.txt
+++ b/features/org.jkiss.dbeaver.ce.feature/root/readme.txt
@@ -38,7 +38,9 @@ Command line parameters
 
   -vm <java vm path>
     Use Java VM installed in <java vm path> folder instead of default
-    location.
+    location. On Windows, pointing to jre/bin/server/jvm.dll loads the
+    JVM in-process and prevents a duplicate taskbar icon when the app
+    is pinned.
 
   -vmargs <jvm parameters>
     Allows to pass any number of additional parameters to JVM.

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/DBeaverApplication.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/DBeaverApplication.java
@@ -185,6 +185,11 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
         // hide standard Eclipse exit message if exit code is not OK (otherwise it may be confusing)
         System.setProperty(ECLIPSE_EXIT_DATA, "");
 
+        // Must run before any SWT Display / dialog is created (workspace lock UI, splash, etc.)
+        if (RuntimeUtils.isWindows()) {
+            setWindowsAppUserModelID();
+        }
+
         var args = preprocessCommandLine();
         Location instanceLoc = Platform.getInstanceLocation();
         Path defaultHomePath = getDefaultInstanceLocation();
@@ -294,10 +299,6 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
 
         // Write version info
         writeWorkspaceInfo();
-
-        if (RuntimeUtils.isWindows()) {
-            setWindowsAppUserModelID();
-        }
 
         // Initialize display early
         // It sets main windows name and images
@@ -515,26 +516,36 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
     }
 
     /**
-     * Sets an explicit AppUserModelID so Windows can group the native launcher
-     * and the JVM process under the same taskbar button.
+     * Sets an explicit AppUserModelID so Windows groups the app under one taskbar button.
      * Must be called before the first SWT Display is created.
-     * Uses reflection to avoid a compile-time dependency on the Windows-only SWT class.
+     * <p>
+     * Delegates to the Windows SWT fragment via reflection so this class stays
+     * platform-agnostic at compile time. The fragment loads through SWT's classloader.
      */
     private void setWindowsAppUserModelID() {
         try {
             ClassLoader swtClassLoader = Display.class.getClassLoader();
-            Class<?> osClass = Class.forName(
-                    "org.eclipse.swt.internal.win32.OS",
-                    true,
-                    swtClassLoader
+            Class<?> aumidClass = Class.forName(
+                "org.jkiss.dbeaver.ui.swt.windows.WindowsAppUserModelId",
+                true,
+                swtClassLoader
             );
-            java.lang.reflect.Method method = osClass.getMethod(
-                    "SetCurrentProcessExplicitAppUserModelID", char[].class
-            );
-            method.invoke(null, (Object) "DBeaverCorp.DBeaverCE".toCharArray());
+            String appId = buildAppUserModelId();
+            aumidClass.getMethod("setCurrentProcessId", String.class).invoke(null, appId);
         } catch (Exception e) {
             log.debug("Failed to set Windows AppUserModelID", e);
         }
+    }
+
+    /**
+     * Builds a Windows AppUserModelID from the current product identity.
+     * Edition is taken from {@link GeneralUtils#getProductName()}; version is omitted so
+     * pinned taskbar icons remain valid after upgrades (see Microsoft AppUserModelID rules).
+     */
+    @NotNull
+    private static String buildAppUserModelId() {
+        String productPart = GeneralUtils.getProductName().replaceAll("[^A-Za-z0-9]", "");
+        return "DBeaverCorp." + productPart;
     }
 
     private Display getDisplay() {

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/DBeaverApplication.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/DBeaverApplication.java
@@ -295,6 +295,10 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
         // Write version info
         writeWorkspaceInfo();
 
+        if (RuntimeUtils.isWindows()) {
+            setWindowsAppUserModelID();
+        }
+
         // Initialize display early
         // It sets main windows name and images
         getDisplay();
@@ -507,6 +511,29 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
             } catch (Exception e) {
                 log.debug(e);
             }
+        }
+    }
+
+    /**
+     * Sets an explicit AppUserModelID so Windows can group the native launcher
+     * and the JVM process under the same taskbar button.
+     * Must be called before the first SWT Display is created.
+     * Uses reflection to avoid a compile-time dependency on the Windows-only SWT class.
+     */
+    private void setWindowsAppUserModelID() {
+        try {
+            ClassLoader swtClassLoader = Display.class.getClassLoader();
+            Class<?> osClass = Class.forName(
+                    "org.eclipse.swt.internal.win32.OS",
+                    true,
+                    swtClassLoader
+            );
+            java.lang.reflect.Method method = osClass.getMethod(
+                    "SetCurrentProcessExplicitAppUserModelID", char[].class
+            );
+            method.invoke(null, (Object) "DBeaverCorp.DBeaverCE".toCharArray());
+        } catch (Exception e) {
+            log.debug("Failed to set Windows AppUserModelID", e);
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/DBeaverApplication.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/DBeaverApplication.java
@@ -185,6 +185,11 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
         // hide standard Eclipse exit message if exit code is not OK (otherwise it may be confusing)
         System.setProperty(ECLIPSE_EXIT_DATA, "");
 
+        // Must run before any SWT Display / dialog is created (workspace lock UI, splash, etc.)
+        if (RuntimeUtils.isWindows()) {
+            setWindowsAppUserModelID();
+        }
+
         var args = preprocessCommandLine();
         Location instanceLoc = Platform.getInstanceLocation();
         Path defaultHomePath = getDefaultInstanceLocation();
@@ -294,10 +299,6 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
 
         // Write version info
         writeWorkspaceInfo();
-
-        if (RuntimeUtils.isWindows()) {
-            setWindowsAppUserModelID();
-        }
 
         // Initialize display early
         // It sets main windows name and images
@@ -515,23 +516,22 @@ public class DBeaverApplication extends DesktopApplicationImpl implements DBPApp
     }
 
     /**
-     * Sets an explicit AppUserModelID so Windows can group the native launcher
-     * and the JVM process under the same taskbar button.
+     * Sets an explicit AppUserModelID so Windows groups the app under one taskbar button.
      * Must be called before the first SWT Display is created.
-     * Uses reflection to avoid a compile-time dependency on the Windows-only SWT class.
+     * <p>
+     * Delegates to the Windows SWT fragment via reflection so this class stays
+     * platform-agnostic at compile time. The fragment loads through SWT's classloader.
      */
     private void setWindowsAppUserModelID() {
         try {
             ClassLoader swtClassLoader = Display.class.getClassLoader();
-            Class<?> osClass = Class.forName(
-                    "org.eclipse.swt.internal.win32.OS",
-                    true,
-                    swtClassLoader
+            Class<?> aumidClass = Class.forName(
+                "org.jkiss.dbeaver.ui.swt.windows.WindowsAppUserModelId",
+                true,
+                swtClassLoader
             );
-            java.lang.reflect.Method method = osClass.getMethod(
-                    "SetCurrentProcessExplicitAppUserModelID", char[].class
-            );
-            method.invoke(null, (Object) "DBeaverCorp.DBeaverCE".toCharArray());
+            String appId = (String) aumidClass.getField("CE_APP_ID").get(null);
+            aumidClass.getMethod("setCurrentProcessId", String.class).invoke(null, appId);
         } catch (Exception e) {
             log.debug("Failed to set Windows AppUserModelID", e);
         }

--- a/plugins/org.jkiss.dbeaver.ui.swt.windows/src/org/jkiss/dbeaver/ui/swt/windows/WindowsAppUserModelId.java
+++ b/plugins/org.jkiss.dbeaver.ui.swt.windows/src/org/jkiss/dbeaver/ui/swt/windows/WindowsAppUserModelId.java
@@ -1,0 +1,59 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.swt.windows;
+
+import org.eclipse.swt.internal.win32.OS;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.Log;
+
+/**
+ * Sets the Windows Application User Model ID for the current process.
+ * <p>
+ * Must be called before any SWT {@link org.eclipse.swt.widgets.Display} is created
+ * so the taskbar can group the launcher and UI under one pinned icon.
+ */
+public final class WindowsAppUserModelId {
+
+    private static final Log log = Log.getLog(WindowsAppUserModelId.class);
+
+    /**
+     * Stable AUMID for DBeaver Community. Must not contain spaces
+     * (see Microsoft AppUserModelID rules).
+     */
+    public static final String CE_APP_ID = "DBeaverCorp.DBeaverCE";
+
+    private WindowsAppUserModelId() {
+    }
+
+    /**
+     * Assigns an explicit AppUserModelID to the current process.
+     *
+     * @param appUserModelId Pascal-cased ID without spaces, e.g. {@link #CE_APP_ID}
+     * @return {@code true} if the Win32 call succeeded
+     */
+    public static boolean setCurrentProcessId(@NotNull String appUserModelId) {
+        // Win32 PCWSTR requires a trailing null; String.toCharArray() does not add one.
+        char[] buffer = new char[appUserModelId.length() + 1];
+        appUserModelId.getChars(0, appUserModelId.length(), buffer, 0);
+        int hr = OS.SetCurrentProcessExplicitAppUserModelID(buffer);
+        if (hr != OS.S_OK) {
+            log.debug("SetCurrentProcessExplicitAppUserModelID failed, HRESULT=" + hr);
+            return false;
+        }
+        return true;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.swt.windows/src/org/jkiss/dbeaver/ui/swt/windows/WindowsAppUserModelId.java
+++ b/plugins/org.jkiss.dbeaver.ui.swt.windows/src/org/jkiss/dbeaver/ui/swt/windows/WindowsAppUserModelId.java
@@ -1,0 +1,53 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.swt.windows;
+
+import org.eclipse.swt.internal.win32.OS;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.Log;
+
+/**
+ * Sets the Windows Application User Model ID for the current process.
+ * <p>
+ * Must be called before any SWT {@link org.eclipse.swt.widgets.Display} is created
+ * so the taskbar can group the launcher and UI under one pinned icon.
+ */
+public final class WindowsAppUserModelId {
+
+    private static final Log log = Log.getLog(WindowsAppUserModelId.class);
+
+    private WindowsAppUserModelId() {
+    }
+
+    /**
+     * Assigns an explicit AppUserModelID to the current process.
+     *
+     * @param appUserModelId Pascal-cased ID without spaces, e.g. {@code DBeaverCorp.DBeaver}
+     * @return {@code true} if the Win32 call succeeded
+     */
+    public static boolean setCurrentProcessId(@NotNull String appUserModelId) {
+        // Win32 PCWSTR requires a trailing null; String.toCharArray() does not add one.
+        char[] buffer = new char[appUserModelId.length() + 1];
+        appUserModelId.getChars(0, appUserModelId.length(), buffer, 0);
+        int hr = OS.SetCurrentProcessExplicitAppUserModelID(buffer);
+        if (hr != OS.S_OK) {
+            log.debug("SetCurrentProcessExplicitAppUserModelID failed, HRESULT=" + hr);
+            return false;
+        }
+        return true;
+    }
+}

--- a/product/community-msstore/DBeaverCommunityMSStore.product
+++ b/product/community-msstore/DBeaverCommunityMSStore.product
@@ -9,6 +9,8 @@
     </configIni>
 
     <launcherArgs>
+        <!-- Load JVM in-process so UI runs inside dbeaver.exe (complements explicit AppUserModelID; avoids duplicate pinned icons). -->
+        <programArgsWin>-vm jre/bin/server/jvm.dll</programArgsWin>
         <vmArgs>
             -XX:+IgnoreUnrecognizedVMOptions
             -Dosgi.requiredJavaVersion=21

--- a/product/community-msstore/DBeaverCommunityMSStore.product
+++ b/product/community-msstore/DBeaverCommunityMSStore.product
@@ -9,6 +9,8 @@
     </configIni>
 
     <launcherArgs>
+        <!-- Load JVM in-process so the taskbar identity matches dbeaver.exe (avoids duplicate pinned icons). -->
+        <programArgsWin>-vm jre/bin/server/jvm.dll</programArgsWin>
         <vmArgs>
             -XX:+IgnoreUnrecognizedVMOptions
             -Dosgi.requiredJavaVersion=21

--- a/product/community/DBeaver.product
+++ b/product/community/DBeaver.product
@@ -10,6 +10,8 @@
 
     <launcherArgs>
         <programArgs></programArgs>
+        <!-- Load JVM in-process so UI runs inside dbeaver.exe (complements explicit AppUserModelID; avoids duplicate pinned icons). -->
+        <programArgsWin>-vm jre/bin/server/jvm.dll</programArgsWin>
         <programArgsMac>-vm ../Eclipse/jre/Contents/Home/lib/libjli.dylib</programArgsMac>
 
         <vmArgs>

--- a/product/community/DBeaver.product
+++ b/product/community/DBeaver.product
@@ -10,6 +10,8 @@
 
     <launcherArgs>
         <programArgs></programArgs>
+        <!-- Load JVM in-process so the taskbar identity matches dbeaver.exe (avoids duplicate pinned icons). -->
+        <programArgsWin>-vm jre/bin/server/jvm.dll</programArgsWin>
         <programArgsMac>-vm ../Eclipse/jre/Contents/Home/lib/libjli.dylib</programArgsMac>
 
         <vmArgs>

--- a/product/testing/DBeaverUnitTest.product
+++ b/product/testing/DBeaverUnitTest.product
@@ -10,6 +10,7 @@
 
     <launcherArgs>
         <programArgs></programArgs>
+        <programArgsWin>-vm jre/bin/server/jvm.dll</programArgsWin>
         <programArgsMac>-vm ../Eclipse/jre/Contents/Home/lib/libjli.dylib</programArgsMac>
 
         <vmArgs>


### PR DESCRIPTION
Fixes #40782

## Problem

When DBeaver is pinned to the Windows taskbar, launching the application creates a duplicate taskbar icon instead of reusing the pinned one.

This happens because the Equinox launcher often starts the UI in a separate `javaw.exe` process while the pin targets `dbeaver.exe`. Without a shared process identity / AppUserModelID (AUMID), Windows treats them as different applications and shows a second taskbar button.

## Solution

Two complementary changes:

1. **In-process JVM on Windows**  
   Product configs now pass:
   `-vm jre/bin/server/jvm.dll`
   
   so the JVM is loaded inside `dbeaver.exe` instead of spawning a separate `javaw` UI process. Updated:
- `product/community/DBeaver.product`
- `product/community-msstore/DBeaverCommunityMSStore.product`
- `product/testing/DBeaverUnitTest.product`

2. **Explicit AppUserModelID before first SWT Display**  
On Windows, `DBeaverApplication.start()` sets AUMID `DBeaverCorp.DBeaverCE` before any workspace dialog / Display is created.  
The call is delegated via reflection to `WindowsAppUserModelId` in the Windows SWT fragment (`org.jkiss.dbeaver.ui.swt.windows`), which invokes `SetCurrentProcessExplicitAppUserModelID` with a **null-terminated** buffer (required by the Win32 API).  
Failures are logged at debug level and do not affect startup.

## Why reflection?

`DBeaverApplication` is platform-independent. Direct references to Windows-only APIs would break non-Windows builds. Reflection through `Display.class.getClassLoader()` resolves the Windows SWT fragment correctly in OSGi while keeping compile-time platform neutrality.

## Testing

**Automated**
- Packaged `dbeaver.exe` launches with UI hosted by `dbeaver.exe` (not a separate `javaw` window).
- `dbeaver.ini` contains `-vm jre/bin/server/jvm.dll`.

**Manual**
1. Unpin any existing DBeaver icons.
2. Launch packaged `dbeaver.exe` (not IntelliJ Run/Debug).
3. Pin the running taskbar button.
4. Close DBeaver completely.
5. Relaunch from the pinned icon.

**Before:** a duplicate taskbar icon appears.  
**After:** the pinned icon is reused; only one DBeaver icon is shown.

**evidence:**
<img width="1365" height="767" alt="appIconFix" src="https://github.com/user-attachments/assets/25a44ed0-7ab8-431c-907b-15c836e84b4d" />
