### PR TITLE
fix a subclause number in sql1992.txt

### DIFF
--- a/docs/sql1992.txt
+++ b/docs/sql1992.txt
@@ -37112,7 +37112,7 @@
          21.2 Information Schema
 
 
-         21.2.5  SCHEMATA view
+         21.2.4  SCHEMATA view
 
          Function
 


### PR DESCRIPTION
Problem: In 2021, a commit changed several files to replace the string "21.2.4" by "21.2.5". It had an impact on the following file: sql1992.txt. This file was not supposed to be modified. Consequence: A subclause number is wrong in this file. https://github.com/dbeaver/dbeaver/commit/ac49bb03a7f6f0b2f47b55c236538ba53b37a5bc

Solution: I fixed this problem by replacing the string "21.2.5" by "21.2.4" in this file.

Note: You can see the original file here: https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt