### PR TITLE
#38554 Honor "Use fully qualified names" option for foreign keys and constraints in DDL

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLConstraintManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLConstraintManager.java
@@ -64,7 +64,7 @@ public abstract class SQLConstraintManager<OBJECT_TYPE extends AbstractTableCons
         actions.add(
             new SQLDatabasePersistAction(
                 ModelMessages.model_jdbc_create_new_constraint,
-                "ALTER TABLE " + table.getFullyQualifiedName(DBPEvaluationContext.DDL) + " ADD " + getNestedDeclaration(monitor, table, command, options)));
+                "ALTER TABLE " + DBUtils.getEntityScriptName(table, options) + " ADD " + getNestedDeclaration(monitor, table, command, options)));
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLForeignKeyManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLForeignKeyManager.java
@@ -69,7 +69,7 @@ public abstract class SQLForeignKeyManager<OBJECT_TYPE extends AbstractTableCons
         actions.add(
             new SQLDatabasePersistAction(
                 ModelMessages.model_jdbc_create_new_foreign_key,
-                "ALTER TABLE " + table.getFullyQualifiedName(DBPEvaluationContext.DDL) + " ADD " + getNestedDeclaration(monitor, table, command, options)) //$NON-NLS-1$ //$NON-NLS-2$
+                "ALTER TABLE " + DBUtils.getEntityScriptName(table, options) + " ADD " + getNestedDeclaration(monitor, table, command, options)) //$NON-NLS-1$ //$NON-NLS-2$
         );
     }
 


### PR DESCRIPTION
### Implementation

When generating table DDL (Generate SQL -> DDL) with **Separate foreign keys** /
separate constraints enabled, the standalone `ALTER TABLE ... ADD CONSTRAINT ...`
statement always used the fully qualified table name, ignoring the dialog's
**Use fully qualified names** (`useFQN`) option. Toggling the option had no
effect on the foreign-key / constraint lines (reported in #38554).

The create-action path in the two generic edit managers hardcoded
`table.getFullyQualifiedName(DBPEvaluationContext.DDL)`. This routes the target
table name through the option-aware helper `DBUtils.getEntityScriptName(table, options)`
instead, which returns the fully qualified name when `useFQN` is set (the
default, so existing output is unchanged) and the plain quoted name otherwise:

- `SQLForeignKeyManager.addObjectCreateActions`
- `SQLConstraintManager.addObjectCreateActions`

This matches the pattern already used by `SQLIndexManager`, `SQLTableManager`,
and the referenced-table branch of `SQLForeignKeyManager` itself, so foreign
keys and constraints now behave consistently with the rest of the generated DDL.

Only the create path is changed; the drop/delete paths are left as-is.

**Manual verification:** right-click a table that has a foreign key ->
Generate SQL -> DDL; with **Separate foreign keys** enabled, toggle **Use fully
qualified names**. The `ALTER TABLE ... ADD CONSTRAINT` line now drops the
catalog/schema prefix when the option is off and keeps it when on.

### Issue reference

Closes dbeaver/dbeaver#38554
