### PR TITLE
dbeaver/dbeaver#23137 Add code folding for --region/--endregion marke…

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFolding.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFolding.java
@@ -1,0 +1,247 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.parser;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.IDocumentPartitioner;
+import org.eclipse.jface.text.IRegion;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.Log;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Scans {@code --region}/{@code --endregion} script markers and decides when folding gutter refresh is needed.
+ */
+public final class SQLRegionMarkerFolding {
+
+    private static final Log log = Log.getLog(SQLRegionMarkerFolding.class);
+
+    private static final Pattern REGION_START_PATTERN = Pattern.compile("^\\s*--\\s*region\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REGION_END_PATTERN = Pattern.compile("^\\s*--\\s*endregion\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REGION_MARKER_NAME_PATTERN = Pattern.compile("^\\s*--\\s*region\\s*(.*)", Pattern.CASE_INSENSITIVE);
+
+    private SQLRegionMarkerFolding() {
+    }
+
+    public record RegionFold(@NotNull String regionKey, int offset, int length) {
+    }
+
+    private record RegionStartFrame(int offset, @NotNull String regionKey) {
+    }
+
+    @NotNull
+    public static List<RegionFold> scanRegions(@NotNull IDocument document) {
+        List<RegionFold> regions = new ArrayList<>();
+        if (document.getLength() == 0) {
+            return regions;
+        }
+        IDocumentPartitioner partitioner = getSqlDocumentPartitioner(document);
+        Deque<RegionStartFrame> regionStarts = new ArrayDeque<>();
+        int lineCount = document.getNumberOfLines();
+        for (int line = 0; line < lineCount; line++) {
+            collectRegionFoldingOnLine(document, line, lineCount, partitioner, regionStarts, regions);
+        }
+        return regions;
+    }
+
+    @NotNull
+    public static List<RegionFold> scanFoldableRegions(@NotNull IDocument document) {
+        List<RegionFold> foldable = new ArrayList<>();
+        for (RegionFold region : scanRegions(document)) {
+            if (isValidDocumentRange(document, region.offset(), region.length())
+                && getRegionNumberOfLines(document, region) > 1
+            ) {
+                foldable.add(region);
+            }
+        }
+        return foldable;
+    }
+
+    public static boolean needsFoldingGutterRefresh(
+        boolean annotationStructureChanged,
+        boolean collapseApplied,
+        boolean regionSetChanged,
+        int editOffset,
+        @NotNull Collection<RegionFold> regions
+    ) {
+        if (annotationStructureChanged || collapseApplied || regionSetChanged) {
+            return true;
+        }
+        return documentEditShiftsRegionMarkers(editOffset, regions);
+    }
+
+    public static boolean documentEditShiftsRegionMarkers(int editOffset, @NotNull Collection<RegionFold> regions) {
+        if (regions.isEmpty()) {
+            return false;
+        }
+        for (RegionFold region : regions) {
+            if (editOffset <= region.offset()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static int getRegionNumberOfLines(@NotNull IDocument document, @NotNull RegionFold region) {
+        if (!isValidDocumentRange(document, region.offset(), region.length())) {
+            return 1;
+        }
+        try {
+            int startLine = document.getLineOfOffset(region.offset());
+            int endLine = document.getLineOfOffset(region.offset() + region.length() - 1);
+            return endLine - startLine + 1;
+        } catch (BadLocationException e) {
+            return 1;
+        }
+    }
+
+    public static boolean isValidDocumentRange(@NotNull IDocument document, int offset, int length) {
+        if (offset < 0 || length <= 0) {
+            return false;
+        }
+        int end = offset + length;
+        if (end > document.getLength()) {
+            return false;
+        }
+        try {
+            document.getLineOfOffset(offset);
+            if (end == document.getLength()) {
+                if (document.getLength() == 0) {
+                    return false;
+                }
+                document.getLineOfOffset(document.getLength() - 1);
+            } else {
+                document.getLineOfOffset(end);
+            }
+            return true;
+        } catch (BadLocationException e) {
+            return false;
+        }
+    }
+
+    public static boolean isStrictlyEnclosedInAnyRegion(
+        int innerStart,
+        int innerEnd,
+        @NotNull Collection<RegionFold> regions
+    ) {
+        for (RegionFold region : regions) {
+            int outerStart = region.offset();
+            int outerEnd = outerStart + region.length();
+            if (isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void collectRegionFoldingOnLine(
+        @NotNull IDocument document,
+        int line,
+        int lineCount,
+        IDocumentPartitioner partitioner,
+        @NotNull Deque<RegionStartFrame> regionStarts,
+        @NotNull List<RegionFold> regions
+    ) {
+        try {
+            IRegion lineInfo = document.getLineInformation(line);
+            int lineOffset = lineInfo.getOffset();
+            int lineLength = lineInfo.getLength();
+            if (lineLength == 0) {
+                return;
+            }
+            String lineText = document.get(lineOffset, lineLength);
+            if (!isSqlRegionMarkerCommentLine(lineText, lineOffset, partitioner)) {
+                return;
+            }
+            if (REGION_START_PATTERN.matcher(lineText).find()) {
+                String markerName = extractRegionMarkerName(lineText);
+                String regionKey = regionStarts.isEmpty()
+                    ? markerName
+                    : regionStarts.peek().regionKey() + "/" + markerName;
+                regionStarts.push(new RegionStartFrame(lineOffset, regionKey));
+            } else if (REGION_END_PATTERN.matcher(lineText).find() && !regionStarts.isEmpty()) {
+                addClosedRegion(document, line, lineCount, regionStarts, regions);
+            }
+        } catch (BadLocationException e) {
+            log.warn("Error scanning for region folding markers", e);
+        }
+    }
+
+    private static boolean isSqlRegionMarkerCommentLine(
+        @NotNull String lineText,
+        int lineOffset,
+        IDocumentPartitioner partitioner
+    ) {
+        if (partitioner == null) {
+            return true;
+        }
+        int commentPos = lineText.indexOf("--");
+        if (commentPos < 0) {
+            return false;
+        }
+        String contentType = partitioner.getContentType(lineOffset + commentPos);
+        return SQLParserPartitions.CONTENT_TYPE_SQL_COMMENT.equals(contentType);
+    }
+
+    private static void addClosedRegion(
+        @NotNull IDocument document,
+        int endMarkerLine,
+        int lineCount,
+        @NotNull Deque<RegionStartFrame> regionStarts,
+        @NotNull List<RegionFold> regions
+    ) throws BadLocationException {
+        RegionStartFrame regionStart = regionStarts.pop();
+        int endOffset = endMarkerLine + 1 < lineCount
+            ? document.getLineOffset(endMarkerLine + 1)
+            : document.getLength();
+        int length = endOffset - regionStart.offset();
+        if (length > 0) {
+            regions.add(new RegionFold(regionStart.regionKey(), regionStart.offset(), length));
+        }
+    }
+
+    @NotNull
+    private static String extractRegionMarkerName(@NotNull String lineText) {
+        var matcher = REGION_MARKER_NAME_PATTERN.matcher(lineText);
+        if (!matcher.find()) {
+            return "region";
+        }
+        String markerName = matcher.group(1).trim();
+        return markerName.isEmpty() ? "region" : markerName.toUpperCase(Locale.ROOT);
+    }
+
+    private static IDocumentPartitioner getSqlDocumentPartitioner(@NotNull IDocument document) {
+        if (document instanceof IDocumentExtension3 ext) {
+            return ext.getDocumentPartitioner(SQLParserPartitions.SQL_PARTITIONING);
+        }
+        return null;
+    }
+
+    private static boolean isStrictlyEnclosed(int innerStart, int innerEnd, int outerStart, int outerEnd) {
+        return innerStart >= outerStart && innerEnd <= outerEnd
+            && (innerStart > outerStart || innerEnd < outerEnd);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
@@ -355,6 +355,22 @@ public abstract class SQLEditorBase extends BaseTextEditor implements
         return viewer != null ? viewer.getProjectionAnnotationModel() : null;
     }
 
+    public void refreshProjectionFoldingPresentation() {
+        ProjectionAnnotationModel projectionModel = getProjectionAnnotationModel();
+        if (projectionModel != null) {
+            projectionModel.modifyAnnotations(null, null, null);
+        }
+        // Gutter desync is fixed by vertical ruler refresh; full-document invalidateTextPresentation
+        // does not repaint projection icons and is costly on large scripts.
+        IVerticalRuler verticalRuler = getVerticalRuler();
+        if (verticalRuler != null) {
+            verticalRuler.update();
+            if (verticalRuler.getControl() != null && !verticalRuler.getControl().isDisposed()) {
+                verticalRuler.getControl().redraw();
+            }
+        }
+    }
+
     public SQLEditorSourceViewerConfiguration getViewerConfiguration() {
         return (SQLEditorSourceViewerConfiguration) super.getSourceViewerConfiguration();
     }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorSourceViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorSourceViewer.java
@@ -28,7 +28,8 @@ import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
 import org.jkiss.dbeaver.ui.editors.sql.syntax.SQLProjectionAnnotationModel;
 
-import java.lang.reflect.Field;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import org.eclipse.swt.custom.ST;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.custom.VerifyKeyListener;
@@ -119,21 +120,26 @@ public class SQLEditorSourceViewer extends ProjectionViewer {
     @Override
     protected IAnnotationModel createVisualAnnotationModel(IAnnotationModel annotationModel) {
         IAnnotationModel visualModel = super.createVisualAnnotationModel(annotationModel);
+        installSqlProjectionAnnotationModel();
+        return visualModel;
+    }
+
+    /**
+     * ProjectionViewer creates a plain {@link ProjectionAnnotationModel} in a private field during
+     * {@link #createVisualAnnotationModel(IAnnotationModel)}. Eclipse does not expose a hook to substitute
+     * a subclass, so the field is replaced here before projection mode is enabled.
+     */
+    private void installSqlProjectionAnnotationModel() {
         try {
-            Field field = ProjectionViewer.class.getDeclaredField("fProjectionAnnotationModel");
-            field.setAccessible(true);
-            ProjectionAnnotationModel wiredModel = (ProjectionAnnotationModel) field.get(this);
-            if (wiredModel != null && !(wiredModel instanceof SQLProjectionAnnotationModel)) {
-                SQLProjectionAnnotationModel sqlModel = new SQLProjectionAnnotationModel();
-                field.set(this, sqlModel);
-                if (visualModel == wiredModel) {
-                    return sqlModel;
-                }
+            VarHandle projectionModelHandle = MethodHandles.privateLookupIn(ProjectionViewer.class, MethodHandles.lookup())
+                .findVarHandle(ProjectionViewer.class, "fProjectionAnnotationModel", ProjectionAnnotationModel.class);
+            if (projectionModelHandle.get(this) instanceof SQLProjectionAnnotationModel) {
+                return;
             }
+            projectionModelHandle.set(this, new SQLProjectionAnnotationModel());
         } catch (ReflectiveOperationException e) {
             log.warn("Failed to install SQL projection annotation model", e);
         }
-        return visualModel;
     }
     
     private boolean expandAnnotationsContaining(@NotNull ProjectionAnnotationModel projectionAnnotationModel, int offset) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorSourceViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorSourceViewer.java
@@ -20,11 +20,15 @@ package org.jkiss.dbeaver.ui.editors.sql;
 import org.eclipse.jface.text.*;
 import org.eclipse.jface.text.hyperlink.IHyperlinkPresenter;
 import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.text.source.IOverviewRuler;
 import org.eclipse.jface.text.source.IVerticalRuler;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
+import org.jkiss.dbeaver.ui.editors.sql.syntax.SQLProjectionAnnotationModel;
+
+import java.lang.reflect.Field;
 import org.eclipse.swt.custom.ST;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.custom.VerifyKeyListener;
@@ -110,6 +114,26 @@ public class SQLEditorSourceViewer extends ProjectionViewer {
         
         //textWidget.setAlwaysShowScrollBars(false);
         return textWidget;
+    }
+
+    @Override
+    protected IAnnotationModel createVisualAnnotationModel(IAnnotationModel annotationModel) {
+        IAnnotationModel visualModel = super.createVisualAnnotationModel(annotationModel);
+        try {
+            Field field = ProjectionViewer.class.getDeclaredField("fProjectionAnnotationModel");
+            field.setAccessible(true);
+            ProjectionAnnotationModel wiredModel = (ProjectionAnnotationModel) field.get(this);
+            if (wiredModel != null && !(wiredModel instanceof SQLProjectionAnnotationModel)) {
+                SQLProjectionAnnotationModel sqlModel = new SQLProjectionAnnotationModel();
+                field.set(this, sqlModel);
+                if (visualModel == wiredModel) {
+                    return sqlModel;
+                }
+            }
+        } catch (ReflectiveOperationException e) {
+            log.warn("Failed to install SQL projection annotation model", e);
+        }
+        return visualModel;
     }
     
     private boolean expandAnnotationsContaining(@NotNull ProjectionAnnotationModel projectionAnnotationModel, int offset) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
@@ -1,0 +1,172 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.editors.sql.syntax;
+
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
+import org.jkiss.code.NotNull;
+
+import java.util.*;
+
+/**
+ * Expands enclosed collapsed folds before collapsing a parent region.
+ * Remembers enclosed collapse state and restores it when the parent is expanded.
+ */
+public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
+
+    private final Map<Integer, Set<Integer>> deferredCollapsedEnclosedOffsets = new HashMap<>();
+
+    @NotNull
+    public Set<Integer> getDeferredCollapsedOffsets() {
+        Set<Integer> all = new HashSet<>();
+        for (Set<Integer> offsets : deferredCollapsedEnclosedOffsets.values()) {
+            all.addAll(offsets);
+        }
+        return all;
+    }
+
+    @Override
+    public void collapse(Annotation annotation) {
+        saveAndExpandEnclosedCollapsed(annotation);
+        super.collapse(annotation);
+    }
+
+    @Override
+    public void expand(Annotation annotation) {
+        super.expand(annotation);
+        restoreDeferredCollapsedEnclosed(annotation);
+    }
+
+    @Override
+    public void toggleExpansionState(Annotation annotation) {
+        boolean wasCollapsed = annotation instanceof ProjectionAnnotation projectionAnnotation && projectionAnnotation.isCollapsed();
+        if (!wasCollapsed) {
+            saveAndExpandEnclosedCollapsed(annotation);
+        }
+        super.toggleExpansionState(annotation);
+        if (wasCollapsed) {
+            restoreDeferredCollapsedEnclosed(annotation);
+        }
+    }
+
+    private void saveAndExpandEnclosedCollapsed(@NotNull Annotation outerAnnotation) {
+        Position outerPosition = getPosition(outerAnnotation);
+        if (outerPosition == null) {
+            return;
+        }
+        Set<Integer> enclosedCollapsedOffsets = collectEnclosedCollapsedOffsets(outerPosition, outerAnnotation);
+        if (enclosedCollapsedOffsets.isEmpty()) {
+            return;
+        }
+        deferredCollapsedEnclosedOffsets.put(outerPosition.getOffset(), enclosedCollapsedOffsets);
+        expandEnclosedCollapsed(outerPosition, outerAnnotation);
+    }
+
+    @NotNull
+    private Set<Integer> collectEnclosedCollapsedOffsets(
+        @NotNull Position outerPosition,
+        @NotNull Annotation outerAnnotation
+    ) {
+        int outerStart = outerPosition.getOffset();
+        int outerEnd = outerStart + outerPosition.getLength();
+        Set<Integer> enclosedCollapsedOffsets = new HashSet<>();
+        Iterator<Annotation> it = getAnnotationIterator();
+        while (it.hasNext()) {
+            Annotation enclosedAnnotation = it.next();
+            if (enclosedAnnotation == outerAnnotation
+                || !(enclosedAnnotation instanceof ProjectionAnnotation inner)
+                || !inner.isCollapsed()
+            ) {
+                continue;
+            }
+            Position innerPosition = getPosition(enclosedAnnotation);
+            if (innerPosition == null) {
+                continue;
+            }
+            int innerStart = innerPosition.getOffset();
+            int innerEnd = innerStart + innerPosition.getLength();
+            if (isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
+                enclosedCollapsedOffsets.add(innerStart);
+            }
+        }
+        return enclosedCollapsedOffsets;
+    }
+
+    private void expandEnclosedCollapsed(
+        @NotNull Position outerPosition,
+        @NotNull Annotation outerAnnotation
+    ) {
+        int outerStart = outerPosition.getOffset();
+        int outerEnd = outerStart + outerPosition.getLength();
+        Iterator<Annotation> it = getAnnotationIterator();
+        while (it.hasNext()) {
+            Annotation enclosedAnnotation = it.next();
+            if (enclosedAnnotation == outerAnnotation
+                || !(enclosedAnnotation instanceof ProjectionAnnotation inner)
+                || !inner.isCollapsed()
+            ) {
+                continue;
+            }
+            Position innerPosition = getPosition(enclosedAnnotation);
+            if (innerPosition == null) {
+                continue;
+            }
+            int innerStart = innerPosition.getOffset();
+            int innerEnd = innerStart + innerPosition.getLength();
+            if (isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
+                super.expand(enclosedAnnotation);
+            }
+        }
+    }
+
+    private void restoreDeferredCollapsedEnclosed(@NotNull Annotation outerAnnotation) {
+        Position outerPosition = getPosition(outerAnnotation);
+        if (outerPosition == null) {
+            return;
+        }
+        Set<Integer> deferredOffsets = deferredCollapsedEnclosedOffsets.remove(outerPosition.getOffset());
+        if (deferredOffsets == null || deferredOffsets.isEmpty()) {
+            return;
+        }
+        List<ProjectionAnnotation> toCollapse = new ArrayList<>();
+        Iterator<Annotation> it = getAnnotationIterator();
+        while (it.hasNext()) {
+            Annotation annotation = it.next();
+            if (!(annotation instanceof ProjectionAnnotation projectionAnnotation)) {
+                continue;
+            }
+            Position position = getPosition(annotation);
+            if (position != null && deferredOffsets.contains(position.getOffset())) {
+                toCollapse.add(projectionAnnotation);
+            }
+        }
+        toCollapse.sort(Comparator.comparingInt(annotation -> {
+            Position position = getPosition(annotation);
+            return position != null ? position.getLength() : Integer.MAX_VALUE;
+        }));
+        for (ProjectionAnnotation annotation : toCollapse) {
+            super.collapse(annotation);
+        }
+    }
+
+    private static boolean isStrictlyEnclosed(int innerStart, int innerEnd, int outerStart, int outerEnd) {
+        return innerStart >= outerStart && innerEnd <= outerEnd
+            && (innerStart > outerStart || innerEnd < outerEnd);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
@@ -27,19 +27,18 @@ import java.util.*;
 /**
  * Expands enclosed collapsed folds before collapsing a parent region.
  * Remembers enclosed collapse state and restores it when the parent is expanded.
+ * <p>
+ * Nested collapse/expand behavior is covered by manual UI tests only (requires SWT projection viewer).
+ * Manual test plan:
+ * <ul>
+ *   <li>Collapse OUTER with expanded INNER → expand OUTER → INNER collapse state restored</li>
+ *   <li>Toggle expansion is symmetric for parent and enclosed regions</li>
+ *   <li>Manually expand INNER then expand OUTER → INNER stays expanded ({@code forgetDeferredCollapse})</li>
+ * </ul>
  */
 public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
 
     private final Map<Integer, Set<Integer>> deferredCollapsedEnclosedOffsets = new HashMap<>();
-
-    @NotNull
-    public Set<Integer> getDeferredCollapsedOffsets() {
-        Set<Integer> all = new HashSet<>();
-        for (Set<Integer> offsets : deferredCollapsedEnclosedOffsets.values()) {
-            all.addAll(offsets);
-        }
-        return all;
-    }
 
     @Override
     public void collapse(Annotation annotation) {
@@ -50,6 +49,7 @@ public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
     @Override
     public void expand(Annotation annotation) {
         super.expand(annotation);
+        forgetDeferredCollapse(annotation);
         restoreDeferredCollapsedEnclosed(annotation);
     }
 
@@ -61,8 +61,21 @@ public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
         }
         super.toggleExpansionState(annotation);
         if (wasCollapsed) {
+            forgetDeferredCollapse(annotation);
             restoreDeferredCollapsedEnclosed(annotation);
         }
+    }
+
+    private void forgetDeferredCollapse(@NotNull Annotation annotation) {
+        Position position = getPosition(annotation);
+        if (position == null) {
+            return;
+        }
+        int offset = position.getOffset();
+        for (Set<Integer> offsets : deferredCollapsedEnclosedOffsets.values()) {
+            offsets.remove(offset);
+        }
+        deferredCollapsedEnclosedOffsets.entrySet().removeIf(entry -> entry.getValue().isEmpty());
     }
 
     private void saveAndExpandEnclosedCollapsed(@NotNull Annotation outerAnnotation) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -260,9 +260,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         }
 
         List<SQLScriptElementImpl> regionElements = extractRegionFoldingPositions();
-        List<SQLRegionMarkerFolding.RegionFold> regionFolds = regionElements.stream()
-            .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
-            .toList();
+        List<SQLRegionMarkerFolding.RegionFold> regionFolds = toRegionFolds(regionElements);
 
         Set<SQLScriptElementImpl> parsedElements = new HashSet<>(parsedQueries.stream()
             .filter(this::deservesFolding)
@@ -321,14 +319,49 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         @NotNull Set<Integer> savedCollapsedAnnotationsOffsets,
         int editOffset
     ) {
-        List<SQLScriptElementImpl> scannedRegions = extractFoldableRegionFoldingPositions();
+        Map<String, SQLScriptElementImpl> scannedByKey = buildScannedRegionsByKey();
+        Map<String, Boolean> collapsedByKey = buildCollapsedRegionKeys(scannedByKey, savedCollapsedAnnotationsOffsets);
+
+        List<Annotation> deletions = collectObsoleteRegionAnnotations(scannedByKey);
+        Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
+        Map<String, SQLScriptElementImpl> nextRegionCache = new LinkedHashMap<>();
+        reconcileRegionAnnotationChanges(scannedByKey, collapsedByKey, model, deletions, additions, nextRegionCache);
+
+        if (!deletions.isEmpty() || !additions.isEmpty()) {
+            model.modifyAnnotations(deletions.toArray(Annotation[]::new), additions, null);
+        }
+
+        boolean collapseApplied = applySavedCollapsedStates(model, nextRegionCache, collapsedByKey);
+        boolean regionSetChanged = !regionCache.keySet().equals(scannedByKey.keySet());
+        updateRegionCache(nextRegionCache);
+
+        if (SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            !deletions.isEmpty() || !additions.isEmpty(),
+            collapseApplied,
+            regionSetChanged,
+            editOffset,
+            toRegionFolds(scannedByKey.values())
+        )) {
+            scheduleProjectionPresentationRefresh();
+        }
+    }
+
+    @NotNull
+    private Map<String, SQLScriptElementImpl> buildScannedRegionsByKey() {
         Map<String, SQLScriptElementImpl> scannedByKey = new LinkedHashMap<>();
-        for (SQLScriptElementImpl region : scannedRegions) {
+        for (SQLScriptElementImpl region : extractFoldableRegionFoldingPositions()) {
             if (region.getRegionKey() != null) {
                 scannedByKey.put(region.getRegionKey(), region);
             }
         }
+        return scannedByKey;
+    }
 
+    @NotNull
+    private Map<String, Boolean> buildCollapsedRegionKeys(
+        @NotNull Map<String, SQLScriptElementImpl> scannedByKey,
+        @NotNull Set<Integer> savedCollapsedAnnotationsOffsets
+    ) {
         Map<String, Boolean> collapsedByKey = new HashMap<>();
         for (SQLScriptElementImpl cachedRegion : regionCache.values()) {
             ProjectionAnnotation annotation = cachedRegion.getAnnotation();
@@ -341,11 +374,12 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 collapsedByKey.put(scannedEntry.getKey(), true);
             }
         }
+        return collapsedByKey;
+    }
 
-        Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
+    @NotNull
+    private List<Annotation> collectObsoleteRegionAnnotations(@NotNull Map<String, SQLScriptElementImpl> scannedByKey) {
         List<Annotation> deletions = new ArrayList<>();
-        Map<String, SQLScriptElementImpl> nextRegionCache = new LinkedHashMap<>();
-
         for (Map.Entry<String, SQLScriptElementImpl> cachedEntry : regionCache.entrySet()) {
             if (!scannedByKey.containsKey(cachedEntry.getKey())) {
                 ProjectionAnnotation annotation = cachedEntry.getValue().getAnnotation();
@@ -354,7 +388,17 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 }
             }
         }
+        return deletions;
+    }
 
+    private void reconcileRegionAnnotationChanges(
+        @NotNull Map<String, SQLScriptElementImpl> scannedByKey,
+        @NotNull Map<String, Boolean> collapsedByKey,
+        @NotNull ProjectionAnnotationModel model,
+        @NotNull List<Annotation> deletions,
+        @NotNull Map<Annotation, SQLScriptElementImpl> additions,
+        @NotNull Map<String, SQLScriptElementImpl> nextRegionCache
+    ) {
         for (Map.Entry<String, SQLScriptElementImpl> scannedEntry : scannedByKey.entrySet()) {
             String regionKey = scannedEntry.getKey();
             SQLScriptElementImpl scannedRegion = scannedEntry.getValue();
@@ -380,11 +424,13 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             additions.put(annotation, scannedRegion);
             nextRegionCache.put(regionKey, scannedRegion);
         }
+    }
 
-        if (!deletions.isEmpty() || !additions.isEmpty()) {
-            model.modifyAnnotations(deletions.toArray(Annotation[]::new), additions, null);
-        }
-
+    private boolean applySavedCollapsedStates(
+        @NotNull ProjectionAnnotationModel model,
+        @NotNull Map<String, SQLScriptElementImpl> nextRegionCache,
+        @NotNull Map<String, Boolean> collapsedByKey
+    ) {
         boolean collapseApplied = false;
         for (Map.Entry<String, SQLScriptElementImpl> entry : nextRegionCache.entrySet()) {
             SQLScriptElementImpl region = entry.getValue();
@@ -400,23 +446,19 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 collapseApplied = true;
             }
         }
+        return collapseApplied;
+    }
 
-        boolean regionSetChanged = !regionCache.keySet().equals(scannedByKey.keySet());
-
+    private void updateRegionCache(@NotNull Map<String, SQLScriptElementImpl> nextRegionCache) {
         regionCache.clear();
         regionCache.putAll(nextRegionCache);
+    }
 
-        if (SQLRegionMarkerFolding.needsFoldingGutterRefresh(
-            !deletions.isEmpty() || !additions.isEmpty(),
-            collapseApplied,
-            regionSetChanged,
-            editOffset,
-            scannedByKey.values().stream()
-                .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
-                .toList()
-        )) {
-            scheduleProjectionPresentationRefresh();
-        }
+    @NotNull
+    private List<SQLRegionMarkerFolding.RegionFold> toRegionFolds(@NotNull Collection<SQLScriptElementImpl> regions) {
+        return regions.stream()
+            .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
+            .toList();
     }
 
     /**

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -39,15 +39,15 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.sql.SQLScriptElement;
-import org.jkiss.dbeaver.model.sql.parser.SQLParserPartitions;
+import org.jkiss.dbeaver.model.sql.parser.SQLRegionMarkerFolding;
 import org.jkiss.dbeaver.ui.editors.EditorUtils;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorUtils;
 import org.jkiss.dbeaver.ui.editors.sql.internal.SQLEditorActivator;
+import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.utils.CommonUtils;
 
 import java.util.*;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilingStrategyExtension {
@@ -56,10 +56,11 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     private static final QualifiedName COLLAPSED_ANNOTATIONS =
         new QualifiedName(SQLEditorActivator.PLUGIN_ID, SQLReconcilingStrategy.class.getName() + ".collapsedFoldingAnnotations");
 
-    private static final Pattern REGION_START_PATTERN = Pattern.compile("^\\s*--\\s*region\\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern REGION_END_PATTERN = Pattern.compile("^\\s*--\\s*endregion\\b", Pattern.CASE_INSENSITIVE);
-
     private final NavigableSet<SQLScriptElementImpl> cache = new TreeSet<>();
+    private final Map<String, SQLScriptElementImpl> regionCache = new LinkedHashMap<>();
+
+    private volatile boolean projectionRefreshScheduled;
+    private volatile boolean projectionRefreshPending;
 
     private final SQLEditorBase editor;
 
@@ -87,6 +88,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     public void setDocument(IDocument document) {
         this.document = document;
         this.cache.clear();
+        this.regionCache.clear();
 
         spellingService = EditorsUI.getSpellingService();
         if (spellingService.getActiveSpellingEngineDescriptor(editor.getViewerConfiguration().getPreferenceStore()) != null) {
@@ -166,9 +168,10 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 stringJoiner.add(Integer.toString(position.getOffset()));
             }
         }
-        if (annotationModel instanceof SQLProjectionAnnotationModel sqlProjectionModel) {
-            for (int offset : sqlProjectionModel.getDeferredCollapsedOffsets()) {
-                stringJoiner.add(Integer.toString(offset));
+        for (SQLScriptElementImpl position : regionCache.values()) {
+            ProjectionAnnotation annotation = position.getAnnotation();
+            if (annotation != null && annotation.isCollapsed()) {
+                stringJoiner.add(Integer.toString(position.getOffset()));
             }
         }
         String value;
@@ -203,12 +206,15 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     private void reconcile(int damagedRegionOffset, int damagedRegionLength, boolean restoreCollapsedAnnotations) {
         if (!editor.isFoldingEnabled()) {
             cache.clear(); // underlying annotation model being cleared, so reset the cache too
+            regionCache.clear();
             return;
         }
         ProjectionAnnotationModel model = editor.getProjectionAnnotationModel();
         if (model == null) {
             return;
         }
+
+        final int editOffset = damagedRegionOffset; // original dirty region; damagedRegionOffset is widened below for parser cache
 
         SQLScriptElementImpl leftBound = cache.lower(new SQLScriptElementImpl(damagedRegionOffset, damagedRegionLength));
         if (leftBound != null) {
@@ -254,11 +260,14 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         }
 
         List<SQLScriptElementImpl> regionElements = extractRegionFoldingPositions();
+        List<SQLRegionMarkerFolding.RegionFold> regionFolds = regionElements.stream()
+            .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
+            .toList();
 
         Set<SQLScriptElementImpl> parsedElements = new HashSet<>(parsedQueries.stream()
             .filter(this::deservesFolding)
             .map(this::getExpandedScriptElement)
-            .filter(element -> !isStrictlyEnclosedInAnyRegion(element, regionElements))
+            .filter(element -> !isStrictlyEnclosedInAnyRegion(element, regionFolds))
             .collect(Collectors.toSet()));
         Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
         Set<Integer> savedCollapsedAnnotationsOffsets = restoreCollapsedAnnotations ? getSavedCollapsedAnnotationsOffsets() : Collections.emptySet();
@@ -267,18 +276,6 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 ProjectionAnnotation annotation = new ProjectionAnnotation();
                 element.setAnnotation(annotation);
                 additions.put(annotation, element);
-            }
-        }
-        // Add region-based folding annotations for --region/--endregion markers
-        for (SQLScriptElementImpl regionElement : regionElements) {
-            if (getNumberOfLines(regionElement) <= 1) {
-                continue;
-            }
-            parsedElements.add(regionElement);
-            if (!cachedQueries.contains(regionElement)) {
-                ProjectionAnnotation annotation = new ProjectionAnnotation();
-                regionElement.setAnnotation(annotation);
-                additions.put(annotation, regionElement);
             }
         }
         Collection<SQLScriptElementImpl> deletedPositions = cachedQueries.stream()
@@ -303,9 +300,10 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 }
             }
         }
-        syncCollapsedProjectionAnnotations(model);
         cache.removeAll(deletedPositions);
         cache.addAll(additions.values());
+
+        syncRegionFolds(model, savedCollapsedAnnotationsOffsets, editOffset);
 
         if (isSpellingEnabled() && spellingContext != null) {
             IRegion[] regions = new IRegion[]{
@@ -318,6 +316,167 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         }
     }
 
+    private void syncRegionFolds(
+        @NotNull ProjectionAnnotationModel model,
+        @NotNull Set<Integer> savedCollapsedAnnotationsOffsets,
+        int editOffset
+    ) {
+        List<SQLScriptElementImpl> scannedRegions = extractFoldableRegionFoldingPositions();
+        Map<String, SQLScriptElementImpl> scannedByKey = new LinkedHashMap<>();
+        for (SQLScriptElementImpl region : scannedRegions) {
+            if (region.getRegionKey() != null) {
+                scannedByKey.put(region.getRegionKey(), region);
+            }
+        }
+
+        Map<String, Boolean> collapsedByKey = new HashMap<>();
+        for (SQLScriptElementImpl cachedRegion : regionCache.values()) {
+            ProjectionAnnotation annotation = cachedRegion.getAnnotation();
+            if (annotation != null && annotation.isCollapsed() && cachedRegion.getRegionKey() != null) {
+                collapsedByKey.put(cachedRegion.getRegionKey(), true);
+            }
+        }
+        for (Map.Entry<String, SQLScriptElementImpl> scannedEntry : scannedByKey.entrySet()) {
+            if (savedCollapsedAnnotationsOffsets.contains(scannedEntry.getValue().getOffset())) {
+                collapsedByKey.put(scannedEntry.getKey(), true);
+            }
+        }
+
+        Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
+        List<Annotation> deletions = new ArrayList<>();
+        Map<String, SQLScriptElementImpl> nextRegionCache = new LinkedHashMap<>();
+
+        for (Map.Entry<String, SQLScriptElementImpl> cachedEntry : regionCache.entrySet()) {
+            if (!scannedByKey.containsKey(cachedEntry.getKey())) {
+                ProjectionAnnotation annotation = cachedEntry.getValue().getAnnotation();
+                if (annotation != null) {
+                    deletions.add(annotation);
+                }
+            }
+        }
+
+        for (Map.Entry<String, SQLScriptElementImpl> scannedEntry : scannedByKey.entrySet()) {
+            String regionKey = scannedEntry.getKey();
+            SQLScriptElementImpl scannedRegion = scannedEntry.getValue();
+            SQLScriptElementImpl cachedRegion = regionCache.get(regionKey);
+
+            if (!needsRegionAnnotationRecreate(cachedRegion, scannedRegion, model)) {
+                nextRegionCache.put(regionKey, cachedRegion);
+                continue;
+            }
+
+            if (cachedRegion != null) {
+                ProjectionAnnotation oldAnnotation = cachedRegion.getAnnotation();
+                if (oldAnnotation != null) {
+                    if (oldAnnotation.isCollapsed()) {
+                        collapsedByKey.put(regionKey, true);
+                    }
+                    deletions.add(oldAnnotation);
+                }
+            }
+
+            ProjectionAnnotation annotation = new ProjectionAnnotation();
+            scannedRegion.setAnnotation(annotation);
+            additions.put(annotation, scannedRegion);
+            nextRegionCache.put(regionKey, scannedRegion);
+        }
+
+        if (!deletions.isEmpty() || !additions.isEmpty()) {
+            model.modifyAnnotations(deletions.toArray(Annotation[]::new), additions, null);
+        }
+
+        boolean collapseApplied = false;
+        for (Map.Entry<String, SQLScriptElementImpl> entry : nextRegionCache.entrySet()) {
+            SQLScriptElementImpl region = entry.getValue();
+            ProjectionAnnotation annotation = region.getAnnotation();
+            if (annotation == null
+                || document == null
+                || !SQLRegionMarkerFolding.isValidDocumentRange(document, region.getOffset(), region.getLength())
+            ) {
+                continue;
+            }
+            if (collapsedByKey.getOrDefault(entry.getKey(), false) && !annotation.isCollapsed()) {
+                model.collapse(annotation);
+                collapseApplied = true;
+            }
+        }
+
+        boolean regionSetChanged = !regionCache.keySet().equals(scannedByKey.keySet());
+
+        regionCache.clear();
+        regionCache.putAll(nextRegionCache);
+
+        if (SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            !deletions.isEmpty() || !additions.isEmpty(),
+            collapseApplied,
+            regionSetChanged,
+            editOffset,
+            scannedByKey.values().stream()
+                .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
+                .toList()
+        )) {
+            scheduleProjectionPresentationRefresh();
+        }
+    }
+
+    /**
+     * Reconcile updates annotations off the UI thread; projection gutter icons may stay stale until
+     * the viewer repaints (scrolling happens to trigger that). Force the same refresh explicitly.
+     */
+    private void scheduleProjectionPresentationRefresh() {
+        if (projectionRefreshScheduled) {
+            projectionRefreshPending = true;
+            return;
+        }
+        projectionRefreshScheduled = true;
+        UIUtils.asyncExec(this::runProjectionPresentationRefresh);
+    }
+
+    private void runProjectionPresentationRefresh() {
+        try {
+            if (document != null && editor.isFoldingEnabled()) {
+                editor.refreshProjectionFoldingPresentation();
+            }
+        } catch (RuntimeException e) {
+            log.warn("Failed to refresh projection folding presentation", e);
+        }
+        if (projectionRefreshPending) {
+            projectionRefreshPending = false;
+            UIUtils.asyncExec(this::runProjectionPresentationRefresh);
+        } else {
+            projectionRefreshScheduled = false;
+        }
+    }
+
+    private boolean needsRegionAnnotationRecreate(
+        @Nullable SQLScriptElementImpl cachedRegion,
+        @NotNull SQLScriptElementImpl scannedRegion,
+        @NotNull ProjectionAnnotationModel model
+    ) {
+        if (cachedRegion == null || cachedRegion.getAnnotation() == null) {
+            return true;
+        }
+        int scannedOffset = scannedRegion.getOffset();
+        int scannedLength = scannedRegion.getLength();
+        if (cachedRegion.getOffset() != scannedOffset || cachedRegion.getLength() != scannedLength) {
+            return true;
+        }
+        Position modelPosition = model.getPosition(cachedRegion.getAnnotation());
+        return modelPosition == null
+            || modelPosition.getOffset() != scannedOffset
+            || modelPosition.getLength() != scannedLength;
+    }
+
+    private int getRegionNumberOfLines(@NotNull SQLScriptElementImpl region) {
+        if (document == null || region.getRegionKey() == null) {
+            return 1;
+        }
+        return SQLRegionMarkerFolding.getRegionNumberOfLines(
+            document,
+            new SQLRegionMarkerFolding.RegionFold(region.getRegionKey(), region.getOffset(), region.getLength())
+        );
+    }
+
     @Nullable
     private List<SQLScriptElement> extractQueries(int offset, int length) {
         return editor.extractScriptQueries(offset, length, false, true, false);
@@ -325,82 +484,31 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
 
     @NotNull
     private List<SQLScriptElementImpl> extractRegionFoldingPositions() {
-        List<SQLScriptElementImpl> regions = new ArrayList<>();
-        if (document == null || document.getLength() == 0) {
-            return regions;
+        if (document == null) {
+            return List.of();
         }
-        IDocumentPartitioner partitioner = document instanceof IDocumentExtension3 ext
-            ? ext.getDocumentPartitioner(SQLParserPartitions.SQL_PARTITIONING)
-            : null;
-        Deque<Integer> regionStarts = new ArrayDeque<>();
-        int lineCount = document.getNumberOfLines();
-        for (int line = 0; line < lineCount; line++) {
-            try {
-                IRegion lineInfo = document.getLineInformation(line);
-                int lineOffset = lineInfo.getOffset();
-                int lineLength = lineInfo.getLength();
-                if (lineLength == 0) {
-                    continue;
-                }
-                String lineText = document.get(lineOffset, lineLength);
-                if (partitioner != null) {
-                    int commentPos = lineText.indexOf("--");
-                    if (commentPos < 0) {
-                        continue;
-                    }
-                    String contentType = partitioner.getContentType(lineOffset + commentPos);
-                    if (!SQLParserPartitions.CONTENT_TYPE_SQL_COMMENT.equals(contentType)) {
-                        continue;
-                    }
-                }
-                if (REGION_START_PATTERN.matcher(lineText).find()) {
-                    regionStarts.push(lineOffset);
-                } else if (REGION_END_PATTERN.matcher(lineText).find()) {
-                    if (!regionStarts.isEmpty()) {
-                        int startOffset = regionStarts.pop();
-                        int endOffset = line + 1 < lineCount
-                            ? document.getLineOffset(line + 1)
-                            : document.getLength();
-                        int length = endOffset - startOffset;
-                        if (length > 0) {
-                            regions.add(new SQLScriptElementImpl(startOffset, length));
-                        }
-                    }
-                }
-            } catch (BadLocationException e) {
-                log.warn("Error scanning for region folding markers", e);
-            }
+        return SQLRegionMarkerFolding.scanRegions(document).stream()
+            .map(f -> new SQLScriptElementImpl(f.offset(), f.length(), f.regionKey()))
+            .toList();
+    }
+
+    @NotNull
+    private List<SQLScriptElementImpl> extractFoldableRegionFoldingPositions() {
+        if (document == null) {
+            return List.of();
         }
-        return regions;
+        return SQLRegionMarkerFolding.scanFoldableRegions(document).stream()
+            .map(f -> new SQLScriptElementImpl(f.offset(), f.length(), f.regionKey()))
+            .toList();
     }
 
     private boolean isStrictlyEnclosedInAnyRegion(
         @NotNull SQLScriptElementImpl element,
-        @NotNull List<SQLScriptElementImpl> regions
+        @NotNull List<SQLRegionMarkerFolding.RegionFold> regions
     ) {
         int start = element.getOffset();
         int end = start + element.getLength();
-        for (SQLScriptElementImpl region : regions) {
-            if (isStrictlyEnclosed(start, end, region.getOffset(), region.getOffset() + region.getLength())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isStrictlyEnclosed(int innerStart, int innerEnd, int outerStart, int outerEnd) {
-        return innerStart >= outerStart && innerEnd <= outerEnd
-            && (innerStart > outerStart || innerEnd < outerEnd);
-    }
-
-    private void syncCollapsedProjectionAnnotations(@NotNull ProjectionAnnotationModel model) {
-        Iterator<Annotation> it = model.getAnnotationIterator();
-        while (it.hasNext()) {
-            Annotation annotation = it.next();
-            if (annotation instanceof ProjectionAnnotation projectionAnnotation && projectionAnnotation.isCollapsed()) {
-                model.collapse(annotation);
-            }
-        }
+        return SQLRegionMarkerFolding.isStrictlyEnclosedInAnyRegion(start, end, regions);
     }
 
     private boolean deservesFolding(SQLScriptElement element) {
@@ -470,9 +578,21 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     private static class SQLScriptElementImpl extends Position implements SQLScriptElement, Comparable<SQLScriptElementImpl> {
         @Nullable
         private ProjectionAnnotation annotation;
+        @Nullable
+        private final String regionKey;
 
         SQLScriptElementImpl(int offset, int length) {
+            this(offset, length, null);
+        }
+
+        SQLScriptElementImpl(int offset, int length, @Nullable String regionKey) {
             super(offset, length);
+            this.regionKey = regionKey;
+        }
+
+        @Nullable
+        public String getRegionKey() {
+            return regionKey;
         }
 
         @Nullable

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.sql.SQLScriptElement;
+import org.jkiss.dbeaver.model.sql.parser.SQLParserPartitions;
 import org.jkiss.dbeaver.ui.editors.EditorUtils;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorUtils;
@@ -46,6 +47,7 @@ import org.jkiss.dbeaver.ui.editors.sql.internal.SQLEditorActivator;
 import org.jkiss.utils.CommonUtils;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilingStrategyExtension {
@@ -53,6 +55,9 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
 
     private static final QualifiedName COLLAPSED_ANNOTATIONS =
         new QualifiedName(SQLEditorActivator.PLUGIN_ID, SQLReconcilingStrategy.class.getName() + ".collapsedFoldingAnnotations");
+
+    private static final Pattern REGION_START_PATTERN = Pattern.compile("^\\s*--\\s*region\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REGION_END_PATTERN = Pattern.compile("^\\s*--\\s*endregion\\b", Pattern.CASE_INSENSITIVE);
 
     private final NavigableSet<SQLScriptElementImpl> cache = new TreeSet<>();
 
@@ -161,6 +166,11 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 stringJoiner.add(Integer.toString(position.getOffset()));
             }
         }
+        if (annotationModel instanceof SQLProjectionAnnotationModel sqlProjectionModel) {
+            for (int offset : sqlProjectionModel.getDeferredCollapsedOffsets()) {
+                stringJoiner.add(Integer.toString(offset));
+            }
+        }
         String value;
         if (stringJoiner.length() == 0) {
             value = null;
@@ -243,10 +253,13 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             cachedQueries = Collections.unmodifiableNavigableSet(cache.subSet(leftBound, false, rightBound, true));
         }
 
-        Collection<SQLScriptElementImpl> parsedElements = parsedQueries.stream()
+        List<SQLScriptElementImpl> regionElements = extractRegionFoldingPositions();
+
+        Set<SQLScriptElementImpl> parsedElements = new HashSet<>(parsedQueries.stream()
             .filter(this::deservesFolding)
             .map(this::getExpandedScriptElement)
-            .collect(Collectors.toSet());
+            .filter(element -> !isStrictlyEnclosedInAnyRegion(element, regionElements))
+            .collect(Collectors.toSet()));
         Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
         Set<Integer> savedCollapsedAnnotationsOffsets = restoreCollapsedAnnotations ? getSavedCollapsedAnnotationsOffsets() : Collections.emptySet();
         for (SQLScriptElementImpl element : parsedElements) {
@@ -254,18 +267,43 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 ProjectionAnnotation annotation = new ProjectionAnnotation();
                 element.setAnnotation(annotation);
                 additions.put(annotation, element);
-                if (savedCollapsedAnnotationsOffsets.contains(element.getOffset())) {
-                    annotation.markCollapsed();
-                }
+            }
+        }
+        // Add region-based folding annotations for --region/--endregion markers
+        for (SQLScriptElementImpl regionElement : regionElements) {
+            if (getNumberOfLines(regionElement) <= 1) {
+                continue;
+            }
+            parsedElements.add(regionElement);
+            if (!cachedQueries.contains(regionElement)) {
+                ProjectionAnnotation annotation = new ProjectionAnnotation();
+                regionElement.setAnnotation(annotation);
+                additions.put(annotation, regionElement);
             }
         }
         Collection<SQLScriptElementImpl> deletedPositions = cachedQueries.stream()
             .filter(element -> !parsedElements.contains(element))
             .toList();
+        Set<Integer> collapsedOffsetsToRestore = new HashSet<>(savedCollapsedAnnotationsOffsets);
+        for (SQLScriptElementImpl deleted : deletedPositions) {
+            ProjectionAnnotation annotation = deleted.getAnnotation();
+            if (annotation != null && annotation.isCollapsed()) {
+                collapsedOffsetsToRestore.add(deleted.getOffset());
+            }
+        }
         Annotation[] deletions = deletedPositions.stream()
             .map(SQLScriptElementImpl::getAnnotation)
             .toArray(Annotation[]::new);
         model.modifyAnnotations(deletions, additions, null);
+        for (SQLScriptElementImpl element : additions.values()) {
+            if (collapsedOffsetsToRestore.contains(element.getOffset())) {
+                ProjectionAnnotation annotation = element.getAnnotation();
+                if (annotation != null) {
+                    model.collapse(annotation);
+                }
+            }
+        }
+        syncCollapsedProjectionAnnotations(model);
         cache.removeAll(deletedPositions);
         cache.addAll(additions.values());
 
@@ -285,6 +323,86 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         return editor.extractScriptQueries(offset, length, false, true, false);
     }
 
+    @NotNull
+    private List<SQLScriptElementImpl> extractRegionFoldingPositions() {
+        List<SQLScriptElementImpl> regions = new ArrayList<>();
+        if (document == null || document.getLength() == 0) {
+            return regions;
+        }
+        IDocumentPartitioner partitioner = document instanceof IDocumentExtension3 ext
+            ? ext.getDocumentPartitioner(SQLParserPartitions.SQL_PARTITIONING)
+            : null;
+        Deque<Integer> regionStarts = new ArrayDeque<>();
+        int lineCount = document.getNumberOfLines();
+        for (int line = 0; line < lineCount; line++) {
+            try {
+                IRegion lineInfo = document.getLineInformation(line);
+                int lineOffset = lineInfo.getOffset();
+                int lineLength = lineInfo.getLength();
+                if (lineLength == 0) {
+                    continue;
+                }
+                String lineText = document.get(lineOffset, lineLength);
+                if (partitioner != null) {
+                    int commentPos = lineText.indexOf("--");
+                    if (commentPos < 0) {
+                        continue;
+                    }
+                    String contentType = partitioner.getContentType(lineOffset + commentPos);
+                    if (!SQLParserPartitions.CONTENT_TYPE_SQL_COMMENT.equals(contentType)) {
+                        continue;
+                    }
+                }
+                if (REGION_START_PATTERN.matcher(lineText).find()) {
+                    regionStarts.push(lineOffset);
+                } else if (REGION_END_PATTERN.matcher(lineText).find()) {
+                    if (!regionStarts.isEmpty()) {
+                        int startOffset = regionStarts.pop();
+                        int endOffset = line + 1 < lineCount
+                            ? document.getLineOffset(line + 1)
+                            : document.getLength();
+                        int length = endOffset - startOffset;
+                        if (length > 0) {
+                            regions.add(new SQLScriptElementImpl(startOffset, length));
+                        }
+                    }
+                }
+            } catch (BadLocationException e) {
+                log.warn("Error scanning for region folding markers", e);
+            }
+        }
+        return regions;
+    }
+
+    private boolean isStrictlyEnclosedInAnyRegion(
+        @NotNull SQLScriptElementImpl element,
+        @NotNull List<SQLScriptElementImpl> regions
+    ) {
+        int start = element.getOffset();
+        int end = start + element.getLength();
+        for (SQLScriptElementImpl region : regions) {
+            if (isStrictlyEnclosed(start, end, region.getOffset(), region.getOffset() + region.getLength())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isStrictlyEnclosed(int innerStart, int innerEnd, int outerStart, int outerEnd) {
+        return innerStart >= outerStart && innerEnd <= outerEnd
+            && (innerStart > outerStart || innerEnd < outerEnd);
+    }
+
+    private void syncCollapsedProjectionAnnotations(@NotNull ProjectionAnnotationModel model) {
+        Iterator<Annotation> it = model.getAnnotationIterator();
+        while (it.hasNext()) {
+            Annotation annotation = it.next();
+            if (annotation instanceof ProjectionAnnotation projectionAnnotation && projectionAnnotation.isCollapsed()) {
+                model.collapse(annotation);
+            }
+        }
+    }
+
     private boolean deservesFolding(SQLScriptElement element) {
         int numberOfLines = getNumberOfLines(element);
         if (numberOfLines == 1) {
@@ -298,7 +416,13 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
 
     private int getNumberOfLines(SQLScriptElement element) {
         try {
-            return document.getLineOfOffset(element.getOffset() + element.getLength()) - document.getLineOfOffset(element.getOffset()) + 1;
+            int start = element.getOffset();
+            int exclusiveEnd = start + element.getLength();
+            if (exclusiveEnd <= start) {
+                return 1;
+            }
+            int lastIncludedOffset = exclusiveEnd - 1;
+            return document.getLineOfOffset(lastIncludedOffset) - document.getLineOfOffset(start) + 1;
         } catch (BadLocationException e) {
             throw new SQLReconcilingStrategyException(e);
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -509,16 +509,6 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             || modelPosition.getLength() != scannedLength;
     }
 
-    private int getRegionNumberOfLines(@NotNull SQLScriptElementImpl region) {
-        if (document == null || region.getRegionKey() == null) {
-            return 1;
-        }
-        return SQLRegionMarkerFolding.getRegionNumberOfLines(
-            document,
-            new SQLRegionMarkerFolding.RegionFold(region.getRegionKey(), region.getOffset(), region.getLength())
-        );
-    }
-
     @Nullable
     private List<SQLScriptElement> extractQueries(int offset, int length) {
         return editor.extractScriptQueries(offset, length, false, true, false);

--- a/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionFoldingPresentationTest.java
+++ b/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionFoldingPresentationTest.java
@@ -1,0 +1,90 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.parser;
+
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class SQLRegionFoldingPresentationTest extends DBeaverUnitTest {
+
+    private static final List<SQLRegionMarkerFolding.RegionFold> SAMPLE_REGIONS = List.of(
+        new SQLRegionMarkerFolding.RegionFold("OUTER", 0, 120)
+    );
+
+    @Test
+    public void editBeforeRegionRequiresGutterRefresh() {
+        int editOffset = 0;
+        Assertions.assertTrue(SQLRegionMarkerFolding.documentEditShiftsRegionMarkers(editOffset, SAMPLE_REGIONS));
+        Assertions.assertTrue(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            editOffset,
+            SAMPLE_REGIONS
+        ));
+    }
+
+    @Test
+    public void editOnRegionMarkerRequiresGutterRefresh() {
+        int editOffset = SAMPLE_REGIONS.getFirst().offset();
+        Assertions.assertTrue(SQLRegionMarkerFolding.documentEditShiftsRegionMarkers(editOffset, SAMPLE_REGIONS));
+        Assertions.assertTrue(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            editOffset,
+            SAMPLE_REGIONS
+        ));
+    }
+
+    @Test
+    public void editAfterAllRegionsDoesNotRequireGutterRefresh() {
+        int editOffset = SAMPLE_REGIONS.getFirst().offset() + SAMPLE_REGIONS.getFirst().length() + 10;
+        Assertions.assertFalse(SQLRegionMarkerFolding.documentEditShiftsRegionMarkers(editOffset, SAMPLE_REGIONS));
+        Assertions.assertFalse(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            editOffset,
+            SAMPLE_REGIONS
+        ));
+    }
+
+    @Test
+    public void widenedDamagedRegionOffsetMustNotTriggerRefreshForEditsInsideRegion() {
+        int originalEditOffset = 80;
+        int widenedDamagedRegionOffset = SAMPLE_REGIONS.getFirst().offset();
+
+        Assertions.assertFalse(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            originalEditOffset,
+            SAMPLE_REGIONS
+        ));
+        Assertions.assertTrue(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            widenedDamagedRegionOffset,
+            SAMPLE_REGIONS
+        ));
+    }
+}

--- a/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFoldingTest.java
+++ b/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFoldingTest.java
@@ -1,0 +1,153 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.parser;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.rules.FastPartitioner;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.sql.SQLDialect;
+import org.jkiss.dbeaver.model.sql.SQLDialectMetadataRegistry;
+import org.jkiss.dbeaver.model.sql.SQLPartitionScanner;
+import org.jkiss.dbeaver.model.sql.SQLSyntaxManager;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class SQLRegionMarkerFoldingTest extends DBeaverUnitTest {
+
+    private static final String NESTED_REGIONS_SCRIPT = """
+        --region OUTER
+        SELECT 0
+        --region INNER1
+        SELECT 1
+        --region INNER11
+        SELECT 2
+        --endregion
+        SELECT 3
+        --endregion
+        SELECT 4
+        --endregion
+        SELECT 5
+        """;
+
+    @Test
+    public void nestedRegionsHaveHierarchicalKeysAndStartOffsets() throws DBException {
+        Document document = createPartitionedDocument(NESTED_REGIONS_SCRIPT);
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanFoldableRegions(document);
+        Map<String, SQLRegionMarkerFolding.RegionFold> byKey = regions.stream()
+            .collect(Collectors.toMap(SQLRegionMarkerFolding.RegionFold::regionKey, Function.identity()));
+
+        Assertions.assertEquals(3, regions.size());
+        Assertions.assertTrue(byKey.containsKey("OUTER"));
+        Assertions.assertTrue(byKey.containsKey("OUTER/INNER1"));
+        Assertions.assertTrue(byKey.containsKey("OUTER/INNER1/INNER11"));
+
+        for (String markerLine : List.of("--region OUTER", "--region INNER1", "--region INNER11")) {
+            int expectedOffset = document.get().indexOf(markerLine);
+            String key = markerLine.replace("--region ", "").trim();
+            if (!key.equals("OUTER")) {
+                if (key.equals("INNER1")) {
+                    key = "OUTER/INNER1";
+                } else {
+                    key = "OUTER/INNER1/INNER11";
+                }
+            }
+            Assertions.assertEquals(expectedOffset, byKey.get(key).offset(), key);
+        }
+    }
+
+    @Test
+    public void orphanEndRegionIsIgnored() {
+        Document document = new Document("""
+            SELECT 1
+            --endregion
+            SELECT 2
+            """);
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanRegions(document);
+        Assertions.assertTrue(regions.isEmpty());
+    }
+
+    @Test
+    public void unclosedRegionIsNotReturned() {
+        Document document = new Document("""
+            --region OPEN
+            SELECT 1
+            SELECT 2
+            """);
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanRegions(document);
+        Assertions.assertTrue(regions.isEmpty());
+    }
+
+    @Test
+    public void regionMarkerInsideStringIsIgnored() throws DBException {
+        Document document = createPartitionedDocument("SELECT '--region' FROM t;\n");
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanRegions(document);
+        Assertions.assertTrue(regions.isEmpty());
+    }
+
+    @Test
+    public void markerOnlyPairIsFoldableWhenItSpansTwoLines() {
+        Document document = new Document("""
+            --region A
+            --endregion
+            """);
+        List<SQLRegionMarkerFolding.RegionFold> allRegions = SQLRegionMarkerFolding.scanRegions(document);
+        Assertions.assertEquals(1, allRegions.size());
+        Assertions.assertEquals(2, SQLRegionMarkerFolding.getRegionNumberOfLines(document, allRegions.getFirst()));
+        Assertions.assertEquals(1, SQLRegionMarkerFolding.scanFoldableRegions(document).size());
+    }
+
+    @Test
+    public void renamedRegionMarkerProducesDifferentKey() {
+        Document documentBefore = new Document("""
+            --region INNER1
+            SELECT 1
+            --endregion
+            """);
+        Document documentAfter = new Document("""
+            --region INNER2
+            SELECT 1
+            --endregion
+            """);
+        List<SQLRegionMarkerFolding.RegionFold> before = SQLRegionMarkerFolding.scanRegions(documentBefore);
+        List<SQLRegionMarkerFolding.RegionFold> after = SQLRegionMarkerFolding.scanRegions(documentAfter);
+        Assertions.assertEquals("INNER1", before.getFirst().regionKey());
+        Assertions.assertEquals("INNER2", after.getFirst().regionKey());
+    }
+
+    private static Document createPartitionedDocument(String sql) throws DBException {
+        SQLDialectMetadataRegistry registry = DBWorkbench.getPlatform().getSQLDialectRegistry();
+        SQLDialect dialect = registry.getDialect("generic").createInstance();
+        SQLSyntaxManager syntaxManager = new SQLSyntaxManager();
+        syntaxManager.init(dialect, DBWorkbench.getPlatform().getPreferenceStore());
+        SQLRuleManager ruleManager = new SQLRuleManager(syntaxManager);
+        ruleManager.loadRules();
+        Document document = new Document(sql);
+        FastPartitioner partitioner = new FastPartitioner(
+            new SQLPartitionScanner(null, dialect, ruleManager),
+            SQLParserPartitions.SQL_CONTENT_TYPES);
+        partitioner.connect(document);
+        document.setDocumentPartitioner(SQLParserPartitions.SQL_PARTITIONING, partitioner);
+        return document;
+    }
+}


### PR DESCRIPTION
Closes dbeaver/dbeaver#23137

## Problem

DBeaver supports code folding for multi-line SQL statements (parser-based), but not for explicit section markers `--region` / `--endregion` commonly used in Visual Studio, VS Code, and Rider to organize large scripts. Issue #23137 requests parity with those editors.

The existing folding pipeline (`SQLReconcilingStrategy` + Eclipse `ProjectionAnnotationModel`) was built only around `extractScriptQueries()` results. Region markers are comments and are invisible to the SQL parser as fold targets, so a separate detection path is required.

## Scope of changes

Three files in `org.jkiss.dbeaver.ui.editors.sql`:

### 1. `SQLReconcilingStrategy.java` — region detection and reconcile integration

**What changed**

- Added `extractRegionFoldingPositions()` — a line-by-line document scan for `--region` / `--endregion`.
- Region fold annotations are merged into the same reconcile cycle as parser-based folds.
- Parser-based folds strictly enclosed inside a region are excluded from the annotation model.
- Reworked collapsed-state restore: `markCollapsed()` on new annotations replaced with `model.collapse()` after `modifyAnnotations()`.
- Added `syncCollapsedProjectionAnnotations()` to re-apply collapse on all marked annotations after reconcile.
- Extended `saveState()` to persist deferred inner collapse offsets from `SQLProjectionAnnotationModel`.
- Fixed `getNumberOfLines()` boundary handling for exclusive end offsets.

**Why these decisions**

| Decision | Rationale |
|----------|-----------|
| **Separate scanner instead of extending SQL parser** | Region markers are editor-organizational comments, not SQL syntax. A lightweight line scan keeps the change localized, avoids dialect/parser coupling, and does not affect query execution or completion. |
| **Match only SQL comment partitions** | Before pattern matching, the scanner checks that `--` is in `CONTENT_TYPE_SQL_COMMENT`. This prevents false positives inside string literals (e.g. `'--region'`) or other partitions. |
| **Case-insensitive patterns (`(?i)`)** | Matches VS Code / Visual Studio behavior where `--REGION`, `--EndRegion`, etc. are accepted. |
| **Stack-based pairing (`Deque`)** | Supports nested regions naturally: inner `--endregion` closes the nearest `--region`, outer pairs remain valid. Unmatched `--endregion` is ignored (no orphan end). |
| **Region span includes marker lines through end of `--endregion` line** | Fold range starts at `--region` line offset and ends at the start of the line *after* `--endregion` (or EOF). This keeps both marker lines visible when expanded and hides the full section when collapsed — consistent with how users expect region folding to behave. |
| **Skip single-line regions** | Folding a one-line region provides no benefit and clutters the gutter; same rule as `deservesFolding()` for statements. |
| **Suppress parser folds strictly inside regions** | Without this, a region containing multiple statements would show overlapping +/- handles (region + each statement). Eclipse projection folding does not handle overlapping annotations well. The region becomes the single fold handle for that section — intentional trade-off for clarity. |
| **`isStrictlyEnclosed` (not merely overlapping)** | Folds with identical bounds as the region are not suppressed (edge case). Folds that share a boundary with the region but extend outside remain visible. |
| **`model.collapse()` instead of `markCollapsed()`** | During testing, region folds created with `markCollapsed()` did not reliably show collapse UI (+/- icons, hidden lines). Calling `collapse()` on the projection model after annotations are registered correctly wires the visual projection layer. |
| **Preserve collapsed offsets of deleted annotations** | When reconcile removes and recreates annotations (e.g. after edit), offsets of previously collapsed folds are collected from deleted elements and reapplied to new annotations at the same document offsets. |
| **`syncCollapsedProjectionAnnotations()` after reconcile** | Ensures all annotations marked collapsed are fully applied in the projection model, including cases where reconcile recreates annotation instances. |
| **Exclusive-end fix in `getNumberOfLines()`** | Region length uses an exclusive end offset (start of next line). Using `offset + length` directly as a document offset could point past the last included character and miscount lines for regions ending at file boundary. |

### 2. `SQLProjectionAnnotationModel.java` (new) — nested fold behavior

**What changed**

New subclass of `ProjectionAnnotationModel` overriding `collapse()`, `expand()`, and `toggleExpansionState()`.

When collapsing a parent fold:
1. Collect offsets of strictly enclosed *collapsed* child folds.
2. Store them in `deferredCollapsedEnclosedOffsets` keyed by parent offset.
3. Expand those children before collapsing the parent.

When expanding the parent:
1. Restore previously deferred children, collapsed in ascending order by fold length (inner/smaller folds first).

`getDeferredCollapsedOffsets()` exposes deferred state for editor persistence.

**Why a separate class**

Eclipse's default `ProjectionAnnotationModel` does not handle nested collapsed projections: collapsing an outer region while an inner region/statement is already collapsed leads to inconsistent UI (hidden inner state, broken +/- icons). This is a known limitation of stacking projection collapses.

The custom model solves two scenarios discovered during manual testing:
- **OUTER collapsed alone** — works with default model.
- **INNER collapsed, then OUTER collapsed** — default model breaks; inner collapse must be temporarily undone and remembered.

Keeping this logic in a dedicated class avoids polluting `SQLReconcilingStrategy` (annotation lifecycle) with projection UI behavior (collapse/expand interaction).

**Why restore inner folds sorted by length**

When re-collapsing multiple nested folds, smaller (inner) folds must be collapsed before larger enclosing ones; otherwise the outer collapse logic would re-trigger deferral. Sorting by annotation position length ensures stable restoration order.

### 3. `SQLEditorSourceViewer.java` — install custom projection model

**What changed**

Override `createVisualAnnotationModel()` to replace Eclipse's internal `fProjectionAnnotationModel` field with `SQLProjectionAnnotationModel` via reflection.

**Why reflection**

`ProjectionViewer` creates and owns `fProjectionAnnotationModel` internally; there is no public extension point or setter to substitute a subclass. Reflection is a pragmatic workaround used only at viewer initialization. If reflection fails, the editor falls back to the default model (region folding still appears, but nested collapse behavior degrades gracefully — a warning is logged).

**Why check `visualModel == wiredModel`**

`ProjectionViewer` may use the same instance as both the wired model and the visual model. The override returns the SQL model only when they are the same object, avoiding incorrect model substitution in configurations where visual and wired models differ.

## What is intentionally out of scope

- No changes to SQL parsing, execution, or formatting.
- No folding for `(` `)` brackets — DBeaver never had parenthesis-level folds; regions do not affect bracket matching or auto-close.
- Parser-based folds inside a region are hidden, not nested under the region fold in the gutter. Users choose region-level folding *instead of* per-statement folding within that section.
- No new preferences — regions use the existing **Enable code folding** setting.

## Test plan

- [x] Multi-line `--region` / `--endregion` — gutter fold appears and collapses/expands correctly
- [x] Case variants: `--REGION`, `--EndRegion`
- [x] Nested regions — independent fold at each level
- [x] Collapse inner region, then outer — inner expands visually; expanding outer restores inner state
- [x] Multiple statements inside one region — only region +/- visible (no duplicate statement folds)
- [x] Marker inside string literal — no spurious fold
- [x] Save/reopen script file — collapsed state preserved (including deferred inner folds)
- [x] Statement folding outside regions — unchanged

## AI disclosure

This PR was assisted by AI (Cursor).