### PR TITLE
dbeaver/dbeaver#23137 Add folding for SQL region markers

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFolding.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFolding.java
@@ -21,8 +21,12 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentExtension3;
 import org.eclipse.jface.text.IDocumentPartitioner;
 import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITypedRegion;
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.model.impl.sql.BasicSQLDialect;
+import org.jkiss.dbeaver.model.sql.SQLDialect;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -30,18 +34,15 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
-import java.util.regex.Pattern;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 
 /**
- * Scans {@code --region}/{@code --endregion} script markers and decides when folding gutter refresh is needed.
+ * Scans SQL comment region markers and provides indexes used by the SQL editor folding reconciler.
  */
 public final class SQLRegionMarkerFolding {
 
     private static final Log log = Log.getLog(SQLRegionMarkerFolding.class);
-
-    private static final Pattern REGION_START_PATTERN = Pattern.compile("^\\s*--\\s*region\\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern REGION_END_PATTERN = Pattern.compile("^\\s*--\\s*endregion\\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern REGION_MARKER_NAME_PATTERN = Pattern.compile("^\\s*--\\s*region\\s*(.*)", Pattern.CASE_INSENSITIVE);
 
     private SQLRegionMarkerFolding() {
     }
@@ -52,25 +53,81 @@ public final class SQLRegionMarkerFolding {
     private record RegionStartFrame(int offset, @NotNull String regionKey) {
     }
 
+    private enum RegionMarkerType {
+        START,
+        END
+    }
+
+    private record RegionMarker(@NotNull RegionMarkerType type, @NotNull String name) {
+    }
+
+    private static final class RegionIndexNode {
+        private final RegionFold region;
+        private final RegionIndexNode parent;
+
+        private RegionIndexNode(RegionFold region, RegionIndexNode parent) {
+            this.region = region;
+            this.parent = parent;
+        }
+    }
+
+    /**
+     * Index of nested region intervals. The latest region start is found in O(log n), then its
+     * enclosing parents are checked until a containing region is found.
+     */
+    public static final class RegionIndex {
+        private final NavigableMap<Integer, RegionIndexNode> regionsByOffset;
+
+        private RegionIndex(NavigableMap<Integer, RegionIndexNode> regionsByOffset) {
+            this.regionsByOffset = regionsByOffset;
+        }
+
+        public boolean isStrictlyEnclosed(int innerStart, int innerEnd) {
+            var entry = regionsByOffset.floorEntry(innerStart);
+            RegionIndexNode node = entry == null ? null : entry.getValue();
+            while (node != null) {
+                int outerStart = node.region.offset();
+                int outerEnd = outerStart + node.region.length();
+                if (SQLRegionMarkerFolding.isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
+                    return true;
+                }
+                node = node.parent;
+            }
+            return false;
+        }
+    }
+
     @NotNull
     public static List<RegionFold> scanRegions(@NotNull IDocument document) {
+        return scanRegions(document, BasicSQLDialect.INSTANCE);
+    }
+
+    @NotNull
+    public static List<RegionFold> scanRegions(@NotNull IDocument document, @NotNull SQLDialect dialect) {
         List<RegionFold> regions = new ArrayList<>();
         if (document.getLength() == 0) {
             return regions;
         }
         IDocumentPartitioner partitioner = getSqlDocumentPartitioner(document);
         Deque<RegionStartFrame> regionStarts = new ArrayDeque<>();
-        int lineCount = document.getNumberOfLines();
-        for (int line = 0; line < lineCount; line++) {
-            collectRegionFoldingOnLine(document, line, lineCount, partitioner, regionStarts, regions);
+        if (partitioner == null) {
+            scanUnpartitionedDocument(document, dialect, regionStarts, regions);
+        } else {
+            scanCommentPartitions(document, dialect, partitioner, regionStarts, regions);
         }
+        regions.sort((left, right) -> Integer.compare(left.offset(), right.offset()));
         return regions;
     }
 
     @NotNull
     public static List<RegionFold> scanFoldableRegions(@NotNull IDocument document) {
+        return scanFoldableRegions(document, BasicSQLDialect.INSTANCE);
+    }
+
+    @NotNull
+    public static List<RegionFold> scanFoldableRegions(@NotNull IDocument document, @NotNull SQLDialect dialect) {
         List<RegionFold> foldable = new ArrayList<>();
-        for (RegionFold region : scanRegions(document)) {
+        for (RegionFold region : scanRegions(document, dialect)) {
             if (isValidDocumentRange(document, region.offset(), region.length())
                 && getRegionNumberOfLines(document, region) > 1
             ) {
@@ -78,6 +135,84 @@ public final class SQLRegionMarkerFolding {
             }
         }
         return foldable;
+    }
+
+    /**
+     * Checks only the lines and partitions affected by an edit. This lets the reconciler avoid a full region scan
+     * for ordinary SQL text insertion while still detecting a newly-created marker.
+     */
+    public static boolean hasRegionMarkerInRange(
+        @NotNull IDocument document,
+        @NotNull SQLDialect dialect,
+        int offset,
+        int length
+    ) {
+        if (document.getLength() == 0) {
+            return false;
+        }
+        try {
+            int safeOffset = Math.max(0, Math.min(offset, document.getLength() - 1));
+            int lastOffset = Math.max(safeOffset, Math.min(offset + Math.max(length, 1) - 1, document.getLength() - 1));
+            int firstLine = document.getLineOfOffset(safeOffset);
+            int lastLine = document.getLineOfOffset(lastOffset);
+            int rangeOffset = document.getLineOffset(firstLine);
+            int rangeEnd = document.getLineOffset(lastLine) + document.getLineInformation(lastLine).getLength();
+            IDocumentPartitioner partitioner = getSqlDocumentPartitioner(document);
+            if (partitioner == null) {
+                for (int line = firstLine; line <= lastLine; line++) {
+                    IRegion lineInfo = document.getLineInformation(line);
+                    if (parseRegionMarker(document.get(lineInfo.getOffset(), lineInfo.getLength()), dialect) != null) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            for (ITypedRegion partition : partitioner.computePartitioning(rangeOffset, rangeEnd - rangeOffset)) {
+                if (SQLParserPartitions.CONTENT_TYPE_SQL_COMMENT.equals(partition.getType())
+                    && parsePartitionRegionMarker(document, dialect, partition) != null
+                ) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (BadLocationException e) {
+            log.warn("Error checking SQL region marker changes", e);
+            return true;
+        }
+    }
+
+    /**
+     * Returns true when an edit touches a string or multi-line comment partition. Such an edit can change the
+     * interpretation of markers outside the edited line, so the reconciler must use its safe full-scan path.
+     */
+    public static boolean hasPartitionSensitiveContentInRange(@NotNull IDocument document, int offset, int length) {
+        if (document.getLength() == 0) {
+            return false;
+        }
+        IDocumentPartitioner partitioner = getSqlDocumentPartitioner(document);
+        if (partitioner == null) {
+            return false;
+        }
+        try {
+            int safeOffset = Math.max(0, Math.min(offset, document.getLength() - 1));
+            int lastOffset = Math.max(safeOffset, Math.min(offset + Math.max(length, 1) - 1, document.getLength() - 1));
+            int firstLine = document.getLineOfOffset(safeOffset);
+            int lastLine = document.getLineOfOffset(lastOffset);
+            int rangeOffset = document.getLineOffset(firstLine);
+            int rangeEnd = document.getLineOffset(lastLine) + document.getLineInformation(lastLine).getLength();
+            for (ITypedRegion partition : partitioner.computePartitioning(rangeOffset, rangeEnd - rangeOffset)) {
+                if (SQLParserPartitions.CONTENT_TYPE_SQL_MULTILINE_COMMENT.equals(partition.getType())
+                    || SQLParserPartitions.CONTENT_TYPE_SQL_STRING.equals(partition.getType())
+                    || SQLParserPartitions.CONTENT_TYPE_SQL_QUOTED.equals(partition.getType())
+                ) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (BadLocationException e) {
+            log.warn("Error checking SQL partitions affected by edit", e);
+            return true;
+        }
     }
 
     public static boolean needsFoldingGutterRefresh(
@@ -142,77 +277,151 @@ public final class SQLRegionMarkerFolding {
         }
     }
 
-    public static boolean isStrictlyEnclosedInAnyRegion(
-        int innerStart,
-        int innerEnd,
-        @NotNull Collection<RegionFold> regions
-    ) {
-        for (RegionFold region : regions) {
-            int outerStart = region.offset();
-            int outerEnd = outerStart + region.length();
-            if (isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
-                return true;
+    @NotNull
+    public static RegionIndex createRegionIndex(@NotNull Collection<RegionFold> regions) {
+        List<RegionFold> sortedRegions = regions.stream()
+            .sorted((left, right) -> Integer.compare(left.offset(), right.offset()))
+            .toList();
+        NavigableMap<Integer, RegionIndexNode> regionsByOffset = new TreeMap<>();
+        Deque<RegionIndexNode> openRegions = new ArrayDeque<>();
+        for (RegionFold region : sortedRegions) {
+            while (!openRegions.isEmpty() && region.offset() >= endOffset(openRegions.peek().region)) {
+                openRegions.pop();
             }
+            RegionIndexNode node = new RegionIndexNode(region, openRegions.peek());
+            regionsByOffset.put(region.offset(), node);
+            openRegions.push(node);
         }
-        return false;
+        return new RegionIndex(regionsByOffset);
     }
 
-    private static void collectRegionFoldingOnLine(
+    private static void scanCommentPartitions(
         @NotNull IDocument document,
-        int line,
-        int lineCount,
+        @NotNull SQLDialect dialect,
         IDocumentPartitioner partitioner,
         @NotNull Deque<RegionStartFrame> regionStarts,
         @NotNull List<RegionFold> regions
     ) {
         try {
-            IRegion lineInfo = document.getLineInformation(line);
-            int lineOffset = lineInfo.getOffset();
-            int lineLength = lineInfo.getLength();
-            if (lineLength == 0) {
-                return;
-            }
-            String lineText = document.get(lineOffset, lineLength);
-            if (!isSqlRegionMarkerCommentLine(lineText, lineOffset, partitioner)) {
-                return;
-            }
-            if (REGION_START_PATTERN.matcher(lineText).find()) {
-                String markerName = extractRegionMarkerName(lineText);
-                String regionKey = regionStarts.isEmpty()
-                    ? markerName
-                    : regionStarts.peek().regionKey() + "/" + markerName;
-                regionStarts.push(new RegionStartFrame(lineOffset, regionKey));
-            } else if (REGION_END_PATTERN.matcher(lineText).find() && !regionStarts.isEmpty()) {
-                addClosedRegion(document, line, lineCount, regionStarts, regions);
+            for (ITypedRegion partition : partitioner.computePartitioning(0, document.getLength())) {
+                if (!SQLParserPartitions.CONTENT_TYPE_SQL_COMMENT.equals(partition.getType())) {
+                    continue;
+                }
+                RegionMarker marker = parsePartitionRegionMarker(document, dialect, partition);
+                if (marker != null) {
+                    collectRegionMarker(document, marker, partition.getOffset(), regionStarts, regions);
+                }
             }
         } catch (BadLocationException e) {
             log.warn("Error scanning for region folding markers", e);
         }
     }
 
-    private static boolean isSqlRegionMarkerCommentLine(
-        @NotNull String lineText,
-        int lineOffset,
-        IDocumentPartitioner partitioner
+    private static void scanUnpartitionedDocument(
+        @NotNull IDocument document,
+        @NotNull SQLDialect dialect,
+        @NotNull Deque<RegionStartFrame> regionStarts,
+        @NotNull List<RegionFold> regions
     ) {
-        if (partitioner == null) {
-            return true;
+        int lineCount = document.getNumberOfLines();
+        for (int line = 0; line < lineCount; line++) {
+            try {
+                IRegion lineInfo = document.getLineInformation(line);
+                RegionMarker marker = parseRegionMarker(document.get(lineInfo.getOffset(), lineInfo.getLength()), dialect);
+                if (marker != null) {
+                    collectRegionMarker(document, marker, lineInfo.getOffset(), regionStarts, regions);
+                }
+            } catch (BadLocationException e) {
+                log.warn("Error scanning for region folding markers", e);
+            }
         }
-        int commentPos = lineText.indexOf("--");
-        if (commentPos < 0) {
-            return false;
+    }
+
+    private static void collectRegionMarker(
+        @NotNull IDocument document,
+        @NotNull RegionMarker marker,
+        int markerOffset,
+        @NotNull Deque<RegionStartFrame> regionStarts,
+        @NotNull List<RegionFold> regions
+    ) throws BadLocationException {
+        if (marker.type() == RegionMarkerType.START) {
+            String regionKey = regionStarts.isEmpty()
+                ? marker.name()
+                : regionStarts.peek().regionKey() + "/" + marker.name();
+            regionStarts.push(new RegionStartFrame(markerOffset, regionKey));
+        } else if (!regionStarts.isEmpty()) {
+            int endMarkerLine = document.getLineOfOffset(markerOffset);
+            addClosedRegion(document, endMarkerLine, regionStarts, regions);
         }
-        String contentType = partitioner.getContentType(lineOffset + commentPos);
-        return SQLParserPartitions.CONTENT_TYPE_SQL_COMMENT.equals(contentType);
+    }
+
+    @Nullable
+    private static RegionMarker parsePartitionRegionMarker(
+        @NotNull IDocument document,
+        @NotNull SQLDialect dialect,
+        @NotNull ITypedRegion partition
+    ) throws BadLocationException {
+        IRegion lineInfo = document.getLineInformation(document.getLineOfOffset(partition.getOffset()));
+        if (!document.get(lineInfo.getOffset(), partition.getOffset() - lineInfo.getOffset()).isBlank()) {
+            return null;
+        }
+        return parseRegionMarker(document.get(partition.getOffset(), partition.getLength()), dialect);
+    }
+
+    private static RegionMarker parseRegionMarker(@NotNull String lineText, @NotNull SQLDialect dialect) {
+        String markerText = lineText.stripLeading();
+        String commentPrefix = findCommentPrefix(markerText, dialect.getSingleLineComments());
+        if (commentPrefix == null) {
+            return null;
+        }
+        String markerBody = markerText.substring(commentPrefix.length()).stripLeading();
+        String startName = markerBodyAfterKeyword(markerBody, "region");
+        if (startName != null) {
+            String name = startName.trim();
+            return new RegionMarker(RegionMarkerType.START, name.isEmpty() ? "REGION" : name.toUpperCase(Locale.ROOT));
+        }
+        if (markerBodyAfterKeyword(markerBody, "endregion") != null) {
+            return new RegionMarker(RegionMarkerType.END, "");
+        }
+        return null;
+    }
+
+    private static String findCommentPrefix(@NotNull String markerText, String[] commentPrefixes) {
+        if (commentPrefixes == null) {
+            return null;
+        }
+        String matchingPrefix = null;
+        for (String prefix : commentPrefixes) {
+            if (prefix != null && !prefix.isEmpty() && markerText.startsWith(prefix)
+                && (matchingPrefix == null || prefix.length() > matchingPrefix.length())
+            ) {
+                matchingPrefix = prefix;
+            }
+        }
+        return matchingPrefix;
+    }
+
+    private static String markerBodyAfterKeyword(@NotNull String markerBody, @NotNull String keyword) {
+        if (!markerBody.regionMatches(true, 0, keyword, 0, keyword.length())) {
+            return null;
+        }
+        if (markerBody.length() == keyword.length()) {
+            return "";
+        }
+        char next = markerBody.charAt(keyword.length());
+        if (Character.isLetterOrDigit(next) || next == '_') {
+            return null;
+        }
+        return markerBody.substring(keyword.length());
     }
 
     private static void addClosedRegion(
         @NotNull IDocument document,
         int endMarkerLine,
-        int lineCount,
         @NotNull Deque<RegionStartFrame> regionStarts,
         @NotNull List<RegionFold> regions
     ) throws BadLocationException {
+        int lineCount = document.getNumberOfLines();
         RegionStartFrame regionStart = regionStarts.pop();
         int endOffset = endMarkerLine + 1 < lineCount
             ? document.getLineOffset(endMarkerLine + 1)
@@ -223,14 +432,8 @@ public final class SQLRegionMarkerFolding {
         }
     }
 
-    @NotNull
-    private static String extractRegionMarkerName(@NotNull String lineText) {
-        var matcher = REGION_MARKER_NAME_PATTERN.matcher(lineText);
-        if (!matcher.find()) {
-            return "region";
-        }
-        String markerName = matcher.group(1).trim();
-        return markerName.isEmpty() ? "region" : markerName.toUpperCase(Locale.ROOT);
+    private static int endOffset(@NotNull RegionFold region) {
+        return region.offset() + region.length();
     }
 
     private static IDocumentPartitioner getSqlDocumentPartitioner(@NotNull IDocument document) {

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFolding.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFolding.java
@@ -1,0 +1,247 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.parser;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.IDocumentPartitioner;
+import org.eclipse.jface.text.IRegion;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.Log;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Scans {@code --region}/{@code --endregion} script markers and decides when folding gutter refresh is needed.
+ */
+public final class SQLRegionMarkerFolding {
+
+    private static final Log log = Log.getLog(SQLRegionMarkerFolding.class);
+
+    private static final Pattern REGION_START_PATTERN = Pattern.compile("^\\s*--\\s*region\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REGION_END_PATTERN = Pattern.compile("^\\s*--\\s*endregion\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REGION_MARKER_NAME_PATTERN = Pattern.compile("^\\s*--\\s*region\\s*(.*)", Pattern.CASE_INSENSITIVE);
+
+    private SQLRegionMarkerFolding() {
+    }
+
+    public record RegionFold(@NotNull String regionKey, int offset, int length) {
+    }
+
+    private record RegionStartFrame(int offset, @NotNull String regionKey) {
+    }
+
+    @NotNull
+    public static List<RegionFold> scanRegions(@NotNull IDocument document) {
+        List<RegionFold> regions = new ArrayList<>();
+        if (document.getLength() == 0) {
+            return regions;
+        }
+        IDocumentPartitioner partitioner = getSqlDocumentPartitioner(document);
+        Deque<RegionStartFrame> regionStarts = new ArrayDeque<>();
+        int lineCount = document.getNumberOfLines();
+        for (int line = 0; line < lineCount; line++) {
+            collectRegionFoldingOnLine(document, line, lineCount, partitioner, regionStarts, regions);
+        }
+        return regions;
+    }
+
+    @NotNull
+    public static List<RegionFold> scanFoldableRegions(@NotNull IDocument document) {
+        List<RegionFold> foldable = new ArrayList<>();
+        for (RegionFold region : scanRegions(document)) {
+            if (isValidDocumentRange(document, region.offset(), region.length())
+                && getRegionNumberOfLines(document, region) > 1
+            ) {
+                foldable.add(region);
+            }
+        }
+        return foldable;
+    }
+
+    public static boolean needsFoldingGutterRefresh(
+        boolean annotationStructureChanged,
+        boolean collapseApplied,
+        boolean regionSetChanged,
+        int editOffset,
+        @NotNull Collection<RegionFold> regions
+    ) {
+        if (annotationStructureChanged || collapseApplied || regionSetChanged) {
+            return true;
+        }
+        return documentEditShiftsRegionMarkers(editOffset, regions);
+    }
+
+    public static boolean documentEditShiftsRegionMarkers(int editOffset, @NotNull Collection<RegionFold> regions) {
+        if (regions.isEmpty()) {
+            return false;
+        }
+        for (RegionFold region : regions) {
+            if (editOffset <= region.offset()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static int getRegionNumberOfLines(@NotNull IDocument document, @NotNull RegionFold region) {
+        if (!isValidDocumentRange(document, region.offset(), region.length())) {
+            return 1;
+        }
+        try {
+            int startLine = document.getLineOfOffset(region.offset());
+            int endLine = document.getLineOfOffset(region.offset() + region.length() - 1);
+            return endLine - startLine + 1;
+        } catch (BadLocationException e) {
+            return 1;
+        }
+    }
+
+    public static boolean isValidDocumentRange(@NotNull IDocument document, int offset, int length) {
+        if (offset < 0 || length <= 0) {
+            return false;
+        }
+        int end = offset + length;
+        if (end > document.getLength()) {
+            return false;
+        }
+        try {
+            document.getLineOfOffset(offset);
+            if (end == document.getLength()) {
+                if (document.getLength() == 0) {
+                    return false;
+                }
+                document.getLineOfOffset(document.getLength() - 1);
+            } else {
+                document.getLineOfOffset(end);
+            }
+            return true;
+        } catch (BadLocationException e) {
+            return false;
+        }
+    }
+
+    public static boolean isStrictlyEnclosedInAnyRegion(
+        int innerStart,
+        int innerEnd,
+        @NotNull Collection<RegionFold> regions
+    ) {
+        for (RegionFold region : regions) {
+            int outerStart = region.offset();
+            int outerEnd = outerStart + region.length();
+            if (isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void collectRegionFoldingOnLine(
+        @NotNull IDocument document,
+        int line,
+        int lineCount,
+        IDocumentPartitioner partitioner,
+        @NotNull Deque<RegionStartFrame> regionStarts,
+        @NotNull List<RegionFold> regions
+    ) {
+        try {
+            IRegion lineInfo = document.getLineInformation(line);
+            int lineOffset = lineInfo.getOffset();
+            int lineLength = lineInfo.getLength();
+            if (lineLength == 0) {
+                return;
+            }
+            String lineText = document.get(lineOffset, lineLength);
+            if (!isSqlRegionMarkerCommentLine(lineText, lineOffset, partitioner)) {
+                return;
+            }
+            if (REGION_START_PATTERN.matcher(lineText).find()) {
+                String markerName = extractRegionMarkerName(lineText);
+                String regionKey = regionStarts.isEmpty()
+                    ? markerName
+                    : regionStarts.peek().regionKey() + "/" + markerName;
+                regionStarts.push(new RegionStartFrame(lineOffset, regionKey));
+            } else if (REGION_END_PATTERN.matcher(lineText).find() && !regionStarts.isEmpty()) {
+                addClosedRegion(document, line, lineCount, regionStarts, regions);
+            }
+        } catch (BadLocationException e) {
+            log.warn("Error scanning for region folding markers", e);
+        }
+    }
+
+    private static boolean isSqlRegionMarkerCommentLine(
+        @NotNull String lineText,
+        int lineOffset,
+        IDocumentPartitioner partitioner
+    ) {
+        if (partitioner == null) {
+            return true;
+        }
+        int commentPos = lineText.indexOf("--");
+        if (commentPos < 0) {
+            return false;
+        }
+        String contentType = partitioner.getContentType(lineOffset + commentPos);
+        return SQLParserPartitions.CONTENT_TYPE_SQL_COMMENT.equals(contentType);
+    }
+
+    private static void addClosedRegion(
+        @NotNull IDocument document,
+        int endMarkerLine,
+        int lineCount,
+        @NotNull Deque<RegionStartFrame> regionStarts,
+        @NotNull List<RegionFold> regions
+    ) throws BadLocationException {
+        RegionStartFrame regionStart = regionStarts.pop();
+        int endOffset = endMarkerLine + 1 < lineCount
+            ? document.getLineOffset(endMarkerLine + 1)
+            : document.getLength();
+        int length = endOffset - regionStart.offset();
+        if (length > 0) {
+            regions.add(new RegionFold(regionStart.regionKey(), regionStart.offset(), length));
+        }
+    }
+
+    @NotNull
+    private static String extractRegionMarkerName(@NotNull String lineText) {
+        var matcher = REGION_MARKER_NAME_PATTERN.matcher(lineText);
+        if (!matcher.find()) {
+            return "region";
+        }
+        String markerName = matcher.group(1).trim();
+        return markerName.isEmpty() ? "region" : markerName.toUpperCase(Locale.ROOT);
+    }
+
+    private static IDocumentPartitioner getSqlDocumentPartitioner(@NotNull IDocument document) {
+        if (document instanceof IDocumentExtension3 ext) {
+            return ext.getDocumentPartitioner(SQLParserPartitions.SQL_PARTITIONING);
+        }
+        return null;
+    }
+
+    private static boolean isStrictlyEnclosed(int innerStart, int innerEnd, int outerStart, int outerEnd) {
+        return innerStart >= outerStart && innerEnd <= outerEnd
+            && (innerStart > outerStart || innerEnd < outerEnd);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
@@ -355,6 +355,22 @@ public abstract class SQLEditorBase extends BaseTextEditor implements
         return viewer != null ? viewer.getProjectionAnnotationModel() : null;
     }
 
+    public void refreshProjectionFoldingPresentation() {
+        ProjectionAnnotationModel projectionModel = getProjectionAnnotationModel();
+        if (projectionModel != null) {
+            projectionModel.modifyAnnotations(null, null, null);
+        }
+        // Gutter desync is fixed by vertical ruler refresh; full-document invalidateTextPresentation
+        // does not repaint projection icons and is costly on large scripts.
+        IVerticalRuler verticalRuler = getVerticalRuler();
+        if (verticalRuler != null) {
+            verticalRuler.update();
+            if (verticalRuler.getControl() != null && !verticalRuler.getControl().isDisposed()) {
+                verticalRuler.getControl().redraw();
+            }
+        }
+    }
+
     public SQLEditorSourceViewerConfiguration getViewerConfiguration() {
         return (SQLEditorSourceViewerConfiguration) super.getSourceViewerConfiguration();
     }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorSourceViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorSourceViewer.java
@@ -28,7 +28,8 @@ import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
 import org.jkiss.dbeaver.ui.editors.sql.syntax.SQLProjectionAnnotationModel;
 
-import java.lang.reflect.Field;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import org.eclipse.swt.custom.ST;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.custom.VerifyKeyListener;
@@ -119,21 +120,26 @@ public class SQLEditorSourceViewer extends ProjectionViewer {
     @Override
     protected IAnnotationModel createVisualAnnotationModel(IAnnotationModel annotationModel) {
         IAnnotationModel visualModel = super.createVisualAnnotationModel(annotationModel);
+        installSqlProjectionAnnotationModel();
+        return visualModel;
+    }
+
+    /**
+     * ProjectionViewer creates a plain {@link ProjectionAnnotationModel} in a private field during
+     * {@link #createVisualAnnotationModel(IAnnotationModel)}. Eclipse does not expose a hook to substitute
+     * a subclass, so the field is replaced here before projection mode is enabled.
+     */
+    private void installSqlProjectionAnnotationModel() {
         try {
-            Field field = ProjectionViewer.class.getDeclaredField("fProjectionAnnotationModel");
-            field.setAccessible(true);
-            ProjectionAnnotationModel wiredModel = (ProjectionAnnotationModel) field.get(this);
-            if (wiredModel != null && !(wiredModel instanceof SQLProjectionAnnotationModel)) {
-                SQLProjectionAnnotationModel sqlModel = new SQLProjectionAnnotationModel();
-                field.set(this, sqlModel);
-                if (visualModel == wiredModel) {
-                    return sqlModel;
-                }
+            VarHandle projectionModelHandle = MethodHandles.privateLookupIn(ProjectionViewer.class, MethodHandles.lookup())
+                .findVarHandle(ProjectionViewer.class, "fProjectionAnnotationModel", ProjectionAnnotationModel.class);
+            if (projectionModelHandle.get(this) instanceof SQLProjectionAnnotationModel) {
+                return;
             }
+            projectionModelHandle.set(this, new SQLProjectionAnnotationModel());
         } catch (ReflectiveOperationException e) {
             log.warn("Failed to install SQL projection annotation model", e);
         }
-        return visualModel;
     }
     
     private boolean expandAnnotationsContaining(@NotNull ProjectionAnnotationModel projectionAnnotationModel, int offset) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorSourceViewer.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorSourceViewer.java
@@ -20,11 +20,15 @@ package org.jkiss.dbeaver.ui.editors.sql;
 import org.eclipse.jface.text.*;
 import org.eclipse.jface.text.hyperlink.IHyperlinkPresenter;
 import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.text.source.IOverviewRuler;
 import org.eclipse.jface.text.source.IVerticalRuler;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
+import org.jkiss.dbeaver.ui.editors.sql.syntax.SQLProjectionAnnotationModel;
+
+import java.lang.reflect.Field;
 import org.eclipse.swt.custom.ST;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.custom.VerifyKeyListener;
@@ -110,6 +114,26 @@ public class SQLEditorSourceViewer extends ProjectionViewer {
         
         //textWidget.setAlwaysShowScrollBars(false);
         return textWidget;
+    }
+
+    @Override
+    protected IAnnotationModel createVisualAnnotationModel(IAnnotationModel annotationModel) {
+        IAnnotationModel visualModel = super.createVisualAnnotationModel(annotationModel);
+        try {
+            Field field = ProjectionViewer.class.getDeclaredField("fProjectionAnnotationModel");
+            field.setAccessible(true);
+            ProjectionAnnotationModel wiredModel = (ProjectionAnnotationModel) field.get(this);
+            if (wiredModel != null && !(wiredModel instanceof SQLProjectionAnnotationModel)) {
+                SQLProjectionAnnotationModel sqlModel = new SQLProjectionAnnotationModel();
+                field.set(this, sqlModel);
+                if (visualModel == wiredModel) {
+                    return sqlModel;
+                }
+            }
+        } catch (ReflectiveOperationException e) {
+            log.warn("Failed to install SQL projection annotation model", e);
+        }
+        return visualModel;
     }
     
     private boolean expandAnnotationsContaining(@NotNull ProjectionAnnotationModel projectionAnnotationModel, int offset) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
@@ -1,0 +1,172 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.editors.sql.syntax;
+
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
+import org.jkiss.code.NotNull;
+
+import java.util.*;
+
+/**
+ * Expands enclosed collapsed folds before collapsing a parent region.
+ * Remembers enclosed collapse state and restores it when the parent is expanded.
+ */
+public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
+
+    private final Map<Integer, Set<Integer>> deferredCollapsedEnclosedOffsets = new HashMap<>();
+
+    @NotNull
+    public Set<Integer> getDeferredCollapsedOffsets() {
+        Set<Integer> all = new HashSet<>();
+        for (Set<Integer> offsets : deferredCollapsedEnclosedOffsets.values()) {
+            all.addAll(offsets);
+        }
+        return all;
+    }
+
+    @Override
+    public void collapse(Annotation annotation) {
+        saveAndExpandEnclosedCollapsed(annotation);
+        super.collapse(annotation);
+    }
+
+    @Override
+    public void expand(Annotation annotation) {
+        super.expand(annotation);
+        restoreDeferredCollapsedEnclosed(annotation);
+    }
+
+    @Override
+    public void toggleExpansionState(Annotation annotation) {
+        boolean wasCollapsed = annotation instanceof ProjectionAnnotation projectionAnnotation && projectionAnnotation.isCollapsed();
+        if (!wasCollapsed) {
+            saveAndExpandEnclosedCollapsed(annotation);
+        }
+        super.toggleExpansionState(annotation);
+        if (wasCollapsed) {
+            restoreDeferredCollapsedEnclosed(annotation);
+        }
+    }
+
+    private void saveAndExpandEnclosedCollapsed(@NotNull Annotation outerAnnotation) {
+        Position outerPosition = getPosition(outerAnnotation);
+        if (outerPosition == null) {
+            return;
+        }
+        Set<Integer> enclosedCollapsedOffsets = collectEnclosedCollapsedOffsets(outerPosition, outerAnnotation);
+        if (enclosedCollapsedOffsets.isEmpty()) {
+            return;
+        }
+        deferredCollapsedEnclosedOffsets.put(outerPosition.getOffset(), enclosedCollapsedOffsets);
+        expandEnclosedCollapsed(outerPosition, outerAnnotation);
+    }
+
+    @NotNull
+    private Set<Integer> collectEnclosedCollapsedOffsets(
+        @NotNull Position outerPosition,
+        @NotNull Annotation outerAnnotation
+    ) {
+        int outerStart = outerPosition.getOffset();
+        int outerEnd = outerStart + outerPosition.getLength();
+        Set<Integer> enclosedCollapsedOffsets = new HashSet<>();
+        Iterator<Annotation> it = getAnnotationIterator();
+        while (it.hasNext()) {
+            Annotation enclosedAnnotation = it.next();
+            if (enclosedAnnotation == outerAnnotation
+                || !(enclosedAnnotation instanceof ProjectionAnnotation inner)
+                || !inner.isCollapsed()
+            ) {
+                continue;
+            }
+            Position innerPosition = getPosition(enclosedAnnotation);
+            if (innerPosition == null) {
+                continue;
+            }
+            int innerStart = innerPosition.getOffset();
+            int innerEnd = innerStart + innerPosition.getLength();
+            if (isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
+                enclosedCollapsedOffsets.add(innerStart);
+            }
+        }
+        return enclosedCollapsedOffsets;
+    }
+
+    private void expandEnclosedCollapsed(
+        @NotNull Position outerPosition,
+        @NotNull Annotation outerAnnotation
+    ) {
+        int outerStart = outerPosition.getOffset();
+        int outerEnd = outerStart + outerPosition.getLength();
+        Iterator<Annotation> it = getAnnotationIterator();
+        while (it.hasNext()) {
+            Annotation enclosedAnnotation = it.next();
+            if (enclosedAnnotation == outerAnnotation
+                || !(enclosedAnnotation instanceof ProjectionAnnotation inner)
+                || !inner.isCollapsed()
+            ) {
+                continue;
+            }
+            Position innerPosition = getPosition(enclosedAnnotation);
+            if (innerPosition == null) {
+                continue;
+            }
+            int innerStart = innerPosition.getOffset();
+            int innerEnd = innerStart + innerPosition.getLength();
+            if (isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
+                super.expand(enclosedAnnotation);
+            }
+        }
+    }
+
+    private void restoreDeferredCollapsedEnclosed(@NotNull Annotation outerAnnotation) {
+        Position outerPosition = getPosition(outerAnnotation);
+        if (outerPosition == null) {
+            return;
+        }
+        Set<Integer> deferredOffsets = deferredCollapsedEnclosedOffsets.remove(outerPosition.getOffset());
+        if (deferredOffsets == null || deferredOffsets.isEmpty()) {
+            return;
+        }
+        List<ProjectionAnnotation> toCollapse = new ArrayList<>();
+        Iterator<Annotation> it = getAnnotationIterator();
+        while (it.hasNext()) {
+            Annotation annotation = it.next();
+            if (!(annotation instanceof ProjectionAnnotation projectionAnnotation)) {
+                continue;
+            }
+            Position position = getPosition(annotation);
+            if (position != null && deferredOffsets.contains(position.getOffset())) {
+                toCollapse.add(projectionAnnotation);
+            }
+        }
+        toCollapse.sort(Comparator.comparingInt(annotation -> {
+            Position position = getPosition(annotation);
+            return position != null ? position.getLength() : Integer.MAX_VALUE;
+        }));
+        for (ProjectionAnnotation annotation : toCollapse) {
+            super.collapse(annotation);
+        }
+    }
+
+    private static boolean isStrictlyEnclosed(int innerStart, int innerEnd, int outerStart, int outerEnd) {
+        return innerStart >= outerStart && innerEnd <= outerEnd
+            && (innerStart > outerStart || innerEnd < outerEnd);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
@@ -27,19 +27,18 @@ import java.util.*;
 /**
  * Expands enclosed collapsed folds before collapsing a parent region.
  * Remembers enclosed collapse state and restores it when the parent is expanded.
+ * <p>
+ * Nested collapse/expand behavior is covered by manual UI tests only (requires SWT projection viewer).
+ * Manual test plan:
+ * <ul>
+ *   <li>Collapse OUTER with expanded INNER → expand OUTER → INNER collapse state restored</li>
+ *   <li>Toggle expansion is symmetric for parent and enclosed regions</li>
+ *   <li>Manually expand INNER then expand OUTER → INNER stays expanded ({@code forgetDeferredCollapse})</li>
+ * </ul>
  */
 public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
 
     private final Map<Integer, Set<Integer>> deferredCollapsedEnclosedOffsets = new HashMap<>();
-
-    @NotNull
-    public Set<Integer> getDeferredCollapsedOffsets() {
-        Set<Integer> all = new HashSet<>();
-        for (Set<Integer> offsets : deferredCollapsedEnclosedOffsets.values()) {
-            all.addAll(offsets);
-        }
-        return all;
-    }
 
     @Override
     public void collapse(Annotation annotation) {
@@ -50,6 +49,7 @@ public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
     @Override
     public void expand(Annotation annotation) {
         super.expand(annotation);
+        forgetDeferredCollapse(annotation);
         restoreDeferredCollapsedEnclosed(annotation);
     }
 
@@ -61,8 +61,21 @@ public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
         }
         super.toggleExpansionState(annotation);
         if (wasCollapsed) {
+            forgetDeferredCollapse(annotation);
             restoreDeferredCollapsedEnclosed(annotation);
         }
+    }
+
+    private void forgetDeferredCollapse(@NotNull Annotation annotation) {
+        Position position = getPosition(annotation);
+        if (position == null) {
+            return;
+        }
+        int offset = position.getOffset();
+        for (Set<Integer> offsets : deferredCollapsedEnclosedOffsets.values()) {
+            offsets.remove(offset);
+        }
+        deferredCollapsedEnclosedOffsets.entrySet().removeIf(entry -> entry.getValue().isEmpty());
     }
 
     private void saveAndExpandEnclosedCollapsed(@NotNull Annotation outerAnnotation) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLProjectionAnnotationModel.java
@@ -38,16 +38,18 @@ import java.util.*;
  */
 public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
 
-    private final Map<Integer, Set<Integer>> deferredCollapsedEnclosedOffsets = new HashMap<>();
+    private final Map<Annotation, Set<Annotation>> deferredCollapsedEnclosedAnnotations = new IdentityHashMap<>();
 
     @Override
     public void collapse(Annotation annotation) {
+        pruneDeferredCollapseState();
         saveAndExpandEnclosedCollapsed(annotation);
         super.collapse(annotation);
     }
 
     @Override
     public void expand(Annotation annotation) {
+        pruneDeferredCollapseState();
         super.expand(annotation);
         forgetDeferredCollapse(annotation);
         restoreDeferredCollapsedEnclosed(annotation);
@@ -55,6 +57,7 @@ public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
 
     @Override
     public void toggleExpansionState(Annotation annotation) {
+        pruneDeferredCollapseState();
         boolean wasCollapsed = annotation instanceof ProjectionAnnotation projectionAnnotation && projectionAnnotation.isCollapsed();
         if (!wasCollapsed) {
             saveAndExpandEnclosedCollapsed(annotation);
@@ -66,16 +69,21 @@ public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
         }
     }
 
+    private void pruneDeferredCollapseState() {
+        deferredCollapsedEnclosedAnnotations.entrySet().removeIf(entry -> {
+            if (getPosition(entry.getKey()) == null) {
+                return true;
+            }
+            entry.getValue().removeIf(annotation -> getPosition(annotation) == null);
+            return entry.getValue().isEmpty();
+        });
+    }
+
     private void forgetDeferredCollapse(@NotNull Annotation annotation) {
-        Position position = getPosition(annotation);
-        if (position == null) {
-            return;
+        for (Set<Annotation> annotations : deferredCollapsedEnclosedAnnotations.values()) {
+            annotations.remove(annotation);
         }
-        int offset = position.getOffset();
-        for (Set<Integer> offsets : deferredCollapsedEnclosedOffsets.values()) {
-            offsets.remove(offset);
-        }
-        deferredCollapsedEnclosedOffsets.entrySet().removeIf(entry -> entry.getValue().isEmpty());
+        deferredCollapsedEnclosedAnnotations.entrySet().removeIf(entry -> entry.getValue().isEmpty());
     }
 
     private void saveAndExpandEnclosedCollapsed(@NotNull Annotation outerAnnotation) {
@@ -83,22 +91,22 @@ public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
         if (outerPosition == null) {
             return;
         }
-        Set<Integer> enclosedCollapsedOffsets = collectEnclosedCollapsedOffsets(outerPosition, outerAnnotation);
-        if (enclosedCollapsedOffsets.isEmpty()) {
+        Set<Annotation> enclosedCollapsedAnnotations = collectEnclosedCollapsedAnnotations(outerPosition, outerAnnotation);
+        if (enclosedCollapsedAnnotations.isEmpty()) {
             return;
         }
-        deferredCollapsedEnclosedOffsets.put(outerPosition.getOffset(), enclosedCollapsedOffsets);
-        expandEnclosedCollapsed(outerPosition, outerAnnotation);
+        deferredCollapsedEnclosedAnnotations.put(outerAnnotation, enclosedCollapsedAnnotations);
+        expandEnclosedCollapsed(enclosedCollapsedAnnotations);
     }
 
     @NotNull
-    private Set<Integer> collectEnclosedCollapsedOffsets(
+    private Set<Annotation> collectEnclosedCollapsedAnnotations(
         @NotNull Position outerPosition,
         @NotNull Annotation outerAnnotation
     ) {
         int outerStart = outerPosition.getOffset();
         int outerEnd = outerStart + outerPosition.getLength();
-        Set<Integer> enclosedCollapsedOffsets = new HashSet<>();
+        Set<Annotation> enclosedCollapsedAnnotations = Collections.newSetFromMap(new IdentityHashMap<>());
         Iterator<Annotation> it = getAnnotationIterator();
         while (it.hasNext()) {
             Annotation enclosedAnnotation = it.next();
@@ -115,57 +123,36 @@ public class SQLProjectionAnnotationModel extends ProjectionAnnotationModel {
             int innerStart = innerPosition.getOffset();
             int innerEnd = innerStart + innerPosition.getLength();
             if (isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
-                enclosedCollapsedOffsets.add(innerStart);
+                enclosedCollapsedAnnotations.add(enclosedAnnotation);
             }
         }
-        return enclosedCollapsedOffsets;
+        return enclosedCollapsedAnnotations;
     }
 
     private void expandEnclosedCollapsed(
-        @NotNull Position outerPosition,
-        @NotNull Annotation outerAnnotation
+        @NotNull Set<Annotation> enclosedCollapsedAnnotations
     ) {
-        int outerStart = outerPosition.getOffset();
-        int outerEnd = outerStart + outerPosition.getLength();
-        Iterator<Annotation> it = getAnnotationIterator();
-        while (it.hasNext()) {
-            Annotation enclosedAnnotation = it.next();
-            if (enclosedAnnotation == outerAnnotation
-                || !(enclosedAnnotation instanceof ProjectionAnnotation inner)
-                || !inner.isCollapsed()
+        for (Annotation enclosedAnnotation : enclosedCollapsedAnnotations) {
+            if (enclosedAnnotation instanceof ProjectionAnnotation inner && inner.isCollapsed()
+                && getPosition(enclosedAnnotation) != null
             ) {
-                continue;
-            }
-            Position innerPosition = getPosition(enclosedAnnotation);
-            if (innerPosition == null) {
-                continue;
-            }
-            int innerStart = innerPosition.getOffset();
-            int innerEnd = innerStart + innerPosition.getLength();
-            if (isStrictlyEnclosed(innerStart, innerEnd, outerStart, outerEnd)) {
                 super.expand(enclosedAnnotation);
             }
         }
     }
 
     private void restoreDeferredCollapsedEnclosed(@NotNull Annotation outerAnnotation) {
-        Position outerPosition = getPosition(outerAnnotation);
-        if (outerPosition == null) {
-            return;
-        }
-        Set<Integer> deferredOffsets = deferredCollapsedEnclosedOffsets.remove(outerPosition.getOffset());
-        if (deferredOffsets == null || deferredOffsets.isEmpty()) {
+        Set<Annotation> deferredAnnotations = deferredCollapsedEnclosedAnnotations.remove(outerAnnotation);
+        if (deferredAnnotations == null || deferredAnnotations.isEmpty()) {
             return;
         }
         List<ProjectionAnnotation> toCollapse = new ArrayList<>();
-        Iterator<Annotation> it = getAnnotationIterator();
-        while (it.hasNext()) {
-            Annotation annotation = it.next();
+        for (Annotation annotation : deferredAnnotations) {
             if (!(annotation instanceof ProjectionAnnotation projectionAnnotation)) {
                 continue;
             }
             Position position = getPosition(annotation);
-            if (position != null && deferredOffsets.contains(position.getOffset())) {
+            if (position != null) {
                 toCollapse.add(projectionAnnotation);
             }
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -260,9 +260,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         }
 
         List<SQLScriptElementImpl> regionElements = extractRegionFoldingPositions();
-        List<SQLRegionMarkerFolding.RegionFold> regionFolds = regionElements.stream()
-            .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
-            .toList();
+        List<SQLRegionMarkerFolding.RegionFold> regionFolds = toRegionFolds(regionElements);
 
         Set<SQLScriptElementImpl> parsedElements = new HashSet<>(parsedQueries.stream()
             .filter(this::deservesFolding)
@@ -321,14 +319,49 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         @NotNull Set<Integer> savedCollapsedAnnotationsOffsets,
         int editOffset
     ) {
-        List<SQLScriptElementImpl> scannedRegions = extractFoldableRegionFoldingPositions();
+        Map<String, SQLScriptElementImpl> scannedByKey = buildScannedRegionsByKey();
+        Map<String, Boolean> collapsedByKey = buildCollapsedRegionKeys(scannedByKey, savedCollapsedAnnotationsOffsets);
+
+        List<Annotation> deletions = collectObsoleteRegionAnnotations(scannedByKey);
+        Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
+        Map<String, SQLScriptElementImpl> nextRegionCache = new LinkedHashMap<>();
+        reconcileRegionAnnotationChanges(scannedByKey, collapsedByKey, model, deletions, additions, nextRegionCache);
+
+        if (!deletions.isEmpty() || !additions.isEmpty()) {
+            model.modifyAnnotations(deletions.toArray(Annotation[]::new), additions, null);
+        }
+
+        boolean collapseApplied = applySavedCollapsedStates(model, nextRegionCache, collapsedByKey);
+        boolean regionSetChanged = !regionCache.keySet().equals(scannedByKey.keySet());
+        updateRegionCache(nextRegionCache);
+
+        if (SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            !deletions.isEmpty() || !additions.isEmpty(),
+            collapseApplied,
+            regionSetChanged,
+            editOffset,
+            toRegionFolds(scannedByKey.values())
+        )) {
+            scheduleProjectionPresentationRefresh();
+        }
+    }
+
+    @NotNull
+    private Map<String, SQLScriptElementImpl> buildScannedRegionsByKey() {
         Map<String, SQLScriptElementImpl> scannedByKey = new LinkedHashMap<>();
-        for (SQLScriptElementImpl region : scannedRegions) {
+        for (SQLScriptElementImpl region : extractFoldableRegionFoldingPositions()) {
             if (region.getRegionKey() != null) {
                 scannedByKey.put(region.getRegionKey(), region);
             }
         }
+        return scannedByKey;
+    }
 
+    @NotNull
+    private Map<String, Boolean> buildCollapsedRegionKeys(
+        @NotNull Map<String, SQLScriptElementImpl> scannedByKey,
+        @NotNull Set<Integer> savedCollapsedAnnotationsOffsets
+    ) {
         Map<String, Boolean> collapsedByKey = new HashMap<>();
         for (SQLScriptElementImpl cachedRegion : regionCache.values()) {
             ProjectionAnnotation annotation = cachedRegion.getAnnotation();
@@ -341,11 +374,12 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 collapsedByKey.put(scannedEntry.getKey(), true);
             }
         }
+        return collapsedByKey;
+    }
 
-        Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
+    @NotNull
+    private List<Annotation> collectObsoleteRegionAnnotations(@NotNull Map<String, SQLScriptElementImpl> scannedByKey) {
         List<Annotation> deletions = new ArrayList<>();
-        Map<String, SQLScriptElementImpl> nextRegionCache = new LinkedHashMap<>();
-
         for (Map.Entry<String, SQLScriptElementImpl> cachedEntry : regionCache.entrySet()) {
             if (!scannedByKey.containsKey(cachedEntry.getKey())) {
                 ProjectionAnnotation annotation = cachedEntry.getValue().getAnnotation();
@@ -354,7 +388,17 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 }
             }
         }
+        return deletions;
+    }
 
+    private void reconcileRegionAnnotationChanges(
+        @NotNull Map<String, SQLScriptElementImpl> scannedByKey,
+        @NotNull Map<String, Boolean> collapsedByKey,
+        @NotNull ProjectionAnnotationModel model,
+        @NotNull List<Annotation> deletions,
+        @NotNull Map<Annotation, SQLScriptElementImpl> additions,
+        @NotNull Map<String, SQLScriptElementImpl> nextRegionCache
+    ) {
         for (Map.Entry<String, SQLScriptElementImpl> scannedEntry : scannedByKey.entrySet()) {
             String regionKey = scannedEntry.getKey();
             SQLScriptElementImpl scannedRegion = scannedEntry.getValue();
@@ -380,11 +424,13 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             additions.put(annotation, scannedRegion);
             nextRegionCache.put(regionKey, scannedRegion);
         }
+    }
 
-        if (!deletions.isEmpty() || !additions.isEmpty()) {
-            model.modifyAnnotations(deletions.toArray(Annotation[]::new), additions, null);
-        }
-
+    private boolean applySavedCollapsedStates(
+        @NotNull ProjectionAnnotationModel model,
+        @NotNull Map<String, SQLScriptElementImpl> nextRegionCache,
+        @NotNull Map<String, Boolean> collapsedByKey
+    ) {
         boolean collapseApplied = false;
         for (Map.Entry<String, SQLScriptElementImpl> entry : nextRegionCache.entrySet()) {
             SQLScriptElementImpl region = entry.getValue();
@@ -400,23 +446,19 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 collapseApplied = true;
             }
         }
+        return collapseApplied;
+    }
 
-        boolean regionSetChanged = !regionCache.keySet().equals(scannedByKey.keySet());
-
+    private void updateRegionCache(@NotNull Map<String, SQLScriptElementImpl> nextRegionCache) {
         regionCache.clear();
         regionCache.putAll(nextRegionCache);
+    }
 
-        if (SQLRegionMarkerFolding.needsFoldingGutterRefresh(
-            !deletions.isEmpty() || !additions.isEmpty(),
-            collapseApplied,
-            regionSetChanged,
-            editOffset,
-            scannedByKey.values().stream()
-                .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
-                .toList()
-        )) {
-            scheduleProjectionPresentationRefresh();
-        }
+    @NotNull
+    private List<SQLRegionMarkerFolding.RegionFold> toRegionFolds(@NotNull Collection<SQLScriptElementImpl> regions) {
+        return regions.stream()
+            .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
+            .toList();
     }
 
     /**

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -39,15 +39,15 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.sql.SQLScriptElement;
-import org.jkiss.dbeaver.model.sql.parser.SQLParserPartitions;
+import org.jkiss.dbeaver.model.sql.parser.SQLRegionMarkerFolding;
 import org.jkiss.dbeaver.ui.editors.EditorUtils;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorUtils;
 import org.jkiss.dbeaver.ui.editors.sql.internal.SQLEditorActivator;
+import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.utils.CommonUtils;
 
 import java.util.*;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilingStrategyExtension {
@@ -56,10 +56,11 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     private static final QualifiedName COLLAPSED_ANNOTATIONS =
         new QualifiedName(SQLEditorActivator.PLUGIN_ID, SQLReconcilingStrategy.class.getName() + ".collapsedFoldingAnnotations");
 
-    private static final Pattern REGION_START_PATTERN = Pattern.compile("^\\s*--\\s*region\\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern REGION_END_PATTERN = Pattern.compile("^\\s*--\\s*endregion\\b", Pattern.CASE_INSENSITIVE);
-
     private final NavigableSet<SQLScriptElementImpl> cache = new TreeSet<>();
+    private final Map<String, SQLScriptElementImpl> regionCache = new LinkedHashMap<>();
+
+    private volatile boolean projectionRefreshScheduled;
+    private volatile boolean projectionRefreshPending;
 
     private final SQLEditorBase editor;
 
@@ -87,6 +88,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     public void setDocument(IDocument document) {
         this.document = document;
         this.cache.clear();
+        this.regionCache.clear();
 
         spellingService = EditorsUI.getSpellingService();
         if (spellingService.getActiveSpellingEngineDescriptor(editor.getViewerConfiguration().getPreferenceStore()) != null) {
@@ -166,9 +168,10 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 stringJoiner.add(Integer.toString(position.getOffset()));
             }
         }
-        if (annotationModel instanceof SQLProjectionAnnotationModel sqlProjectionModel) {
-            for (int offset : sqlProjectionModel.getDeferredCollapsedOffsets()) {
-                stringJoiner.add(Integer.toString(offset));
+        for (SQLScriptElementImpl position : regionCache.values()) {
+            ProjectionAnnotation annotation = position.getAnnotation();
+            if (annotation != null && annotation.isCollapsed()) {
+                stringJoiner.add(Integer.toString(position.getOffset()));
             }
         }
         String value;
@@ -203,12 +206,15 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     private void reconcile(int damagedRegionOffset, int damagedRegionLength, boolean restoreCollapsedAnnotations) {
         if (!editor.isFoldingEnabled()) {
             cache.clear(); // underlying annotation model being cleared, so reset the cache too
+            regionCache.clear();
             return;
         }
         ProjectionAnnotationModel model = editor.getProjectionAnnotationModel();
         if (model == null) {
             return;
         }
+
+        final int editOffset = damagedRegionOffset; // original dirty region; damagedRegionOffset is widened below for parser cache
 
         SQLScriptElementImpl leftBound = cache.lower(new SQLScriptElementImpl(damagedRegionOffset, damagedRegionLength));
         if (leftBound != null) {
@@ -254,11 +260,14 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         }
 
         List<SQLScriptElementImpl> regionElements = extractRegionFoldingPositions();
+        List<SQLRegionMarkerFolding.RegionFold> regionFolds = regionElements.stream()
+            .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
+            .toList();
 
         Set<SQLScriptElementImpl> parsedElements = new HashSet<>(parsedQueries.stream()
             .filter(this::deservesFolding)
             .map(this::getExpandedScriptElement)
-            .filter(element -> !isStrictlyEnclosedInAnyRegion(element, regionElements))
+            .filter(element -> !isStrictlyEnclosedInAnyRegion(element, regionFolds))
             .collect(Collectors.toSet()));
         Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
         Set<Integer> savedCollapsedAnnotationsOffsets = restoreCollapsedAnnotations ? getSavedCollapsedAnnotationsOffsets() : Collections.emptySet();
@@ -267,18 +276,6 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 ProjectionAnnotation annotation = new ProjectionAnnotation();
                 element.setAnnotation(annotation);
                 additions.put(annotation, element);
-            }
-        }
-        // Add region-based folding annotations for --region/--endregion markers
-        for (SQLScriptElementImpl regionElement : regionElements) {
-            if (getNumberOfLines(regionElement) <= 1) {
-                continue;
-            }
-            parsedElements.add(regionElement);
-            if (!cachedQueries.contains(regionElement)) {
-                ProjectionAnnotation annotation = new ProjectionAnnotation();
-                regionElement.setAnnotation(annotation);
-                additions.put(annotation, regionElement);
             }
         }
         Collection<SQLScriptElementImpl> deletedPositions = cachedQueries.stream()
@@ -303,9 +300,10 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 }
             }
         }
-        syncCollapsedProjectionAnnotations(model);
         cache.removeAll(deletedPositions);
         cache.addAll(additions.values());
+
+        syncRegionFolds(model, savedCollapsedAnnotationsOffsets, editOffset);
 
         if (isSpellingEnabled() && spellingContext != null) {
             IRegion[] regions = new IRegion[]{
@@ -318,6 +316,167 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         }
     }
 
+    private void syncRegionFolds(
+        @NotNull ProjectionAnnotationModel model,
+        @NotNull Set<Integer> savedCollapsedAnnotationsOffsets,
+        int editOffset
+    ) {
+        List<SQLScriptElementImpl> scannedRegions = extractFoldableRegionFoldingPositions();
+        Map<String, SQLScriptElementImpl> scannedByKey = new LinkedHashMap<>();
+        for (SQLScriptElementImpl region : scannedRegions) {
+            if (region.getRegionKey() != null) {
+                scannedByKey.put(region.getRegionKey(), region);
+            }
+        }
+
+        Map<String, Boolean> collapsedByKey = new HashMap<>();
+        for (SQLScriptElementImpl cachedRegion : regionCache.values()) {
+            ProjectionAnnotation annotation = cachedRegion.getAnnotation();
+            if (annotation != null && annotation.isCollapsed() && cachedRegion.getRegionKey() != null) {
+                collapsedByKey.put(cachedRegion.getRegionKey(), true);
+            }
+        }
+        for (Map.Entry<String, SQLScriptElementImpl> scannedEntry : scannedByKey.entrySet()) {
+            if (savedCollapsedAnnotationsOffsets.contains(scannedEntry.getValue().getOffset())) {
+                collapsedByKey.put(scannedEntry.getKey(), true);
+            }
+        }
+
+        Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
+        List<Annotation> deletions = new ArrayList<>();
+        Map<String, SQLScriptElementImpl> nextRegionCache = new LinkedHashMap<>();
+
+        for (Map.Entry<String, SQLScriptElementImpl> cachedEntry : regionCache.entrySet()) {
+            if (!scannedByKey.containsKey(cachedEntry.getKey())) {
+                ProjectionAnnotation annotation = cachedEntry.getValue().getAnnotation();
+                if (annotation != null) {
+                    deletions.add(annotation);
+                }
+            }
+        }
+
+        for (Map.Entry<String, SQLScriptElementImpl> scannedEntry : scannedByKey.entrySet()) {
+            String regionKey = scannedEntry.getKey();
+            SQLScriptElementImpl scannedRegion = scannedEntry.getValue();
+            SQLScriptElementImpl cachedRegion = regionCache.get(regionKey);
+
+            if (!needsRegionAnnotationRecreate(cachedRegion, scannedRegion, model)) {
+                nextRegionCache.put(regionKey, cachedRegion);
+                continue;
+            }
+
+            if (cachedRegion != null) {
+                ProjectionAnnotation oldAnnotation = cachedRegion.getAnnotation();
+                if (oldAnnotation != null) {
+                    if (oldAnnotation.isCollapsed()) {
+                        collapsedByKey.put(regionKey, true);
+                    }
+                    deletions.add(oldAnnotation);
+                }
+            }
+
+            ProjectionAnnotation annotation = new ProjectionAnnotation();
+            scannedRegion.setAnnotation(annotation);
+            additions.put(annotation, scannedRegion);
+            nextRegionCache.put(regionKey, scannedRegion);
+        }
+
+        if (!deletions.isEmpty() || !additions.isEmpty()) {
+            model.modifyAnnotations(deletions.toArray(Annotation[]::new), additions, null);
+        }
+
+        boolean collapseApplied = false;
+        for (Map.Entry<String, SQLScriptElementImpl> entry : nextRegionCache.entrySet()) {
+            SQLScriptElementImpl region = entry.getValue();
+            ProjectionAnnotation annotation = region.getAnnotation();
+            if (annotation == null
+                || document == null
+                || !SQLRegionMarkerFolding.isValidDocumentRange(document, region.getOffset(), region.getLength())
+            ) {
+                continue;
+            }
+            if (collapsedByKey.getOrDefault(entry.getKey(), false) && !annotation.isCollapsed()) {
+                model.collapse(annotation);
+                collapseApplied = true;
+            }
+        }
+
+        boolean regionSetChanged = !regionCache.keySet().equals(scannedByKey.keySet());
+
+        regionCache.clear();
+        regionCache.putAll(nextRegionCache);
+
+        if (SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            !deletions.isEmpty() || !additions.isEmpty(),
+            collapseApplied,
+            regionSetChanged,
+            editOffset,
+            scannedByKey.values().stream()
+                .map(r -> new SQLRegionMarkerFolding.RegionFold(r.getRegionKey(), r.getOffset(), r.getLength()))
+                .toList()
+        )) {
+            scheduleProjectionPresentationRefresh();
+        }
+    }
+
+    /**
+     * Reconcile updates annotations off the UI thread; projection gutter icons may stay stale until
+     * the viewer repaints (scrolling happens to trigger that). Force the same refresh explicitly.
+     */
+    private void scheduleProjectionPresentationRefresh() {
+        if (projectionRefreshScheduled) {
+            projectionRefreshPending = true;
+            return;
+        }
+        projectionRefreshScheduled = true;
+        UIUtils.asyncExec(this::runProjectionPresentationRefresh);
+    }
+
+    private void runProjectionPresentationRefresh() {
+        try {
+            if (document != null && editor.isFoldingEnabled()) {
+                editor.refreshProjectionFoldingPresentation();
+            }
+        } catch (RuntimeException e) {
+            log.warn("Failed to refresh projection folding presentation", e);
+        }
+        if (projectionRefreshPending) {
+            projectionRefreshPending = false;
+            UIUtils.asyncExec(this::runProjectionPresentationRefresh);
+        } else {
+            projectionRefreshScheduled = false;
+        }
+    }
+
+    private boolean needsRegionAnnotationRecreate(
+        @Nullable SQLScriptElementImpl cachedRegion,
+        @NotNull SQLScriptElementImpl scannedRegion,
+        @NotNull ProjectionAnnotationModel model
+    ) {
+        if (cachedRegion == null || cachedRegion.getAnnotation() == null) {
+            return true;
+        }
+        int scannedOffset = scannedRegion.getOffset();
+        int scannedLength = scannedRegion.getLength();
+        if (cachedRegion.getOffset() != scannedOffset || cachedRegion.getLength() != scannedLength) {
+            return true;
+        }
+        Position modelPosition = model.getPosition(cachedRegion.getAnnotation());
+        return modelPosition == null
+            || modelPosition.getOffset() != scannedOffset
+            || modelPosition.getLength() != scannedLength;
+    }
+
+    private int getRegionNumberOfLines(@NotNull SQLScriptElementImpl region) {
+        if (document == null || region.getRegionKey() == null) {
+            return 1;
+        }
+        return SQLRegionMarkerFolding.getRegionNumberOfLines(
+            document,
+            new SQLRegionMarkerFolding.RegionFold(region.getRegionKey(), region.getOffset(), region.getLength())
+        );
+    }
+
     @Nullable
     private List<SQLScriptElement> extractQueries(int offset, int length) {
         return editor.extractScriptQueries(offset, length, false, true, false);
@@ -325,82 +484,31 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
 
     @NotNull
     private List<SQLScriptElementImpl> extractRegionFoldingPositions() {
-        List<SQLScriptElementImpl> regions = new ArrayList<>();
-        if (document == null || document.getLength() == 0) {
-            return regions;
+        if (document == null) {
+            return List.of();
         }
-        IDocumentPartitioner partitioner = document instanceof IDocumentExtension3 ext
-            ? ext.getDocumentPartitioner(SQLParserPartitions.SQL_PARTITIONING)
-            : null;
-        Deque<Integer> regionStarts = new ArrayDeque<>();
-        int lineCount = document.getNumberOfLines();
-        for (int line = 0; line < lineCount; line++) {
-            try {
-                IRegion lineInfo = document.getLineInformation(line);
-                int lineOffset = lineInfo.getOffset();
-                int lineLength = lineInfo.getLength();
-                if (lineLength == 0) {
-                    continue;
-                }
-                String lineText = document.get(lineOffset, lineLength);
-                if (partitioner != null) {
-                    int commentPos = lineText.indexOf("--");
-                    if (commentPos < 0) {
-                        continue;
-                    }
-                    String contentType = partitioner.getContentType(lineOffset + commentPos);
-                    if (!SQLParserPartitions.CONTENT_TYPE_SQL_COMMENT.equals(contentType)) {
-                        continue;
-                    }
-                }
-                if (REGION_START_PATTERN.matcher(lineText).find()) {
-                    regionStarts.push(lineOffset);
-                } else if (REGION_END_PATTERN.matcher(lineText).find()) {
-                    if (!regionStarts.isEmpty()) {
-                        int startOffset = regionStarts.pop();
-                        int endOffset = line + 1 < lineCount
-                            ? document.getLineOffset(line + 1)
-                            : document.getLength();
-                        int length = endOffset - startOffset;
-                        if (length > 0) {
-                            regions.add(new SQLScriptElementImpl(startOffset, length));
-                        }
-                    }
-                }
-            } catch (BadLocationException e) {
-                log.warn("Error scanning for region folding markers", e);
-            }
+        return SQLRegionMarkerFolding.scanRegions(document).stream()
+            .map(f -> new SQLScriptElementImpl(f.offset(), f.length(), f.regionKey()))
+            .toList();
+    }
+
+    @NotNull
+    private List<SQLScriptElementImpl> extractFoldableRegionFoldingPositions() {
+        if (document == null) {
+            return List.of();
         }
-        return regions;
+        return SQLRegionMarkerFolding.scanFoldableRegions(document).stream()
+            .map(f -> new SQLScriptElementImpl(f.offset(), f.length(), f.regionKey()))
+            .toList();
     }
 
     private boolean isStrictlyEnclosedInAnyRegion(
         @NotNull SQLScriptElementImpl element,
-        @NotNull List<SQLScriptElementImpl> regions
+        @NotNull List<SQLRegionMarkerFolding.RegionFold> regions
     ) {
         int start = element.getOffset();
         int end = start + element.getLength();
-        for (SQLScriptElementImpl region : regions) {
-            if (isStrictlyEnclosed(start, end, region.getOffset(), region.getOffset() + region.getLength())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isStrictlyEnclosed(int innerStart, int innerEnd, int outerStart, int outerEnd) {
-        return innerStart >= outerStart && innerEnd <= outerEnd
-            && (innerStart > outerStart || innerEnd < outerEnd);
-    }
-
-    private void syncCollapsedProjectionAnnotations(@NotNull ProjectionAnnotationModel model) {
-        Iterator<Annotation> it = model.getAnnotationIterator();
-        while (it.hasNext()) {
-            Annotation annotation = it.next();
-            if (annotation instanceof ProjectionAnnotation projectionAnnotation && projectionAnnotation.isCollapsed()) {
-                model.collapse(annotation);
-            }
-        }
+        return SQLRegionMarkerFolding.isStrictlyEnclosedInAnyRegion(start, end, regions);
     }
 
     private boolean deservesFolding(SQLScriptElement element) {
@@ -470,9 +578,21 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     private static class SQLScriptElementImpl extends Position implements SQLScriptElement, Comparable<SQLScriptElementImpl> {
         @Nullable
         private ProjectionAnnotation annotation;
+        @Nullable
+        private final String regionKey;
 
         SQLScriptElementImpl(int offset, int length) {
+            this(offset, length, null);
+        }
+
+        SQLScriptElementImpl(int offset, int length, @Nullable String regionKey) {
             super(offset, length);
+            this.regionKey = regionKey;
+        }
+
+        @Nullable
+        public String getRegionKey() {
+            return regionKey;
         }
 
         @Nullable

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.sql.SQLScriptElement;
+import org.jkiss.dbeaver.model.sql.parser.SQLParserPartitions;
 import org.jkiss.dbeaver.ui.editors.EditorUtils;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorBase;
 import org.jkiss.dbeaver.ui.editors.sql.SQLEditorUtils;
@@ -46,6 +47,7 @@ import org.jkiss.dbeaver.ui.editors.sql.internal.SQLEditorActivator;
 import org.jkiss.utils.CommonUtils;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilingStrategyExtension {
@@ -53,6 +55,9 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
 
     private static final QualifiedName COLLAPSED_ANNOTATIONS =
         new QualifiedName(SQLEditorActivator.PLUGIN_ID, SQLReconcilingStrategy.class.getName() + ".collapsedFoldingAnnotations");
+
+    private static final Pattern REGION_START_PATTERN = Pattern.compile("^\\s*--\\s*region\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REGION_END_PATTERN = Pattern.compile("^\\s*--\\s*endregion\\b", Pattern.CASE_INSENSITIVE);
 
     private final NavigableSet<SQLScriptElementImpl> cache = new TreeSet<>();
 
@@ -161,6 +166,11 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 stringJoiner.add(Integer.toString(position.getOffset()));
             }
         }
+        if (annotationModel instanceof SQLProjectionAnnotationModel sqlProjectionModel) {
+            for (int offset : sqlProjectionModel.getDeferredCollapsedOffsets()) {
+                stringJoiner.add(Integer.toString(offset));
+            }
+        }
         String value;
         if (stringJoiner.length() == 0) {
             value = null;
@@ -243,10 +253,13 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             cachedQueries = Collections.unmodifiableNavigableSet(cache.subSet(leftBound, false, rightBound, true));
         }
 
-        Collection<SQLScriptElementImpl> parsedElements = parsedQueries.stream()
+        List<SQLScriptElementImpl> regionElements = extractRegionFoldingPositions();
+
+        Set<SQLScriptElementImpl> parsedElements = new HashSet<>(parsedQueries.stream()
             .filter(this::deservesFolding)
             .map(this::getExpandedScriptElement)
-            .collect(Collectors.toSet());
+            .filter(element -> !isStrictlyEnclosedInAnyRegion(element, regionElements))
+            .collect(Collectors.toSet()));
         Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
         Set<Integer> savedCollapsedAnnotationsOffsets = restoreCollapsedAnnotations ? getSavedCollapsedAnnotationsOffsets() : Collections.emptySet();
         for (SQLScriptElementImpl element : parsedElements) {
@@ -254,18 +267,43 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 ProjectionAnnotation annotation = new ProjectionAnnotation();
                 element.setAnnotation(annotation);
                 additions.put(annotation, element);
-                if (savedCollapsedAnnotationsOffsets.contains(element.getOffset())) {
-                    annotation.markCollapsed();
-                }
+            }
+        }
+        // Add region-based folding annotations for --region/--endregion markers
+        for (SQLScriptElementImpl regionElement : regionElements) {
+            if (getNumberOfLines(regionElement) <= 1) {
+                continue;
+            }
+            parsedElements.add(regionElement);
+            if (!cachedQueries.contains(regionElement)) {
+                ProjectionAnnotation annotation = new ProjectionAnnotation();
+                regionElement.setAnnotation(annotation);
+                additions.put(annotation, regionElement);
             }
         }
         Collection<SQLScriptElementImpl> deletedPositions = cachedQueries.stream()
             .filter(element -> !parsedElements.contains(element))
             .toList();
+        Set<Integer> collapsedOffsetsToRestore = new HashSet<>(savedCollapsedAnnotationsOffsets);
+        for (SQLScriptElementImpl deleted : deletedPositions) {
+            ProjectionAnnotation annotation = deleted.getAnnotation();
+            if (annotation != null && annotation.isCollapsed()) {
+                collapsedOffsetsToRestore.add(deleted.getOffset());
+            }
+        }
         Annotation[] deletions = deletedPositions.stream()
             .map(SQLScriptElementImpl::getAnnotation)
             .toArray(Annotation[]::new);
         model.modifyAnnotations(deletions, additions, null);
+        for (SQLScriptElementImpl element : additions.values()) {
+            if (collapsedOffsetsToRestore.contains(element.getOffset())) {
+                ProjectionAnnotation annotation = element.getAnnotation();
+                if (annotation != null) {
+                    model.collapse(annotation);
+                }
+            }
+        }
+        syncCollapsedProjectionAnnotations(model);
         cache.removeAll(deletedPositions);
         cache.addAll(additions.values());
 
@@ -285,6 +323,86 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         return editor.extractScriptQueries(offset, length, false, true, false);
     }
 
+    @NotNull
+    private List<SQLScriptElementImpl> extractRegionFoldingPositions() {
+        List<SQLScriptElementImpl> regions = new ArrayList<>();
+        if (document == null || document.getLength() == 0) {
+            return regions;
+        }
+        IDocumentPartitioner partitioner = document instanceof IDocumentExtension3 ext
+            ? ext.getDocumentPartitioner(SQLParserPartitions.SQL_PARTITIONING)
+            : null;
+        Deque<Integer> regionStarts = new ArrayDeque<>();
+        int lineCount = document.getNumberOfLines();
+        for (int line = 0; line < lineCount; line++) {
+            try {
+                IRegion lineInfo = document.getLineInformation(line);
+                int lineOffset = lineInfo.getOffset();
+                int lineLength = lineInfo.getLength();
+                if (lineLength == 0) {
+                    continue;
+                }
+                String lineText = document.get(lineOffset, lineLength);
+                if (partitioner != null) {
+                    int commentPos = lineText.indexOf("--");
+                    if (commentPos < 0) {
+                        continue;
+                    }
+                    String contentType = partitioner.getContentType(lineOffset + commentPos);
+                    if (!SQLParserPartitions.CONTENT_TYPE_SQL_COMMENT.equals(contentType)) {
+                        continue;
+                    }
+                }
+                if (REGION_START_PATTERN.matcher(lineText).find()) {
+                    regionStarts.push(lineOffset);
+                } else if (REGION_END_PATTERN.matcher(lineText).find()) {
+                    if (!regionStarts.isEmpty()) {
+                        int startOffset = regionStarts.pop();
+                        int endOffset = line + 1 < lineCount
+                            ? document.getLineOffset(line + 1)
+                            : document.getLength();
+                        int length = endOffset - startOffset;
+                        if (length > 0) {
+                            regions.add(new SQLScriptElementImpl(startOffset, length));
+                        }
+                    }
+                }
+            } catch (BadLocationException e) {
+                log.warn("Error scanning for region folding markers", e);
+            }
+        }
+        return regions;
+    }
+
+    private boolean isStrictlyEnclosedInAnyRegion(
+        @NotNull SQLScriptElementImpl element,
+        @NotNull List<SQLScriptElementImpl> regions
+    ) {
+        int start = element.getOffset();
+        int end = start + element.getLength();
+        for (SQLScriptElementImpl region : regions) {
+            if (isStrictlyEnclosed(start, end, region.getOffset(), region.getOffset() + region.getLength())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isStrictlyEnclosed(int innerStart, int innerEnd, int outerStart, int outerEnd) {
+        return innerStart >= outerStart && innerEnd <= outerEnd
+            && (innerStart > outerStart || innerEnd < outerEnd);
+    }
+
+    private void syncCollapsedProjectionAnnotations(@NotNull ProjectionAnnotationModel model) {
+        Iterator<Annotation> it = model.getAnnotationIterator();
+        while (it.hasNext()) {
+            Annotation annotation = it.next();
+            if (annotation instanceof ProjectionAnnotation projectionAnnotation && projectionAnnotation.isCollapsed()) {
+                model.collapse(annotation);
+            }
+        }
+    }
+
     private boolean deservesFolding(SQLScriptElement element) {
         int numberOfLines = getNumberOfLines(element);
         if (numberOfLines == 1) {
@@ -298,7 +416,13 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
 
     private int getNumberOfLines(SQLScriptElement element) {
         try {
-            return document.getLineOfOffset(element.getOffset() + element.getLength()) - document.getLineOfOffset(element.getOffset()) + 1;
+            int start = element.getOffset();
+            int exclusiveEnd = start + element.getLength();
+            if (exclusiveEnd <= start) {
+                return 1;
+            }
+            int lastIncludedOffset = exclusiveEnd - 1;
+            return document.getLineOfOffset(lastIncludedOffset) - document.getLineOfOffset(start) + 1;
         } catch (BadLocationException e) {
             throw new SQLReconcilingStrategyException(e);
         }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -509,16 +509,6 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             || modelPosition.getLength() != scannedLength;
     }
 
-    private int getRegionNumberOfLines(@NotNull SQLScriptElementImpl region) {
-        if (document == null || region.getRegionKey() == null) {
-            return 1;
-        }
-        return SQLRegionMarkerFolding.getRegionNumberOfLines(
-            document,
-            new SQLRegionMarkerFolding.RegionFold(region.getRegionKey(), region.getOffset(), region.getLength())
-        );
-    }
-
     @Nullable
     private List<SQLScriptElement> extractQueries(int offset, int length) {
         return editor.extractScriptQueries(offset, length, false, true, false);

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/syntax/SQLReconcilingStrategy.java
@@ -48,7 +48,6 @@ import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.utils.CommonUtils;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilingStrategyExtension {
     private static final Log log = Log.getLog(SQLReconcilingStrategy.class);
@@ -57,10 +56,12 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         new QualifiedName(SQLEditorActivator.PLUGIN_ID, SQLReconcilingStrategy.class.getName() + ".collapsedFoldingAnnotations");
 
     private final NavigableSet<SQLScriptElementImpl> cache = new TreeSet<>();
-    private final Map<String, SQLScriptElementImpl> regionCache = new LinkedHashMap<>();
+    private final List<SQLScriptElementImpl> regionCache = new ArrayList<>();
+    private boolean regionsInitialized;
 
-    private volatile boolean projectionRefreshScheduled;
-    private volatile boolean projectionRefreshPending;
+    private final Object projectionRefreshLock = new Object();
+    private boolean projectionRefreshScheduled;
+    private boolean projectionRefreshPending;
 
     private final SQLEditorBase editor;
 
@@ -89,6 +90,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         this.document = document;
         this.cache.clear();
         this.regionCache.clear();
+        this.regionsInitialized = false;
 
         spellingService = EditorsUI.getSpellingService();
         if (spellingService.getActiveSpellingEngineDescriptor(editor.getViewerConfiguration().getPreferenceStore()) != null) {
@@ -105,9 +107,23 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     @Override
     public void reconcile(DirtyRegion dirtyRegion, IRegion subRegion) {
         if (DirtyRegion.INSERT.equals(dirtyRegion.getType())) {
-            reconcile(subRegion.getOffset(), subRegion.getLength(), false);
+            reconcile(
+                subRegion.getOffset(),
+                subRegion.getLength(),
+                false,
+                dirtyRegion.getOffset(),
+                dirtyRegion.getLength(),
+                false
+            );
         } else {
-            reconcile(subRegion.getOffset(), 0, false);
+            reconcile(
+                subRegion.getOffset(),
+                0,
+                false,
+                dirtyRegion.getOffset(),
+                dirtyRegion.getLength(),
+                true
+            );
         }
     }
 
@@ -168,7 +184,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 stringJoiner.add(Integer.toString(position.getOffset()));
             }
         }
-        for (SQLScriptElementImpl position : regionCache.values()) {
+        for (SQLScriptElementImpl position : regionCache) {
             ProjectionAnnotation annotation = position.getAnnotation();
             if (annotation != null && annotation.isCollapsed()) {
                 stringJoiner.add(Integer.toString(position.getOffset()));
@@ -204,17 +220,34 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     }
 
     private void reconcile(int damagedRegionOffset, int damagedRegionLength, boolean restoreCollapsedAnnotations) {
+        reconcile(
+            damagedRegionOffset,
+            damagedRegionLength,
+            restoreCollapsedAnnotations,
+            damagedRegionOffset,
+            damagedRegionLength,
+            true
+        );
+    }
+
+    private void reconcile(
+        int damagedRegionOffset,
+        int damagedRegionLength,
+        boolean restoreCollapsedAnnotations,
+        int editOffset,
+        int editLength,
+        boolean forceRegionScan
+    ) {
         if (!editor.isFoldingEnabled()) {
             cache.clear(); // underlying annotation model being cleared, so reset the cache too
             regionCache.clear();
+            regionsInitialized = false;
             return;
         }
         ProjectionAnnotationModel model = editor.getProjectionAnnotationModel();
         if (model == null) {
             return;
         }
-
-        final int editOffset = damagedRegionOffset; // original dirty region; damagedRegionOffset is widened below for parser cache
 
         SQLScriptElementImpl leftBound = cache.lower(new SQLScriptElementImpl(damagedRegionOffset, damagedRegionLength));
         if (leftBound != null) {
@@ -259,14 +292,26 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             cachedQueries = Collections.unmodifiableNavigableSet(cache.subSet(leftBound, false, rightBound, true));
         }
 
-        List<SQLScriptElementImpl> regionElements = extractRegionFoldingPositions();
+        boolean rescanRegions = forceRegionScan || shouldRescanRegions(editOffset, editLength);
+        List<SQLScriptElementImpl> regionElements = rescanRegions
+            ? extractFoldableRegionFoldingPositions()
+            : new ArrayList<>(regionCache);
+        if (rescanRegions) {
+            regionsInitialized = true;
+        }
         List<SQLRegionMarkerFolding.RegionFold> regionFolds = toRegionFolds(regionElements);
+        SQLRegionMarkerFolding.RegionIndex regionIndex = SQLRegionMarkerFolding.createRegionIndex(regionFolds);
 
-        Set<SQLScriptElementImpl> parsedElements = new HashSet<>(parsedQueries.stream()
-            .filter(this::deservesFolding)
-            .map(this::getExpandedScriptElement)
-            .filter(element -> !isStrictlyEnclosedInAnyRegion(element, regionFolds))
-            .collect(Collectors.toSet()));
+        Set<SQLScriptElementImpl> parsedElements = new HashSet<>();
+        for (SQLScriptElement parsedQuery : parsedQueries) {
+            if (!deservesFolding(parsedQuery)) {
+                continue;
+            }
+            SQLScriptElementImpl element = getExpandedScriptElement(parsedQuery);
+            if (!regionIndex.isStrictlyEnclosed(element.getOffset(), element.getOffset() + element.getLength())) {
+                parsedElements.add(element);
+            }
+        }
         Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
         Set<Integer> savedCollapsedAnnotationsOffsets = restoreCollapsedAnnotations ? getSavedCollapsedAnnotationsOffsets() : Collections.emptySet();
         for (SQLScriptElementImpl element : parsedElements) {
@@ -301,7 +346,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         cache.removeAll(deletedPositions);
         cache.addAll(additions.values());
 
-        syncRegionFolds(model, savedCollapsedAnnotationsOffsets, editOffset);
+        syncRegionFolds(model, savedCollapsedAnnotationsOffsets, editOffset, regionElements, regionFolds, rescanRegions);
 
         if (isSpellingEnabled() && spellingContext != null) {
             IRegion[] regions = new IRegion[]{
@@ -317,22 +362,30 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     private void syncRegionFolds(
         @NotNull ProjectionAnnotationModel model,
         @NotNull Set<Integer> savedCollapsedAnnotationsOffsets,
-        int editOffset
+        int editOffset,
+        @NotNull List<SQLScriptElementImpl> scannedRegions,
+        @NotNull List<SQLRegionMarkerFolding.RegionFold> regionFolds,
+        boolean rescanRegions
     ) {
-        Map<String, SQLScriptElementImpl> scannedByKey = buildScannedRegionsByKey();
-        Map<String, Boolean> collapsedByKey = buildCollapsedRegionKeys(scannedByKey, savedCollapsedAnnotationsOffsets);
-
-        List<Annotation> deletions = collectObsoleteRegionAnnotations(scannedByKey);
-        Map<Annotation, SQLScriptElementImpl> additions = new HashMap<>();
-        Map<String, SQLScriptElementImpl> nextRegionCache = new LinkedHashMap<>();
-        reconcileRegionAnnotationChanges(scannedByKey, collapsedByKey, model, deletions, additions, nextRegionCache);
+        Set<Integer> collapsedRegionOffsets = buildCollapsedRegionOffsets(savedCollapsedAnnotationsOffsets);
+        List<Annotation> deletions = new ArrayList<>();
+        Map<Annotation, SQLScriptElementImpl> additions = new LinkedHashMap<>();
+        List<SQLScriptElementImpl> nextRegionCache = new ArrayList<>(scannedRegions.size());
+        reconcileRegionAnnotationChanges(
+            scannedRegions,
+            collapsedRegionOffsets,
+            model,
+            deletions,
+            additions,
+            nextRegionCache
+        );
 
         if (!deletions.isEmpty() || !additions.isEmpty()) {
             model.modifyAnnotations(deletions.toArray(Annotation[]::new), additions, null);
         }
 
-        boolean collapseApplied = applySavedCollapsedStates(model, nextRegionCache, collapsedByKey);
-        boolean regionSetChanged = !regionCache.keySet().equals(scannedByKey.keySet());
+        boolean collapseApplied = applySavedCollapsedStates(model, nextRegionCache, collapsedRegionOffsets);
+        boolean regionSetChanged = rescanRegions && !sameRegionSet(regionCache, scannedRegions);
         updateRegionCache(nextRegionCache);
 
         if (SQLRegionMarkerFolding.needsFoldingGutterRefresh(
@@ -340,72 +393,54 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             collapseApplied,
             regionSetChanged,
             editOffset,
-            toRegionFolds(scannedByKey.values())
+            regionFolds
         )) {
             scheduleProjectionPresentationRefresh();
         }
     }
 
-    @NotNull
-    private Map<String, SQLScriptElementImpl> buildScannedRegionsByKey() {
-        Map<String, SQLScriptElementImpl> scannedByKey = new LinkedHashMap<>();
-        for (SQLScriptElementImpl region : extractFoldableRegionFoldingPositions()) {
-            if (region.getRegionKey() != null) {
-                scannedByKey.put(region.getRegionKey(), region);
-            }
+    private boolean shouldRescanRegions(int editOffset, int editLength) {
+        if (!regionsInitialized || document == null) {
+            return true;
         }
-        return scannedByKey;
+        if (SQLRegionMarkerFolding.hasRegionMarkerInRange(document, editor.getSQLDialect(), editOffset, editLength)) {
+            return true;
+        }
+        return SQLRegionMarkerFolding.hasPartitionSensitiveContentInRange(document, editOffset, editLength);
     }
 
     @NotNull
-    private Map<String, Boolean> buildCollapsedRegionKeys(
-        @NotNull Map<String, SQLScriptElementImpl> scannedByKey,
+    private Set<Integer> buildCollapsedRegionOffsets(
         @NotNull Set<Integer> savedCollapsedAnnotationsOffsets
     ) {
-        Map<String, Boolean> collapsedByKey = new HashMap<>();
-        for (SQLScriptElementImpl cachedRegion : regionCache.values()) {
+        Set<Integer> collapsedRegionOffsets = new HashSet<>(savedCollapsedAnnotationsOffsets);
+        for (SQLScriptElementImpl cachedRegion : regionCache) {
             ProjectionAnnotation annotation = cachedRegion.getAnnotation();
-            if (annotation != null && annotation.isCollapsed() && cachedRegion.getRegionKey() != null) {
-                collapsedByKey.put(cachedRegion.getRegionKey(), true);
+            if (annotation != null && annotation.isCollapsed()) {
+                collapsedRegionOffsets.add(cachedRegion.getOffset());
             }
         }
-        for (Map.Entry<String, SQLScriptElementImpl> scannedEntry : scannedByKey.entrySet()) {
-            if (savedCollapsedAnnotationsOffsets.contains(scannedEntry.getValue().getOffset())) {
-                collapsedByKey.put(scannedEntry.getKey(), true);
-            }
-        }
-        return collapsedByKey;
-    }
-
-    @NotNull
-    private List<Annotation> collectObsoleteRegionAnnotations(@NotNull Map<String, SQLScriptElementImpl> scannedByKey) {
-        List<Annotation> deletions = new ArrayList<>();
-        for (Map.Entry<String, SQLScriptElementImpl> cachedEntry : regionCache.entrySet()) {
-            if (!scannedByKey.containsKey(cachedEntry.getKey())) {
-                ProjectionAnnotation annotation = cachedEntry.getValue().getAnnotation();
-                if (annotation != null) {
-                    deletions.add(annotation);
-                }
-            }
-        }
-        return deletions;
+        return collapsedRegionOffsets;
     }
 
     private void reconcileRegionAnnotationChanges(
-        @NotNull Map<String, SQLScriptElementImpl> scannedByKey,
-        @NotNull Map<String, Boolean> collapsedByKey,
+        @NotNull List<SQLScriptElementImpl> scannedRegions,
+        @NotNull Set<Integer> collapsedRegionOffsets,
         @NotNull ProjectionAnnotationModel model,
         @NotNull List<Annotation> deletions,
         @NotNull Map<Annotation, SQLScriptElementImpl> additions,
-        @NotNull Map<String, SQLScriptElementImpl> nextRegionCache
+        @NotNull List<SQLScriptElementImpl> nextRegionCache
     ) {
-        for (Map.Entry<String, SQLScriptElementImpl> scannedEntry : scannedByKey.entrySet()) {
-            String regionKey = scannedEntry.getKey();
-            SQLScriptElementImpl scannedRegion = scannedEntry.getValue();
-            SQLScriptElementImpl cachedRegion = regionCache.get(regionKey);
+        Map<Integer, SQLScriptElementImpl> cachedByOffset = new HashMap<>();
+        for (SQLScriptElementImpl cachedRegion : regionCache) {
+            cachedByOffset.put(cachedRegion.getOffset(), cachedRegion);
+        }
+
+        for (SQLScriptElementImpl scannedRegion : scannedRegions) {
+            SQLScriptElementImpl cachedRegion = cachedByOffset.remove(scannedRegion.getOffset());
 
             if (!needsRegionAnnotationRecreate(cachedRegion, scannedRegion, model)) {
-                nextRegionCache.put(regionKey, cachedRegion);
+                nextRegionCache.add(cachedRegion);
                 continue;
             }
 
@@ -413,7 +448,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
                 ProjectionAnnotation oldAnnotation = cachedRegion.getAnnotation();
                 if (oldAnnotation != null) {
                     if (oldAnnotation.isCollapsed()) {
-                        collapsedByKey.put(regionKey, true);
+                        collapsedRegionOffsets.add(scannedRegion.getOffset());
                     }
                     deletions.add(oldAnnotation);
                 }
@@ -422,18 +457,24 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             ProjectionAnnotation annotation = new ProjectionAnnotation();
             scannedRegion.setAnnotation(annotation);
             additions.put(annotation, scannedRegion);
-            nextRegionCache.put(regionKey, scannedRegion);
+            nextRegionCache.add(scannedRegion);
+        }
+
+        for (SQLScriptElementImpl obsoleteRegion : cachedByOffset.values()) {
+            ProjectionAnnotation annotation = obsoleteRegion.getAnnotation();
+            if (annotation != null) {
+                deletions.add(annotation);
+            }
         }
     }
 
     private boolean applySavedCollapsedStates(
         @NotNull ProjectionAnnotationModel model,
-        @NotNull Map<String, SQLScriptElementImpl> nextRegionCache,
-        @NotNull Map<String, Boolean> collapsedByKey
+        @NotNull List<SQLScriptElementImpl> nextRegionCache,
+        @NotNull Set<Integer> collapsedRegionOffsets
     ) {
         boolean collapseApplied = false;
-        for (Map.Entry<String, SQLScriptElementImpl> entry : nextRegionCache.entrySet()) {
-            SQLScriptElementImpl region = entry.getValue();
+        for (SQLScriptElementImpl region : nextRegionCache) {
             ProjectionAnnotation annotation = region.getAnnotation();
             if (annotation == null
                 || document == null
@@ -441,7 +482,7 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
             ) {
                 continue;
             }
-            if (collapsedByKey.getOrDefault(entry.getKey(), false) && !annotation.isCollapsed()) {
+            if (collapsedRegionOffsets.contains(region.getOffset()) && !annotation.isCollapsed()) {
                 model.collapse(annotation);
                 collapseApplied = true;
             }
@@ -449,9 +490,24 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         return collapseApplied;
     }
 
-    private void updateRegionCache(@NotNull Map<String, SQLScriptElementImpl> nextRegionCache) {
+    private void updateRegionCache(@NotNull List<SQLScriptElementImpl> nextRegionCache) {
         regionCache.clear();
-        regionCache.putAll(nextRegionCache);
+        regionCache.addAll(nextRegionCache);
+    }
+
+    private boolean sameRegionSet(
+        @NotNull List<SQLScriptElementImpl> left,
+        @NotNull List<SQLScriptElementImpl> right
+    ) {
+        if (left.size() != right.size()) {
+            return false;
+        }
+        for (int index = 0; index < left.size(); index++) {
+            if (left.get(index).getOffset() != right.get(index).getOffset()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @NotNull
@@ -466,11 +522,13 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
      * the viewer repaints (scrolling happens to trigger that). Force the same refresh explicitly.
      */
     private void scheduleProjectionPresentationRefresh() {
-        if (projectionRefreshScheduled) {
-            projectionRefreshPending = true;
-            return;
+        synchronized (projectionRefreshLock) {
+            if (projectionRefreshScheduled) {
+                projectionRefreshPending = true;
+                return;
+            }
+            projectionRefreshScheduled = true;
         }
-        projectionRefreshScheduled = true;
         UIUtils.asyncExec(this::runProjectionPresentationRefresh);
     }
 
@@ -482,11 +540,17 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
         } catch (RuntimeException e) {
             log.warn("Failed to refresh projection folding presentation", e);
         }
-        if (projectionRefreshPending) {
-            projectionRefreshPending = false;
+        boolean schedulePendingRefresh;
+        synchronized (projectionRefreshLock) {
+            schedulePendingRefresh = projectionRefreshPending;
+            if (schedulePendingRefresh) {
+                projectionRefreshPending = false;
+            } else {
+                projectionRefreshScheduled = false;
+            }
+        }
+        if (schedulePendingRefresh) {
             UIUtils.asyncExec(this::runProjectionPresentationRefresh);
-        } else {
-            projectionRefreshScheduled = false;
         }
     }
 
@@ -515,32 +579,13 @@ public class SQLReconcilingStrategy implements IReconcilingStrategy, IReconcilin
     }
 
     @NotNull
-    private List<SQLScriptElementImpl> extractRegionFoldingPositions() {
-        if (document == null) {
-            return List.of();
-        }
-        return SQLRegionMarkerFolding.scanRegions(document).stream()
-            .map(f -> new SQLScriptElementImpl(f.offset(), f.length(), f.regionKey()))
-            .toList();
-    }
-
-    @NotNull
     private List<SQLScriptElementImpl> extractFoldableRegionFoldingPositions() {
         if (document == null) {
             return List.of();
         }
-        return SQLRegionMarkerFolding.scanFoldableRegions(document).stream()
+        return SQLRegionMarkerFolding.scanFoldableRegions(document, editor.getSQLDialect()).stream()
             .map(f -> new SQLScriptElementImpl(f.offset(), f.length(), f.regionKey()))
             .toList();
-    }
-
-    private boolean isStrictlyEnclosedInAnyRegion(
-        @NotNull SQLScriptElementImpl element,
-        @NotNull List<SQLRegionMarkerFolding.RegionFold> regions
-    ) {
-        int start = element.getOffset();
-        int end = start + element.getLength();
-        return SQLRegionMarkerFolding.isStrictlyEnclosedInAnyRegion(start, end, regions);
     }
 
     private boolean deservesFolding(SQLScriptElement element) {

--- a/test/org.jkiss.dbeaver.model.sql.test/META-INF/MANIFEST.MF
+++ b/test/org.jkiss.dbeaver.model.sql.test/META-INF/MANIFEST.MF
@@ -9,4 +9,6 @@ Bundle-Vendor: DBeaver Corp
 Fragment-Host: org.jkiss.dbeaver.model
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.jkiss.dbeaver.test.platform,
- org.jkiss.dbeaver.model
+ org.jkiss.dbeaver.model,
+ org.jkiss.dbeaver.model.sql,
+ org.eclipse.text

--- a/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionFoldingPresentationTest.java
+++ b/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionFoldingPresentationTest.java
@@ -16,6 +16,14 @@
  */
 package org.jkiss.dbeaver.model.sql.parser;
 
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.rules.FastPartitioner;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.impl.sql.BasicSQLDialect;
+import org.jkiss.dbeaver.model.sql.SQLDialect;
+import org.jkiss.dbeaver.model.sql.SQLPartitionScanner;
+import org.jkiss.dbeaver.model.sql.SQLSyntaxManager;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.junit.DBeaverUnitTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -86,5 +94,44 @@ public class SQLRegionFoldingPresentationTest extends DBeaverUnitTest {
             widenedDamagedRegionOffset,
             SAMPLE_REGIONS
         ));
+    }
+
+    @Test
+    public void markerRangeCheckDetectsOnlyAffectedMarkerLines() throws DBException {
+        Document document = createPartitionedDocument("""
+            SELECT 1
+            --region A
+            SELECT 2
+            --endregion
+            """);
+        int markerOffset = document.get().indexOf("--region");
+
+        Assertions.assertTrue(SQLRegionMarkerFolding.hasRegionMarkerInRange(
+            document,
+            BasicSQLDialect.INSTANCE,
+            markerOffset,
+            "--region A".length()
+        ));
+        Assertions.assertFalse(SQLRegionMarkerFolding.hasRegionMarkerInRange(
+            document,
+            BasicSQLDialect.INSTANCE,
+            0,
+            "SELECT 1".length()
+        ));
+    }
+
+    private static Document createPartitionedDocument(String sql) throws DBException {
+        SQLDialect dialect = BasicSQLDialect.INSTANCE;
+        SQLSyntaxManager syntaxManager = new SQLSyntaxManager();
+        syntaxManager.init(dialect, DBWorkbench.getPlatform().getPreferenceStore());
+        SQLRuleManager ruleManager = new SQLRuleManager(syntaxManager);
+        ruleManager.loadRules();
+        Document document = new Document(sql);
+        FastPartitioner partitioner = new FastPartitioner(
+            new SQLPartitionScanner(null, dialect, ruleManager),
+            SQLParserPartitions.SQL_CONTENT_TYPES);
+        partitioner.connect(document);
+        document.setDocumentPartitioner(SQLParserPartitions.SQL_PARTITIONING, partitioner);
+        return document;
     }
 }

--- a/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionFoldingPresentationTest.java
+++ b/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionFoldingPresentationTest.java
@@ -1,0 +1,90 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.parser;
+
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class SQLRegionFoldingPresentationTest extends DBeaverUnitTest {
+
+    private static final List<SQLRegionMarkerFolding.RegionFold> SAMPLE_REGIONS = List.of(
+        new SQLRegionMarkerFolding.RegionFold("OUTER", 0, 120)
+    );
+
+    @Test
+    public void editBeforeRegionRequiresGutterRefresh() {
+        int editOffset = 0;
+        Assertions.assertTrue(SQLRegionMarkerFolding.documentEditShiftsRegionMarkers(editOffset, SAMPLE_REGIONS));
+        Assertions.assertTrue(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            editOffset,
+            SAMPLE_REGIONS
+        ));
+    }
+
+    @Test
+    public void editOnRegionMarkerRequiresGutterRefresh() {
+        int editOffset = SAMPLE_REGIONS.getFirst().offset();
+        Assertions.assertTrue(SQLRegionMarkerFolding.documentEditShiftsRegionMarkers(editOffset, SAMPLE_REGIONS));
+        Assertions.assertTrue(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            editOffset,
+            SAMPLE_REGIONS
+        ));
+    }
+
+    @Test
+    public void editAfterAllRegionsDoesNotRequireGutterRefresh() {
+        int editOffset = SAMPLE_REGIONS.getFirst().offset() + SAMPLE_REGIONS.getFirst().length() + 10;
+        Assertions.assertFalse(SQLRegionMarkerFolding.documentEditShiftsRegionMarkers(editOffset, SAMPLE_REGIONS));
+        Assertions.assertFalse(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            editOffset,
+            SAMPLE_REGIONS
+        ));
+    }
+
+    @Test
+    public void widenedDamagedRegionOffsetMustNotTriggerRefreshForEditsInsideRegion() {
+        int originalEditOffset = 80;
+        int widenedDamagedRegionOffset = SAMPLE_REGIONS.getFirst().offset();
+
+        Assertions.assertFalse(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            originalEditOffset,
+            SAMPLE_REGIONS
+        ));
+        Assertions.assertTrue(SQLRegionMarkerFolding.needsFoldingGutterRefresh(
+            false,
+            false,
+            false,
+            widenedDamagedRegionOffset,
+            SAMPLE_REGIONS
+        ));
+    }
+}

--- a/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFoldingTest.java
+++ b/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFoldingTest.java
@@ -1,0 +1,153 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.sql.parser;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.rules.FastPartitioner;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.sql.SQLDialect;
+import org.jkiss.dbeaver.model.sql.SQLDialectMetadataRegistry;
+import org.jkiss.dbeaver.model.sql.SQLPartitionScanner;
+import org.jkiss.dbeaver.model.sql.SQLSyntaxManager;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class SQLRegionMarkerFoldingTest extends DBeaverUnitTest {
+
+    private static final String NESTED_REGIONS_SCRIPT = """
+        --region OUTER
+        SELECT 0
+        --region INNER1
+        SELECT 1
+        --region INNER11
+        SELECT 2
+        --endregion
+        SELECT 3
+        --endregion
+        SELECT 4
+        --endregion
+        SELECT 5
+        """;
+
+    @Test
+    public void nestedRegionsHaveHierarchicalKeysAndStartOffsets() throws DBException {
+        Document document = createPartitionedDocument(NESTED_REGIONS_SCRIPT);
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanFoldableRegions(document);
+        Map<String, SQLRegionMarkerFolding.RegionFold> byKey = regions.stream()
+            .collect(Collectors.toMap(SQLRegionMarkerFolding.RegionFold::regionKey, Function.identity()));
+
+        Assertions.assertEquals(3, regions.size());
+        Assertions.assertTrue(byKey.containsKey("OUTER"));
+        Assertions.assertTrue(byKey.containsKey("OUTER/INNER1"));
+        Assertions.assertTrue(byKey.containsKey("OUTER/INNER1/INNER11"));
+
+        for (String markerLine : List.of("--region OUTER", "--region INNER1", "--region INNER11")) {
+            int expectedOffset = document.get().indexOf(markerLine);
+            String key = markerLine.replace("--region ", "").trim();
+            if (!key.equals("OUTER")) {
+                if (key.equals("INNER1")) {
+                    key = "OUTER/INNER1";
+                } else {
+                    key = "OUTER/INNER1/INNER11";
+                }
+            }
+            Assertions.assertEquals(expectedOffset, byKey.get(key).offset(), key);
+        }
+    }
+
+    @Test
+    public void orphanEndRegionIsIgnored() {
+        Document document = new Document("""
+            SELECT 1
+            --endregion
+            SELECT 2
+            """);
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanRegions(document);
+        Assertions.assertTrue(regions.isEmpty());
+    }
+
+    @Test
+    public void unclosedRegionIsNotReturned() {
+        Document document = new Document("""
+            --region OPEN
+            SELECT 1
+            SELECT 2
+            """);
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanRegions(document);
+        Assertions.assertTrue(regions.isEmpty());
+    }
+
+    @Test
+    public void regionMarkerInsideStringIsIgnored() throws DBException {
+        Document document = createPartitionedDocument("SELECT '--region' FROM t;\n");
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanRegions(document);
+        Assertions.assertTrue(regions.isEmpty());
+    }
+
+    @Test
+    public void markerOnlyPairIsFoldableWhenItSpansTwoLines() {
+        Document document = new Document("""
+            --region A
+            --endregion
+            """);
+        List<SQLRegionMarkerFolding.RegionFold> allRegions = SQLRegionMarkerFolding.scanRegions(document);
+        Assertions.assertEquals(1, allRegions.size());
+        Assertions.assertEquals(2, SQLRegionMarkerFolding.getRegionNumberOfLines(document, allRegions.getFirst()));
+        Assertions.assertEquals(1, SQLRegionMarkerFolding.scanFoldableRegions(document).size());
+    }
+
+    @Test
+    public void renamedRegionMarkerProducesDifferentKey() {
+        Document documentBefore = new Document("""
+            --region INNER1
+            SELECT 1
+            --endregion
+            """);
+        Document documentAfter = new Document("""
+            --region INNER2
+            SELECT 1
+            --endregion
+            """);
+        List<SQLRegionMarkerFolding.RegionFold> before = SQLRegionMarkerFolding.scanRegions(documentBefore);
+        List<SQLRegionMarkerFolding.RegionFold> after = SQLRegionMarkerFolding.scanRegions(documentAfter);
+        Assertions.assertEquals("INNER1", before.getFirst().regionKey());
+        Assertions.assertEquals("INNER2", after.getFirst().regionKey());
+    }
+
+    private static Document createPartitionedDocument(String sql) throws DBException {
+        SQLDialectMetadataRegistry registry = DBWorkbench.getPlatform().getSQLDialectRegistry();
+        SQLDialect dialect = registry.getDialect("generic").createInstance();
+        SQLSyntaxManager syntaxManager = new SQLSyntaxManager();
+        syntaxManager.init(dialect, DBWorkbench.getPlatform().getPreferenceStore());
+        SQLRuleManager ruleManager = new SQLRuleManager(syntaxManager);
+        ruleManager.loadRules();
+        Document document = new Document(sql);
+        FastPartitioner partitioner = new FastPartitioner(
+            new SQLPartitionScanner(null, dialect, ruleManager),
+            SQLParserPartitions.SQL_CONTENT_TYPES);
+        partitioner.connect(document);
+        document.setDocumentPartitioner(SQLParserPartitions.SQL_PARTITIONING, partitioner);
+        return document;
+    }
+}

--- a/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFoldingTest.java
+++ b/test/org.jkiss.dbeaver.model.sql.test/src/org/jkiss/dbeaver/model/sql/parser/SQLRegionMarkerFoldingTest.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.model.sql.parser;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.rules.FastPartitioner;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.impl.sql.BasicSQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLDialectMetadataRegistry;
 import org.jkiss.dbeaver.model.sql.SQLPartitionScanner;
@@ -135,9 +136,66 @@ public class SQLRegionMarkerFoldingTest extends DBeaverUnitTest {
         Assertions.assertEquals("INNER2", after.getFirst().regionKey());
     }
 
+    @Test
+    public void duplicateRegionNamesProduceSeparateFolds() throws DBException {
+        Document document = createPartitionedDocument("""
+            --region A
+            SELECT 1
+            --endregion
+            --region A
+            SELECT 2
+            --endregion
+            """);
+
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanFoldableRegions(document);
+
+        Assertions.assertEquals(2, regions.size());
+        Assertions.assertNotEquals(regions.get(0).offset(), regions.get(1).offset());
+    }
+
+    @Test
+    public void regionIndexFindsEnclosingNestedRegion() {
+        List<SQLRegionMarkerFolding.RegionFold> regions = List.of(
+            new SQLRegionMarkerFolding.RegionFold("OUTER", 0, 100),
+            new SQLRegionMarkerFolding.RegionFold("OUTER/INNER", 20, 30)
+        );
+        SQLRegionMarkerFolding.RegionIndex index = SQLRegionMarkerFolding.createRegionIndex(regions);
+
+        Assertions.assertTrue(index.isStrictlyEnclosed(25, 35));
+        Assertions.assertTrue(index.isStrictlyEnclosed(10, 50));
+        Assertions.assertFalse(index.isStrictlyEnclosed(80, 110));
+    }
+
+    @Test
+    public void dialectCommentPrefixControlsRegionMarkers() throws DBException {
+        SQLDialect slashCommentDialect = new BasicSQLDialect() {
+            @Override
+            public String[] getSingleLineComments() {
+                return new String[]{"//"};
+            }
+        };
+        Document document = createPartitionedDocument("""
+            //region SLASH
+            SELECT 1
+            //endregion
+            --region DASH
+            SELECT 2
+            --endregion
+            """, slashCommentDialect);
+
+        List<SQLRegionMarkerFolding.RegionFold> regions = SQLRegionMarkerFolding.scanFoldableRegions(document, slashCommentDialect);
+
+        Assertions.assertEquals(1, regions.size());
+        Assertions.assertEquals("SLASH", regions.getFirst().regionKey());
+    }
+
     private static Document createPartitionedDocument(String sql) throws DBException {
         SQLDialectMetadataRegistry registry = DBWorkbench.getPlatform().getSQLDialectRegistry();
         SQLDialect dialect = registry.getDialect("generic").createInstance();
+        return createPartitionedDocument(sql, dialect);
+    }
+
+    private static Document createPartitionedDocument(String sql, SQLDialect dialect) throws DBException {
         SQLSyntaxManager syntaxManager = new SQLSyntaxManager();
         syntaxManager.init(dialect, DBWorkbench.getPlatform().getPreferenceStore());
         SQLRuleManager ruleManager = new SQLRuleManager(syntaxManager);


### PR DESCRIPTION
Closes dbeaver/dbeaver#23137

  ## Problem

  DBeaver supports parser-based folding for multi-line SQL statements, but
  it does not recognize explicit `--region` / `--endregion` markers commonly
  used to organize large scripts.

  Region markers are SQL comments and are therefore not returned as foldable
  elements by the existing query extraction pipeline. They require a
  separate detection path integrated with the existing projection annotation
  model.

  ## Changes

  ### Region marker scanner

  Added `SQLRegionMarkerFolding` in the SQL model plugin.

  It:

  - scans SQL documents line by line for `--region` / `--endregion`;
  - matches markers case-insensitively;
  - verifies SQL comment partitions to avoid matching markers inside string
  literals;
  - uses a stack to support nested regions;
  - creates hierarchical region keys such as `OUTER/INNER/CHILD`;
  - ignores orphan `--endregion` and unclosed regions;
  - validates document ranges and excludes non-foldable single-line ranges;
  - determines when document edits require a projection gutter refresh.

  The scanner is independent of SQL dialect parsing because region markers
  are editor organization comments rather than SQL syntax.

  ### Reconcile integration

  Updated `SQLReconcilingStrategy` to:

  - combine region folds with existing parser-based folds;
  - suppress parser folds strictly enclosed by a region, avoiding
  overlapping projection handles;
  - cache regions by their hierarchical keys;
  - preserve collapsed state when annotations are recreated or shifted after
  edits;
  - restore collapsed regions through
  `ProjectionAnnotationModel.collapse()`;
  - correctly calculate line counts for ranges with an exclusive end offset;
  - schedule UI-thread refreshes when the projection gutter needs
  repainting;
  - coalesce repeated refresh requests;
  - keep the original edit offset separate from the widened damaged region
  used for SQL reconciliation.

  ### Nested folding state

  Added `SQLProjectionAnnotationModel`, which preserves nested collapse
  state.

  When an outer region is collapsed, already-collapsed enclosed folds are
  temporarily expanded and remembered. When the outer region is expanded,
  the enclosed folds are restored in ascending order of their range length.

  This avoids inconsistent projection state when nested collapsed
  annotations overlap.

  ### Projection model installation

  Updated `SQLEditorSourceViewer` to install `SQLProjectionAnnotationModel`
  during visual annotation model initialization.

  The internal Eclipse projection model is accessed through
  `MethodHandles.privateLookupIn()` and a `VarHandle`. The implementation
  does not use `java.lang.reflect.Field` or `setAccessible()`.

  If the custom model cannot be installed, a warning is logged and the
  standard Eclipse projection model remains available.

  ### Gutter refresh

  Added `SQLEditorBase.refreshProjectionFoldingPresentation()` to refresh
  projection annotations and repaint the vertical ruler without invalidating
  the presentation of the entire SQL document.

  ## Tests

  Added unit tests covering:

  - nested regions and hierarchical region keys;
  - correct marker offsets;
  - orphan `--endregion` markers;
  - unclosed regions;
  - markers inside SQL string literals;
  - two-line marker-only regions;
  - renamed region keys;
  - gutter refresh decisions for edits before, on, inside, and after
  regions.

  Manual verification covered:

  - collapsing and expanding nested regions;
  - restoring an inner collapsed state after expanding an outer region;
  - projection gutter synchronization after edits above a region;
  - parser-based folding outside regions.

  The full aggregate build is currently blocked locally by an unrelated
  missing upstream bundle: `com.dbeaver.rest.client`.

  ## Out of scope

  - SQL parsing, execution, and formatting behavior;
  - folding based on parentheses;
  - new user preferences;
  - displaying parser folds inside an enclosing explicit region.

  ## AI disclosure

  This PR was assisted by AI (Cursor).