### PR TITLE
Fix error dialog parent shell during data transfer

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/dialogs/exec/ExecutionQueueErrorJob.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/dialogs/exec/ExecutionQueueErrorJob.java
@@ -19,6 +19,8 @@ package org.jkiss.dbeaver.ui.dialogs.exec;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.runtime.ui.DBPPlatformUI;
@@ -48,8 +50,12 @@ public class ExecutionQueueErrorJob extends AbstractUIJob {
     @Override
     public IStatus runInUIThread(@NotNull DBRProgressMonitor monitor)
     {
+        Shell activeShell = Display.getCurrent().getActiveShell();
+        Shell parentShell = activeShell != null && !activeShell.isDisposed()
+            ? activeShell
+            : UIUtils.getActiveWorkbenchShell();
         ExecutionQueueErrorDialog dialog = new ExecutionQueueErrorDialog(
-            UIUtils.getActiveWorkbenchShell(),
+            parentShell,
             "Execution Error",
             "Error occurred during " + errorName,
             GeneralUtils.makeExceptionStatus(error),


### PR DESCRIPTION
## Summary

- Parent execution-error dialogs to the active SWT shell.
- Fall back to the active workbench shell when no active shell is available.

## Root cause

Data-transfer errors were shown as children of the workbench shell instead of the active transfer/progress shell. On Linux this could let the modal transfer window obscure the error dialog.

## Validation

- `git diff --check`
- Full DBeaver CE aggregate build in Colab: `BUILD SUCCESS`
