### PR TITLE
dbeaver/dbeaver#40575 Fix psql dump

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
@@ -21,14 +21,14 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.custom.SashForm;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.postgresql.PostgreMessages;
@@ -54,13 +54,12 @@ import org.jkiss.utils.CommonUtils;
 import java.util.*;
 
 
-class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<PostgreBackupWizard>
-{
+class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<PostgreBackupWizard> {
     private static final Log log = Log.getLog(PostgreBackupWizardPageObjects.class);
 
     private Table schemasTable;
     private Table tablesTable;
-    private Map<PostgreSchema, Set<PostgreTableBase>> checkedObjects = new HashMap<>();
+    private final Map<PostgreSchema, Set<PostgreTableBase>> checkedObjects = new HashMap<>();
 
     private PostgreSchema curSchema;
     private PostgreDatabase dataBase;
@@ -115,13 +114,11 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
             
                         
             fullSchemaBackupCheck = UIUtils.createCheckbox(buttonsPanel, PostgreMessages.wizard_backup_page_object_checkbox_complete_backup, false);
-            fullSchemaBackupCheck.addSelectionListener(new SelectionAdapter() {
-                @Override
-                public void widgetSelected(SelectionEvent e) {
-                    wizard.getSettings().setFullSchemaBackup(fullSchemaBackupCheck.getSelection());
-                    tablesTable.setVisible(!fullSchemaBackupCheck.getSelection());
-                }
-            });
+            fullSchemaBackupCheck.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+                wizard.getSettings().setFullSchemaBackup(fullSchemaBackupCheck.getSelection());
+                tablesTable.setVisible(!fullSchemaBackupCheck.getSelection());
+                updateState();
+            }));
             fullSchemaBackupCheck.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL));
             buttonsPanel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
             createCheckButtons(buttonsPanel, schemasTable);
@@ -145,14 +142,11 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
             Composite buttonsPanel = UIUtils.createComposite(tablesPanel, 3);
             buttonsPanel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
             exportViewsCheck = UIUtils.createCheckbox(buttonsPanel, PostgreMessages.wizard_backup_page_object_checkbox_show_view, false);
-            exportViewsCheck.setSelection(wizard.getSettings().isFullSchemaBackup());
-            exportViewsCheck.addSelectionListener(new SelectionAdapter() {
-                @Override
-                public void widgetSelected(SelectionEvent e) {
-                    wizard.getSettings().setShowViews(exportViewsCheck.getSelection());
-                    loadTables(null);
-                }
-            });
+            exportViewsCheck.setSelection(wizard.getSettings().isShowViews());
+            exportViewsCheck.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+                wizard.getSettings().setShowViews(exportViewsCheck.getSelection());
+                loadTables(null);
+            }));
             exportViewsCheck.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL));
             createCheckButtons(buttonsPanel, tablesTable);
         }
@@ -165,10 +159,7 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
 
     @Override
     protected boolean determinePageCompletion() {
-        boolean complete = false;
-        if (!checkedObjects.isEmpty()) {
-            complete = true;
-        }
+        boolean complete = !checkedObjects.isEmpty();
         for (TableItem item : schemasTable.getItems()) {
             if (item.getChecked()) {
                 complete = true;
@@ -209,10 +200,9 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
             if (!CommonUtils.isEmpty(info.getTables())) {
                 for (PostgreTableBase table : info.getTables()) {
                     PostgreTableContainer tableContainer = table.getContainer();
-                    if (!(tableContainer instanceof PostgreSchema)) {
+                    if (!(tableContainer instanceof PostgreSchema schema)) {
                         continue;
                     }
-                    PostgreSchema schema = (PostgreSchema) tableContainer;
                     activeSchemas.add(schema);
                     Set<PostgreTableBase> tables = checkedObjects.computeIfAbsent(schema, k -> new HashSet<>());
                     tables.add(table);
@@ -226,6 +216,9 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
             wizard.getSettings().setShowViews(true);
             exportViewsCheck.setSelection(true);
         }
+        boolean fullSchemaBackup = wizard.getSettings().isFullSchemaBackup();
+        fullSchemaBackupCheck.setSelection(fullSchemaBackup);
+        tablesTable.setVisible(!fullSchemaBackup);
         if (dataBase != null) {
             setConnectionInfo(dataBase.getDataSource().getContainer(), dataBase.getName());
 
@@ -274,7 +267,7 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         }
     }
 
-    private boolean isChecked(PostgreSchema catalog) {
+    private boolean isChecked(@NotNull PostgreSchema catalog) {
         for (TableItem item : schemasTable.getItems()) {
             if (item.getData() == catalog) {
                 return item.getChecked();
@@ -283,7 +276,8 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         return false;
     }
 
-    private List<PostgreTableBase> loadTables(final PostgreSchema catalog) {
+    @Nullable
+    private List<PostgreTableBase> loadTables(@Nullable PostgreSchema catalog) {
         if (catalog != null) {
             curSchema = catalog;
         }
@@ -371,15 +365,19 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         return true;
     }
     
-    private void updatefullSchemaBackupState() {
-    	boolean allSchemasSelected =isAllSchemaSelected();
+    private void updateFullSchemaBackupState() {
+        boolean allSchemasSelected = isAllSchemaSelected();
         fullSchemaBackupCheck.setEnabled(allSchemasSelected);
-        wizard.getSettings().setFullSchemaBackup(allSchemasSelected);
+        if (!allSchemasSelected && fullSchemaBackupCheck.getSelection()) {
+            fullSchemaBackupCheck.setSelection(false);
+            wizard.getSettings().setFullSchemaBackup(false);
+            tablesTable.setVisible(true);
+        }
     }
+
     @Override
-    protected void updateState()
-    {
-    	updatefullSchemaBackupState();
+    protected void updateState() {
+        updateFullSchemaBackupState();
         updatePageCompletion();
         getContainer().updateButtons();
     }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
@@ -57,6 +57,7 @@ import java.util.*;
 class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<PostgreBackupWizard> {
     private static final Log log = Log.getLog(PostgreBackupWizardPageObjects.class);
 
+    private Composite tablesPanel;
     private Table schemasTable;
     private Table tablesTable;
     private final Map<PostgreSchema, Set<PostgreTableBase>> checkedObjects = new HashMap<>();
@@ -93,9 +94,9 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         sash.setLayoutData(new GridData(GridData.FILL_BOTH));
 
         {
-            Composite catPanel = UIUtils.createComposite(sash, 1);
-            catPanel.setLayoutData(new GridData(GridData.FILL_BOTH));
-            schemasTable = new Table(catPanel, SWT.BORDER | SWT.CHECK);
+            Composite schemasPanel = UIUtils.createComposite(sash, 1);
+            schemasPanel.setLayoutData(new GridData(GridData.FILL_BOTH));
+            schemasTable = new Table(schemasPanel, SWT.BORDER | SWT.CHECK);
             schemasTable.addListener(SWT.Selection, event -> {
                 TableItem item = (TableItem) event.item;
                 PostgreSchema catalog = (PostgreSchema) item.getData();
@@ -110,13 +111,13 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
             gd.heightHint = 50;
             schemasTable.setLayoutData(gd);
 
-            Composite buttonsPanel = UIUtils.createComposite(catPanel, 3);
+            Composite buttonsPanel = UIUtils.createComposite(schemasPanel, 3);
             
                         
             fullSchemaBackupCheck = UIUtils.createCheckbox(buttonsPanel, PostgreMessages.wizard_backup_page_object_checkbox_complete_backup, false);
             fullSchemaBackupCheck.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
                 wizard.getSettings().setFullSchemaBackup(fullSchemaBackupCheck.getSelection());
-                tablesTable.setVisible(!fullSchemaBackupCheck.getSelection());
+                setTablesSectionEnabled(!fullSchemaBackupCheck.getSelection());
                 updateState();
             }));
             fullSchemaBackupCheck.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL));
@@ -125,7 +126,7 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         }
 
         {
-            Composite tablesPanel = UIUtils.createComposite(sash, 1);
+            tablesPanel = UIUtils.createComposite(sash, 1);
             tablesPanel.setLayoutData(new GridData(GridData.FILL_BOTH));
 
             tablesTable = new Table(tablesPanel, SWT.BORDER | SWT.CHECK);
@@ -218,7 +219,7 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         }
         boolean fullSchemaBackup = wizard.getSettings().isFullSchemaBackup();
         fullSchemaBackupCheck.setSelection(fullSchemaBackup);
-        tablesTable.setVisible(!fullSchemaBackup);
+        setTablesSectionEnabled(!fullSchemaBackup);
         if (dataBase != null) {
             setConnectionInfo(dataBase.getDataSource().getContainer(), dataBase.getName());
 
@@ -371,8 +372,12 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         if (!allSchemasSelected && fullSchemaBackupCheck.getSelection()) {
             fullSchemaBackupCheck.setSelection(false);
             wizard.getSettings().setFullSchemaBackup(false);
-            tablesTable.setVisible(true);
+            setTablesSectionEnabled(true);
         }
+    }
+
+    private void setTablesSectionEnabled(boolean enabled) {
+        UIUtils.enableWithChildren(tablesPanel, enabled);
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/dbeaver/dbeaver/issues/40575

Looks like regression after https://github.com/dbeaver/dbeaver/issues/38860

My STR:
<img width="685" height="378" alt="image" src="https://github.com/user-attachments/assets/be25254e-e1f8-47c6-afd5-c9d4ae956920" />

The command result on "PostgreSQL dump progress" was
/opt/homebrew/Cellar/postgresql@17/17.10/bin/pg_dump --verbose --host=localhost --port=5432 ****** --format=c --file /Users/ivangorsecnikov/dump-postgres-202607161408.sql ******                                                                        
But it should be
/opt/homebrew/Cellar/postgresql@17/17.10/bin/pg_dump --verbose --host=localhost --port=5432 ****** --format=c --file /Users/ivangorsecnikov/dump-postgres-202607161409.sql -t test."1" ******

Also, now close the table picker if a complete backup is checked
<img width="864" height="502" alt="image" src="https://github.com/user-attachments/assets/2a23748a-c7c4-4e5b-9159-63ea79f8556b" />


And look at this tickets https://github.com/dbeaver/dbeaver/issues/40575#issuecomment-4852997550, they should be fixed 
