### PR TITLE
#41553 Fix GaussDB schema switch from the SQL Editor toolbar

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/PostgreServerGaussDB.java
+++ b/plugins/org.jkiss.dbeaver.ext.gaussdb/src/org/jkiss/dbeaver/ext/gaussdb/model/PostgreServerGaussDB.java
@@ -42,6 +42,11 @@ public class PostgreServerGaussDB extends PostgreServerExtensionBase {
         return false;
     }
 
+    @Override
+    public boolean isDefaultSchemaPublic() {
+        return false;
+    }
+
     public boolean isSupportJobs() {
         return supportJobs;
     }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreExecutionContext.java
@@ -143,7 +143,7 @@ public class PostgreExecutionContext extends JDBCExecutionContext implements DBC
             return false;
         }
 
-        if (!schema.isSystem() && !schema.isPublicSchema()) {
+        if (!schema.isSystem() && !(schema.isPublicSchema() && getDataSource().getServerType().isDefaultSchemaPublic())) {
             setSearchPath(monitor, schema.getName());
             addSearchPath(schema.getName());
         }
@@ -244,16 +244,16 @@ public class PostgreExecutionContext extends JDBCExecutionContext implements DBC
     private void setSearchPath(@NotNull DBRProgressMonitor monitor, @NotNull String defSchemaName) throws DBException {
         List<String> newSearchPath = new ArrayList<>(searchPath);
         int schemaIndex = newSearchPath.indexOf(defSchemaName);
-        {
-            if (schemaIndex < 0) {
-                // Remove from previous position
-                if (!getDataSource().getServerType().supportsStandardSearchPath()
-                    && getDefaultCatalog().getSchema(monitor, PostgreConstants.PUBLIC_SCHEMA_NAME) == null
-                    && !PostgreConstants.PUBLIC_SCHEMA_NAME.equals(defSchemaName)) {
-                    newSearchPath.removeIf(PostgreConstants.PUBLIC_SCHEMA_NAME::equals);
-                }
-                newSearchPath.addFirst(defSchemaName);
+        if (schemaIndex < 0) {
+            if (!getDataSource().getServerType().supportsStandardSearchPath()
+                && getDefaultCatalog().getSchema(monitor, PostgreConstants.PUBLIC_SCHEMA_NAME) == null
+                && !PostgreConstants.PUBLIC_SCHEMA_NAME.equals(defSchemaName)) {
+                newSearchPath.removeIf(PostgreConstants.PUBLIC_SCHEMA_NAME::equals);
             }
+            newSearchPath.addFirst(defSchemaName);
+        } else if (schemaIndex > 0) {
+            newSearchPath.remove(schemaIndex);
+            newSearchPath.addFirst(defSchemaName);
         }
         if (Objects.equals(newSearchPath, searchPath)) {
             return;

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtension.java
@@ -99,6 +99,8 @@ public interface PostgreServerExtension {
 
     boolean supportsStandardSearchPath();
 
+    boolean isDefaultSchemaPublic();
+
     boolean supportsRelationSizeCalc();
 
     boolean supportsExplainPlan();

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/impls/PostgreServerExtensionBase.java
@@ -196,6 +196,11 @@ public abstract class PostgreServerExtensionBase implements PostgreServerExtensi
         return true;
     }
 
+    @Override
+    public boolean isDefaultSchemaPublic() {
+        return true;
+    }
+
     @Nullable
     @Override
     public String readTableDDL(@NotNull DBRProgressMonitor monitor, @NotNull PostgreTableBase table) throws DBException {

--- a/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtensionBaseTest.java
+++ b/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreServerExtensionBaseTest.java
@@ -41,6 +41,11 @@ public class PostgreServerExtensionBaseTest extends DBeaverUnitTest {
     }
 
     @Test
+    public void isDefaultSchemaPublic_forStandardPostgreSQL_returnsTrue() {
+        Assertions.assertTrue(serverExtension.isDefaultSchemaPublic());
+    }
+
+    @Test
     public void createWithClause_whenOidsAreSupported_shouldDisplayWithClauseWithOidsAsTrue() {
         setupGeneralWhenMocks(true);
 


### PR DESCRIPTION
On GaussDB/openGauss, selecting `public` in the SQL Editor toolbar left `current_schema()` pointing at the schema chosen on connect (the user's own schema), so the switch had no effect.

Root cause is in the shared `PostgreExecutionContext`:
- `changeDefaultSchema()` skipped `SET search_path` whenever the target was the `public` schema. That is valid for standard PostgreSQL, where `public` is already the default, but GaussDB defaults to the connected user's schema, so switching to `public` must actually update the search path.
- `setSearchPath()` only prepended a schema when it was absent from the current path; a schema already present (like `public` in `"$user", public`) was never moved to the front, so `current_schema()` never changed.

The fix adds a `PostgreServerExtension.isDefaultSchemaPublic()` flag (default `true`, so every existing driver is unchanged) and overrides it to `false` for GaussDB, which lets the search path be applied when switching to `public`. `setSearchPath()` now also moves an already-present schema to the front so the selection takes effect.

Verification: added a unit test asserting the default flag value in `PostgreServerExtensionBaseTest`; the standard-PostgreSQL code path is unchanged (`!(isPublicSchema && isDefaultSchemaPublic)` reduces to the previous `!isPublicSchema`). Manual before/after on GaussDB: switch toolbar to `public`, run `select current_schema();` — now returns `public` instead of the default schema.

Closes dbeaver/dbeaver#41553

This PR was prepared with AI assistance (Claude Code); the change is small, understood, and verified by the author.
