### PR TITLE
dbeaver/pro#9643 Show icon modifiers everywhere but in spreadsheet

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCAttribute.java
+++ b/plugins/org.jkiss.dbeaver.model.jdbc/src/org/jkiss/dbeaver/model/impl/jdbc/struct/JDBCAttribute.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,7 @@ package org.jkiss.dbeaver.model.impl.jdbc.struct;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.model.DBPDataKind;
-import org.jkiss.dbeaver.model.DBPImage;
-import org.jkiss.dbeaver.model.DBPImageProvider;
-import org.jkiss.dbeaver.model.DBValueFormatting;
+import org.jkiss.dbeaver.model.*;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.struct.AbstractAttribute;
 import org.jkiss.dbeaver.model.struct.DBSAttributeBase;
@@ -51,12 +48,16 @@ public abstract class JDBCAttribute extends AbstractAttribute implements DBSObje
 
     @Nullable
     @Override
-    public DBPImage getObjectImage()
-    {
+    public DBPImage getObjectImage() {
+        return getObjectImage(true);
+    }
+
+    @Nullable
+    @Override
+    public DBPImage getObjectImage(boolean includeModifiers) {
         DBPImage columnImage = DBValueFormatting.getTypeImage(this);
-        JDBCColumnKeyType keyType = getKeyType();
-        if (keyType != null) {
-            columnImage = getOverlayImage(columnImage, keyType);
+        if (includeModifiers) {
+            columnImage = getOverlayImage(columnImage, getKeyType());
         }
         return columnImage;
     }
@@ -74,10 +75,8 @@ public abstract class JDBCAttribute extends AbstractAttribute implements DBSObje
         return JDBCUtils.resolveDataKind(getDataSource(), typeName, valueType);
     }
 
-    protected static DBPImage getOverlayImage(DBPImage columnImage, JDBCColumnKeyType keyType)
-    {
-        return columnImage;
-/*
+    @NotNull
+    protected static DBPImage getOverlayImage(@NotNull DBPImage columnImage, @Nullable JDBCColumnKeyType keyType) {
         if (keyType == null || !(keyType.isInUniqueKey() || keyType.isInReferenceKey())) {
             return columnImage;
         }
@@ -91,7 +90,6 @@ public abstract class JDBCAttribute extends AbstractAttribute implements DBSObje
             return columnImage;
         }
         return new DBIconComposite(columnImage, false, null, null, null, overImage);
-*/
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPImageProvider.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPImageProvider.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,5 +26,10 @@ public interface DBPImageProvider {
 
     @Nullable
     DBPImage getObjectImage();
+
+    @Nullable
+    default DBPImage getObjectImage(boolean includeModifiers) {
+        return getObjectImage();
+    }
 
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBValueFormatting.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBValueFormatting.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.model;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.NotNullWhen;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ModelPreferences;
@@ -117,48 +118,36 @@ public final class DBValueFormatting {
     }
 
     @NotNull
-    public static DBPImage getObjectImage(DBPObject object)
-    {
+    public static DBPImage getObjectImage(@Nullable DBPObject object) {
         return getObjectImage(object, true);
     }
 
-    @Nullable
-    public static DBPImage getObjectImage(DBPObject object, boolean useDefault)
-    {
+    @NotNullWhen("useDefault")
+    public static DBPImage getObjectImage(@Nullable DBPObject object, boolean useDefault) {
+        return getObjectImage(object, useDefault, true);
+    }
+
+    @NotNullWhen("useDefault")
+    public static DBPImage getObjectImage(@Nullable DBPObject object, boolean useDefault, boolean includeModifiers) {
         DBPImage image = null;
-        if (object instanceof DBPImageProvider) {
-            image = ((DBPImageProvider)object).getObjectImage();
+        if (object instanceof DBPImageProvider provider) {
+            image = provider.getObjectImage(includeModifiers);
         }
         if (image == null) {
-            if (object instanceof DBSTypedObject) {
-                image = getTypeImage((DBSTypedObject) object);
+            if (object instanceof DBSTypedObject typedObject) {
+                image = getTypeImage(typedObject);
             }
             if (image == null && useDefault) {
-                if (object instanceof DBSEntity) {
-                    if (DBUtils.isView((DBSEntity) object)) {
-                        image = DBIcon.TREE_VIEW;
-                    } else {
-                        image = DBIcon.TREE_TABLE;
-                    }
-                } else if (object instanceof DBSEntityAssociation) {
-                    image = DBIcon.TREE_ASSOCIATION;
-                } else if (object instanceof DBSProcedure) {
-                    image = DBIcon.TREE_PROCEDURE;
-                } else if (object instanceof DBSPackage) {
-                    image = DBIcon.TREE_PACKAGE;
-                } else if (object instanceof DBSTrigger) {
-                    image = DBIcon.TREE_TRIGGER;
-                } else if (object instanceof DBSSchema s) {
-                    if (s instanceof DBPSystemObject so && so.isSystem()) {
-                        image = DBIcon.TREE_SCHEMA_SYSTEM;
-                    } else {
-                        image = DBIcon.TREE_SCHEMA;
-                    }
-                } else if (object instanceof DBSCatalog) {
-                    image = DBIcon.TREE_DATABASE;
-                } else {
-                    image = DBIcon.TYPE_OBJECT;
-                }
+                image = switch (object) {
+                    case DBSEntity entity -> DBUtils.isView(entity) ? DBIcon.TREE_VIEW : DBIcon.TREE_TABLE;
+                    case DBSEntityAssociation ignored -> DBIcon.TREE_ASSOCIATION;
+                    case DBSProcedure ignored -> DBIcon.TREE_PROCEDURE;
+                    case DBSPackage ignored -> DBIcon.TREE_PACKAGE;
+                    case DBSTrigger ignored -> DBIcon.TREE_TRIGGER;
+                    case DBSSchema s -> s instanceof DBPSystemObject so && so.isSystem() ? DBIcon.TREE_SCHEMA_SYSTEM : DBIcon.TREE_SCHEMA;
+                    case DBSCatalog ignored -> DBIcon.TREE_DATABASE;
+                    case null, default -> DBIcon.TYPE_OBJECT;
+                };
             }
         }
         return image;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/FilterSettingsDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/FilterSettingsDialog.java
@@ -53,8 +53,8 @@ import org.jkiss.dbeaver.utils.RuntimeUtils;
 import org.jkiss.utils.ArrayUtils;
 import org.jkiss.utils.CommonUtils;
 
-import java.util.List;
 import java.util.*;
+import java.util.List;
 
 class FilterSettingsDialog extends HelpEnabledDialog {
     private static final String DIALOG_ID = "DBeaver.FilterSettingsDialog";//$NON-NLS-1$
@@ -133,7 +133,7 @@ class FilterSettingsDialog extends HelpEnabledDialog {
                     final DBDAttributeBinding binding = (DBDAttributeBinding) cell.getElement();
                     final DBDAttributeConstraint constraint = getBindingConstraint(binding);
                     cell.setText(constraint.getAttribute().getName());
-                    cell.setImage(DBeaverIcons.getImage(DBValueFormatting.getObjectImage(binding.getMetaAttribute())));
+                    cell.setImage(DBeaverIcons.getImage(DBValueFormatting.getObjectImage(binding.getAttribute())));
                 }
             });
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
@@ -34,7 +34,10 @@ import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.widgets.*;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.menus.CommandContributionItem;
 import org.eclipse.ui.themes.ITheme;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
@@ -63,10 +66,10 @@ import org.jkiss.dbeaver.ui.*;
 import org.jkiss.dbeaver.ui.controls.PropertyPageStandard;
 import org.jkiss.dbeaver.ui.controls.bool.BooleanMode;
 import org.jkiss.dbeaver.ui.controls.bool.BooleanStyleSet;
+import org.jkiss.dbeaver.ui.controls.findandreplace.FindReplaceOverlay;
 import org.jkiss.dbeaver.ui.controls.lightgrid.*;
 import org.jkiss.dbeaver.ui.controls.resultset.*;
 import org.jkiss.dbeaver.ui.controls.resultset.IResultSetController.RowPlacement;
-import org.jkiss.dbeaver.ui.controls.findandreplace.FindReplaceOverlay;
 import org.jkiss.dbeaver.ui.controls.resultset.handler.ResultSetPropertyTester;
 import org.jkiss.dbeaver.ui.controls.resultset.internal.ResultSetMessages;
 import org.jkiss.dbeaver.ui.controls.resultset.panel.valueviewer.ValueViewerPanel;
@@ -91,7 +94,6 @@ import org.jkiss.utils.xml.XMLUtils;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
-import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -3188,11 +3190,9 @@ public class SpreadsheetPresentation extends AbstractPresentation
             }
 
             if (item.getElement() instanceof DBDAttributeBinding attr) {
-                DBPImage image = DBValueFormatting.getObjectImage(attr.getAttribute());
-                return DBeaverIcons.getImage(image);
+                return DBeaverIcons.getImage(DBValueFormatting.getObjectImage(attr.getAttribute(), true, false));
             } else if (item.getElement() instanceof DBSAttributeBase attrBase) {
-                return DBeaverIcons.getImage(
-                    DBValueFormatting.getObjectImage(attrBase));
+                return DBeaverIcons.getImage(DBValueFormatting.getObjectImage(attrBase));
             }
 
             return null;

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/spreadsheet/SpreadsheetPresentation.java
@@ -3190,7 +3190,8 @@ public class SpreadsheetPresentation extends AbstractPresentation
             }
 
             if (item.getElement() instanceof DBDAttributeBinding attr) {
-                return DBeaverIcons.getImage(DBValueFormatting.getObjectImage(attr.getAttribute(), true, false));
+                boolean includeModifiers = controller.isRecordMode();
+                return DBeaverIcons.getImage(DBValueFormatting.getObjectImage(attr.getAttribute(), true, includeModifiers));
             } else if (item.getElement() instanceof DBSAttributeBase attrBase) {
                 return DBeaverIcons.getImage(DBValueFormatting.getObjectImage(attrBase));
             }


### PR DESCRIPTION
In Properties:

<img width="947" height="531" alt="image" src="https://github.com/user-attachments/assets/c016318c-daf1-4fb7-8e9a-bb77660c1b5c" />

Filters dialog also has icon modifiers now:

<img width="724" height="426" alt="image" src="https://github.com/user-attachments/assets/3d7140b2-ba7c-4e49-91bf-aa418ec2de69" />

Record mode as well:

<img width="394" height="398" alt="image" src="https://github.com/user-attachments/assets/0d0a8974-eb95-40e6-8883-2b63a5b1f2b1" />
