### PR TITLE
dbeaver/pro#9872 Nullability checks and annotations

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/model/SQLServerTable.java
@@ -73,21 +73,21 @@ public class SQLServerTable extends SQLServerTableBase
         return false;
     }
 
-    @Property(category = DBConstants.CAT_STATISTICS, viewable = false, expensive = true, order = 30)
+    @Property(viewable = true, category = DBConstants.CAT_STATISTICS, visibleIf = IsPersistedValidator.class, order = 30)
     @Override
-    public Long getRowCount(DBRProgressMonitor monitor) throws DBCException {
+    public Long getRowCount(@Nullable DBRProgressMonitor monitor) throws DBCException {
         readTableStats(monitor);
         return super.getRowCount(monitor);
     }
 
-    @Property(viewable = true, category = DBConstants.CAT_STATISTICS, order = 31)
-    public long getTotalBytes(DBRProgressMonitor monitor) throws DBCException {
+    @Property(viewable = true, category = DBConstants.CAT_STATISTICS, visibleIf = IsPersistedValidator.class, order = 31)
+    public long getTotalBytes(@Nullable DBRProgressMonitor monitor) throws DBCException {
         readTableStats(monitor);
         return totalBytes;
     }
 
-    @Property(viewable = true, category = DBConstants.CAT_STATISTICS, order = 32)
-    public long getUsedBytes(DBRProgressMonitor monitor) throws DBCException {
+    @Property(viewable = true, category = DBConstants.CAT_STATISTICS, visibleIf = IsPersistedValidator.class, order = 32)
+    public long getUsedBytes(@Nullable DBRProgressMonitor monitor) throws DBCException {
         readTableStats(monitor);
         return usedBytes;
     }
@@ -212,8 +212,8 @@ public class SQLServerTable extends SQLServerTableBase
         return totalBytes;
     }
 
-    private void readTableStats(DBRProgressMonitor monitor) throws DBCException {
-        if (hasStatistics()) {
+    private void readTableStats(@Nullable DBRProgressMonitor monitor) throws DBCException {
+        if (monitor == null || monitor.isForceCacheUsage() || hasStatistics()) {
             return;
         }
         if (SQLServerUtils.isDriverBabelfish(getDataSource().getContainer().getDriver())) {

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPPersistedObject.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPPersistedObject.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2025 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,11 @@
 
 package org.jkiss.dbeaver.model;
 
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.model.meta.IPropertyValueValidator;
+import org.jkiss.dbeaver.model.meta.Property;
+
 /**
  * Abstract persisted object
  */
@@ -28,5 +33,17 @@ public interface DBPPersistedObject extends DBPObject {
      * @return true if object is persisted in external data source
      */
     boolean isPersisted();
+
+    /**
+     * A validator that checks if the object is persisted.
+     *
+     * @see Property#visibleIf()
+     */
+    final class IsPersistedValidator implements IPropertyValueValidator<DBPPersistedObject, Object> {
+        @Override
+        public boolean isValidValue(@NotNull DBPPersistedObject object, @Nullable Object value) throws IllegalArgumentException {
+            return object.isPersisted();
+        }
+    }
 
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractSession.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/AbstractSession.java
@@ -26,26 +26,27 @@ import org.jkiss.dbeaver.model.impl.data.DefaultValueHandler;
 import org.jkiss.dbeaver.model.qm.QMUtils;
 import org.jkiss.dbeaver.model.runtime.DBRBlockingObject;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.utils.CommonUtils;
 
 /**
  * Abstract execution context
  */
 public abstract class AbstractSession implements DBCSession, DBDFormatSettingsExt, DBRBlockingObject {
 
-    private DBRProgressMonitor monitor;
-    private DBCExecutionPurpose purpose;
-    private String taskTitle;
+    private final DBRProgressMonitor monitor;
+    private final DBCExecutionPurpose purpose;
+    private final String taskTitle;
     private DBDDataFormatterProfile dataFormatterProfile;
     private boolean holdsBlock = false;
     private boolean loggingEnabled = true;
     private byte useNativeDateTimeFormat = -1;
 
-    public AbstractSession(DBRProgressMonitor monitor, DBCExecutionPurpose purpose, String taskTitle) {
+    public AbstractSession(@NotNull DBRProgressMonitor monitor, @NotNull DBCExecutionPurpose purpose, @NotNull String taskTitle) {
         this.monitor = monitor;
         this.purpose = purpose;
         this.taskTitle = taskTitle;
 
-        if (taskTitle != null) {
+        if (CommonUtils.isNotEmpty(taskTitle)) {
             monitor.startBlock(this, taskTitle);
             holdsBlock = true;
         }


### PR DESCRIPTION
Original STR:
1. Create a new table in SQL Server, **don't** persist it
2. Switch to Properties -> Statistics
3. Observe NPEs in the log

Now the Statistics tab should not be visible for non-persisted tables at all.