### PR TITLE
dbeaver/dbeaver#41566 Restore Value viewer find routing

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/plugin.xml
@@ -510,7 +510,11 @@
             </enabledWhen>
         </handler>
         <handler commandId="org.eclipse.ui.edit.findReplace" class="org.jkiss.dbeaver.ui.controls.resultset.handler.ResultSetHandlerMain">
-            <activeWhen><reference definitionId="org.jkiss.dbeaver.core.ui.resultset.presentation.control"/></activeWhen>
+            <activeWhen>
+                <with variable="activePart">
+                    <test property="org.jkiss.dbeaver.core.resultset.active"/>
+                </with>
+            </activeWhen>
         </handler>
         <handler commandId="org.jkiss.dbeaver.core.resultset.toggleMode" class="org.jkiss.dbeaver.ui.controls.resultset.handler.ResultSetHandlerToggleMode">
             <activeWhen><reference definitionId="org.jkiss.dbeaver.core.ui.resultset.part"/></activeWhen>

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/plugin.xml
@@ -510,11 +510,7 @@
             </enabledWhen>
         </handler>
         <handler commandId="org.eclipse.ui.edit.findReplace" class="org.jkiss.dbeaver.ui.controls.resultset.handler.ResultSetHandlerMain">
-            <activeWhen>
-                <with variable="activePart">
-                    <test property="org.jkiss.dbeaver.core.resultset.active"/>
-                </with>
-            </activeWhen>
+            <activeWhen><reference definitionId="org.jkiss.dbeaver.core.ui.resultset.presentation.control"/></activeWhen>
         </handler>
         <handler commandId="org.jkiss.dbeaver.core.resultset.toggleMode" class="org.jkiss.dbeaver.ui.controls.resultset.handler.ResultSetHandlerToggleMode">
             <activeWhen><reference definitionId="org.jkiss.dbeaver.core.ui.resultset.part"/></activeWhen>

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerMain.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/handler/ResultSetHandlerMain.java
@@ -30,6 +30,7 @@ import org.eclipse.jface.fieldassist.IContentProposalProvider;
 import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.resource.FontRegistry;
 import org.eclipse.jface.resource.StringConverter;
+import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
@@ -39,6 +40,7 @@ import org.eclipse.swt.widgets.*;
 import org.eclipse.ui.IWorkbenchCommandConstants;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartSite;
+import org.eclipse.ui.ISources;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.IElementUpdater;
 import org.eclipse.ui.handlers.HandlerUtil;
@@ -70,10 +72,12 @@ import org.jkiss.dbeaver.ui.actions.ConnectionCommands;
 import org.jkiss.dbeaver.ui.contentassist.ContentAssistUtils;
 import org.jkiss.dbeaver.ui.contentassist.ContentProposalExt;
 import org.jkiss.dbeaver.ui.contentassist.SmartTextContentAdapter;
+import org.jkiss.dbeaver.ui.controls.StyledTextUtils;
 import org.jkiss.dbeaver.ui.controls.findandreplace.FindReplaceOverlay;
 import org.jkiss.dbeaver.ui.controls.resultset.*;
 import org.jkiss.dbeaver.ui.controls.resultset.IResultSetController.RowPlacement;
 import org.jkiss.dbeaver.ui.controls.resultset.internal.ResultSetMessages;
+import org.jkiss.dbeaver.ui.controls.resultset.panel.valueviewer.ValueViewerPanel;
 import org.jkiss.dbeaver.ui.controls.resultset.spreadsheet.Spreadsheet;
 import org.jkiss.dbeaver.ui.controls.resultset.spreadsheet.SpreadsheetPresentation;
 import org.jkiss.dbeaver.ui.data.IValueController;
@@ -415,6 +419,15 @@ public class ResultSetHandlerMain extends AbstractHandler implements IElementUpd
                 }
                 break;
             case IWorkbenchCommandConstants.EDIT_FIND_AND_REPLACE: {
+                if (ValueViewerPanel.VALUE_VIEW_CONTROL_ID.equals(
+                    HandlerUtil.getVariable(event, ISources.ACTIVE_FOCUS_CONTROL_ID_NAME)
+                )) {
+                    IFindReplaceTarget target = rsv.getAdapter(IFindReplaceTarget.class);
+                    if (target != null) {
+                        StyledTextUtils.createFindReplaceAction(activeShell, target).run();
+                    }
+                    break;
+                }
                 FindReplaceOverlay findReplaceOverlay;
                 if (event.getTrigger() instanceof Event ev && ev.widget instanceof Spreadsheet s) {
                     findReplaceOverlay = s.getPresentation().getFindReplaceOverlay();

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/panel/valueviewer/ValueViewerPanel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/panel/valueviewer/ValueViewerPanel.java
@@ -19,11 +19,13 @@ package org.jkiss.dbeaver.ui.controls.resultset.panel.valueviewer;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.layout.FillLayoutFactory;
+import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
+import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.TraverseEvent;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
@@ -42,6 +44,7 @@ import org.jkiss.dbeaver.model.data.DBDValue;
 import org.jkiss.dbeaver.model.impl.data.DBDValueError;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 import org.jkiss.dbeaver.ui.*;
+import org.jkiss.dbeaver.ui.controls.StyledTextFindReplaceTarget;
 import org.jkiss.dbeaver.ui.controls.resultset.*;
 import org.jkiss.dbeaver.ui.controls.resultset.internal.ResultSetMessages;
 import org.jkiss.dbeaver.ui.controls.resultset.panel.ResultSetPanelBase;
@@ -62,7 +65,7 @@ public class ValueViewerPanel extends ResultSetPanelBase implements DBPAdaptable
 
     public static final String PANEL_ID = "value-view";
 
-    private static final String VALUE_VIEW_CONTROL_ID = "org.jkiss.dbeaver.ui.resultset.panel.valueView";
+    public static final String VALUE_VIEW_CONTROL_ID = "org.jkiss.dbeaver.ui.resultset.panel.valueView";
 
     private IResultSetPresentation presentation;
     private Composite viewPlaceholder;
@@ -406,7 +409,13 @@ public class ValueViewerPanel extends ResultSetPanelBase implements DBPAdaptable
                 return adapter.cast(valueEditor);
             }
             if (valueEditor instanceof IAdaptable) {
-                return ((IAdaptable) valueEditor).getAdapter(adapter);
+                T result = ((IAdaptable) valueEditor).getAdapter(adapter);
+                if (result != null) {
+                    return result;
+                }
+            }
+            if (adapter == IFindReplaceTarget.class && valueEditor.getControl() instanceof StyledText text) {
+                return adapter.cast(new StyledTextFindReplaceTarget(text));
             }
         }
 


### PR DESCRIPTION
## Summary

- Route Find/Replace according to focused result-set control.
- Use focused Value editor native find target.
- Keep result-set overlay available from grid and filter panel.
- Add find-target fallback for plain `StyledText` Value editors.

## Root cause

Spreadsheet quick-filter change replaced focus-aware `IFindReplaceTarget` dispatch with unconditional result-set overlay dispatch. Because result-set handler is active for whole result-set editor, it intercepted Find/Replace while focus was inside Value editor.

## User impact

Ctrl/Cmd+F, Edit → Find/Replace, and Value editor context-menu action now target focused Value text. Grid and filter-panel activation continue to open result-set overlay.

## Validation

- `xmllint --noout plugins/org.jkiss.dbeaver.ui.editors.data/plugin.xml`
- `git diff --check`
- `mvn package -f product/aggregate/pom.xml -Pproduct-dbeaver-ce,product-dbeaver-eclipse-ce` (203 modules, build successful)
- Manual macOS regression test:
  - Value editor focus → Value Find/Replace
  - Result grid focus → result-set overlay
  - Filter panel focus → result-set overlay

## AI assistance

This change was generated with assistance from OpenAI Codex, then reviewed and validated by contributor.

Closes dbeaver/dbeaver#41566
