### PR TITLE
Dbeaver/pro#9894 te fix filter not shown

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
@@ -96,7 +96,9 @@ final class ResultSetFilterDialog extends AbstractPopupPanel {
         viewer.addSelectionChangedListener(e -> {
             var filter = (QMQueryFilter) e.getStructuredSelection().getFirstElement();
             selection = filters.indexOf(filter);
-            persistFilter(filter);
+            if (filter != null) {
+                persistFilter(filter);
+            }
         });
         viewer.getTable().addSelectionListener(SelectionListener.widgetDefaultSelectedAdapter(selectionEvent ->
             okPressed()));

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
@@ -96,9 +96,6 @@ final class ResultSetFilterDialog extends AbstractPopupPanel {
         viewer.addSelectionChangedListener(e -> {
             var filter = (QMQueryFilter) e.getStructuredSelection().getFirstElement();
             selection = filters.indexOf(filter);
-            if (filter != null) {
-                persistFilter(filter);
-            }
         });
         viewer.getTable().addSelectionListener(SelectionListener.widgetDefaultSelectedAdapter(selectionEvent ->
             okPressed()));

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
@@ -179,7 +179,7 @@ final class ResultSetFilterDialog extends AbstractPopupPanel {
             (f, s) -> {
                 if (f != null) {
                     f.setTitle(s);
-                    persistFilter(f);
+                    UIUtils.asyncExec(() -> persistFilter(f));
                 }
         }));
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
@@ -88,7 +88,6 @@ final class ResultSetFilterDialog extends AbstractPopupPanel {
             public boolean select(@NotNull Viewer viewer, @NotNull Object parentElement, @NotNull Object element) {
                 var filter = (QMQueryFilter) element;
                 var criteria = searchText.getText().trim();
-                persistFilter(filter);
                 return criteria.isEmpty()
                     || StringUtils.containsIgnoreCase(filter.text(), criteria)
                     || (filter.title() != null && StringUtils.containsIgnoreCase(filter.title(), criteria));
@@ -97,6 +96,7 @@ final class ResultSetFilterDialog extends AbstractPopupPanel {
         viewer.addSelectionChangedListener(e -> {
             var filter = (QMQueryFilter) e.getStructuredSelection().getFirstElement();
             selection = filters.indexOf(filter);
+            persistFilter(filter);
         });
         viewer.getTable().addSelectionListener(SelectionListener.widgetDefaultSelectedAdapter(selectionEvent ->
             okPressed()));

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/ResultSetFilterDialog.java
@@ -180,7 +180,7 @@ final class ResultSetFilterDialog extends AbstractPopupPanel {
         titleColumn.setEditingSupport(new TextGetSetEditingSupport<QMQueryFilter>(viewer,
             f -> CommonUtils.notEmpty(f.title()),
             (f, s) -> {
-                if (f != null && !CommonUtils.isEmpty(s)) {
+                if (f != null) {
                     f.setTitle(s);
                     persistFilter(f);
                 }


### PR DESCRIPTION
closes dbeaver/pro#9894. Pressing the filter every time it was selected caused bugs in TE and, moreover, caused server requests every time the filter was selected.  Also its purpose is unclear, since the only thing that can be changed is title - which has its own persister when title changes