### PR TITLE
#38554 Respect fully qualified names option in foreign key DDL

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLForeignKeyManager.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/sql/edit/struct/SQLForeignKeyManager.java
@@ -66,10 +66,11 @@ public abstract class SQLForeignKeyManager<OBJECT_TYPE extends AbstractTableCons
     protected void addObjectCreateActions(@NotNull DBRProgressMonitor monitor, @NotNull DBCExecutionContext executionContext, @NotNull List<DBEPersistAction> actions, @NotNull ObjectCreateCommand command, @NotNull Map<String, Object> options) throws DBException
     {
         final TABLE_TYPE table = (TABLE_TYPE) command.getObject().getTable();
+        final String tableName = DBUtils.getEntityScriptName(table, options);
         actions.add(
             new SQLDatabasePersistAction(
                 ModelMessages.model_jdbc_create_new_foreign_key,
-                "ALTER TABLE " + table.getFullyQualifiedName(DBPEvaluationContext.DDL) + " ADD " + getNestedDeclaration(monitor, table, command, options)) //$NON-NLS-1$ //$NON-NLS-2$
+                "ALTER TABLE " + tableName + " ADD " + getNestedDeclaration(monitor, table, command, options)) //$NON-NLS-1$ //$NON-NLS-2$
         );
     }
 


### PR DESCRIPTION
Closes dbeaver/dbeaver#38554

## Problem

The issue reports this verbatim:

> when in addition I enable the "Separate foreign keys" option, the "use fully qualified names"
> option does not affect the DDL for the foreign keys. They read like
> `ALTER TABLE [database].schema.table ADD CONSTRAINT ...`
> no matter if "use fully qualified names" is selected or not, this line does not change.

## AS-IS

*Generate SQL → DDL* with **Use fully qualified names OFF** and **Separate foreign keys ON**.
A single generated script mixes both styles — `CREATE TABLE` and `REFERENCES` drop the schema,
but the `ALTER TABLE` owner keeps it:

```sql
CREATE TABLE daily_token_usage (                          -- unqualified
    ...
);

ALTER TABLE public.daily_token_usage ADD CONSTRAINT ...    -- qualified  <-- the issue
    FOREIGN KEY (github_id) REFERENCES users(github_id);   -- unqualified
```

<img width="1184" height="938" alt="image" src="https://github.com/user-attachments/assets/9f9e8c5d-f0e5-401e-b990-2e73ab479324" />

`SQLForeignKeyManager.addObjectCreateActions` hardcoded
`table.getFullyQualifiedName(DBPEvaluationContext.DDL)` for the owning table, even though the
`options` map was already in scope on that line and already passed to `getNestedDeclaration`.

## TO-BE

Same settings, after the change — consistent throughout:

```sql
CREATE TABLE daily_token_usage (
    ...
);

ALTER TABLE daily_token_usage ADD CONSTRAINT ...
    FOREIGN KEY (github_id) REFERENCES users(github_id);
```

<img width="1212" height="986" alt="image" src="https://github.com/user-attachments/assets/f95af93f-1ea5-46ce-ab31-51b00e89218a" />

With the option **ON**, output is unchanged:

<img width="1136" height="828" alt="image" src="https://github.com/user-attachments/assets/d4475b95-d529-4a28-8c21-d75e8f6dbcaa" />

## Change

One line, using `DBUtils.getEntityScriptName(table, options)` — the same idiom as
`SQLTableManager.java:103`, which is why `CREATE TABLE` already honoured the option.
The helper defaults `useFQN` to `true`, so the editor-save persist path (which never sets
the option) behaves exactly as before. Extracting the local also brings the line back under
the 140-character limit (183 → 139).

## Scope, and how this differs from the withdrawn #41433

#41433 changed both `SQLForeignKeyManager` and `SQLConstraintManager`, and was withdrawn as
out of scope. This PR changes **only** `SQLForeignKeyManager` — the line the issue reports.
`SQLConstraintManager` (PK/unique constraints) is left untouched; the issue does not mention it.
Happy to handle it in a follow-up if you want it.

The `addObjectDeleteActions` (DROP) path is also left as-is.

The `CREATE INDEX` lines visible in the screenshots are unaffected by this change and still
carry the prefix — that is a separate path, and I have deliberately not touched it here.

## Verification

Built DBeaver CE from `devel` and reproduced against PostgreSQL, selecting only the child
table so the foreign key is emitted as a separate statement (screenshots above).

`mvn clean verify` on `product/aggregate` is green — 203 tests, no regressions.

There is currently no test coverage for `SQLForeignKeyManager`. I can add a unit test for this
behaviour if you'd like it in this PR.