### PR TITLE
#41509 Ensure changes to search_path are committed

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
@@ -396,14 +396,11 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
         if (activeSchema != null) {
             postgreContext.setDefaultCatalog(monitor, activeSchema.getDatabase(), activeSchema, true);
 
-            // Commit possible changes to search_path
-            var txnManager = DBUtils.getTransactionManager(context);
-            if (txnManager != null && !txnManager.isAutoCommit()) {
-                try (DBCSession session = context.openSession(monitor, DBCExecutionPurpose.UTIL, "Commit transaction")) {
-                    txnManager.commit(session);
-                } catch (DBCException e) {
-                    log.warn("Error committing changes context defaults for new connection", e);
-                }
+            try {
+                // Commit possible changes to search_path
+                DBExecUtils.commitContextTransaction(monitor, context);
+            } catch (DBCException e) {
+                log.warn("Error committing changes context defaults for new connection", e);
             }
         }
     }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
@@ -395,6 +395,16 @@ public class PostgreDataSource extends JDBCDataSource implements DBSInstanceCont
         postgreContext.refreshDefaults(monitor, true);
         if (activeSchema != null) {
             postgreContext.setDefaultCatalog(monitor, activeSchema.getDatabase(), activeSchema, true);
+
+            // Commit possible changes to search_path
+            var txnManager = DBUtils.getTransactionManager(context);
+            if (txnManager != null && !txnManager.isAutoCommit()) {
+                try (DBCSession session = context.openSession(monitor, DBCExecutionPurpose.UTIL, "Commit transaction")) {
+                    txnManager.commit(session);
+                } catch (DBCException e) {
+                    log.warn("Error committing changes context defaults for new connection", e);
+                }
+            }
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/exec/DBExecUtils.java
@@ -545,6 +545,26 @@ public class DBExecUtils {
         }
     }
 
+    /**
+     * Commit a transaction within the active context. If the context is in auto-commit mode, this method does nothing.
+     *
+     * @param monitor progress monitor
+     * @param context execution context to commit the transaction for
+     * @throws DBCException on any DB error during commit
+     */
+    public static void commitContextTransaction(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull DBCExecutionContext context
+    ) throws DBCException {
+        var manager = DBUtils.getTransactionManager(context);
+        if (manager == null || manager.isAutoCommit()) {
+            return;
+        }
+        try (DBCSession session = context.openSession(monitor, DBCExecutionPurpose.UTIL, "Commit transaction")) {
+            manager.commit(session);
+        }
+    }
+
     @Nullable
     public static DBSEntityConstraint getBestIdentifier(
         @NotNull DBRProgressMonitor monitor,

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -120,7 +120,10 @@ import org.jkiss.dbeaver.ui.editors.text.ScriptPositionColumn;
 import org.jkiss.dbeaver.ui.internal.UIMessages;
 import org.jkiss.dbeaver.ui.navigator.INavigatorModelView;
 import org.jkiss.dbeaver.utils.*;
-import org.jkiss.utils.*;
+import org.jkiss.utils.ArrayUtils;
+import org.jkiss.utils.CommonUtils;
+import org.jkiss.utils.IOUtils;
+import org.jkiss.utils.StringUtils;
 
 import java.io.*;
 import java.net.URI;
@@ -848,6 +851,14 @@ public class SQLEditor extends SQLEditorBase implements
                     } catch (DBException e) {
                         DBWorkbench.getPlatformUI()
                             .showError("New connection default", "Error setting default catalog/schema for new connection", e);
+                    }
+                }
+                var txnManager = DBUtils.getTransactionManager(newContext);
+                if (txnManager != null && !txnManager.isAutoCommit()) {
+                    try (DBCSession session = newContext.openSession(monitor, DBCExecutionPurpose.UTIL, "Commit transaction")) {
+                        txnManager.commit(session);
+                    } catch (DBCException e) {
+                        log.warn("Error committing changes context defaults for new connection", e);
                     }
                 }
                 SQLEditor.this.isolatedExecutionContext = newContext;

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -853,13 +853,10 @@ public class SQLEditor extends SQLEditorBase implements
                             .showError("New connection default", "Error setting default catalog/schema for new connection", e);
                     }
                 }
-                var txnManager = DBUtils.getTransactionManager(newContext);
-                if (txnManager != null && !txnManager.isAutoCommit()) {
-                    try (DBCSession session = newContext.openSession(monitor, DBCExecutionPurpose.UTIL, "Commit transaction")) {
-                        txnManager.commit(session);
-                    } catch (DBCException e) {
-                        log.warn("Error committing changes context defaults for new connection", e);
-                    }
+                try {
+                    DBExecUtils.commitContextTransaction(monitor, newContext);
+                } catch (DBCException e) {
+                    log.warn("Error committing changes context defaults for new connection", e);
                 }
                 SQLEditor.this.isolatedExecutionContext = newContext;
                 // Needed to update main toolbar
@@ -1483,7 +1480,6 @@ public class SQLEditor extends SQLEditorBase implements
                 }
             });
         }
-        resultTabs.setSimple(true);
         resultTabs.setFont(JFaceResources.getFont(UIFonts.Eclipse.PART_TITLE_FONT));
 
         resultTabs.addMouseListener(MouseListener.mouseUpAdapter(e -> {


### PR DESCRIPTION
- [ ] Test whether the search_path doesn't change when opening a new editor and running a faulty query with manual commit enabled
- [ ] Test whether it affects transactions made in other editors when this option is set to "Always":
<img width="606" height="208" alt="image" src="https://github.com/user-attachments/assets/20a990b7-18ad-4d02-9813-892246f442c3" />

- [ ] Changing the active catalog/schema from the editor will still result in the original issue (and it should not commit changes made in other editors, see the previous item). This PR does not fix it