### PR TITLE
dbeaver/dbeaver#41705 Preserve raw SHOW CREATE DDL output for StarRocks and Doris

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/DorisUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/DorisUtils.java
@@ -30,7 +30,6 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
-import org.jkiss.dbeaver.model.sql.format.SQLFormatUtils;
 
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -59,14 +58,14 @@ public class DorisUtils {
     }
 
     /**
-     * Loads and formats DDL using SHOW CREATE commands for Doris tables and views.
+     * Loads DDL using SHOW CREATE commands for Doris tables and views.
      *
      * @param monitor progress monitor
      * @param table the table or view to load DDL for
      * @param sessionTitle title for the metadata session
      * @param showCommand the SHOW CREATE command (e.g., "SHOW CREATE TABLE", "SHOW CREATE VIEW")
      * @param columnName the result column name (e.g., "Create Table", "Create View")
-     * @return formatted DDL string, or null if not found
+     * @return DDL string, or null if not found
      * @throws DBCException if DDL loading fails
      */
     @Nullable
@@ -90,7 +89,7 @@ public class DorisUtils {
                     if (dbResult.next()) {
                         String definition = JDBCUtils.safeGetString(dbResult, columnName);
                         if (definition != null) {
-                            return SQLFormatUtils.formatSQL(table.getDataSource(), definition);
+                            return definition;
                         }
                     }
                 }

--- a/plugins/org.jkiss.dbeaver.ext.starrocks/src/org/jkiss/dbeaver/ext/starrocks/StarRocksUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.starrocks/src/org/jkiss/dbeaver/ext/starrocks/StarRocksUtils.java
@@ -30,7 +30,6 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
-import org.jkiss.dbeaver.model.sql.format.SQLFormatUtils;
 
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -56,14 +55,14 @@ public class StarRocksUtils {
     }
 
     /**
-     * Loads and formats DDL using SHOW CREATE commands for StarRocks tables and views.
+     * Loads DDL using SHOW CREATE commands for StarRocks tables and views.
      *
      * @param monitor progress monitor
      * @param table the table or view to load DDL for
      * @param sessionTitle title for the metadata session
      * @param showCommand the SHOW CREATE command (e.g., "SHOW CREATE TABLE", "SHOW CREATE VIEW")
      * @param columnName the result column name (e.g., "Create Table", "Create View")
-     * @return formatted DDL string, or null if not found
+     * @return DDL string, or null if not found
      * @throws DBCException if DDL loading fails
      */
     @Nullable
@@ -87,7 +86,7 @@ public class StarRocksUtils {
                     if (dbResult.next()) {
                         String definition = JDBCUtils.safeGetString(dbResult, columnName);
                         if (definition != null) {
-                            return SQLFormatUtils.formatSQL(table.getDataSource(), definition);
+                            return definition;
                         }
                     }
                 }


### PR DESCRIPTION
## Description
This PR preserves the raw `SHOW CREATE` DDL output for StarRocks and Apache Doris.
Previously, the DDL returned by `SHOW CREATE TABLE` / `SHOW CREATE VIEW` was passed through DBeaver's generic SQL formatter via `SQLFormatUtils.formatSQL(...)`. This could unexpectedly change the database-provided DDL formatting depending on local SQL formatter preferences, for example by moving commas to separate lines.
For StarRocks and Doris, the database already returns the canonical DDL from `SHOW CREATE`, so this PR returns that DDL directly without applying an additional formatting pass.
## Changes
- Removed `SQLFormatUtils.formatSQL(...)` from StarRocks `SHOW CREATE` DDL loading.
- Removed `SQLFormatUtils.formatSQL(...)` from Doris `SHOW CREATE` DDL loading.
- Updated method comments to reflect that DDL is loaded directly rather than formatted.
## Affected drivers
- StarRocks
- Apache Doris

## Related issue
Closes dbeaver/dbeaver#41705
