### PR TITLE
dbeaver/dbeaver#41706 Fix DDL normalization for ClickHouse views

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMetaModel.java
@@ -35,7 +35,6 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
 import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCBasicDataTypeCache;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCDataType;
 import org.jkiss.dbeaver.model.impl.sql.QueryTransformerLimit;
-import org.jkiss.dbeaver.model.meta.ForTest;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.utils.CommonUtils;
@@ -180,7 +179,6 @@ public class ClickhouseMetaModel extends GenericMetaModel implements DBCQueryTra
         return false;
     }
 
-    @ForTest
     static String normalizeDDL(String ddl) {
         int declStart = ddl.indexOf("(");
         int declEnd = ddl.indexOf(") ENGINE");

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMetaModel.java
@@ -35,6 +35,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
 import org.jkiss.dbeaver.model.impl.jdbc.cache.JDBCBasicDataTypeCache;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCDataType;
 import org.jkiss.dbeaver.model.impl.sql.QueryTransformerLimit;
+import org.jkiss.dbeaver.model.meta.ForTest;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.utils.CommonUtils;
@@ -179,11 +180,13 @@ public class ClickhouseMetaModel extends GenericMetaModel implements DBCQueryTra
         return false;
     }
 
-    private String normalizeDDL(String ddl) {
+    @ForTest
+    static String normalizeDDL(String ddl) {
         int declStart = ddl.indexOf("(");
         int declEnd = ddl.indexOf(") ENGINE");
-        if (declEnd == -1) {
-            declEnd = ddl.length() - 1;
+        if (declStart == -1 || declEnd == -1 || declStart > declEnd) {
+            // Not a column declaration block (e.g. plain view definition) - leave it as is
+            return ddl;
         }
         return
             ddl.substring(0, declStart) + "(\n" +

--- a/test/org.jkiss.dbeaver.ext.clickhouse.test/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMetaModelDDLTest.java
+++ b/test/org.jkiss.dbeaver.ext.clickhouse.test/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseMetaModelDDLTest.java
@@ -1,0 +1,53 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.clickhouse.model;
+
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ClickhouseMetaModelDDLTest extends DBeaverUnitTest {
+
+    @Test
+    public void normalizesTableColumnDeclaration() {
+        final String ddl = "CREATE TABLE db.t (`a` Int32, `b` String) ENGINE = MergeTree ORDER BY a";
+        Assertions.assertEquals(
+            "CREATE TABLE db.t (\n`a` Int32,\n `b` String\n) ENGINE = MergeTree ORDER BY a",
+            ClickhouseMetaModel.normalizeDDL(ddl));
+    }
+
+    @Test
+    public void keepsViewDefinitionWithoutParenthesesIntact() {
+        // SHOW CREATE TABLE on a plain view returns a statement with no column declaration block.
+        final String ddl = "CREATE VIEW db.v AS SELECT id FROM db.t";
+        Assertions.assertEquals(ddl, ClickhouseMetaModel.normalizeDDL(ddl));
+    }
+
+    @Test
+    public void keepsViewDefinitionWithParenthesesIntact() {
+        // Parentheses belonging to the view query must not be mistaken for a column declaration.
+        final String ddl = "CREATE VIEW db.v AS SELECT count(id), toInt32(x) FROM db.t";
+        Assertions.assertEquals(ddl, ClickhouseMetaModel.normalizeDDL(ddl));
+    }
+
+    @Test
+    public void keepsAlreadyFormattedDeclarationIntact() {
+        // ") ENGINE" does not match when the statement is already multi-line formatted.
+        final String ddl = "CREATE TABLE db.t\n(\n    `a` Int32\n)\nENGINE = MergeTree";
+        Assertions.assertEquals(ddl, ClickhouseMetaModel.normalizeDDL(ddl));
+    }
+}


### PR DESCRIPTION
`ClickhouseMetaModel.normalizeDDL()` assumed the statement returned by `SHOW CREATE TABLE` always contains both `(` and `) ENGINE`. Since `getViewDDL()` delegates to `getTableDDL()`, a view definition without parentheses reached it and `ddl.substring(0, -1)` threw `StringIndexOutOfBoundsException`. The `declEnd == -1` fallback additionally split the final character off the statement.

Normalization is now skipped when there is no real column declaration block, so the DDL is returned unchanged instead of being mangled. The working table case is byte-identical to before.

Added `ClickhouseMetaModelDDLTest` covering four cases: a normal table declaration, a view without parentheses, a view whose query contains parentheses, and an already-multi-line-formatted declaration. The last three all failed on `devel` — one threw, two silently corrupted the SQL.

`normalizeDDL` was made package-private and annotated `@ForTest` so the test fragment can call it directly.

Closes dbeaver/dbeaver#41706

This PR was generated with AI assistance (Claude Code); the change and its rationale have been reviewed by me.