### PR TITLE
dbeaver/pro#10214 Fix test tunnel when required connection params are not set

### DIFF
--- a/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHTunnelDefaultConfiguratorUI.java
+++ b/plugins/org.jkiss.dbeaver.net.ssh.ui/src/org/jkiss/dbeaver/ui/net/ssh/SSHTunnelDefaultConfiguratorUI.java
@@ -480,6 +480,7 @@ public class SSHTunnelDefaultConfiguratorUI implements IObjectPropertyConfigurat
         } else {
             configuration.resolveDynamicVariables(SystemVariablesResolver.INSTANCE);
         }
+        configuration.setDataSource(null); // we don't need to operate with database specifics to test the tunnel
 
         final String[] tunnelVersions = new String[2];
 


### PR DESCRIPTION
Closes dbeaver/pro#10214
It's reproducible when you haven't filled in connection parameters like host/port/path, and test the SSH tunnel for any connection