### PR TITLE
#41687 Fix metadata panel column sort being overridden by ordinal pos…

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/controls/ViewerColumnController.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/controls/ViewerColumnController.java
@@ -895,7 +895,7 @@ public class ViewerColumnController<COLUMN, ELEMENT> {
                 return cat1 - cat2;
             }
 
-            if (e1 instanceof DBPObjectWithOrdinalPosition p1 && e2 instanceof DBPObjectWithOrdinalPosition p2) {
+            if (getColumnInfo(viewer) == null && e1 instanceof DBPObjectWithOrdinalPosition p1 && e2 instanceof DBPObjectWithOrdinalPosition p2) {
                 int result = p1.compareTo(p2);
                 if (result != 0) {
                     return result;


### PR DESCRIPTION
Closes #41687 

The default comparator's previous behavior states that if both items have an ordinal position, i.e. index exposed via DBDAttributeBinding::getOrdinalPosition(), sort by index and return immediately. 

So comparing e.g. column 1 vs. column 2 always returned 1 - 2 = -1 and stopped there, so the name comparison never actually ran. What is done now instead is that we check to see if no column header is selected first via ViewerColumnController::getColumnInfo, so that sorting only runs when no column header is selected.

Reproduced issue with mock data of the following SQLite schema:

```
CREATE TABLE repro (
    zeta_id     INTEGER PRIMARY KEY,
    alpha_name  TEXT,
    bravo_value INTEGER,
    kappa_flag  INTEGER,
    gamma_desc  TEXT
);

SELECT * FROM repro;
```
