### PR TITLE
dbeaver/pro#10082 Add Copilot review instructions

### DIFF
--- a/.github/copilot-code-review-instructions.md
+++ b/.github/copilot-code-review-instructions.md
@@ -1,0 +1,77 @@
+# Code Review
+
+## Security Review
+
+Review every pull request for security issues in the changed code and its direct
+call paths. Report only actionable findings introduced by the pull request,
+including the affected file and line, attack scenario, and remediation.
+
+Pay particular attention to:
+
+- SQL, shell, file-path, URL, XML, and deserialization inputs that may be
+  controlled by users, database contents, configuration, or remote services.
+- Authentication, authorization, permission checks, and unsafe default access.
+- Secret, token, password, private key, connection string, or personal-data
+  exposure in code, tests, configuration, logs, exceptions, or documentation.
+- Unsafe handling of credentials and database connection settings.
+- Missing validation, encoding, escaping, canonicalization, or resource limits.
+- Insecure temporary files, archive extraction, redirects, TLS configuration,
+  and external-process execution.
+
+Do not report speculative concerns without a realistic attack path. Do not
+request broad refactoring when a focused fix is sufficient.
+
+## Interface Text
+
+Review changed user-visible interface text for punctuation and tone. Apply
+these rules to titles, headings, labels, controls, commands, messages,
+descriptions, and helper text. Do not apply them to technical documentation or
+release notes unless the text is presented in the interface.
+
+### Ellipses
+
+Use the single ellipsis character `…`, not three periods, at the end of a
+command label only when the user must enter information, make a choice, or
+confirm an action before it takes effect. Do not use an ellipsis when opening a
+window or page completes the command, even if the user can make optional
+changes there.
+
+For example, use `Export Data…` and `New Database Connection…`. A command can
+have different labels depending on its flow: use `Delete…` when the user must
+confirm the deletion, and use `Delete` when the deletion takes effect
+immediately. Do not use an ellipsis for `Preferences`, `Properties`, or `View
+Details` because opening those pages completes the command.
+
+### Periods
+
+Do not use periods in titles, headings, labels, controls, commands, or other
+text that names an interface element or action. In messages, descriptions, and
+other explanatory prose, use normal sentence punctuation: end complete
+sentences with a period, including standalone messages, and do not add a
+period to a fragment.
+
+### Colons
+
+Use a colon after a label that introduces an input field or a group of radio
+buttons or checkboxes. Do not use a colon when the label and the text inside
+the field form a single phrase.
+
+### Contractions
+
+Do not use contractions in interface text. Write words in full, such as `The
+connection cannot be established` rather than `The connection can't be
+established`. Contractions are acceptable in longer reading-oriented content,
+such as release notes.
+
+### Question Marks
+
+Use a question mark only in a confirmation alert that asks a direct question.
+Do not use questions in commands, links, labels, helper text, or informational
+messages; rewrite them as commands or statements.
+
+### Exclamation Points
+
+Do not use exclamation points in interface text.
+
+Report only clear violations introduced by the pull request and suggest the
+correct user-visible wording.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -3,7 +3,7 @@ name: code-review
 description: Review pull requests for copy-paste defects and accidentally committed sensitive data. Use this during code review when changed code may have been copied or pasted.
 ---
 
-# Copy-Paste Review
+# Pull Requests Review
 
 Inspect changed code for signs of copied logic, configuration, tests, and
 documentation that were not fully adapted to their new context.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: code-review
+description: Review pull requests for copy-paste defects and accidentally committed sensitive data. Use this during code review when changed code may have been copied or pasted.
+---
+
+# Copy-Paste Review
+
+Inspect changed code for signs of copied logic, configuration, tests, and
+documentation that were not fully adapted to their new context.
+
+Report a finding only when the copy-paste error can cause incorrect behavior,
+security exposure, maintenance risk, or misleading documentation. Check for:
+
+- Stale class, method, variable, plugin, driver, product, or configuration names.
+- Logic copied from a related implementation but using the wrong API,
+  permission, validation, error handling, resource lifecycle, or UI context.
+- New database support copied from an existing database plugin instead of
+  extending an applicable generic implementation or base database class. Check
+  whether the existing JDBC, SQL dialect, metadata, or other shared framework
+  already supports the behavior before duplicating it in a database-specific
+  plugin.
+- Tests that exercise the original behavior instead of the changed code.
+- Duplicated constants, identifiers, URLs, or messages that should differ in
+  the new context.
+- Pasted secrets, credentials, API keys, tokens, private keys, connection
+  strings, personal data, internal URLs, or other sensitive values in source,
+  tests, fixtures, configuration, logs, exceptions, and documentation.
+
+For each finding, identify the affected file and line, explain why the pasted
+content is incorrect or sensitive in this context, and recommend a focused
+fix. Do not report intentional duplication that is already correct and
+maintained independently.


### PR DESCRIPTION
## Summary
- add security-focused instructions for Copilot code review
- add a review skill to find copy-paste defects and exposed sensitive data

## Why
Helps Copilot identify actionable security and copy-paste risks during pull request reviews.

Closes dbeaver/pro#10082