### PR TITLE
dbeaver/pro#10310 Determine order of AI engines

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.model.ai/plugin.xml
@@ -14,6 +14,7 @@
             icon="icons/engine_openai.svg"
             class="org.jkiss.dbeaver.model.ai.engine.openai.OpenAIEngine"
             properties="org.jkiss.dbeaver.model.ai.engine.openai.OpenAIProperties"
+            promoted="true"
             default="true"
             supportsFunctions="true"
             fallbacks="openai-pro"/>
@@ -22,6 +23,7 @@
             icon="icons/engine_copilot.svg"
             class="org.jkiss.dbeaver.model.ai.engine.copilot.CopilotCompletionEngine"
             properties="org.jkiss.dbeaver.model.ai.engine.copilot.CopilotProperties"
+            promoted="true"
             supportsFunctions="false"
             fallbacks="copilot-pro"/>
     </extension>

--- a/plugins/org.jkiss.dbeaver.model.ai/schema/com.dbeaver.ai.engine.exsd
+++ b/plugins/org.jkiss.dbeaver.model.ai/schema/com.dbeaver.ai.engine.exsd
@@ -35,6 +35,13 @@
                </appInfo>
             </annotation>
          </attribute>
+         <attribute name="promoted" type="boolean">
+             <annotation>
+                <documentation>
+                   Whether the engine should be shown before regular engines in selection controls.
+                </documentation>
+             </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/registry/AIEngineDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/registry/AIEngineDescriptor.java
@@ -37,6 +37,7 @@ public class AIEngineDescriptor extends AbstractDescriptor {
     private final DBPImage icon;
     private final ObjectType objectType;
     private final ObjectType propertiesType;
+    private final boolean promoted;
     private final boolean supportsFunctions;
     private final boolean providesMetadata;
 
@@ -46,6 +47,7 @@ public class AIEngineDescriptor extends AbstractDescriptor {
         this.id = contributorConfig.getAttribute("id");
         this.icon = iconToImage(contributorConfig.getAttribute(RegistryConstants.ATTR_ICON));
         this.objectType = new ObjectType(contributorConfig, RegistryConstants.ATTR_CLASS);
+        this.promoted = CommonUtils.toBoolean(contributorConfig.getAttribute("promoted"));
         this.supportsFunctions = CommonUtils.toBoolean(contributorConfig.getAttribute("supportsFunctions"));
         this.propertiesType = new ObjectType(contributorConfig, "properties");
         this.providesMetadata = CommonUtils.toBoolean(contributorConfig.getAttribute("providesMetadata"), true);
@@ -78,6 +80,10 @@ public class AIEngineDescriptor extends AbstractDescriptor {
 
     public boolean isDefault() {
         return CommonUtils.toBoolean(contributorConfig.getAttribute("default"));
+    }
+
+    public boolean isPromoted() {
+        return promoted;
     }
 
     /**

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/registry/AIEngineRegistry.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/registry/AIEngineRegistry.java
@@ -25,6 +25,7 @@ import org.jkiss.dbeaver.Log;
 import org.jkiss.utils.CommonUtils;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +82,9 @@ public class AIEngineRegistry {
             }
             list.add(entry.getValue());
         }
+        list.sort(Comparator
+            .comparing(AIEngineDescriptor::isPromoted).reversed()
+            .thenComparing(AIEngineDescriptor::getLabel, String.CASE_INSENSITIVE_ORDER));
         return list;
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/chat/controls/ContextComposite.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/chat/controls/ContextComposite.java
@@ -59,6 +59,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -466,9 +467,10 @@ public class ContextComposite extends Composite {
 
         manager.add(new Separator());
         manager.add(new EmptyAction("Active configuration"));
-        for (AIConfigurationProfile profile : AISettingsManager.getInstance().getSettings().getConfigurations()) {
-            manager.add(new ChangeProfileAction(profile));
-        }
+        List.of(AISettingsManager.getInstance().getSettings().getConfigurations()).stream()
+            .sorted(Comparator.comparing(AIConfigurationProfile::getProfileName, String.CASE_INSENSITIVE_ORDER))
+            .map(ChangeProfileAction::new)
+            .forEach(manager::add);
 
         if (RuntimeUtils.isWindows()) {
             // Highlight selected item

--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIProfileCreateDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/preferences/AIProfileCreateDialog.java
@@ -52,10 +52,18 @@ public class AIProfileCreateDialog extends BaseDialog {
 
         Combo engineCombo = UIUtils.createLabelCombo(enginePanel, "Engine", SWT.DROP_DOWN | SWT.READ_ONLY);
         aiEngines = AIEngineRegistry.getInstance().getCompletionEngines();
+        boolean hasPromotedEngines = false;
         for (AIEngineDescriptor ed : aiEngines) {
+            if (hasPromotedEngines && !ed.isPromoted()) {
+                engineCombo.add("----------------");
+                hasPromotedEngines = false;
+            }
             engineCombo.add(ed.getLabel());
+            engineCombo.setData(Integer.toString(engineCombo.getItemCount() - 1), ed);
+            hasPromotedEngines = ed.isPromoted();
         }
         engineCombo.select(0);
+        int[] selectedIndex = {0};
         selectedEngine = aiEngines.getFirst();
         profileId = genProfileId(selectedEngine);
         profileName = selectedEngine.getLabel();
@@ -66,8 +74,15 @@ public class AIProfileCreateDialog extends BaseDialog {
         nameText.addModifyListener(e ->  profileName = nameText.getText());
 
         engineCombo.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+            int selectionIndex = engineCombo.getSelectionIndex();
+            Object selection = engineCombo.getData(Integer.toString(selectionIndex));
+            if (!(selection instanceof AIEngineDescriptor engine)) {
+                engineCombo.select(selectedIndex[0]);
+                return;
+            }
             String oldAutoId = genProfileId(selectedEngine);
-            selectedEngine = aiEngines.get(engineCombo.getSelectionIndex());
+            selectedIndex[0] = selectionIndex;
+            selectedEngine = engine;
             if (oldAutoId.equals(profileId)) {
                 profileId = genProfileId(selectedEngine);
                 profileName = genProfileName(selectedEngine.getLabel());


### PR DESCRIPTION
Closes dbeaver/pro#10310

## Summary
- add optional promoted metadata for AI engine extensions
- show promoted and regular engines in alphabetical groups with a divider
- sort configured profiles alphabetically in the AI chat menu

## Testing
- `mvn package -f product/aggregate/pom.xml -T 1C -Pproduct-dbeaver-ce -DskipTests`

This PR was generated with AI (OpenCode).