### PR TITLE
#41787 Fix connection type color not refreshing on repeated changes

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConnectionTypes.java
+++ b/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConnectionTypes.java
@@ -573,12 +573,13 @@ public class PrefPageConnectionTypes extends AbstractPrefPage implements IWorkbe
             }
         }
 
-        Set<DBPDataSourceRegistry> affectedDataSourceRegs = new HashSet<>();
+        java.util.List<DBPDataSourceContainer> affectedDataSources = new ArrayList<>();
         if (!changedSet.isEmpty()) {
             registry.saveConnectionTypes();
             // Flush projects configs (as they cache connection type information)
             for (DBPProject project : DBWorkbench.getPlatform().getWorkspace().getProjects()) {
                 DBPDataSourceRegistry projectRegistry = project.getDataSourceRegistry();
+                boolean projectAffected = false;
                 for (DBPDataSourceContainer ds : projectRegistry.getDataSources()) {
                     DBPConnectionConfiguration cnnCfg = ds.getConnectionConfiguration();
                     DBPConnectionType cnnType = cnnCfg.getConnectionType();
@@ -586,15 +587,17 @@ public class PrefPageConnectionTypes extends AbstractPrefPage implements IWorkbe
                         if (toRemove.contains(cnnType)) {
                             cnnCfg.setConnectionType(DBPConnectionType.DEFAULT_TYPE);
                         }
-                        projectRegistry.flushConfig();
-                        affectedDataSourceRegs.add(projectRegistry);
-                        break;
+                        affectedDataSources.add(ds);
+                        projectAffected = true;
                     }
+                }
+                if (projectAffected) {
+                    projectRegistry.flushConfig();
                 }
             }
         }
-        for (DBPDataSourceRegistry dsReg : affectedDataSourceRegs) {
-            dsReg.notifyDataSourceListeners(new DBPEvent(DBPEvent.Action.OBJECT_UPDATE, null, dsReg));
+        for (DBPDataSourceContainer ds : affectedDataSources) {
+            ds.getRegistry().notifyDataSourceListeners(new DBPEvent(DBPEvent.Action.OBJECT_UPDATE, ds, ds.getRegistry()));
         }
         return super.performOk();
     }


### PR DESCRIPTION
## Summary
Fixes the navigator tree not updating a connection's color when the connection type's color is changed more than once in the same session (without restarting DBeaver). The first color change applies correctly; subsequent changes don't refresh the tree until the app is restarted.

## Root cause
[PrefPageConnectionTypes.performOk()](https://github.com/dbeaver/dbeaver/blob/devel/plugins/org.jkiss.dbeaver.core/src/org/jkiss/dbeaver/ui/preferences/PrefPageConnectionTypes.java#L597) fired a single `OBJECT_UPDATE` event for each affected registry, but set the event's object to null:
```java
dsReg.notifyDataSourceListeners(
    new DBPEvent(DBPEvent.Action.OBJECT_UPDATE, null, dsReg)
);
```

[DBNProjectDatabases.handleDataSourceEvent()](https://github.com/dbeaver/dbeaver/blob/devel/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/navigator/DBNProjectDatabases.java#L438) uses `event.getObject()` to resolve the navigator node that should be refreshed:
```java
model.getNodeByObject(event.getObject())
```
Because event.getObject() was null, getNodeByObject() returned null, so DBNProjectDatabases could not identify the corresponding navigator node and the tree was never refreshed.

## Fix

Collect the `DBPDataSourceContainers` actually affected by the connection type change, then fire one `OBJECT_UPDATE` event per affected data source, using the data source as the event object instead of null:

```java
ds.getRegistry().notifyDataSourceListeners(
    new DBPEvent(DBPEvent.Action.OBJECT_UPDATE, ds, ds.getRegistry())
);
```

This allows `DBNProjectDatabases.handleDataSourceEvent()` to resolve the affected navigator node via `event.getObject()` and refresh it correctly.

The registry is still passed as `event.getData()` for backward compatibility with listeners that check `event.getData() == registry` instead of the event object

## Testing

Manually verified in a running DBeaver instance: changing a connection type's color now updates the navigator tree correctly on every change, not just the first.

## Screenshot / Video
Before

https://github.com/user-attachments/assets/91c6da71-158a-4758-93e7-2d0312eed225



After

https://github.com/user-attachments/assets/f32448d5-c4d8-4ec6-b01b-bd768156d0bc



Closes dbeaver/dbeaver#41787

---
This PR was generated with AI (Claude Code) and reviewed by the contributor.