### PR TITLE
dbeaver/dbeaver#41842 Fix HTML preview vulnerabilities

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/stream/HtmlEditorPart.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/stream/HtmlEditorPart.java
@@ -84,7 +84,7 @@ public class HtmlEditorPart extends EditorPart implements IRefreshablePart {
         long configuredLimit = Math.max(store.getInt(ResultSetPreferences.RS_EDIT_MAX_TEXT_SIZE), 0) * 1000L;
         int maxContentLength = (int) Math.min(configuredLimit, Integer.MAX_VALUE);
         try (Reader reader = new InputStreamReader(storage.getContents(), input.getEncoding())) {
-            browser.setText(HtmlPanelEditor.readContent(reader, maxContentLength));
+            browser.setText(HtmlPanelEditor.prepareContent(HtmlPanelEditor.readContent(reader, maxContentLength)));
         } catch (CoreException | IOException e) {
             log.error("Error reading HTML content", e); //$NON-NLS-1$
             browser.setText(""); //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/stream/HtmlPanelEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/stream/HtmlPanelEditor.java
@@ -51,6 +51,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class HtmlPanelEditor implements IStreamValueEditor<Composite> {
 
     private static final Log log = Log.getLog(HtmlPanelEditor.class);
+    private static final String CONTENT_SECURITY_POLICY =
+        "default-src 'none'; base-uri 'none'; form-action 'none'; style-src 'unsafe-inline'; img-src data:; font-src data:";
 
     private final IValueController valueController;
     private final AtomicLong updateSequence = new AtomicLong();
@@ -143,10 +145,19 @@ public class HtmlPanelEditor implements IStreamValueEditor<Composite> {
         return content.toString();
     }
 
+    @NotNull
+    static String prepareContent(@NotNull String html) {
+        if (html.isEmpty()) {
+            return html;
+        }
+        return "<!DOCTYPE html><html><head><meta http-equiv=\"Content-Security-Policy\" content=\""
+            + CONTENT_SECURITY_POLICY + "\">" + html + "</head><body></body></html>";
+    }
+
     private void updateBrowser(long updateId, @NotNull String html) {
         UIUtils.syncExec(() -> {
             if (updateId == updateSequence.get() && browser != null && !browser.isDisposed()) {
-                browser.setText(html);
+                browser.setText(prepareContent(html));
             }
         });
     }


### PR DESCRIPTION
Closes dbeaver/dbeaver#41842

## Summary

HTML preview already disables JavaScript, popups, and top-level navigation, but HTML subresources can still perform network or file requests. An HTML value containing `<img>`, CSS `url()`, `@import`, `@font-face`, an iframe, or a form can therefore disclose that the value was viewed and potentially access services reachable from the DBeaver host.

This change adds a restrictive Content Security Policy before untrusted HTML is passed to SWT Browser in both preview paths:

- deny all resources by default
- deny base URL changes and form submissions
- preserve inline CSS used by HTML templates
- allow only `data:` images and fonts
- apply the same preparation in the result-set panel and standalone content editor

## Compatibility

The CSP is inserted while the generated document head remains open. This is intentional: HTML fragments are still parsed into the generated body, while complete documents retain their own `<html>`, `<head>`, and `<body>` semantics instead of becoming a nested document.

The following existing behavior was verified in SWT Browser:

- HTML fragments render normally
- complete documents retain doctype parsing, `<title>`, `<style>`, and content
- attributes on `<html>` and `<body>` are retained
- inline styles continue to work
- `data:` images continue to render
- an existing, stricter CSP remains active and combines with the preview policy
- empty content remains empty

## Testing

Built the affected plugin:

```bash
mvn -pl plugins/org.jkiss.dbeaver.ui.editors.data -DskipTests package
```

Result: `BUILD SUCCESS`.

An SWT Browser/WebKit test loaded six HTML values from a local PostgreSQL table:

| Case | Expected result |
| --- | --- |
| Fragment with inline styles | Formatting is preserved |
| Full `doctype/html/head/body` document | Title, styles, attributes, and body are preserved |
| Full document with `style-src none` CSP | Existing CSP remains active |
| External image, CSS import/background, iframe, and form | External resources are blocked |
| `data:` SVG image | Image renders |
| Closing wrapper tags plus malicious `<base>` and relative image | CSP cannot be bypassed |

The test used a local HTTP server on `127.0.0.1:18080` as a request counter. Result:

```text
6/6 passed
HTTP_REQUESTS=0
FAILURES=0
```

## Manual QA

1. Start an HTTP server with request logging on `127.0.0.1:18080`.
2. Store HTML containing external image, CSS, iframe, font, and form URLs pointing to that server.
3. Open the value in both the result-set HTML panel and the standalone HTML content editor.
4. Verify that the HTTP server receives no requests.
5. Verify that inline formatting and `data:` images still render.
6. Verify a complete HTML document with `<title>`, head styles, body attributes, and its own restrictive CSP.

Automated browser verification was performed on macOS WebKit. Windows WebView2 and Linux WebKitGTK should run the same manual QA matrix.