### PR TITLE
dbeaver/pro#10311 Fix SQL editor toolbar background

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -780,10 +780,10 @@ public class SQLEditor extends SQLEditorBase implements
         // Redraw toolbar to refresh action sets
         this.updateMultipleResultsPerTabToolItem();
         if (topBarMan != null && topBarMan.getControl() instanceof ToolBar topBar) {
-            CSSUtils.refreshConnectionTypeToolbar(topBar);
+            //CSSUtils.refreshConnectionTypeToolbar(topBar);
         }
         if (bottomBarMan != null && bottomBarMan.getControl() instanceof ToolBar bottomBar) {
-            CSSUtils.refreshConnectionTypeToolbar(bottomBar);
+            //CSSUtils.refreshConnectionTypeToolbar(bottomBar);
         }
         MultipleResultsPerTabMenuContribution.syncWithEditor(this);
     }
@@ -1255,13 +1255,7 @@ public class SQLEditor extends SQLEditorBase implements
     }
 
     private void createControlsBar(Composite sqlEditorPanel) {
-        Composite leftToolPanel = new Composite(sqlEditorPanel, SWT.LEFT) {
-            // hack to prevent eclipse from overriding this Composite's class
-            @Override
-            public void setBackground(Color color) {
-                super.setBackground(color);
-            }
-        };
+        Composite leftToolPanel = new Composite(sqlEditorPanel, SWT.NONE);
         GridLayout panelsLayout = new GridLayout(1, true);
         panelsLayout.marginHeight = 2;
         panelsLayout.marginWidth = 1;
@@ -3390,11 +3384,6 @@ public class SQLEditor extends SQLEditorBase implements
         if (resultTabs != null) {
             DatabaseEditorUtils.setPartBackground(this, resultTabs);
         }
-
-        // Re-apply CSS so connection-type colored widgets (side toolbars, sash, etc.)
-        // refresh immediately instead of waiting for the next CSS engine pass
-        CSSUtils.applyStyles(resultsSash);
-        CSSUtils.refreshConnectionTypeControls(resultsSash);
 
         // Repaint the workbench editor tab folder so the custom tab renderer
         // picks up the new connection color immediately after a connection change

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/css/CSSUtils.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/css/CSSUtils.java
@@ -100,41 +100,6 @@ public class CSSUtils {
         }
     }
 
-    public static void refreshConnectionTypeControls(@NotNull Control root) {
-        if (root.isDisposed()) {
-            return;
-        }
-        if (root instanceof ToolBar toolBar) {
-            refreshConnectionTypeToolbar(toolBar);
-            return;
-        }
-        if (isDatabaseColored(root) && root instanceof Composite composite) {
-            Color bgColor = getCurrentEditorConnectionColor(root);
-            Color effectiveBg = bgColor != null ? bgColor : UIStyles.getDefaultWidgetBackground();
-            composite.setBackground(effectiveBg);
-            composite.redraw();
-        }
-        if (root instanceof Composite parent) {
-            for (Control child : parent.getChildren()) {
-                refreshConnectionTypeControls(child);
-            }
-        }
-    }
-
-    public static void refreshConnectionTypeToolbar(@NotNull ToolBar toolBar) {
-        if (toolBar.isDisposed()) {
-            return;
-        }
-        Color bgColor = getCurrentEditorConnectionColor(toolBar);
-        if (bgColor == null && !isDatabaseColored(toolBar)) {
-            return;
-        }
-        markConnectionTypeColor(toolBar);
-        Color effectiveBg = bgColor != null ? bgColor : UIStyles.getDefaultWidgetBackground();
-        toolBar.setBackground(effectiveBg);
-        toolBar.redraw();
-    }
-
     public static void setWidgetDefaultBackGround(@NotNull Control widget) {
         Color bg = CSSUtils.getCurrentEditorConnectionColor(widget);
         if (bg == null && !(widget instanceof Composite)) {


### PR DESCRIPTION
Closes dbeaver/pro#10311

## Summary
- stop forcing connection-type toolbar backgrounds during SQL editor activation
- remove the explicit connection-type control refresh that overrides dark-theme CSS
- use a regular composite for the SQL editor side toolbar

## For QA:
- Check that https://github.com/dbeaver/dbeaver/issues/40744 and https://github.com/dbeaver/dbeaver/issues/41616  are not reproducible, including when changing the connection type's color without changing the connection association.

This PR was generated with AI assistance.