### PR TITLE
#39606 Fix empty request body against plaintext OpenAI-compatible end…

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/AbstractHttpAIClient.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/AbstractHttpAIClient.java
@@ -36,7 +36,9 @@ public abstract class AbstractHttpAIClient implements AutoCloseable {
 
     public AbstractHttpAIClient() {
         this.client = new MonitoredHttpClient(
-            HttpClient.newHttpClient(),
+            // Force HTTP/1.1: over plaintext http:// the default HTTP_2 client attempts an h2c upgrade,
+            // and OpenAI-compatible servers like uvicorn/httptools then drop the request body
+            HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build(),
             this::mapHttpError,
             this::processErrors
         );

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIRequestFilter.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIRequestFilter.java
@@ -32,9 +32,11 @@ public class OpenAIRequestFilter implements OpenAiClientBase.HttpRequestFilter {
     @Override
     public HttpRequest filter(@NotNull HttpRequest request, boolean setContentType) {
         HttpRequest.Builder builder = HttpRequest.newBuilder(request.uri())
-            .uri(request.uri())
             .method(request.method(), request.bodyPublisher().orElse(HttpRequest.BodyPublishers.noBody()))
             .headers(HttpConstants.HEADER_AUTHORIZATION, "Bearer " + token);
+        // Keep the settings configured on the original request
+        request.timeout().ifPresent(builder::timeout);
+        request.version().ifPresent(builder::version);
         for (var headerEntry : request.headers().map().entrySet()) {
             for (String value : headerEntry.getValue()) {
                 builder.header(headerEntry.getKey(), value);

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIRequestFilterTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAIRequestFilterTest.java
@@ -1,0 +1,92 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.engine.openai;
+
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
+public class OpenAIRequestFilterTest extends DBeaverUnitTest {
+
+    private static final URI ENDPOINT = URI.create("http://localhost:8000/v1/responses");
+
+    @Test
+    public void filterShouldKeepRequestTimeout() {
+        //given
+        var timeout = Duration.ofSeconds(42);
+        var request = newRequestBuilder().timeout(timeout).build();
+        //when
+        var result = new OpenAIRequestFilter("token").filter(request, false);
+        //then
+        Assertions.assertEquals(timeout, result.timeout().orElseThrow());
+    }
+
+    @Test
+    public void filterShouldKeepRequestVersion() {
+        //given
+        var request = newRequestBuilder().version(HttpClient.Version.HTTP_1_1).build();
+        //when
+        var result = new OpenAIRequestFilter("token").filter(request, false);
+        //then
+        Assertions.assertEquals(HttpClient.Version.HTTP_1_1, result.version().orElseThrow());
+    }
+
+    @Test
+    public void filterShouldKeepUriMethodAndBody() {
+        //given
+        var body = "{\"model\":\"test\"}";
+        var request = newRequestBuilder().POST(HttpRequest.BodyPublishers.ofString(body)).build();
+        //when
+        var result = new OpenAIRequestFilter("token").filter(request, false);
+        //then
+        Assertions.assertEquals(ENDPOINT, result.uri());
+        Assertions.assertEquals("POST", result.method());
+        Assertions.assertEquals(body.length(), result.bodyPublisher().orElseThrow().contentLength());
+    }
+
+    @Test
+    public void filterShouldAddAuthorizationHeader() {
+        //given
+        var request = newRequestBuilder().build();
+        //when
+        var result = new OpenAIRequestFilter("secret").filter(request, false);
+        //then
+        Assertions.assertEquals("Bearer secret", result.headers().firstValue("Authorization").orElseThrow());
+    }
+
+    @Test
+    public void filterShouldSetContentTypeOnlyWhenRequested() {
+        //given
+        var request = newRequestBuilder().build();
+        var filter = new OpenAIRequestFilter("token");
+        //when
+        var withContentType = filter.filter(request, true);
+        var withoutContentType = filter.filter(request, false);
+        //then
+        Assertions.assertEquals("application/json", withContentType.headers().firstValue("Content-Type").orElseThrow());
+        Assertions.assertTrue(withoutContentType.headers().firstValue("Content-Type").isEmpty());
+    }
+
+    private static HttpRequest.Builder newRequestBuilder() {
+        return HttpRequest.newBuilder(ENDPOINT).POST(HttpRequest.BodyPublishers.noBody());
+    }
+}


### PR DESCRIPTION
### Description

AI requests sent to a self-hosted OpenAI-compatible endpoint over plaintext `http://` (vLLM, Ollama, LM Studio, ...) arrive at the server with an empty body. Depending on the server, the request is rejected or the UI hangs - "Test Connection" and model listing never return. HTTPS endpoints are unaffected.

vLLM/FastAPI answers `POST /v1/responses` with:

```
1 validation error:
{'type': 'missing', 'loc': ('body',), 'msg': 'Field required', 'input': None}
```

### Root cause

`AbstractHttpAIClient` built its client with `HttpClient.newHttpClient()`, which defaults to `HTTP_2`. Without TLS there is no ALPN, so the JDK attempts an h2c upgrade and adds `Connection: Upgrade, HTTP2-Settings` and `Upgrade: h2c` to the request. Servers such as uvicorn with the httptools parser treat that as an unsupported upgrade and stop parsing the request, handing the application an empty body. HTTPS endpoints negotiate via ALPN and never send those headers, which is why only plaintext self-hosted endpoints are affected.

### Fix

Pin the shared AI HTTP client to HTTP/1.1. None of the AI APIs called here benefit from HTTP/2 over an unencrypted local connection, and this covers every engine built on `AbstractHttpAIClient`.

`OpenAIRequestFilter` additionally rebuilt each request from scratch and silently dropped the caller's timeout and version, so the configured request timeout never reached OpenAI requests. Both are now carried over.

### Testing

Built DBeaver CE from this branch (win32/x86_64 product) and verified manually against a plaintext `http://` vLLM endpoint: before the change the server received `POST /v1/responses` with no body and answered `Field required`; after it, the body arrives and the request completes. Other OpenAI-compatible servers and HTTPS endpoints were not re-tested.

Adds `OpenAIRequestFilterTest` to `test/org.jkiss.dbeaver.model.ai.test`, covering the timeout and version that the filter used to drop, plus the authorization and content-type headers.

### Related

Very likely the same root cause as #39606 (LM Studio / vLLM over plaintext, closed as stale). That thread diagnosed HTTP/2 as the trigger and concluded it had to be worked around with a reverse proxy - this fixes it on the DBeaver side.

Closes dbeaver/dbeaver#39606

---

*This PR was generated with AI (Claude Code). The change has been reviewed and tested by a human contributor.*