### PR TITLE
dbeaver/pro#10368 Easy config hangs

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/app/config/ProductConfigCreateSampleDatabaseAction.java
+++ b/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/app/config/ProductConfigCreateSampleDatabaseAction.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.ui.app.config;
 
 import org.jkiss.dbeaver.runtime.DBWorkbench;
+import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.app.config.registry.ProductConfigAction;
 import org.jkiss.dbeaver.ui.config.sample.SampleDatabaseUtil;
 
@@ -35,7 +36,9 @@ public final class ProductConfigCreateSampleDatabaseAction implements ProductCon
         if (project == null) {
             return;
         }
-        SampleDatabaseUtil.createSampleDatabase(project.getDataSourceRegistry());
+        UIUtils.asyncExec(() -> {
+            SampleDatabaseUtil.createSampleDatabase(project.getDataSourceRegistry());
+        });
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/app/config/ProductConfigCreateSampleDatabaseAction.java
+++ b/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/app/config/ProductConfigCreateSampleDatabaseAction.java
@@ -45,6 +45,6 @@ public final class ProductConfigCreateSampleDatabaseAction implements ProductCon
             return false;
         }
         // Don't show the option to create a sample database if it already exists in the workspace
-        return !SampleDatabaseUtil.isSampleDatabaseExists(project.getDataSourceRegistry());
+        return !SampleDatabaseUtil.isSampleDatabaseExists(project);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/config/sample/SampleDatabaseHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/config/sample/SampleDatabaseHandler.java
@@ -35,7 +35,7 @@ public class SampleDatabaseHandler extends AbstractHandler {
         }
         DBPDataSourceRegistry registry = activeProject.getDataSourceRegistry();
         Shell shell = UIUtils.getActiveWorkbenchShell();
-        if (SampleDatabaseUtil.isSampleDatabaseExists(registry)) {
+        if (SampleDatabaseUtil.isSampleDatabaseExists(activeProject)) {
             UIUtils.showMessageBox(shell, SampleDatabaseMessages.dialog_already_created_title, SampleDatabaseMessages.dialog_already_created_description, SWT.ICON_WARNING);
             return null;
         }

--- a/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/config/sample/SampleDatabaseUtil.java
+++ b/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/config/sample/SampleDatabaseUtil.java
@@ -21,6 +21,7 @@ import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.app.DBPDataSourceRegistry;
+import org.jkiss.dbeaver.model.app.DBPProject;
 import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
 import org.jkiss.dbeaver.model.connection.DBPConnectionType;
 import org.jkiss.dbeaver.model.connection.DBPDataSourceProviderDescriptor;
@@ -31,6 +32,7 @@ import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.utils.IOUtils;
 
 import java.io.*;
+import java.nio.file.Files;
 
 public final class SampleDatabaseUtil {
     private static final Log log = Log.getLog(SampleDatabaseUtil.class);
@@ -43,8 +45,14 @@ public final class SampleDatabaseUtil {
     private SampleDatabaseUtil() {
     }
 
-    public static boolean isSampleDatabaseExists(@NotNull DBPDataSourceRegistry registry) {
-        return registry.getDataSource(SAMPLE_DB1_ID) != null;
+    public static boolean isSampleDatabaseExists(@NotNull DBPProject project) {
+        try {
+            String configuration = Files.readString(
+                project.getMetadataFolder(false).resolve(DBPDataSourceRegistry.MODERN_CONFIG_FILE_NAME));
+            return configuration.contains(SAMPLE_DB1_ID);
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     public static void createSampleDatabase(@NotNull DBPDataSourceRegistry registry) {

--- a/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/config/sample/WorkbenchInitializerCreateSampleDatabase.java
+++ b/plugins/org.jkiss.dbeaver.ui.config.sample/src/org/jkiss/dbeaver/ui/config/sample/WorkbenchInitializerCreateSampleDatabase.java
@@ -56,7 +56,7 @@ public class WorkbenchInitializerCreateSampleDatabase implements IWorkbenchWindo
             return;
         }
         DBPDataSourceRegistry registry = activeProject.getDataSourceRegistry();
-        if (SampleDatabaseUtil.isSampleDatabaseExists(registry)) {
+        if (SampleDatabaseUtil.isSampleDatabaseExists(activeProject)) {
             // Already exist
             return;
         }
@@ -76,4 +76,3 @@ public class WorkbenchInitializerCreateSampleDatabase implements IWorkbenchWindo
     }
 
 }
-


### PR DESCRIPTION
Closes dbeaver/pro#10368

## Summary
- check the sample database presence directly in the project datasource configuration
- avoid loading the datasource registry from Easy Config applicability checks

## Testing
- `mvn -pl plugins/org.jkiss.dbeaver.ui.config.sample -am compile -DskipTests`