### PR TITLE
dbeaver/pro#10369 fix NPE in LogOutputStream

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/LogOutputStream.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/LogOutputStream.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
 
 import java.io.File;
@@ -47,6 +48,7 @@ public class LogOutputStream extends OutputStream {
     /**
      * The Writer to log messages to.
      */
+    @Nullable
     private volatile FileOutputStream currentLogFileOutput = null;
     private volatile long currentLogSize;
 
@@ -130,18 +132,21 @@ public class LogOutputStream extends OutputStream {
         }
     }
 
+    @NotNull
     private synchronized OutputStream getLogFileWriter() throws IOException {
-        if (this.currentLogFileOutput == null || this.rotateCurrentLogFile(false)) {
+        if (this.currentLogFileOutput != null) {
+            this.rotateCurrentLogFile(false);
+        }
+        if (this.currentLogFileOutput == null) {
             this.currentLogFileOutput = new FileOutputStream(this.currentLogFile, true);
         }
         return this.currentLogFileOutput;
     }
 
     /**
-     * Checks the log file size. If the log file size reaches the limit then the log is rotated
-     * @return false if the file doesn't exist or the log files doesn't need to be rotated
+     * Checks the log file size. If the log file size reaches the limit then the log is rotated.
      */
-    private boolean rotateCurrentLogFile(boolean force) throws IOException {
+    private void rotateCurrentLogFile(boolean force) throws IOException {
         if ((this.currentLogFileOutput != null || this.currentLogFile.exists()) // if we are initializing log file for new launch
             && (this.currentLogSize > this.maxLogSize || force)
         ) {
@@ -149,23 +154,18 @@ public class LogOutputStream extends OutputStream {
             
             File newFile = new File(this.logFileLocation, this.logFileName + "-" + System.currentTimeMillis() + this.logFileNameExtension);
             if (!this.currentLogFile.renameTo(newFile)) {
-                return false;
+                return;
             }
             this.currentLogSize = 0;
             
             File[] logFiles = this.logFileLocation.listFiles((File dir, String name) -> this.logFileNamePattern.test(name));
             if (logFiles == null) {
-                return false;
+                return;
             }
             Arrays.sort(logFiles, Comparator.comparing(File::getName));
             for (int i = 0, count = logFiles.length; i < logFiles.length && count > maxLogFiles; i++, count--) {
                 logFiles[i].delete();
             }
-            
-            return true;
-        } else {
-            return false;
         }
     }
-    
 }

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/LogOutputStreamTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/LogOutputStreamTest.java
@@ -1,0 +1,75 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serial;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LogOutputStreamTest extends DBeaverUnitTest {
+
+    @Test
+    public void testWriteAfterFailedRotation() throws IOException {
+        Path tempDirectory = Files.createTempDirectory("dbeaver-log-output");
+        Path logPath = tempDirectory.resolve("dbeaver.log");
+        DBPPreferenceStore preferenceStore = ModelPreferences.getPreferences();
+        long originalMaxLogSize = preferenceStore.getLong(LogOutputStream.LOGS_MAX_FILE_SIZE);
+
+        try {
+            NonRenamableFile logFile = new NonRenamableFile(logPath);
+            try (LogOutputStream output = new LogOutputStream(logFile)) {
+                output.write(new byte[]{1, 2});
+                preferenceStore.setValue(LogOutputStream.LOGS_MAX_FILE_SIZE, 1L);
+                output.write(new byte[]{3});
+            }
+
+            assertEquals(1, logFile.renameAttempts);
+            assertArrayEquals(new byte[]{1, 2, 3}, Files.readAllBytes(logPath));
+        } finally {
+            preferenceStore.setValue(LogOutputStream.LOGS_MAX_FILE_SIZE, originalMaxLogSize);
+            Files.deleteIfExists(logPath);
+            Files.deleteIfExists(tempDirectory);
+        }
+    }
+
+    private static final class NonRenamableFile extends File {
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private int renameAttempts;
+
+        private NonRenamableFile(@NotNull Path path) {
+            super(path.toString());
+        }
+
+        @Override
+        public boolean renameTo(@NotNull File destination) {
+            renameAttempts++;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Resolves dbeaver/pro#10369.

## What Was Wrong

The original writer initialization combined a null check and rotation into one short-circuit expression:

```java
if (currentLogFileOutput == null || rotateCurrentLogFile(false)) {
    currentLogFileOutput = new FileOutputStream(currentLogFile, true);
}
return currentLogFileOutput;
```

The failure sequence was:

1. `currentLogFileOutput` was non-null, so the first condition evaluated to `false`.
2. The log exceeded its size limit, so rotation began.
3. Rotation called `close()`, which closed the stream and set `currentLogFileOutput` to null.
4. Renaming the current log failed, causing `rotateCurrentLogFile()` to return `false`.
5. The complete condition became `false || false`, so a new stream was not opened.
6. `getLogFileWriter()` returned null, and the subsequent `.write(...)` caused the reported NPE.

The same problem could happen if the rename succeeded but listing old log files failed.

Despite appearing race-related, this was not an ordinary thread race. `write()`, `close()`, and writer acquisition are synchronized, preventing another thread from closing the stream between acquisition and writing. The bug was state mutation hidden inside the boolean expression.

Scheduler executions make rename failure more likely because separate DBeaver processes may contend for the same log file. File locking, permissions, antivirus software, or other filesystem conditions can also cause `File.renameTo()` to return `false`.

**How The Fix Works**

The rotation and writer initialization are now separate:

```java
if (currentLogFileOutput != null) {
    rotateCurrentLogFile(false);
}
if (currentLogFileOutput == null) {
    currentLogFileOutput = new FileOutputStream(currentLogFile, true);
}
return currentLogFileOutput;
```

The second check observes the writer’s state after rotation:

- If no rotation is needed, the existing writer remains open and is reused.
- If rotation succeeds, the closed writer is replaced with one for the new active log.
- If renaming fails, the original log is reopened in append mode.
- If reopening fails, an appropriate `IOException` is propagated instead of an unrelated NPE.

The regression test forces `renameTo()` to fail, exceeds the log-size threshold, and verifies that the next write succeeds and all bytes remain in the active log.