### PR TITLE
#41844 Fix disconnects triggering save prompts on dirty SQL scripts

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPDataSourceTask.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPDataSourceTask.java
@@ -23,4 +23,15 @@ package org.jkiss.dbeaver.model;
 public interface DBPDataSourceTask
 {
     boolean isActiveTask();
+
+    /**
+     * Per default, the current behavior is that saveable DBPDataSourceTasks are included when disconnecting users of
+     * data sources. Certain cases (see #41844) where application users can set the application to not "Auto-save upon
+     * close" unfortunately interfered with this behavior, i.e. SQL script was recently edited -> application user
+     * decides to disconnect -> prompt to save the script is triggered.
+     * @return
+     */
+    default boolean shouldSaveOnDisconnect() {
+        return true;
+    }
 }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPDataSourceTask.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/DBPDataSourceTask.java
@@ -29,7 +29,7 @@ public interface DBPDataSourceTask
      * data sources. Certain cases (see #41844) where application users can set the application to not "Auto-save upon
      * close" unfortunately interfered with this behavior, i.e. SQL script was recently edited -> application user
      * decides to disconnect -> prompt to save the script is triggered.
-     * @return
+     * @return true on default; we save on disconnects in the standard case
      */
     default boolean shouldSaveOnDisconnect() {
         return true;

--- a/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/actions/datasource/DataSourceHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.connection/src/org/jkiss/dbeaver/ui/actions/datasource/DataSourceHandler.java
@@ -156,6 +156,9 @@ public class DataSourceHandler {
         // Save users
         for (DBPDataSourceTask user : dataSourceContainer.getTasks()) {
             if (user instanceof ISaveablePart) {
+                if (!user.shouldSaveOnDisconnect()) {
+                    continue;
+                }
                 if (!SaveChangesHandler.validateAndSave(new VoidProgressMonitor(), (ISaveablePart) user)) {
                     return;
                 }

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -5041,4 +5041,9 @@ public class SQLEditor extends SQLEditorBase implements
             return Status.OK_STATUS;
         }
     };
+
+    @Override
+    public boolean shouldSaveOnDisconnect() {
+        return getActivePreferenceStore().getBoolean(SQLPreferenceConstants.AUTO_SAVE_ON_CLOSE);
+    }
 }


### PR DESCRIPTION
Closes #41844 

When a DBeaver user attempts to disconnect a data source while the following conditions are met:

1) SQL script edited
2) "Auto-save editor on close" set to false

A save script prompt is triggered even though the SQL editor itself is not closing and stays open after disconnect. 

In DataSourceHandler::disconnectDataSource(), SaveChangesHandler::validateAndSave() checks if the saveable datasource user is dirty or not. 

Since the SQL editor is dirty and "Auto-save editor on close" is disabled, SQLEditor::promptToSaveOnClose() returns DEFAULT which triggers the save dialog, even though the SQL editor is not closing and will stay open after disconnect anyways.

```java
if (super.isDirty() || (extraPresentationManager.activePresentation instanceof ISaveablePart
            && ((ISaveablePart) extraPresentationManager.activePresentation).isDirty())) {
            return ISaveablePart2.DEFAULT;
}
```

In order to fix this:
- opted to add a default method to DBPDataSourceTask in order to preserve existing behavior for all implementers
- Override SQLEditor to respect AUTO_SAVE_ON_CLOSE setting
- Added a check to skip saveable entities if shouldSaveOnDisconnect() returns false before triggering any save prompts