### PR TITLE
dbeaver/pro#10208 Fix Show tips on startup checkbox background in Tip of the day dialog

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/tipoftheday/ShowTipOfTheDayDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/tipoftheday/ShowTipOfTheDayDialog.java
@@ -149,6 +149,7 @@ public class ShowTipOfTheDayDialog extends AbstractPopupPanel {
 
         if (displayShowOnStartup) {
             Button showTipButton = UIUtils.createCheckbox(form.getBody(), TipOfTheDayMessages.show_tips_on_startup, isShowOnStartup());
+            showTipButton.setBackground(form.getBody().getBackground());
 
             showTipButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e ->
                 setShowOnStartup(showTipButton.getSelection())));


### PR DESCRIPTION
Closes dbeaver/pro#10208
I have checked both Light and Dark themes on Windows 11. Please test it on macOS