### PR TITLE
dbeaver/dbeaver#20261 Propose routines as row sources in SQL completion

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/completion/SQLCompletionAnalyzer.java
@@ -1053,6 +1053,16 @@ public class SQLCompletionAnalyzer implements DBRRunnableParametrized<DBRProgres
         if (parent instanceof DBSObjectContainer objectContainer) {
             if (DBStructUtils.isConnectedContainer(parent)) {
                 children = objectContainer.getChildren(mdMonitor);
+                if (request.getContext().isSearchProcedures() && parent instanceof DBSProcedureContainer procedureContainer) {
+                    // Routines are not among the container children, although they may serve as a row source (dbeaver/dbeaver#20261)
+                    Collection<? extends DBSProcedure> procedures = procedureContainer.getProcedures(mdMonitor);
+                    if (!CommonUtils.isEmpty(procedures)) {
+                        List<DBSObject> childrenWithProcedures = new ArrayList<>(children.size() + procedures.size());
+                        childrenWithProcedures.addAll(children);
+                        childrenWithProcedures.addAll(procedures);
+                        children = childrenWithProcedures;
+                    }
+                }
             }
         } else if (parent instanceof DBSEntity entity) {
             children = entity.getAttributes(mdMonitor);

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/completion/SQLQueryCompletionAnalyzer.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/completion/SQLQueryCompletionAnalyzer.java
@@ -113,37 +113,38 @@ public class SQLQueryCompletionAnalyzer implements DBRRunnableParametrized<DBRPr
         Collection<SQLQueryCompletionSet> completionSets = completionContext.prepareProposal(monitor, this.request);
         SQLQueryCompletionTextProvider textProvider = new SQLQueryCompletionTextProvider(this.request, completionContext, monitor);
 
-        List<SQLQueryCompletionProposal> proposals = new LinkedList<>();
-
-        // FIXME forcibly exclude duplicated completions for now;
-        //  correct fix requires better completion scenarios distinguishing to not prepare unnecessary items at all
-        Set<String> texts = new HashSet<>();
+        // Exclude duplicated completions produced by different completion scenarios;
+        // prefer the proposal which replaces the already typed part of the identifier
+        // over the one inserting at the cursor position (dbeaver/dbeaver#20261)
+        Map<String, SQLQueryCompletionProposal> proposalsByText = new LinkedHashMap<>();
         for (SQLQueryCompletionSet completionSet : completionSets) {
             for (SQLQueryCompletionItem item : completionSet.getItems()) {
                 DBSObject object = SQLQueryConnectionDummyContext.isDummyObject(item.getObject()) ? null : item.getObject();
                 String text = item.apply(textProvider);
-                if (texts.add(text)) {
-                    String decoration = item.apply(SQLQueryCompletionExtraTextProvider.INSTANCE);
-                    String description = item.apply(SQLQueryCompletionDescriptionProvider.INSTANCE);
-                    String replacementString = this.prepareReplacementString(item, text, completionContext);
-                    proposals.add(this.createProposal(
-                        item.getKind(),
-                        object,
-                        this.prepareProposalImage(item),
-                        text,
-                        decoration,
-                        description,
-                        replacementString,
-                        completionSet.getReplacementPosition(),
-                        completionSet.getReplacementLength(),
-                        item.getFilterInfo(),
-                        item.getScore()
-                    ));
+                SQLQueryCompletionProposal existing = proposalsByText.get(text);
+                if (existing != null && existing.getReplacementLength() >= completionSet.getReplacementLength()) {
+                    continue;
                 }
+                String decoration = item.apply(SQLQueryCompletionExtraTextProvider.INSTANCE);
+                String description = item.apply(SQLQueryCompletionDescriptionProvider.INSTANCE);
+                String replacementString = this.prepareReplacementString(item, text, completionContext);
+                proposalsByText.put(text, this.createProposal(
+                    item.getKind(),
+                    object,
+                    this.prepareProposalImage(item),
+                    text,
+                    decoration,
+                    description,
+                    replacementString,
+                    completionSet.getReplacementPosition(),
+                    completionSet.getReplacementLength(),
+                    item.getFilterInfo(),
+                    item.getScore()
+                ));
             }
         }
 
-        return proposals;
+        return new LinkedList<>(proposalsByText.values());
     }
 
     protected SQLQueryCompletionProposal createProposal(

--- a/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/completion/SQLQueryCompletionContext.java
+++ b/plugins/org.jkiss.dbeaver.model.sql/src/org/jkiss/dbeaver/model/sql/semantics/completion/SQLQueryCompletionContext.java
@@ -36,6 +36,7 @@ import org.jkiss.dbeaver.model.sql.SQLConstants;
 import org.jkiss.dbeaver.model.sql.SQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLSearchUtils;
 import org.jkiss.dbeaver.model.sql.completion.SQLCompletionRequest;
+import org.jkiss.dbeaver.model.sql.parser.SQLWordPartDetector;
 import org.jkiss.dbeaver.model.sql.semantics.*;
 import org.jkiss.dbeaver.model.sql.semantics.context.*;
 import org.jkiss.dbeaver.model.sql.semantics.model.SQLQueryMemberAccessEntry;
@@ -48,6 +49,7 @@ import org.jkiss.dbeaver.model.stm.STMTreeTermErrorNode;
 import org.jkiss.dbeaver.model.stm.STMTreeTermNode;
 import org.jkiss.dbeaver.model.struct.*;
 import org.jkiss.dbeaver.model.struct.rdb.*;
+import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.Pair;
 
 import java.util.*;
@@ -312,6 +314,9 @@ public abstract class SQLQueryCompletionContext {
                 int position = this.getRequestOffset() - this.getOffset();
                 
                 SQLQueryWordEntry currentWord = this.obtainCurrentWord(currentTerm, position);
+                if (currentWord == null) {
+                    currentWord = this.obtainCurrentWordFromDocument(request);
+                }
                 List<SQLQueryWordEntry> parts = this.obtainIdentifierParts(position);
 
                 List<SQLQueryCompletionSet> completionSets = new LinkedList<>();
@@ -322,13 +327,15 @@ public abstract class SQLQueryCompletionContext {
                     this.tryApplyOriginContext();
                     this.prepareInspectedIdentifierCompletions(monitor, request, parts, completionSets);
                 } else if (context.symbolsOrigin() != null) {
-                    this.accomplishFromKnownOrigin(monitor, request, context.symbolsOrigin(), null, completionSets);
+                    // Use the current word as a filter to replace the typed part of the identifier
+                    // instead of inserting the proposal at the cursor position (dbeaver/dbeaver#20261)
+                    this.accomplishFromKnownOrigin(monitor, request, context.symbolsOrigin(), currentWord, completionSets);
                 } else if (syntaxInspectionResult.expectingIdentifier()) {
                     this.tryApplyOriginContext();
                     this.prepareInspectedIdentifierCompletions(monitor, request, parts, completionSets);
                 } else {
                     this.tryApplyOriginContext();
-                    this.prepareInspectedFreeCompletions(monitor, request, completionSets);
+                    this.prepareInspectedFreeCompletions(monitor, request, currentWord, completionSets);
                 }
 
                 boolean keywordsAllowed = (lexicalItem == null || (lexicalItem.getOrigin() != null && !lexicalItem.getOrigin().isChained()) || (lexicalItem.getSymbolClass() != null && potentialKeywordPartClassification.contains(lexicalItem.getSymbolClass()))) && !hasPeriod;
@@ -344,15 +351,17 @@ public abstract class SQLQueryCompletionContext {
             private void prepareInspectedFreeCompletions(
                 @NotNull DBRProgressMonitor monitor,
                 @NotNull SQLCompletionRequest request,
+                @Nullable SQLQueryWordEntry currentWord,
                 @NotNull List<SQLQueryCompletionSet> completionSets
             ) {
                 if ((syntaxInspectionResult.expectingColumnName() || syntaxInspectionResult.expectingColumnReference())
                     && nameNodes.length == 0
                 ) {
-                    this.prepareNonPrefixedColumnCompletions(monitor, request, this.deepestContext, null, completionSets);
+                    this.prepareNonPrefixedColumnCompletions(monitor, request, this.deepestContext, currentWord, completionSets);
                 }
                 if (syntaxInspectionResult.expectingTableReference() && nameNodes.length == 0) {
-                    this.prepareTableCompletions(monitor, request, this.deepestContext.getKnownSources(), null, completionSets);
+                    // Replace the typed part of the identifier instead of inserting at the cursor position (dbeaver/dbeaver#20261)
+                    this.prepareTableCompletions(monitor, request, this.deepestContext.getKnownSources(), currentWord, completionSets);
                 }
             }
 
@@ -371,6 +380,23 @@ public abstract class SQLQueryCompletionContext {
                 } else {
                     return null;
                 }
+            }
+
+            @Nullable
+            private SQLQueryWordEntry obtainCurrentWordFromDocument(@NotNull SQLCompletionRequest request) {
+                // The semantic model may be out of sync with the document state (e.g. while its script item awaits reparse),
+                // so fall back to plain word detection to replace the typed part of the identifier anyway (dbeaver/dbeaver#20261)
+                SQLWordPartDetector wordDetector = new SQLWordPartDetector(
+                    request.getDocument(),
+                    request.getContext().getSyntaxManager(),
+                    this.getRequestOffset()
+                );
+                String wordPart = wordDetector.getWordPart();
+                int startOffset = wordDetector.getStartOffset();
+                if (CommonUtils.isEmpty(wordPart) || startOffset < this.getOffset()) {
+                    return null;
+                }
+                return new SQLQueryWordEntry(startOffset - this.getOffset(), wordPart);
             }
 
             private void prepareInspectedIdentifierCompletions(@NotNull DBRProgressMonitor monitor,
@@ -475,6 +501,8 @@ public abstract class SQLQueryCompletionContext {
                             filterOrNull,
                             items
                         );
+                        // Routines are not among the container children, so collect them separately (dbeaver/dbeaver#20261)
+                        this.collectProcedures(monitor, request, List.of(container), prefixInfo, filterOrNull, items);
                     } catch (DBException e) {
                         log.error(e);
                     }
@@ -978,7 +1006,7 @@ public abstract class SQLQueryCompletionContext {
                     public void visitSyntaxBasedFromRowsData(SQLQuerySymbolOrigin.SyntaxBasedFromRowsData origin) {
                         SQLQueryDataContextInfo contextInfo = SQLQueryDataContextInfo.makeFor(origin.getRowsDataContext());
                         setContextInfo(contextInfo);
-                        prepareInspectedFreeCompletions(monitor, request, results);
+                        prepareInspectedFreeCompletions(monitor, request, filterOrNull, results);
                     }
 
                 });
@@ -1288,8 +1316,8 @@ public abstract class SQLQueryCompletionContext {
                     try {
                         Collection<DBSObjectContainer> containers = this.obtainDefaultContext(monitor, request);
                         this.collectTables(monitor, knownSources, containers, null, filterOrNull, completions);
-                        // usually we don't want procedures in FROM
-                        //this.collectProcedures(monitor, request, containers, null, filterOrNull, completions);
+                        // Routines may serve as a row source (e.g. table functions), so propose them as well (dbeaver/dbeaver#20261)
+                        this.collectProcedures(monitor, request, containers, null, filterOrNull, completions);
                         this.collectPackages(monitor, request, knownSources, this.exposedContexts,  null, filterOrNull, completions);
                     } catch (DBException e) {
                         log.error(e);

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/SQLCompletionAnalyzerTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/SQLCompletionAnalyzerTest.java
@@ -558,4 +558,60 @@ public class SQLCompletionAnalyzerTest extends DBeaverUnitTest {
             .request("SELECT * FROM table1 a, table2 b WHERE c.|");
         Assertions.assertTrue(proposals.isEmpty());
     }
+
+    @Test
+    public void testRowSourceFunctionCompletion() throws DBException {
+        final RequestResult request = RequestBuilder
+            .tables(s -> {
+                s.table("table1", empty());
+                s.procedure("test_func");
+            })
+            .prepare()
+            .setSearchProcedures(true);
+
+        {
+            final List<SQLCompletionProposalBase> proposals = request.request("SELECT * FROM te|");
+            Assertions.assertTrue(
+                proposals.stream().anyMatch(p -> p.getReplacementString().contains("test_func")),
+                () -> "proposals: " + proposals.stream().map(p -> p.getReplacementString()).toList()
+            );
+        }
+
+        {
+            final List<SQLCompletionProposalBase> proposals = request.request("SELECT * FROM |");
+            Assertions.assertTrue(
+                proposals.stream().anyMatch(p -> p.getReplacementString().contains("test_func")),
+                () -> "proposals: " + proposals.stream().map(p -> p.getReplacementString()).toList()
+            );
+        }
+    }
+
+    @Test
+    public void testQualifiedRowSourceFunctionCompletion() throws DBException {
+        final RequestResult request = RequestBuilder
+            .schemas(d -> {
+                d.schema("public", s -> {
+                    s.table("table1", empty());
+                    s.procedure("test_func");
+                });
+            })
+            .prepare()
+            .setSearchProcedures(true);
+
+        final List<SQLCompletionProposalBase> proposals = request.request("SELECT * FROM public.te|");
+        Assertions.assertTrue(proposals.stream().anyMatch(p -> p.getReplacementString().contains("test_func")));
+    }
+
+    @Test
+    public void testRowSourceFunctionCompletionDisabled() throws DBException {
+        final RequestResult request = RequestBuilder
+            .tables(s -> {
+                s.table("table1", empty());
+                s.procedure("test_func");
+            })
+            .prepare();
+
+        final List<SQLCompletionProposalBase> proposals = request.request("SELECT * FROM te|");
+        Assertions.assertFalse(proposals.stream().anyMatch(p -> p.getReplacementString().contains("test_func")));
+    }
 }

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/SQLQueryCompletionAnalyzerTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/SQLQueryCompletionAnalyzerTest.java
@@ -17,15 +17,21 @@
 package org.jkiss.dbeaver.model.sql.analyzer;
 
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.BadLocationException;
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.sql.analyzer.builder.request.RequestBuilder;
 import org.jkiss.dbeaver.model.sql.analyzer.builder.request.RequestResult;
+import org.jkiss.dbeaver.model.sql.semantics.completion.SQLQueryCompletionProposal;
 import org.jkiss.junit.DBeaverUnitTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.jkiss.dbeaver.model.sql.analyzer.builder.Builder.Consumer.empty;
 
@@ -543,5 +549,126 @@ public class SQLQueryCompletionAnalyzerTest extends DBeaverUnitTest {
         Set<String> proposals = modelDataRequest
             .requestNewStrings("SELECT * FROM table1 a, table2 b WHERE c.|");
         Assertions.assertTrue(proposals.isEmpty());
+    }
+
+    @Test
+    public void testRowSourceFunctionCompletion() throws DBException {
+        final RequestResult request = RequestBuilder
+            .schemas(d -> {
+                d.schema("public", s -> {
+                    s.table("table1", empty());
+                    s.procedure("test_func");
+                });
+            })
+            .prepare()
+            .setSearchProcedures(true);
+
+        final Set<String> proposals = request.requestNewStrings("SELECT * FROM te|");
+        Assertions.assertTrue(proposals.stream().anyMatch(p -> p.contains("test_func")));
+    }
+
+    @Test
+    public void testQualifiedRowSourceFunctionCompletion() throws DBException {
+        final RequestResult request = RequestBuilder
+            .schemas(d -> {
+                d.schema("public", s -> {
+                    s.table("table1", empty());
+                    s.procedure("test_func");
+                });
+            })
+            .prepare()
+            .setSearchProcedures(true);
+
+        final Set<String> proposals = request.requestNewStrings("SELECT * FROM public.te|");
+        Assertions.assertTrue(proposals.stream().anyMatch(p -> p.contains("test_func")));
+    }
+
+    @Test
+    public void testRowSourceFunctionCompletionDisabled() throws DBException {
+        final RequestResult request = RequestBuilder
+            .schemas(d -> {
+                d.schema("public", s -> {
+                    s.table("table1", empty());
+                    s.procedure("test_func");
+                });
+            })
+            .prepare();
+
+        {
+            final Set<String> proposals = request.requestNewStrings("SELECT * FROM te|");
+            Assertions.assertFalse(proposals.stream().anyMatch(p -> p.contains("test_func")));
+        }
+
+        {
+            final Set<String> proposals = request.requestNewStrings("SELECT * FROM public.te|");
+            Assertions.assertFalse(proposals.stream().anyMatch(p -> p.contains("test_func")));
+        }
+    }
+
+    /**
+     * Completing a partially typed routine name must replace the typed part of the identifier,
+     * leaving no stale characters behind (dbeaver/dbeaver#20261)
+     */
+    @Test
+    public void testRowSourceFunctionCompletionReplacesTypedPrefix() throws DBException {
+        final RequestResult request = RequestBuilder
+            .schemas(d -> {
+                d.schema("public", s -> {
+                    s.table("table1", empty());
+                    s.procedure("test_func");
+                });
+            })
+            .prepare()
+            .setSearchProcedures(true);
+
+        this.assertProposalsReplaceTypedWord(request, "SELECT * FROM te|");
+        this.assertProposalsReplaceTypedWord(request, "SELECT * FROM public.te|");
+    }
+
+    private void assertProposalsReplaceTypedWord(@NotNull RequestResult request, @NotNull String sql) throws DBException {
+        final int cursor = sql.indexOf('|');
+        Assertions.assertTrue(cursor > 0);
+        final String documentText = sql.substring(0, cursor) + sql.substring(cursor + 1);
+
+        final List<SQLQueryCompletionProposal> proposals = request.requestNewProposals(sql).stream()
+            .filter(p -> p.getReplacementString().contains("test_func"))
+            .collect(Collectors.toList());
+        Assertions.assertFalse(proposals.isEmpty(), "No proposals for " + sql);
+
+        for (SQLQueryCompletionProposal proposal : proposals) {
+            // Reproduces the way the UI applies an accepted proposal over the current document state
+            final Document document = new Document(documentText);
+            try {
+                document.replace(
+                    proposal.getReplacementOffset(),
+                    cursor - proposal.getReplacementOffset(),
+                    proposal.getReplacementString()
+                );
+            } catch (BadLocationException e) {
+                throw new DBException("Invalid replacement range", e);
+            }
+            final String applied = document.get();
+            Assertions.assertEquals(
+                1,
+                countOccurrences(applied, "test_func"),
+                () -> "Duplicated identifier after applying proposal: " + applied
+            );
+            Assertions.assertTrue(
+                applied.startsWith("SELECT * FROM "),
+                () -> "Typed prefix was not replaced: " + applied
+            );
+            Assertions.assertTrue(
+                applied.substring("SELECT * FROM ".length()).matches("(public\\.)?test_func.*"),
+                () -> "Typed prefix was not replaced: " + applied
+            );
+        }
+    }
+
+    private static int countOccurrences(@NotNull String text, @NotNull String fragment) {
+        int count = 0;
+        for (int index = text.indexOf(fragment); index >= 0; index = text.indexOf(fragment, index + 1)) {
+            count++;
+        }
+        return count;
     }
 }

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/SQLQueryCompletionAnalyzerTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/SQLQueryCompletionAnalyzerTest.java
@@ -621,46 +621,43 @@ public class SQLQueryCompletionAnalyzerTest extends DBeaverUnitTest {
             .prepare()
             .setSearchProcedures(true);
 
-        this.assertProposalsReplaceTypedWord(request, "SELECT * FROM te|");
-        this.assertProposalsReplaceTypedWord(request, "SELECT * FROM public.te|");
-    }
+        for (String sql : List.of("SELECT * FROM te|", "SELECT * FROM public.te|")) {
+            final int cursor = sql.indexOf('|');
+            Assertions.assertTrue(cursor > 0);
+            final String documentText = sql.substring(0, cursor) + sql.substring(cursor + 1);
 
-    private void assertProposalsReplaceTypedWord(@NotNull RequestResult request, @NotNull String sql) throws DBException {
-        final int cursor = sql.indexOf('|');
-        Assertions.assertTrue(cursor > 0);
-        final String documentText = sql.substring(0, cursor) + sql.substring(cursor + 1);
+            final List<SQLQueryCompletionProposal> proposals = request.requestNewProposals(sql).stream()
+                .filter(p -> p.getReplacementString().contains("test_func"))
+                .collect(Collectors.toList());
+            Assertions.assertFalse(proposals.isEmpty(), "No proposals for " + sql);
 
-        final List<SQLQueryCompletionProposal> proposals = request.requestNewProposals(sql).stream()
-            .filter(p -> p.getReplacementString().contains("test_func"))
-            .collect(Collectors.toList());
-        Assertions.assertFalse(proposals.isEmpty(), "No proposals for " + sql);
-
-        for (SQLQueryCompletionProposal proposal : proposals) {
-            // Reproduces the way the UI applies an accepted proposal over the current document state
-            final Document document = new Document(documentText);
-            try {
-                document.replace(
-                    proposal.getReplacementOffset(),
-                    cursor - proposal.getReplacementOffset(),
-                    proposal.getReplacementString()
+            for (SQLQueryCompletionProposal proposal : proposals) {
+                // Reproduces the way the UI applies an accepted proposal over the current document state
+                final Document document = new Document(documentText);
+                try {
+                    document.replace(
+                        proposal.getReplacementOffset(),
+                        cursor - proposal.getReplacementOffset(),
+                        proposal.getReplacementString()
+                    );
+                } catch (BadLocationException e) {
+                    throw new DBException("Invalid replacement range", e);
+                }
+                final String applied = document.get();
+                Assertions.assertEquals(
+                    1,
+                    countOccurrences(applied, "test_func"),
+                    () -> "Duplicated identifier after applying proposal: " + applied
                 );
-            } catch (BadLocationException e) {
-                throw new DBException("Invalid replacement range", e);
+                Assertions.assertTrue(
+                    applied.startsWith("SELECT * FROM "),
+                    () -> "Typed prefix was not replaced: " + applied
+                );
+                Assertions.assertTrue(
+                    applied.substring("SELECT * FROM ".length()).matches("(public\\.)?test_func.*"),
+                    () -> "Typed prefix was not replaced: " + applied
+                );
             }
-            final String applied = document.get();
-            Assertions.assertEquals(
-                1,
-                countOccurrences(applied, "test_func"),
-                () -> "Duplicated identifier after applying proposal: " + applied
-            );
-            Assertions.assertTrue(
-                applied.startsWith("SELECT * FROM "),
-                () -> "Typed prefix was not replaced: " + applied
-            );
-            Assertions.assertTrue(
-                applied.substring("SELECT * FROM ".length()).matches("(public\\.)?test_func.*"),
-                () -> "Typed prefix was not replaced: " + applied
-            );
         }
     }
 

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/Builder.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/Builder.java
@@ -20,14 +20,21 @@ import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.dbeaver.model.struct.rdb.DBSProcedure;
+import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureType;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class Builder<T, C> {
     protected final DBPDataSource dataSource;
     protected final DBSObject parent;
     protected final List<C> children;
+    protected final List<DBSProcedure> procedures = new ArrayList<>();
 
     protected Builder(@NotNull DBPDataSource dataSource, @NotNull DBSObject parent) {
         this.dataSource = dataSource;
@@ -41,6 +48,23 @@ public abstract class Builder<T, C> {
     @NotNull
     public List<C> getChildren() {
         return children;
+    }
+
+    @NotNull
+    protected DBSProcedure createProcedure(@NotNull String name) {
+        final DBSProcedure procedure = mock(DBSProcedure.class);
+        when(procedure.getDataSource()).thenReturn(dataSource);
+        when(procedure.getParentObject()).thenReturn(parent);
+        when(procedure.getName()).thenReturn(name);
+        when(procedure.getFullyQualifiedName(any())).thenReturn(name);
+        when(procedure.getProcedureType()).thenReturn(DBSProcedureType.FUNCTION);
+        procedures.add(procedure);
+        return procedure;
+    }
+
+    @NotNull
+    public List<DBSProcedure> getProcedures() {
+        return procedures;
     }
 
     public interface Consumer<T extends Builder<?, ?>> {

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/SchemaContainerBuilder.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/SchemaContainerBuilder.java
@@ -22,11 +22,13 @@ import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSObjectContainer;
+import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureContainer;
 import org.jkiss.dbeaver.model.struct.rdb.DBSCatalog;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 public class SchemaContainerBuilder extends Builder<DBSObjectContainer, DBSObjectContainer> {
     private final DBSObjectContainer container;
@@ -38,13 +40,14 @@ public class SchemaContainerBuilder extends Builder<DBSObjectContainer, DBSObjec
         @NotNull Class<? extends DBSObjectContainer> tableContainerType
     ) throws DBException {
         super(dataSource, parent);
-        this.container = mock(tableContainerType);
+        this.container = mock(tableContainerType, withSettings().extraInterfaces(DBSProcedureContainer.class));
         when(container.getDataSource()).thenReturn(dataSource);
         when(container.getParentObject()).thenReturn(parent);
         when(container.getName()).thenReturn(name);
         when(container.getPrimaryChildType(any())).thenReturn(null);
         when(container.getChildren(any())).then(x -> children);
         when(container.getChild(any(), any())).then(x -> DBUtils.findObject(children, x.getArgument(1, String.class)));
+        when(((DBSProcedureContainer) container).getProcedures(any())).then(x -> procedures);
     }
 
     public SchemaContainerBuilder(@NotNull DBPDataSource dataSource, @NotNull DBSObject parent, @NotNull String name) throws DBException {
@@ -60,6 +63,12 @@ public class SchemaContainerBuilder extends Builder<DBSObjectContainer, DBSObjec
         final TableContainerBuilder builder = new TableContainerBuilder(dataSource, container, name);
         applier.apply(builder);
         children.add(builder.build());
+        return this;
+    }
+
+    @NotNull
+    public SchemaContainerBuilder procedure(@NotNull String name) {
+        createProcedure(name);
         return this;
     }
 

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/TableContainerBuilder.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/TableContainerBuilder.java
@@ -23,11 +23,13 @@ import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.struct.DBSEntity;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSObjectContainer;
+import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureContainer;
 import org.jkiss.dbeaver.model.struct.rdb.DBSSchema;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 public class TableContainerBuilder extends Builder<DBSObjectContainer, DBSEntity> {
     private final DBSObjectContainer container;
@@ -39,13 +41,14 @@ public class TableContainerBuilder extends Builder<DBSObjectContainer, DBSEntity
         @NotNull Class<? extends DBSObjectContainer> tableContainerType
     ) throws DBException {
         super(dataSource, parent);
-        this.container = mock(tableContainerType);
+        this.container = mock(tableContainerType, withSettings().extraInterfaces(DBSProcedureContainer.class));
         when(container.getDataSource()).thenReturn(dataSource);
         when(container.getParentObject()).thenReturn(parent);
         when(container.getName()).thenReturn(name);
         when(container.getPrimaryChildType(any())).thenReturn(null);
         when(container.getChildren(any())).then(x -> children);
         when(container.getChild(any(), any())).then(x -> DBUtils.findObject(children, x.getArgument(1, String.class)));
+        when(((DBSProcedureContainer) container).getProcedures(any())).then(x -> procedures);
     }
 
     public TableContainerBuilder(@NotNull DBPDataSource dataSource, @NotNull DBSObject parent, @NotNull String name) throws DBException {
@@ -61,6 +64,12 @@ public class TableContainerBuilder extends Builder<DBSObjectContainer, DBSEntity
         final TableAttributeContainerBuilder builder = new TableAttributeContainerBuilder(dataSource, container, name);
         applier.apply(builder);
         children.add(builder.build());
+        return this;
+    }
+
+    @NotNull
+    public TableContainerBuilder procedure(@NotNull String name) {
+        createProcedure(name);
         return this;
     }
 

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/request/RequestBuilder.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/request/RequestBuilder.java
@@ -26,14 +26,18 @@ import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
 import org.jkiss.dbeaver.model.impl.struct.RelationalObjectType;
 import org.jkiss.dbeaver.model.preferences.DBPPreferenceStore;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.sql.SQLDialect;
 import org.jkiss.dbeaver.model.sql.SQLDialectMetadataRegistry;
 import org.jkiss.dbeaver.model.sql.analyzer.builder.*;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSObjectContainer;
 import org.jkiss.dbeaver.model.struct.DBSObjectType;
+import org.jkiss.dbeaver.model.struct.rdb.DBSProcedure;
+import org.jkiss.dbeaver.model.struct.rdb.DBSProcedureContainer;
 import org.jkiss.dbeaver.runtime.DBWorkbench;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -44,11 +48,13 @@ public class RequestBuilder {
     private final DataSource dataSource;
     private final DBSObject object;
     private final List<? extends DBSObject> children;
+    private final Builder<?, ?> builder;
 
-    private RequestBuilder(@NotNull DataSource dataSource, @NotNull DBSObject object, @NotNull List<? extends DBSObject> children) {
+    private RequestBuilder(@NotNull DataSource dataSource,@NotNull DBSObject object, @NotNull List<? extends DBSObject> children, @NotNull Builder<?, ?> builder) {
         this.dataSource = dataSource;
         this.object = object;
         this.children = children;
+        this.builder = builder;
         SQLDialect dialect = new GenericSQLDialect() {
             @Override
             public boolean supportsAliasInSelect() {
@@ -62,27 +68,27 @@ public class RequestBuilder {
         final DataSource dataSource = createDataSource();
         final DatabaseContainerBuilder builder = new DatabaseContainerBuilder(dataSource, "<unnamed>");
         applier.apply(builder);
-        return new RequestBuilder(dataSource, builder.build(), builder.getChildren());
+        return new RequestBuilder(dataSource, builder.build(), builder.getChildren(), builder);
     }
 
     public static RequestBuilder schemas(Builder.Consumer<SchemaContainerBuilder> applier) throws DBException {
         final DataSource dataSource = createDataSource();
         final SchemaContainerBuilder builder = new SchemaContainerBuilder(dataSource, "<unnamed>");
         applier.apply(builder);
-        return new RequestBuilder(dataSource, builder.build(), builder.getChildren());
+        return new RequestBuilder(dataSource, builder.build(), builder.getChildren(), builder);
     }
 
     public static RequestBuilder tables(Builder.Consumer<TableContainerBuilder> applier) throws DBException {
         final DataSource dataSource = createDataSource();
         final TableContainerBuilder builder = new TableContainerBuilder(dataSource, "<unnamed>");
         applier.apply(builder);
-        return new RequestBuilder(dataSource, builder.build(), builder.getChildren());
+        return new RequestBuilder(dataSource, builder.build(), builder.getChildren(), builder);
     }
 
     public static RequestBuilder empty() throws DBException {
         final DataSource dataSource = createDataSource();
         final TableAttributeContainerBuilder builder = new TableAttributeContainerBuilder(dataSource, "<unnamed>");
-        return new RequestBuilder(dataSource, builder.build(), builder.getChildren());
+        return new RequestBuilder(dataSource, builder.build(), builder.getChildren(), builder);
     }
 
     @NotNull
@@ -96,8 +102,18 @@ public class RequestBuilder {
         when(dataSourceContainer.getPreferenceStore()).thenReturn(preferenceStore);
 
         when(dataSource.getContainer()).thenReturn(dataSourceContainer);
+        when(dataSource.getDataSource()).thenReturn(dataSource);
         when(dataSource.getChild(any(), any())).then(x -> DBUtils.findObject(children, x.getArgument(1, String.class)));
         when(dataSource.getChildren(any())).then(x -> children);
+        when(((DBSProcedureContainer) dataSource).getProcedures(any())).then(x -> {
+            final List<DBSProcedure> procedures = new ArrayList<>(builder.getProcedures());
+            for (DBSObject child : children) {
+                if (child instanceof DBSProcedureContainer procContainer) {
+                    procedures.addAll(procContainer.getProcedures(x.getArgument(0, DBRProgressMonitor.class)));
+                }
+            }
+            return procedures;
+        });
 
         return new RequestResult(dataSource);
     }
@@ -122,12 +138,13 @@ public class RequestBuilder {
             RelationalObjectType.TYPE_TRIGGER,
             RelationalObjectType.TYPE_DATA_TYPE
         });
+        when(dsInfo.supportsStoredCode()).thenReturn(true);
 
         DataSource ds = mock(DataSource.class);
         when(ds.getInfo()).then(x -> dsInfo);
         return ds;
     }
 
-    public interface DataSource extends DBPDataSource, DBSObjectContainer {
+    public interface DataSource extends DBPDataSource, DBSObjectContainer, DBSProcedureContainer {
     }
 }

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/request/RequestResult.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/sql/analyzer/builder/request/RequestResult.java
@@ -47,6 +47,7 @@ import org.jkiss.utils.Pair;
 import org.junit.jupiter.api.Assertions;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,9 +58,16 @@ import static org.mockito.Mockito.when;
 
 public class RequestResult {
     private final DBPDataSource dataSource;
+    private boolean searchProcedures = false;
 
     public RequestResult(@NotNull DBPDataSource dataSource) {
         this.dataSource = dataSource;
+    }
+
+    @NotNull
+    public RequestResult setSearchProcedures(boolean searchProcedures) {
+        this.searchProcedures = searchProcedures;
+        return this;
     }
 
     @NotNull
@@ -82,6 +90,14 @@ public class RequestResult {
      */
     public Set<String> requestNewStrings(@NotNull String sql) throws DBException {
         return this.requestNewStrings(sql, true);
+    }
+
+    /**
+     * Returns raw proposals of the semantic autocompletion engine for the provided text in simple mode
+     */
+    @NotNull
+    public List<SQLQueryCompletionProposal> requestNewProposals(@NotNull String sql) throws DBException {
+        return new ArrayList<>(this.requestNewInternal(sql, true).getSecond());
     }
 
     /**
@@ -185,7 +201,8 @@ public class RequestResult {
             dataSource,
             syntaxManager,
             ruleManager,
-            executionContext
+            executionContext,
+            searchProcedures
         );
 
         final SQLCompletionRequest request = new SQLCompletionRequest(
@@ -212,12 +229,14 @@ public class RequestResult {
         private final SQLSyntaxManager syntaxManager;
         private final SQLRuleManager ruleManager;
         private final DBCExecutionContext executionContext;
+        private final boolean searchProcedures;
 
-        private CompletionContext(DBPDataSource dataSource, SQLSyntaxManager syntaxManager, SQLRuleManager ruleManager, DBCExecutionContext executionContext) {
+        private CompletionContext(DBPDataSource dataSource, SQLSyntaxManager syntaxManager, SQLRuleManager ruleManager, DBCExecutionContext executionContext, boolean searchProcedures) {
             this.dataSource = dataSource;
             this.syntaxManager = syntaxManager;
             this.ruleManager = ruleManager;
             this.executionContext = executionContext;
+            this.searchProcedures = searchProcedures;
         }
 
         @Override
@@ -267,7 +286,7 @@ public class RequestResult {
 
         @Override
         public boolean isSearchProcedures() {
-            return false;
+            return searchProcedures;
         }
 
         @Override


### PR DESCRIPTION
## Problem

[Autocomplete for user-defined functions in Postgres #20261](https://github.com/dbeaver/dbeaver/issues/20261)

With `Show stored procedures in column list` enabled, functions are offered only after `SELECT`/`WHERE`.
In row source position completion offers nothing:

```sql
CREATE OR REPLACE FUNCTION public.test_f(_val int)
 RETURNS table (a int)
 LANGUAGE sql
 IMMUTABLE PARALLEL SAFE
AS $function$
SELECT * FROM generate_series(1, _val)
                  $function$
;

-- here dbeaver does not show autocomplete for test_f
select * from public.test_f(10);
select * from test_f(10);
```

although the function exists and works: `select * from public.test_f(10)`.

## Cause

1. Row source proposals are built from `DBSObjectContainer.getChildren()`, which never returns routines -
   they must be requested separately via `DBSProcedureContainer.getProcedures()`.
2. Additionally, when the same routine was proposed by several completion scenarios, the proposal
   which inserts at the cursor position (leaving the typed prefix in place) could win over the one
   replacing the typed text, producing duplicated identifiers like `tetest_f`.
3. The semantic model may be out of sync with the document (e.g. while a script item awaits reparse),
   in which case the current word is not detected at all and all proposals are built in insert mode,
   so accepting a proposal duplicates the already typed identifier part.

## Solution

* Legacy engine (`SQLCompletionAnalyzer#makeProposalsFromChildren`) - merge procedures into
  the container children when procedure search is enabled;
* Semantic engine (`SQLQueryCompletionContext`) - enable the previously commented-out
  `collectProcedures` call for row sources and pass the current word to the fallback completion paths,
  so proposals replace the typed part instead of inserting at the cursor;
* Completion deduplication (`SQLQueryCompletionAnalyzer`) - when the same text is proposed by several
  scenarios, prefer the proposal with a proper replacement range;
* When the semantic model provides no current word, fall back to plain word detection over
  the document (`SQLWordPartDetector`), so the typed part is replaced even before the model catches up;
* updated the preference tooltip accordingly.

The behavior remains opt-in (`Show stored procedures in column list`); with the setting off nothing changes.

## Testing

New tests in both engine suites: routine is proposed for `FROM te|` and `FROM public.te|`,
and is not proposed when the setting is disabled. Additionally, a regression test verifies that
applying any of the proposed replacements produces exactly one occurrence of the routine call
(the typed prefix is consumed, not duplicated).

Full suite: `Tests run: 455, Failures: 0, Errors: 0`.