### PR TITLE
dbeaver/dbeaver#41878 Handle incomplete OpenAI stream response

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAiAPIStreamConsumer.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAiAPIStreamConsumer.java
@@ -112,7 +112,7 @@ public class OpenAiAPIStreamConsumer implements Consumer<String> {
         List<String> choices = new ArrayList<>();
         if (EVENT_TYPE_TEXT_DELTA.equals(chunk.type)) {
             choices.add(chunk.delta);
-        } else if (chunk.response != null) {
+        } else if (chunk.response != null && chunk.response.output != null) {
             for (OAIMessage msg : chunk.response.output) {
                 for (OAIMessageContent content : msg.content) {
                     if (!CommonUtils.isEmpty(content.text)) {


### PR DESCRIPTION
### Summary

- Ignore incomplete OpenAI Responses API stream events that omit the `output` field
- Allow subsequent stream events to be processed instead of reporting a `NullPointerException`

### Testing

- `mvn -pl plugins/org.jkiss.dbeaver.model.ai -am verify -DskipTests`
- Provider integration was not tested because the reported endpoint is not available

Closes dbeaver/dbeaver#41878