### PR TITLE
dbeaver/pro#10396 Fix checkbox background in Tip of the day dialog on mac in dark theme

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/tipoftheday/ShowTipOfTheDayDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/tipoftheday/ShowTipOfTheDayDialog.java
@@ -43,6 +43,7 @@ import org.jkiss.dbeaver.ui.BaseThemeSettings;
 import org.jkiss.dbeaver.ui.ShellUtils;
 import org.jkiss.dbeaver.ui.UIUtils;
 import org.jkiss.dbeaver.ui.dialogs.AbstractPopupPanel;
+import org.jkiss.dbeaver.utils.RuntimeUtils;
 import org.jkiss.utils.CommonUtils;
 
 import java.net.URI;
@@ -149,7 +150,9 @@ public class ShowTipOfTheDayDialog extends AbstractPopupPanel {
 
         if (displayShowOnStartup) {
             Button showTipButton = UIUtils.createCheckbox(form.getBody(), TipOfTheDayMessages.show_tips_on_startup, isShowOnStartup());
-            showTipButton.setBackground(form.getBody().getBackground());
+            if (!RuntimeUtils.isMacOS()) {
+                showTipButton.setBackground(form.getBody().getBackground());
+            }
 
             showTipButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e ->
                 setShowOnStartup(showTipButton.getSelection())));


### PR DESCRIPTION
Fix remains on win 
<img width="308" height="326" alt="image" src="https://github.com/user-attachments/assets/77c52ab5-dfec-4cc7-aea8-545d954d0d36" />
<img width="327" height="323" alt="image" src="https://github.com/user-attachments/assets/1bba3b37-a224-4e6e-8fc6-5c991c01a98b" />
