### PR TITLE
dbeaver/pro#10403 Handle unsupported AI profiles across editions

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/registry/AISettingsManager.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/registry/AISettingsManager.java
@@ -302,15 +302,15 @@ public class AISettingsManager {
             in.beginObject();
             while (in.hasNext()) {
                 String engineId = in.nextName();
-                in.beginObject();
-
                 AIEngineDescriptor engineDescriptor = AIEngineRegistry.getInstance().getEngineDescriptor(engineId);
                 if (engineDescriptor == null) {
                     log.error("AI engine '" + engineId + "' not found. Ignore config");
+                    in.skipValue();
                     continue;
                 }
 
-                in.nextName();// properties
+                in.beginObject();
+                in.nextName(); // properties
                 AIEngineProperties engineProperties = AISettingsManager.READ_PROPS_GSON.fromJson(
                     in, engineDescriptor.getPropertiesType());
                 result.put(engineId, engineProperties);

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/registry/AISettingsManagerTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/registry/AISettingsManagerTest.java
@@ -1,0 +1,50 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.registry;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+
+public class AISettingsManagerTest extends DBeaverUnitTest {
+
+    @Test
+    public void skipsUnknownLegacyEngineConfiguration() throws Exception {
+        String config = """
+            {
+              "unsupported": {
+                "properties": {
+                  "applicableAuthTypes": [
+                    {
+                      "title": "Unsupported"
+                    }
+                  ]
+                }
+              }
+            }
+            """;
+
+        try (JsonReader reader = new JsonReader(new StringReader(config))) {
+            Assertions.assertTrue(new AISettingsManager.EngineConfigAdapter().read(reader).isEmpty());
+            Assertions.assertEquals(JsonToken.END_DOCUMENT, reader.peek());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- skip the complete legacy AI engine configuration when its engine is unavailable in the current edition
- keep the JSON reader at the correct nesting level so supported profiles continue loading
- add a regression test covering an unsupported configuration with a nested array

## Testing
- `mvn verify -pl plugins/org.jkiss.dbeaver.model.ai,test/org.jkiss.dbeaver.model.ai.test -am -Dtest=AISettingsManagerTest`

Closes dbeaver/pro#10403

This PR was generated with AI (OpenCode).