### PR TITLE
dbeaver/pro#2658 Dark theme colors for progress bar

### DIFF
--- a/plugins/org.jkiss.dbeaver.core/css/e4-dark_dbeaver_prefstyle.css
+++ b/plugins/org.jkiss.dbeaver.core/css/e4-dark_dbeaver_prefstyle.css
@@ -97,3 +97,9 @@ ExpandableCompositeEx {
 	tb-toggle-hover-color: #F4F7F7;
 	tb-toggle-color: #F4F7F7;
 }
+
+
+ProgressBar {
+    background-color: #3C3F41;
+    color: #2b79d7;
+}

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditorBase.java
@@ -41,8 +41,10 @@ import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.PlatformUI;
@@ -541,6 +543,28 @@ public abstract class SQLEditorBase extends BaseTextEditor implements
 
     protected ISharedTextColors getSharedColors() {
         return UIUtils.getSharedTextColors();
+    }
+
+    protected void updateVerticalRulerColors() {
+        if (!UIStyles.isDarkTheme()) {
+            return;
+        }
+        IVerticalRuler verticalRuler = getVerticalRuler();
+        if (verticalRuler == null) {
+            return;
+        }
+        Control rulerControl = verticalRuler.getControl();
+        if (rulerControl == null || rulerControl.isDisposed()) {
+            return;
+        }
+        Color background = UIStyles.getDefaultTextBackground();
+        rulerControl.setBackground(background);
+        if (rulerControl instanceof Composite composite) {
+            // Each ruler column owns a canvas that does not inherit the background on its own
+            for (Control column : composite.getChildren()) {
+                column.setBackground(background);
+            }
+        }
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/UIServiceSQLImpl.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/UIServiceSQLImpl.java
@@ -175,6 +175,7 @@ public class UIServiceSQLImpl implements UIServiceSQL {
             public void createPartControl(Composite parent) {
                 super.createPartControl(parent);
                 getAction(ITextEditorActionConstants.CONTEXT_PREFERENCES).setEnabled(false);
+                updateVerticalRulerColors();
             }
 
             @Override


### PR DESCRIPTION
Adds dark theme colors for `ProgressBar`.

Note for reviewers: on Windows the native progress bar is painted by the OS and ignores `setBackground()`/`setForeground()` until its visual styles are dropped. That requires `display.setData(org.eclipse.swt.internal.win32.ProgressBar.useColors, true)` to be set before any widget is created, which is not part of this change — so on Windows this rule alone has no visible effect yet.

Closes https://github.com/dbeaver/pro/issues/2658