### PR TITLE
GizmoSQL: page result sets with LIMIT/OFFSET instead of re-execute-and-skip

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/GenericDataSource.java
@@ -44,6 +44,7 @@ import org.jkiss.dbeaver.model.meta.ForTest;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
 import org.jkiss.dbeaver.model.sql.SQLDialect;
+import org.jkiss.dbeaver.model.sql.SQLQuery;
 import org.jkiss.dbeaver.model.struct.DBSDataType;
 import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSObjectFilter;
@@ -62,7 +63,7 @@ import java.util.Properties;
 /**
  * GenericDataSource
  */
-public class GenericDataSource extends JDBCDataSource implements DBPTermProvider, GenericStructContainer {
+public class GenericDataSource extends JDBCDataSource implements DBPTermProvider, GenericStructContainer, DBCQueryTransformProviderExt {
     private static final Log log = Log.getLog(GenericDataSource.class);
 
     private final TableTypeCache tableTypeCache;
@@ -643,6 +644,26 @@ public class GenericDataSource extends JDBCDataSource implements DBPTermProvider
             }
         }
         return super.createQueryTransformer(type);
+    }
+
+    /**
+     * Meta models may force SQL-level result-set limiting (e.g. dialects whose
+     * JDBC drivers cannot page a result set without re-executing the query).
+     */
+    @Override
+    public boolean isForceTransform(DBCSession session, SQLQuery sqlQuery) {
+        if (metaModel instanceof DBCQueryTransformProviderExt ext) {
+            return ext.isForceTransform(session, sqlQuery);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isLimitApplicableTo(SQLQuery query) {
+        if (metaModel instanceof DBCQueryTransformProviderExt ext) {
+            return ext.isLimitApplicableTo(query);
+        }
+        return true;
     }
 
     /**

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/gizmosql/GizmoSQLMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/gizmosql/GizmoSQLMetaModel.java
@@ -25,12 +25,15 @@ import org.jkiss.dbeaver.ext.generic.model.GenericView;
 import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaModel;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.exec.DBCQueryTransformProvider;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformProviderExt;
+import org.jkiss.dbeaver.model.exec.DBCSession;
 import org.jkiss.dbeaver.model.exec.DBCQueryTransformType;
 import org.jkiss.dbeaver.model.exec.DBCQueryTransformer;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.impl.sql.QueryTransformerLimit;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.sql.SQLQuery;
 import org.jkiss.utils.CommonUtils;
 
 import java.sql.SQLException;
@@ -45,7 +48,7 @@ import java.util.Map;
  * catalog view wraps. If neither is available (typically the SQLite backend), we return an
  * informative stub rather than failing the view-DDL tab.
  */
-public class GizmoSQLMetaModel extends GenericMetaModel implements DBCQueryTransformProvider {
+public class GizmoSQLMetaModel extends GenericMetaModel implements DBCQueryTransformProvider, DBCQueryTransformProviderExt {
 
     private static final String DDL_UNAVAILABLE = "-- View definition not available";
     private static final String DDL_UNSUPPORTED_SQLITE =
@@ -67,6 +70,21 @@ public class GizmoSQLMetaModel extends GenericMetaModel implements DBCQueryTrans
             return new QueryTransformerLimit(false, true);
         }
         return null;
+    }
+
+    /**
+     * Always page via SQL: Arrow Flight SQL has no scrollable cursor, so the JDBC
+     * {@code setMaxRows} fallback re-executes the whole statement for every page
+     * and discards the preceding rows client-side.
+     */
+    @Override
+    public boolean isForceTransform(DBCSession session, SQLQuery sqlQuery) {
+        return true;
+    }
+
+    @Override
+    public boolean isLimitApplicableTo(SQLQuery query) {
+        return true;
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/gizmosql/GizmoSQLMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.generic/src/org/jkiss/dbeaver/ext/generic/model/meta/gizmosql/GizmoSQLMetaModel.java
@@ -24,8 +24,12 @@ import org.jkiss.dbeaver.ext.generic.model.GenericCatalog;
 import org.jkiss.dbeaver.ext.generic.model.GenericView;
 import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaModel;
 import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformProvider;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformType;
+import org.jkiss.dbeaver.model.exec.DBCQueryTransformer;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
+import org.jkiss.dbeaver.model.impl.sql.QueryTransformerLimit;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.utils.CommonUtils;
 
@@ -41,12 +45,29 @@ import java.util.Map;
  * catalog view wraps. If neither is available (typically the SQLite backend), we return an
  * informative stub rather than failing the view-DDL tab.
  */
-public class GizmoSQLMetaModel extends GenericMetaModel {
+public class GizmoSQLMetaModel extends GenericMetaModel implements DBCQueryTransformProvider {
 
     private static final String DDL_UNAVAILABLE = "-- View definition not available";
     private static final String DDL_UNSUPPORTED_SQLITE =
         "-- View DDL not supported on this GizmoSQL server: "
             + "duckdb_views() is unavailable (typically means the SQLite backend).";
+
+    /**
+     * Page result sets with {@code LIMIT n OFFSET m} instead of DBeaver's generic
+     * fallback of re-executing the whole query and skipping rows client-side.
+     * Arrow Flight SQL result streams are forward-only with no server-side cursor,
+     * so without this every "fetch next page" re-ran the full statement and
+     * transferred all preceding rows again. Both GizmoSQL backends (DuckDB and
+     * SQLite) accept {@code LIMIT ... OFFSET ...}.
+     */
+    @Nullable
+    @Override
+    public DBCQueryTransformer createQueryTransformer(@NotNull DBCQueryTransformType type) {
+        if (type == DBCQueryTransformType.RESULT_SET_LIMIT) {
+            return new QueryTransformerLimit(false, true);
+        }
+        return null;
+    }
 
     @Override
     public String getViewDDL(


### PR DESCRIPTION
## Summary
- `GizmoSQLMetaModel` now implements `DBCQueryTransformProvider` and returns a `QueryTransformerLimit(false, true)` for `RESULT_SET_LIMIT`, so result-set paging is expressed as `LIMIT n OFFSET m` — the same approach the PostgreSQL extension uses.
- One file changed, no driver/plugin.xml changes.

## Details
GizmoSQL speaks Arrow Flight SQL, whose result streams are forward-only with no server-side cursor. Without a dialect-level limit transformer, DBeaver falls back to the generic strategy for every "fetch next page": re-execute the full statement, then `JDBCUtils.scrollResultSet()` skips the preceding rows client-side. For a wide table that means page *k* re-runs the query and transfers `k × fetchSize` rows over gRPC (quadratic in pages), visible server-side as one `CreatePreparedStatement` per page.

With this change each page becomes `SELECT ... LIMIT 200 OFFSET 400`, which both GizmoSQL backends (DuckDB and SQLite) push down with early termination. Ordering semantics are unchanged from the existing behaviour: both approaches re-execute the statement per page, so without an `ORDER BY` they carry the same (dialect-standard) caveat.

Verified end-to-end: with the patched `GizmoSQLMetaModel` spliced into a DBeaver 25.x install and the SQL-limit path active, paging `SELECT * FROM lineitem` in the SQL editor reached the GizmoSQL server as `SELECT * FROM lineitem LIMIT 200`, `… LIMIT 400`, `… LIMIT 600`, `… LIMIT 800` (one prepared statement per page, bounded scan) instead of the bare statement re-executed per page. The `GenericDataSource` change was compile-checked against the current `org.jkiss.dbeaver.*` bundles.

Follow-up to #40508 (GizmoSQL driver). Related: #15535.