### PR TITLE
#35505 Truncate query text used as detached result tab name

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLResultsEditorInput.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLResultsEditorInput.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,9 @@ import org.jkiss.dbeaver.ui.controls.resultset.IResultSetContainer;
 import org.jkiss.utils.CommonUtils;
 
 public class SQLResultsEditorInput implements IEditorInput {
+
+    private static final int MAX_TAB_NAME_LENGTH = 50;
+
     private final IResultSetContainer container;
 
     public SQLResultsEditorInput(@NotNull IResultSetContainer container) {
@@ -45,7 +48,12 @@ public class SQLResultsEditorInput implements IEditorInput {
         if (dataContainer == null) {
             return "Data";
         } else {
-            return CommonUtils.getSingleLineString(dataContainer.getName());
+            // Data container name for a SQL query result is the raw query text, which can be
+            // arbitrarily long. Truncate it so the detached tab gets a readable title instead
+            // of the whole query.
+            return CommonUtils.truncateString(
+                CommonUtils.getSingleLineString(dataContainer.getName()),
+                MAX_TAB_NAME_LENGTH);
         }
     }
 


### PR DESCRIPTION
## Problem

When a query result tab is detached into its own editor, the tab's title is generated from `SQLResultsEditorInput.getName()`, which uses `SQLQueryDataContainer.getName()`, the raw, untruncated SQL query text. For any non-trivial query, this makes the detached tab title unreadable.

## Fix
Truncate the name using the existing `CommonUtils.truncateString` utility (already used the same way elsewhere in the codebase, e.g. `ConnectionNameResolver`), capped at 50 characters.

## Scope
Single-method change in `SQLResultsEditorInput.getName()`. No other behavior is affected. The result tab's tooltip is unchanged. It does not currently show the full query text for SQL results (it shows a generic "SQL Query" label), so this is not a regression, but could be a good separate follow-up if useful.

## Testing
- Manually verified in a local dev build: detaching a long query's result tab now shows a truncated, readable tab title instead of the full query text.

## AI disclosure
This PR was generated with AI (Claude). I reviewed and understand the change before submitting.