### PR TITLE
Drop the extended property when an object comment is cleared

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/SQLServerUtils.java
@@ -302,6 +302,29 @@ public class SQLServerUtils {
             : "SELECT definition FROM " + systemSchema + ".sql_modules WHERE object_id = %d".formatted(objectId);
     }
 
+    /**
+     * Name of the stored procedure that applies a comment change: an emptied comment is dropped
+     * rather than stored as an empty extended property.
+     */
+    @NotNull
+    public static String getCommentProcedureName(@Nullable String description, boolean commentSet) {
+        if (CommonUtils.isEmpty(description)) {
+            return "sp_dropextendedproperty";
+        }
+        return commentSet ? "sp_updateextendedproperty" : "sp_addextendedproperty";
+    }
+
+    /**
+     * Value argument of a comment change, empty for a comment that is being dropped.
+     */
+    @NotNull
+    public static String getCommentValueArgument(@NotNull DBPDataSource dataSource, @Nullable String description) {
+        if (CommonUtils.isEmpty(description)) {
+            return "";
+        }
+        return ", " + SQLUtils.quoteString(dataSource, description);
+    }
+
     public static boolean isCommentSet(DBRProgressMonitor monitor, SQLServerDatabase database, SQLServerObjectClass objectClass, long majorId, long minorId) {
         try (JDBCSession session = DBUtils.openMetaSession(monitor, database, "Check extended property")) {
             try (JDBCPreparedStatement dbStat = session.prepareStatement(

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerBaseTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerBaseTableManager.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.mssql.edit;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.ModelPreferences;
+import org.jkiss.dbeaver.ext.mssql.SQLServerConstants;
 import org.jkiss.dbeaver.ext.mssql.SQLServerUtils;
 import org.jkiss.dbeaver.ext.mssql.model.*;
 import org.jkiss.dbeaver.model.DBConstants;
@@ -54,20 +55,26 @@ public abstract class SQLServerBaseTableManager<OBJECT extends SQLServerTableBas
     @Override
     protected void addObjectExtraActions(@NotNull DBRProgressMonitor monitor, @NotNull DBCExecutionContext executionContext, @NotNull List<DBEPersistAction> actionList, @NotNull NestedObjectCommand<OBJECT, PropertyHandler> command, @NotNull Map<String, Object> options) throws DBException {
         final OBJECT table = command.getObject();
-        if (command.getProperty(DBConstants.PROP_ID_DESCRIPTION) != null) {
-            boolean isUpdate = SQLServerUtils.isCommentSet(
+        if (command.hasProperty(DBConstants.PROP_ID_DESCRIPTION)) {
+            final String description = CommonUtils.toString(command.getProperty(DBConstants.PROP_ID_DESCRIPTION), null);
+            boolean commentSet = SQLServerUtils.isCommentSet(
                 monitor,
                 table.getDatabase(),
                 SQLServerObjectClass.OBJECT_OR_COLUMN,
                 table.getObjectId(),
                 0);
-            actionList.add(
-                new SQLDatabasePersistAction(
-                    "Add table comment",
-                    "EXEC " + SQLServerUtils.getSystemTableName(table.getDatabase(), isUpdate ? "sp_updateextendedproperty" : "sp_addextendedproperty") +
-                        " 'MS_Description', " + SQLUtils.quoteString(table, table.getDescription()) + "," +
-                        " 'schema', " + SQLUtils.quoteString(table, table.getSchema().getName()) + "," +
-                        " '" + (table.isView() ? "view" : "table") + "', " + SQLUtils.quoteString(table, table.getName())));
+            if (!CommonUtils.isEmpty(description) || commentSet) {
+                actionList.add(
+                    new SQLDatabasePersistAction(
+                        "Set table comment",
+                        "EXEC " + SQLServerUtils.getSystemTableName(
+                            table.getDatabase(),
+                            SQLServerUtils.getCommentProcedureName(description, commentSet)) +
+                            " '" + SQLServerConstants.PROP_MS_DESCRIPTION + "'" +
+                            SQLServerUtils.getCommentValueArgument(table.getDataSource(), description) + "," +
+                            " 'schema', " + SQLUtils.quoteString(table, table.getSchema().getName()) + "," +
+                            " '" + (table.isView() ? "view" : "table") + "', " + SQLUtils.quoteString(table, table.getName())));
+            }
         }
 
         if (CommonUtils.getOption(options, DBPScriptObject.OPTION_INCLUDE_NESTED_OBJECTS)) {

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerProcedureManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerProcedureManager.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.mssql.edit;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.mssql.SQLServerConstants;
 import org.jkiss.dbeaver.ext.mssql.SQLServerUtils;
 import org.jkiss.dbeaver.ext.mssql.model.SQLServerDatabase;
 import org.jkiss.dbeaver.ext.mssql.model.SQLServerObjectClass;
@@ -91,7 +92,7 @@ public class SQLServerProcedureManager extends SQLServerObjectManager<SQLServerP
 
     @Override
     protected void addObjectModifyActions(@NotNull DBRProgressMonitor monitor, @NotNull DBCExecutionContext executionContext, @NotNull List<DBEPersistAction> actionList, @NotNull ObjectChangeCommand command, @NotNull Map<String, Object> options) throws DBException {
-        if (command.getProperties().size() > 1 || command.getProperty(DBConstants.PROP_ID_DESCRIPTION) == null) {
+        if (command.getProperties().size() > 1 || !command.hasProperty(DBConstants.PROP_ID_DESCRIPTION)) {
             createOrReplaceProcedureQuery(executionContext, actionList, command.getObject(), false);
         }
     }
@@ -145,7 +146,8 @@ public class SQLServerProcedureManager extends SQLServerObjectManager<SQLServerP
     @Override
     protected void addObjectExtraActions(@NotNull DBRProgressMonitor monitor, @NotNull DBCExecutionContext executionContext, @NotNull List<DBEPersistAction> actions, @NotNull NestedObjectCommand<SQLServerProcedure, PropertyHandler> command, @NotNull Map<String, Object> options) throws DBException {
         final SQLServerProcedure procedure = command.getObject();
-        if (command.getProperty(DBConstants.PROP_ID_DESCRIPTION) != null) {
+        if (command.hasProperty(DBConstants.PROP_ID_DESCRIPTION)) {
+            final String description = CommonUtils.toString(command.getProperty(DBConstants.PROP_ID_DESCRIPTION), null);
             SQLServerDatabase database = procedure.getContainer().getDatabase();
             if (procedure.getDatabase() == null) {
                 return;
@@ -156,17 +158,23 @@ public class SQLServerProcedureManager extends SQLServerObjectManager<SQLServerP
             } else {
                 procedureType = "procedure";
             }
-            boolean isUpdate = SQLServerUtils.isCommentSet(
+            boolean commentSet = SQLServerUtils.isCommentSet(
                 monitor,
                 database,
                 SQLServerObjectClass.OBJECT_OR_COLUMN,
                 procedure.getObjectId(),
                 0);
+            if (CommonUtils.isEmpty(description) && !commentSet) {
+                return;
+            }
             actions.add(
                 new SQLDatabasePersistAction(
-                    "Add procedure comment",
-                    "EXEC " + SQLServerUtils.getSystemTableName(database, isUpdate ? "sp_updateextendedproperty" : "sp_addextendedproperty") +
-                        " 'MS_Description', " + SQLUtils.quoteString(procedure, procedure.getDescription()) + "," +
+                    "Set procedure comment",
+                    "EXEC " + SQLServerUtils.getSystemTableName(
+                        database,
+                        SQLServerUtils.getCommentProcedureName(description, commentSet)) +
+                        " '" + SQLServerConstants.PROP_MS_DESCRIPTION + "'" +
+                        SQLServerUtils.getCommentValueArgument(procedure.getDataSource(), description) + "," +
                         " 'schema', " + SQLUtils.quoteString(procedure, procedure.getContainer().getName()) + "," +
                         "'" + procedureType + "' ," + SQLUtils.quoteString(procedure, procedure.getName())));
         }

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerTableColumnManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerTableColumnManager.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.mssql.edit;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.ext.mssql.SQLServerConstants;
 import org.jkiss.dbeaver.ext.mssql.SQLServerUtils;
 import org.jkiss.dbeaver.ext.mssql.model.*;
 import org.jkiss.dbeaver.model.*;
@@ -172,7 +173,7 @@ public class SQLServerTableColumnManager extends SQLTableColumnManager<SQLServer
     ) throws DBException {
         super.addObjectCreateActions(monitor, executionContext, actions, command, options);
         if (CommonUtils.isNotEmpty(command.getObject().getDescription())) {
-            addColumnCommentAction(actions, command.getObject(), false);
+            addColumnCommentAction(actions, command.getObject(), command.getObject().getDescription(), false);
         }
     }
 
@@ -186,7 +187,7 @@ public class SQLServerTableColumnManager extends SQLTableColumnManager<SQLServer
     {
         final SQLServerTableColumn column = command.getObject();
         int totalProps = command.getProperties().size();
-        boolean hasComment = command.getProperty(DBConstants.PROP_ID_DESCRIPTION) != null;
+        boolean hasComment = command.hasProperty(DBConstants.PROP_ID_DESCRIPTION);
         if (hasComment) totalProps--;
         if (column.isPersisted() && command.hasProperty("defaultValue")) {
             totalProps--;
@@ -204,13 +205,16 @@ public class SQLServerTableColumnManager extends SQLTableColumnManager<SQLServer
             }
         }
         if (hasComment) {
-            boolean isUpdate = SQLServerUtils.isCommentSet(
+            final String description = CommonUtils.toString(command.getProperty(DBConstants.PROP_ID_DESCRIPTION), null);
+            boolean commentSet = SQLServerUtils.isCommentSet(
                 monitor,
                 column.getTable().getDatabase(),
                 SQLServerObjectClass.OBJECT_OR_COLUMN,
                 column.getTable().getObjectId(),
                 column.getObjectId());
-            addColumnCommentAction(actionList, column, isUpdate);
+            if (!CommonUtils.isEmpty(description) || commentSet) {
+                addColumnCommentAction(actionList, column, description, commentSet);
+            }
         }
         if (totalProps > 0) {
             actionList.add(new SQLDatabasePersistAction(
@@ -220,14 +224,20 @@ public class SQLServerTableColumnManager extends SQLTableColumnManager<SQLServer
         }
     }
 
-    static void addColumnCommentAction(List<DBEPersistAction> actionList, SQLServerTableColumn column, boolean isUpdate) {
+    static void addColumnCommentAction(
+        List<DBEPersistAction> actionList,
+        SQLServerTableColumn column,
+        @Nullable String description,
+        boolean commentSet
+    ) {
         actionList.add(
             new SQLDatabasePersistAction(
-                "Add column comment",
+                "Set column comment",
                 "EXEC " + SQLServerUtils.getSystemTableName(
                     column.getTable().getDatabase(),
-                    isUpdate ? "sp_updateextendedproperty" : "sp_addextendedproperty") +
-                    " 'MS_Description', " + SQLUtils.quoteString(column, column.getDescription()) + "," +
+                    SQLServerUtils.getCommentProcedureName(description, commentSet)) +
+                    " '" + SQLServerConstants.PROP_MS_DESCRIPTION + "'" +
+                    SQLServerUtils.getCommentValueArgument(column.getDataSource(), description) + "," +
                     " 'schema', " + SQLUtils.quoteString(column, column.getTable().getSchema().getName()) + "," +
                     " 'table', " + SQLUtils.quoteString(column, column.getTable().getName()) + "," +
                     " 'column', " + SQLUtils.quoteString(column, column.getName())));

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerTableManager.java
@@ -76,7 +76,7 @@ public class SQLServerTableManager extends SQLServerBaseTableManager<SQLServerTa
         @NotNull List<DBEPersistAction> actionList,
         @NotNull ObjectChangeCommand command,
         @NotNull Map<String, Object> options) {
-        if (command.getProperties().size() > 1 || command.getProperty(DBConstants.PROP_ID_DESCRIPTION) == null) {
+        if (command.getProperties().size() > 1 || !command.hasProperty(DBConstants.PROP_ID_DESCRIPTION)) {
             StringBuilder query = new StringBuilder("ALTER TABLE "); //$NON-NLS-1$
             query.append(command.getObject().getFullyQualifiedName(DBPEvaluationContext.DDL)).append(" "); //$NON-NLS-1$
             appendTableModifiers(monitor, command.getObject(), command, query, true, options);
@@ -186,7 +186,7 @@ public class SQLServerTableManager extends SQLServerBaseTableManager<SQLServerTa
             // Column comments for the newly created table
             for (SQLServerTableColumn column : CommonUtils.safeCollection(tableBase.getAttributes(monitor))) {
                 if (!CommonUtils.isEmpty(column.getDescription())) {
-                    SQLServerTableColumnManager.addColumnCommentAction(actionList, column, false);
+                    SQLServerTableColumnManager.addColumnCommentAction(actionList, column, column.getDescription(), false);
                 }
             }
         }

--- a/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerViewManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.mssql/src/org/jkiss/dbeaver/ext/mssql/edit/SQLServerViewManager.java
@@ -106,7 +106,7 @@ public class SQLServerViewManager extends SQLServerBaseTableManager<SQLServerVie
         @NotNull ObjectChangeCommand command,
         @NotNull Map<String, Object> options
     ) throws DBException {
-        if (command.getProperties().size() > 1 || command.getProperty(DBConstants.PROP_ID_DESCRIPTION) == null) {
+        if (command.getProperties().size() > 1 || !command.hasProperty(DBConstants.PROP_ID_DESCRIPTION)) {
             createOrReplaceViewQuery(monitor, executionContext, actionList, command.getObject(), ViewAction.ALTER);
         }
     }


### PR DESCRIPTION
Fixes #41923

Clearing the comment of a table, view, procedure or column in the object editor produced invalid SQL and left the comment in place. The same edit made in a grid cell worked, which is what made the behaviour look arbitrary.

### Root cause

An emptied comment reaches the manager as `null` from the property field in the object editor, and as an empty string from a grid cell. Every manager tested the property *value* for null, so the null case was indistinguishable from "the description was not changed":

- no `sp_*extendedproperty` action was produced, so the comment stayed as it was, and
- the ALTER branch was entered with nothing to alter, emitting `ALTER TABLE <name> ` with no clauses (`Incorrect syntax near '<name>'`), or for a column a full `ALTER COLUMN` restating the definition, which fails on an identity column with `Incorrect syntax near the keyword 'IDENTITY'`.

For a view or a procedure the same condition caused the object to be redefined from its stored definition instead of just dropping the property.

### What this does

The changed property is detected with `hasProperty()` instead of testing its value, in `SQLServerTableManager`, `SQLServerViewManager`, `SQLServerProcedureManager`, `SQLServerBaseTableManager` and `SQLServerTableColumnManager`. An emptied comment is then applied as `sp_dropextendedproperty` rather than skipped, and nothing is emitted when the comment is already absent — dropping a property that does not exist is an error of its own.

Two small helpers in `SQLServerUtils` keep the add/update/drop choice and the optional value argument in one place instead of repeating them at the three call sites; `sp_dropextendedproperty` takes no value argument, which is what makes the argument list vary.

The persist-action titles change from "Add … comment" to "Set … comment", since they can now also remove one, and `'MS_Description'` comes from the existing `SQLServerConstants.PROP_MS_DESCRIPTION` instead of being repeated as a literal. `addColumnCommentAction` takes the description and the add/update flag explicitly now; its two object-creation callers pass the column's own description.

### Testing

Built the CE product from this branch and ran it against SQL Server 2019 (Microsoft JDBC Driver 13.4). Setting, changing and clearing a comment from the object editor was exercised on all four object types — table, column, view and procedure (a scalar function, which goes through the same manager):

- setting a comment where there was none emits `sp_addextendedproperty`,
- changing it emits `sp_updateextendedproperty`,
- clearing it emits `sp_dropextendedproperty` with the object's level arguments and **no** `ALTER` statement, and the field stays empty after a refresh.

Before the change, clearing failed with `SQL Error [102]` on a table and `SQL Error [156]` on an identity column, and left the comment unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
