### PR TITLE
dbeaver/pro#10425 Fix OpenAI function schema

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAiUtils.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAiUtils.java
@@ -81,8 +81,8 @@ public class OpenAiUtils {
                 tool.name = fd.getFullId();
                 tool.description = fd.getAiDescription();
                 tool.parameters = new OAIToolParameters();
+                tool.parameters.type = OAIToolParameters.TYPE_OBJECT;
                 if (fd.getParameters().length > 0) {
-                    tool.parameters.type = OAIToolParameters.TYPE_OBJECT;
                     List<String> requiredFields = new ArrayList<>();
                     for (AIFunctionParameter param : fd.getParameters()) {
                         OAIToolParameter tp = new OAIToolParameter();


### PR DESCRIPTION
Closes dbeaver/pro#10425

## Summary
- mark OpenAI function parameter schemas as objects, including functions without arguments
- prevent strict Responses API validation from rejecting requests with no-argument tools

## Testing
- `mvn verify` in `plugins/org.jkiss.dbeaver.model.ai`

This PR was generated with AI (OpenCode).