### PR TITLE
dbeaver/pro#10278 Support all data export formats

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/SQLPragmaExport.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/SQLPragmaExport.java
@@ -49,6 +49,7 @@ public class SQLPragmaExport implements SQLPragmaHandler {
 
     public static final String PARAMETER_TYPE = "type";
     public static final String PARAMETER_INCLUDE_PIPES = "includePipesConfiguration";
+    public static final String PARAMETER_SEARCH_SIMILAR = "searchSimilar";
 
     private static final String PRODUCER_NODE_ID = "database_producer";
     private static final String CONSUMER_NODE_ID = "stream_consumer";
@@ -62,6 +63,7 @@ public class SQLPragmaExport implements SQLPragmaHandler {
     ) throws DBException {
         final String type = JSONUtils.getString(parameters, PARAMETER_TYPE);
         final boolean includePipes = JSONUtils.getBoolean(parameters, PARAMETER_INCLUDE_PIPES, false);
+        final boolean searchSimilar = JSONUtils.getBoolean(parameters, PARAMETER_SEARCH_SIMILAR, false);
         if (CommonUtils.isEmpty(type)) {
             throw new DBException("`type` attribute is mandatory");
         }
@@ -69,7 +71,7 @@ public class SQLPragmaExport implements SQLPragmaHandler {
         final DataTransferRegistry registry = DataTransferRegistry.getInstance();
         final DataTransferNodeDescriptor producerNode = registry.getNodeById(PRODUCER_NODE_ID);
         final DataTransferNodeDescriptor consumerNode = registry.getNodeById(CONSUMER_NODE_ID);
-        final DataTransferProcessorDescriptor processor = findProcessor(registry, consumerNode, type);
+        final DataTransferProcessorDescriptor processor = findProcessor(registry, consumerNode, type, searchSimilar);
 
         if (processor == null) {
             throw new DBException("Can't find processor of type '" + type + "'");
@@ -113,10 +115,11 @@ public class SQLPragmaExport implements SQLPragmaHandler {
     private static DataTransferProcessorDescriptor findProcessor(
         @NotNull DataTransferRegistry registry,
         @NotNull DataTransferNodeDescriptor consumerNode,
-        @NotNull String type
+        @NotNull String type,
+        boolean searchSimilar
     ) {
         DataTransferProcessorDescriptor processor = registry.getProcessor(PROCESSOR_ID_PREFIX + type);
-        if (processor != null) {
+        if (processor != null || !searchSimilar) {
             return processor;
         }
 

--- a/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/SQLPragmaExport.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer.ui/src/org/jkiss/dbeaver/tools/transfer/ui/SQLPragmaExport.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.tools.transfer.ui;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.data.json.JSONUtils;
@@ -68,7 +69,7 @@ public class SQLPragmaExport implements SQLPragmaHandler {
         final DataTransferRegistry registry = DataTransferRegistry.getInstance();
         final DataTransferNodeDescriptor producerNode = registry.getNodeById(PRODUCER_NODE_ID);
         final DataTransferNodeDescriptor consumerNode = registry.getNodeById(CONSUMER_NODE_ID);
-        final DataTransferProcessorDescriptor processor = registry.getProcessor(PROCESSOR_ID_PREFIX + type);
+        final DataTransferProcessorDescriptor processor = findProcessor(registry, consumerNode, type);
 
         if (processor == null) {
             throw new DBException("Can't find processor of type '" + type + "'");
@@ -106,6 +107,30 @@ public class SQLPragmaExport implements SQLPragmaHandler {
         });
 
         return RESULT_CONSUME_PRAGMA | RESULT_CONSUME_QUERY;
+    }
+
+    @Nullable
+    private static DataTransferProcessorDescriptor findProcessor(
+        @NotNull DataTransferRegistry registry,
+        @NotNull DataTransferNodeDescriptor consumerNode,
+        @NotNull String type
+    ) {
+        DataTransferProcessorDescriptor processor = registry.getProcessor(PROCESSOR_ID_PREFIX + type);
+        if (processor != null) {
+            return processor;
+        }
+
+        for (DataTransferProcessorDescriptor descriptor : consumerNode.getProcessors()) {
+            if (type.equalsIgnoreCase(descriptor.getShortId())) {
+                return descriptor;
+            }
+        }
+        for (DataTransferProcessorDescriptor descriptor : consumerNode.getProcessors()) {
+            if (type.equalsIgnoreCase(descriptor.getProcessorFileExtension())) {
+                return descriptor;
+            }
+        }
+        return null;
     }
 
     @NotNull


### PR DESCRIPTION
Closes dbeaver/pro#10278

## Summary
- resolve data transfer processors by their short ID when the format does not match the processor ID
- fall back to the default file extension for formats such as Markdown and PHP source code
- preserve direct processor ID lookup and prioritize short IDs over ambiguous extensions

## Testing
- `mvn clean verify` in `plugins/org.jkiss.dbeaver.data.transfer.ui`
- `git diff --check`

This PR was generated with AI (OpenCode).