### PR TITLE
docs: fix typo partiton -> partition

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.db2/src/org/jkiss/dbeaver/ext/db2/model/dict/DB2PackageDepType.java
+++ b/plugins/org.jkiss.dbeaver.ext.db2/src/org/jkiss/dbeaver/ext/db2/model/dict/DB2PackageDepType.java
@@ -67,7 +67,7 @@ public enum DB2PackageDepType implements DBPNamedObject {
 
     m("Module", DB2ObjectType.MODULE),
 
-    n("Database Partiton Group"),
+    n("Database Partition Group"),
 
     q("Sequence alias", DB2ObjectType.ALIAS),
 


### PR DESCRIPTION
Corrects the misspelling `partiton` -> `partition` in `plugins/org.jkiss.dbeaver.ext.db2/src/org/jkiss/dbeaver/ext/db2/model/dict/DB2PackageDepType.java`.

Documentation only, no behaviour change.