### PR TITLE
dbeaver/pro#10466 Fix AI function result serialization

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/qm/QMAIChatHistoryMapper.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/qm/QMAIChatHistoryMapper.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.model.ai.qm;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
@@ -50,6 +51,7 @@ import java.util.stream.Collectors;
 public class QMAIChatHistoryMapper {
 
     private static final Log log = Log.getLog(QMAIChatHistoryMapper.class);
+    private static final String EXCEPTION_MESSAGE_PROPERTY = "detailMessage";
 
     @NotNull
     public static QMAIConversationHistory toQMAIChatHistory(
@@ -175,8 +177,17 @@ public class QMAIChatHistoryMapper {
         String value = toString(result.value());
         Throwable exception = result.exception() == null || result.exception().isJsonNull()
             ? null
-            : new DBException(toString(result.exception()));
+            : new DBException(toExceptionMessage(result.exception(), value));
         return new AIFunctionResult(result.type(), value, null, exception);
+    }
+
+    @NotNull
+    private static String toExceptionMessage(@NotNull JsonElement exception, @NotNull String defaultMessage) {
+        if (exception.isJsonObject()) {
+            JsonElement message = exception.getAsJsonObject().get(EXCEPTION_MESSAGE_PROPERTY);
+            return message == null || message.isJsonNull() ? defaultMessage : toString(message);
+        }
+        return toString(exception);
     }
 
     @NotNull
@@ -267,7 +278,9 @@ public class QMAIChatHistoryMapper {
                 return null;
             }
             String message = exception.getMessage();
-            return new JsonPrimitive(message != null ? message : exception.toString());
+            JsonObject object = new JsonObject();
+            object.addProperty(EXCEPTION_MESSAGE_PROPERTY, message != null ? message : exception.toString());
+            return object;
         }
     }
 

--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/qm/QMAIChatHistoryMapper.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/qm/QMAIChatHistoryMapper.java
@@ -16,6 +16,8 @@
  */
 package org.jkiss.dbeaver.model.ai.qm;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
@@ -135,7 +137,7 @@ public class QMAIChatHistoryMapper {
                 it.message().getRawDisplayMessage(),
                 Objects.requireNonNull(toQMAIChatRole(it.message().getRole()), "Chat role is null"),
                 getFunctionCallsString(it.message()),
-                toJsonString(it.message().getFunctionResult()),
+                toFunctionResultJson(it.message().getFunctionResult()),
                 it.message().getTime().toInstant(ZoneOffset.UTC),
                 false,
                 toQMAIMessageMeta(it.message().getMeta())
@@ -157,6 +159,32 @@ public class QMAIChatHistoryMapper {
             return null;
         }
         return JSONUtils.GSON.toJson(object);
+    }
+
+    @Nullable
+    private static String toFunctionResultJson(@Nullable AIFunctionResult result) {
+        return result == null ? null : JSONUtils.GSON.toJson(new PersistedFunctionResult(result));
+    }
+
+    @NotNull
+    static AIFunctionResult fromFunctionResultJson(@NotNull String json) {
+        PersistedFunctionResult result = Objects.requireNonNull(
+            JSONUtils.GSON.fromJson(json, PersistedFunctionResult.class),
+            "Function result is null"
+        );
+        String value = toString(result.value());
+        Throwable exception = result.exception() == null || result.exception().isJsonNull()
+            ? null
+            : new DBException(toString(result.exception()));
+        return new AIFunctionResult(result.type(), value, null, exception);
+    }
+
+    @NotNull
+    private static String toString(@Nullable JsonElement element) {
+        if (element == null || element.isJsonNull()) {
+            return "";
+        }
+        return element.isJsonPrimitive() ? element.getAsString() : element.toString();
     }
 
     @Nullable
@@ -195,7 +223,7 @@ public class QMAIChatHistoryMapper {
                 } else {
                     AIFunctionCall fc = JSONUtils.GSON.fromJson(fcString, AIFunctionCall.class);
                     setFunctionToFunctionCall(assistant, fc);
-                    AIFunctionResult fr = JSONUtils.GSON.fromJson(frString, AIFunctionResult.class);
+                    AIFunctionResult fr = fromFunctionResultJson(frString);
                     aiMessage = new AIMessage(fc, fr, messageTime, messageMetas);
                 }
             } else {
@@ -217,6 +245,29 @@ public class QMAIChatHistoryMapper {
         AIFunctionDescriptor function = assistant.getToolboxManager().getFunctionByFullId(fc.getFunctionName());
         if (function != null) {
             fc.setFunction(function);
+        }
+    }
+
+    private record PersistedFunctionResult(
+        @NotNull AIFunctionType type,
+        @NotNull JsonElement value,
+        @Nullable JsonElement exception
+    ) {
+        private PersistedFunctionResult(@NotNull AIFunctionResult result) {
+            this(
+                result.getType(),
+                new JsonPrimitive(CommonUtils.toString(result.getValue())),
+                toJsonElement(result.getException())
+            );
+        }
+
+        @Nullable
+        private static JsonElement toJsonElement(@Nullable Throwable exception) {
+            if (exception == null) {
+                return null;
+            }
+            String message = exception.getMessage();
+            return new JsonPrimitive(message != null ? message : exception.toString());
         }
     }
 

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/qm/QMAIChatHistoryMapperTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/qm/QMAIChatHistoryMapperTest.java
@@ -1,0 +1,82 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.qm;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.ai.AIChatMessage;
+import org.jkiss.dbeaver.model.ai.AIFunctionCall;
+import org.jkiss.dbeaver.model.ai.AIFunctionResult;
+import org.jkiss.dbeaver.model.ai.AIFunctionType;
+import org.jkiss.dbeaver.model.ai.AIMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class QMAIChatHistoryMapperTest {
+
+    @Test
+    public void serializesFunctionResultWithoutTraversingValues() {
+        AIFunctionResult result = new AIFunctionResult(
+            AIFunctionType.INFORMATION,
+            new CyclicValue(),
+            null,
+            new DBException("Database error")
+        );
+        AIMessage message = new AIMessage(
+            new AIFunctionCall("test", Map.of()),
+            result,
+            LocalDateTime.now(),
+            null
+        );
+
+        String json = QMAIChatHistoryMapper.toQMAIChatMessages(List.of(new AIChatMessage(1, message)))
+            .getFirst()
+            .functionResult();
+        JsonObject object = JsonParser.parseString(json).getAsJsonObject();
+
+        Assertions.assertEquals("INFORMATION", object.get("type").getAsString());
+        Assertions.assertEquals("Function result", object.get("value").getAsString());
+        Assertions.assertEquals("Database error", object.get("exception").getAsString());
+    }
+
+    @Test
+    public void restoresFunctionResultError() {
+        AIFunctionResult result = QMAIChatHistoryMapper.fromFunctionResultJson(
+            "{\"type\":\"INFORMATION\",\"value\":\"Failed\",\"exception\":{}}"
+        );
+
+        Assertions.assertEquals(AIFunctionType.INFORMATION, result.getType());
+        Assertions.assertEquals("Failed", result.getValue());
+        Assertions.assertNotNull(result.getException());
+        Assertions.assertNull(result.getCallback());
+    }
+
+    private static class CyclicValue {
+        @SuppressWarnings("unused")
+        private final Object self = this;
+
+        @Override
+        public String toString() {
+            return "Function result";
+        }
+    }
+}

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/qm/QMAIChatHistoryMapperTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/qm/QMAIChatHistoryMapperTest.java
@@ -24,6 +24,7 @@ import org.jkiss.dbeaver.model.ai.AIFunctionCall;
 import org.jkiss.dbeaver.model.ai.AIFunctionResult;
 import org.jkiss.dbeaver.model.ai.AIFunctionType;
 import org.jkiss.dbeaver.model.ai.AIMessage;
+import org.jkiss.dbeaver.model.data.json.JSONUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -55,19 +56,37 @@ public class QMAIChatHistoryMapperTest {
 
         Assertions.assertEquals("INFORMATION", object.get("type").getAsString());
         Assertions.assertEquals("Function result", object.get("value").getAsString());
-        Assertions.assertEquals("Database error", object.get("exception").getAsString());
+        Assertions.assertEquals(
+            "Database error",
+            object.getAsJsonObject("exception").get("detailMessage").getAsString()
+        );
+
+        LegacyFunctionResult legacyResult = JSONUtils.GSON.fromJson(json, LegacyFunctionResult.class);
+        Assertions.assertEquals("Function result", legacyResult.value());
+        Assertions.assertEquals("Database error", legacyResult.exception().detailMessage());
     }
 
     @Test
     public void restoresFunctionResultError() {
         AIFunctionResult result = QMAIChatHistoryMapper.fromFunctionResultJson(
-            "{\"type\":\"INFORMATION\",\"value\":\"Failed\",\"exception\":{}}"
+            "{\"type\":\"INFORMATION\",\"value\":\"Failed\",\"exception\":{\"detailMessage\":\"Database error\"}}"
         );
 
         Assertions.assertEquals(AIFunctionType.INFORMATION, result.getType());
         Assertions.assertEquals("Failed", result.getValue());
         Assertions.assertNotNull(result.getException());
+        Assertions.assertEquals("Database error", result.getException().getMessage());
         Assertions.assertNull(result.getCallback());
+    }
+
+    @Test
+    public void restoresStringFunctionResultError() {
+        AIFunctionResult result = QMAIChatHistoryMapper.fromFunctionResultJson(
+            "{\"type\":\"INFORMATION\",\"value\":\"Failed\",\"exception\":\"Database error\"}"
+        );
+
+        Assertions.assertNotNull(result.getException());
+        Assertions.assertEquals("Database error", result.getException().getMessage());
     }
 
     private static class CyclicValue {
@@ -78,5 +97,15 @@ public class QMAIChatHistoryMapperTest {
         public String toString() {
             return "Function result";
         }
+    }
+
+    private record LegacyFunctionResult(
+        AIFunctionType type,
+        String value,
+        LegacyException exception
+    ) {
+    }
+
+    private record LegacyException(String detailMessage) {
     }
 }


### PR DESCRIPTION
Closes dbeaver/pro#10466

## Summary
- persist AI function results through a safe scalar representation
- keep the persisted exception as a minimal object compatible with previous product versions
- preserve failed function status without serializing live exception or callback object graphs
- support loading legacy object-shaped results and string-shaped results written by an intermediate fix
- add regression coverage for cyclic values, database exceptions, and format compatibility

## Testing
- `mvn install -DskipTests` in `plugins/org.jkiss.dbeaver.model.ai`
- `mvn verify -f ../../test/org.jkiss.dbeaver.model.ai.test/pom.xml -Dtest=QMAIChatHistoryMapperTest`

This PR was generated with AI (OpenCode).