### PR TITLE
dbeaver/pro#10548 Preserve AI transfer consent

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/AIContextSettingsDataSource.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/AIContextSettingsDataSource.java
@@ -17,6 +17,7 @@
 
 package org.jkiss.dbeaver.model.ai;
 
+import com.google.gson.JsonParseException;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
@@ -63,9 +64,16 @@ public class AIContextSettingsDataSource extends AIContextSettings {
         Object dsConfig = dataSourceContainer.getExtension(AI_DS_EXTENSION);
         if (dsConfig == null) {
             loadLegacySettings();
-        } else if (dsConfig instanceof Map map){
+        } else if (dsConfig instanceof Map map) {
             // Load settings from map
             loadSettingsFromMap(map);
+        } else if (dsConfig instanceof String string) {
+            // Older datasource serializers flattened extension maps to strings.
+            try {
+                loadSettingsFromString(string);
+            } catch (JsonParseException e) {
+                log.error("Error loading AI settings: " + dsConfig, e);
+            }
         } else {
             log.error("Unknown AI settings format: " + dsConfig);
         }

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/AIContextSettingsTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/AIContextSettingsTest.java
@@ -1,0 +1,47 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai;
+
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.model.DBPDataSourceContainer;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AIContextSettingsTest extends DBeaverUnitTest {
+    @Test
+    public void loadsSettingsFlattenedByLegacyDataSourceSerializer() {
+        AIContextSettings settings = new TestContextSettings();
+
+        settings.loadSettingsFromString("{confirmed=true, mcpEnabled=false}");
+
+        Assertions.assertTrue(settings.isMetaTransferConfirmed());
+        Assertions.assertFalse(settings.isMcpEnabled());
+    }
+
+    private static class TestContextSettings extends AIContextSettings {
+        @Nullable
+        @Override
+        public DBPDataSourceContainer getDataSourceContainer() {
+            return null;
+        }
+
+        @Override
+        public void saveSettings() {
+        }
+    }
+}


### PR DESCRIPTION
Closes dbeaver/pro#10548

## Summary
- load AI datasource settings flattened to strings by legacy datasource serializers
- preserve metadata-transfer consent when Team Edition changes AI profiles or conversations
- add regression coverage for the legacy serialized representation

## Testing
- `mvn verify -f product/aggregate/pom.xml -T1C -Pproduct-dbeaver-ce,product-dbeaver-eclipse-ce -Dtest=AIContextSettingsTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false`

This PR was generated with AI (OpenCode).