### PR TITLE
#40575 Respect table selection in PostgreSQL backup wizard

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
@@ -111,13 +111,9 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
             schemasTable.setLayoutData(gd);
 
             Composite buttonsPanel = UIUtils.createComposite(catPanel, 3);
-            
-                        
+
             fullSchemaBackupCheck = UIUtils.createCheckbox(buttonsPanel, PostgreMessages.wizard_backup_page_object_checkbox_complete_backup, false);
-            fullSchemaBackupCheck.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
-                    wizard.getSettings().setFullSchemaBackup(fullSchemaBackupCheck.getSelection());
-                    tablesTable.setVisible(!fullSchemaBackupCheck.getSelection());
-                }));
+            fullSchemaBackupCheck.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> updateState()));
             fullSchemaBackupCheck.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL));
             buttonsPanel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
             createCheckButtons(buttonsPanel, schemasTable);
@@ -141,7 +137,7 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
             Composite buttonsPanel = UIUtils.createComposite(tablesPanel, 3);
             buttonsPanel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
             exportViewsCheck = UIUtils.createCheckbox(buttonsPanel, PostgreMessages.wizard_backup_page_object_checkbox_show_view, false);
-            exportViewsCheck.setSelection(wizard.getSettings().isFullSchemaBackup());
+            exportViewsCheck.setSelection(wizard.getSettings().isShowViews());
             exportViewsCheck.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
                     wizard.getSettings().setShowViews(exportViewsCheck.getSelection());
                     loadTables(null);
@@ -189,6 +185,7 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         checkedObjects.clear();
         schemasTable.removeAll();
         tablesTable.removeAll();
+        fullSchemaBackupCheck.setSelection(wizard.getSettings().isFullSchemaBackup());
 
         dataBase = null;
         boolean hasViews = false;
@@ -276,12 +273,12 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         return false;
     }
 
-    private List<PostgreTableBase> loadTables(final PostgreSchema catalog) {
+    private void loadTables(final PostgreSchema catalog) {
         if (catalog != null) {
             curSchema = catalog;
         }
         if (curSchema == null) {
-            return null;
+            return;
         }
         final boolean isCatalogChecked = isChecked(curSchema);
         final Set<PostgreTableBase> checkedObjects = this.checkedObjects.get(curSchema);
@@ -323,7 +320,6 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
                 return Status.OK_STATUS;
             }
         }.schedule();
-        return objects;
     }
 
     public void saveState() {
@@ -356,23 +352,34 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
     }
 
     private boolean isAllSchemaSelected() {
-        for (TableItem item : schemasTable.getItems()) {
+        TableItem[] items = schemasTable.getItems();
+        if (items.length == 0) {
+            return false;
+        }
+        for (TableItem item : items) {
             if (!item.getChecked()) {
                 return false;
             }
         }
         return true;
     }
-    
-    private void updatefullSchemaBackupState() {
-    	boolean allSchemasSelected =isAllSchemaSelected();
+
+    private void updateFullSchemaBackupState() {
+        boolean allSchemasSelected = isAllSchemaSelected();
         fullSchemaBackupCheck.setEnabled(allSchemasSelected);
-        wizard.getSettings().setFullSchemaBackup(allSchemasSelected);
+        if (!allSchemasSelected) {
+            // Complete backup dumps the entire database, it makes sense only when all schemas are checked
+            fullSchemaBackupCheck.setSelection(false);
+        }
+        boolean fullSchemaBackup = fullSchemaBackupCheck.getSelection();
+        wizard.getSettings().setFullSchemaBackup(fullSchemaBackup);
+        tablesTable.setVisible(!fullSchemaBackup);
     }
+
     @Override
     protected void updateState()
     {
-    	updatefullSchemaBackupState();
+        updateFullSchemaBackupState();
         updatePageCompletion();
         getContainer().updateButtons();
     }
@@ -387,24 +394,15 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
                     tableItem.setChecked(check);
                 }
             } else {
-                // This is the case when the user selects a backup by pressing the database, and not the scheme. Then tablesTable is empty.
-                TableItem[] schemasItems = schemasTable.getItems();
-                if (schemasItems.length != 0) {
-                    for (TableItem schemaItem : schemasItems) {
-                        Object data = schemaItem.getData();
-                        if (data instanceof PostgreSchema) {
-                            PostgreSchema postgreSchema = (PostgreSchema) data;
-                            if (schemaItem.getChecked() && check && !checkedObjects.containsKey(postgreSchema)) {
-                                List<PostgreTableBase> tableBaseList = loadTables(postgreSchema);
-                                if (!CommonUtils.isEmpty(tableBaseList)) {
-                                    checkedObjects.put(postgreSchema, new HashSet<>(tableBaseList));
-                                }
-                            } else if (!schemaItem.getChecked() && !check) {
-                                checkedObjects.remove(postgreSchema);
-                            }
-                        }
+                // This is the case when the user selects a backup by pressing the database, and not the scheme.
+                // Then tablesTable is empty and there is nothing to reconcile: a checked schema without an entry
+                // in checkedObjects is backed up entirely (see saveState), so dropping the entry is enough.
+                for (TableItem schemaItem : schemasTable.getItems()) {
+                    if (schemaItem.getData() instanceof PostgreSchema postgreSchema) {
+                        checkedObjects.remove(postgreSchema);
                     }
                 }
+                return;
             }
         }
         updateCheckedTables();


### PR DESCRIPTION
Fixes #40575

The PostgreSQL backup wizard ignores the table selection and dumps the whole database instead.

### What was wrong

`PostgreBackupWizardPageObjects.updatefullSchemaBackupState()` wrote the setting from the schema check state rather than from the checkbox:

```java
boolean allSchemasSelected = isAllSchemaSelected();
fullSchemaBackupCheck.setEnabled(allSchemasSelected);
wizard.getSettings().setFullSchemaBackup(allSchemasSelected);
```

`updateState()` calls this on every check event, so whenever all schemas happened to be checked — a database with a single `public` schema, for instance — `fullSchemaBackup` was silently `true` while the "Complete backup" checkbox rendered unchecked. `PostgreDatabaseBackupHandler.fillProcessParameters` then returned before adding any `-n`/`-t`, and pg_dump dumped everything.

The widget and the setting stopped agreeing in 7f27ae84f5 (#38959), which dropped `fullSchemaBackupCheck.setSelection(allSchemasSelected)` from that method but left the setter call in place.

### Changes

1. **The checkbox is the single source of truth.** `updateFullSchemaBackupState()` now only enables the checkbox when all schemas are checked, clears it when they are not, and writes the setting plus the tables-section visibility from the widget state. The checkbox listener just calls `updateState()`, so there is no longer a second path that can write a different value.
2. **`loadSettings()` syncs the checkbox with the persisted setting**, so a `pg.export.fullSchemaBackup` carried over from an earlier session or a saved task is visible instead of hidden.
3. **`isAllSchemaSelected()` returns `false` for an empty list**, so the flag cannot switch on before the schemas are loaded.
4. **The racy table collection in `updateTableCheckedStatus()` is gone.** `loadTables()` schedules an `AbstractJob` and returns its result list immediately, so the caller read a list that the job had not filled yet and could store a partial set in `checkedObjects` — which `saveState()` turns into a `-t` list covering only some of the tables. A checked schema without an entry in `checkedObjects` is already dumped whole via `-n`, so dropping the entry is both sufficient and race-free. `loadTables()` now returns `void`, since its result was never usable.
5. `exportViewsCheck` was initialised from `isFullSchemaBackup()` instead of `isShowViews()`.

### Relation to #41550 / #41683

#41550 fixed point 1 and was reverted in #41694 because of #41683, where a schema backup restored with many tables missing. Point 4 is, as far as I can tell, what caused that: while the flag was being forced to `true` the handler ignored `exportObjects` entirely, which masked the race. Removing the forcing without removing the race makes the partial `-t` list observable, and that is exactly the reported symptom. This PR addresses both, so the earlier regression should not come back.

### How to test

Against a PostgreSQL database with a single `public` schema holding several tables:

1. Tools → Backup → **None** → check one table → Start. The pg_dump command line on the log page must contain `-t "public"."<table>"` and the dump must hold only that table. "Complete backup" stays unchecked and stays enabled.
2. Tick "Complete backup" → the table list is hidden → the command line carries neither `-n` nor `-t` (whole database).
3. Untick it → the table list returns with the previous checkboxes intact → `-t` is used again.
4. With a multi-schema database, uncheck one schema: "Complete backup" becomes disabled and clears itself; the backup uses `-n`/`-t` according to the selection.
5. Regression check for #41683: check a schema with all of its tables and press "All" before the table list has finished loading. The command line must be `-n "public"`, never a partial `-t` list, and a restore of that dump must contain every table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrpGArXT5CsD6ZJWcqouKA
