### PR TITLE
dbeaver/dbeaver#7382 Make PostgreSQL dependency types readable

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependency.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependency.java
@@ -100,28 +100,45 @@ public class PostgreDependency implements PostgreObject, DBPOverloadedObject, DB
 
     @Property(viewable = true, order = 2)
     public String getObjectType() {
-        if (objectType.startsWith("i")) {
-            return "Index";
-        } else if (objectType.startsWith("R")) {
-            return "Rule";
-        } else if (objectType.startsWith("C")) {
-            if (objectType.endsWith("f")) {
-                return "Foreign Key";
-            } else if (objectType.endsWith("p")) {
-                return "Primary Key";
-            } else {
-                return "Constraint";
-            }
-        } else if (objectType.startsWith("r")) {
-            return "Table";
-        } else if (objectType.startsWith("A")) {
-            return "Attribute";
-        } else if (objectType.startsWith("T")) {
-            return "Trigger";
-        } else if (objectType.startsWith("S")) {
-            return "Sequence";
+        if (CommonUtils.isEmpty(objectType)) {
+            return objectType;
         }
-        return objectType;
+        // Disambiguate a standalone procedure ('p') from a partitioned table relkind ('p' + sub-object number)
+        if ("p".equals(objectType)) {
+            return "Procedure";
+        }
+        char code = objectType.charAt(0);
+        return switch (code) {
+            case 'r' -> "Table";
+            case 'i' -> "Index";
+            case 'I' -> "Partitioned Index";
+            case 'S' -> "Sequence";
+            case 't' -> "TOAST Table";
+            case 'v' -> "View";
+            case 'm' -> "Materialized View";
+            case 'c' -> "Composite Type";
+            case 'f' -> "Foreign Table";
+            case 'p' -> "Partitioned Table";
+            case 'T' -> "Trigger";
+            case 'y' -> "Type";
+            case 'n' -> "Schema";
+            case 'l' -> "Language";
+            case 'R' -> "Rule";
+            case 'A' -> "Attribute";
+            case 'C' -> getConstraintType(objectType);
+            default -> objectType;
+        };
+    }
+
+    private static String getConstraintType(String objectType) {
+        return switch (objectType) {
+            case "Cp" -> "Primary Key";
+            case "Cf" -> "Foreign Key";
+            case "Cu" -> "Unique Constraint";
+            case "Cc" -> "Check Constraint";
+            case "Cx" -> "Exclusion Constraint";
+            default -> "Constraint";
+        };
     }
 
     @Property(viewable = true, order = 3)

--- a/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependencyTest.java
+++ b/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependencyTest.java
@@ -1,0 +1,146 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.model;
+
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PostgreDependencyTest extends DBeaverUnitTest {
+
+    @Test
+    public void getObjectType_whenTypeCodeIsKnown_shouldReturnReadableName() {
+        PostgreDependency dependency = new PostgreDependency(
+            null, 0, "a", "some_object", null, "r0", null, null);
+        Assertions.assertEquals("Table", dependency.getObjectType());
+    }
+
+    @Test
+    public void getObjectType_whenSequence_shouldReturnSequence() {
+        Assertions.assertEquals("Sequence", testType("S0"));
+    }
+
+    @Test
+    public void getObjectType_whenToastTable_shouldReturnToastTable() {
+        Assertions.assertEquals("TOAST Table", testType("t0"));
+    }
+
+    @Test
+    public void getObjectType_whenDataType_shouldReturnType() {
+        Assertions.assertEquals("Type", testType("y"));
+    }
+
+    @Test
+    public void getObjectType_whenProcedure_shouldReturnProcedure() {
+        Assertions.assertEquals("Procedure", testType("p"));
+    }
+
+    @Test
+    public void getObjectType_whenPartitionedTable_shouldReturnPartitionedTable() {
+        Assertions.assertEquals("Partitioned Table", testType("p0"));
+    }
+
+    @Test
+    public void getObjectType_whenSchema_shouldReturnSchema() {
+        Assertions.assertEquals("Schema", testType("n"));
+    }
+
+    @Test
+    public void getObjectType_whenLanguage_shouldReturnLanguage() {
+        Assertions.assertEquals("Language", testType("l"));
+    }
+
+    @Test
+    public void getObjectType_whenRule_shouldReturnRule() {
+        Assertions.assertEquals("Rule", testType("R"));
+    }
+
+    @Test
+    public void getObjectType_whenTrigger_shouldReturnTrigger() {
+        Assertions.assertEquals("Trigger", testType("T"));
+    }
+
+    @Test
+    public void getObjectType_whenAttribute_shouldReturnAttribute() {
+        Assertions.assertEquals("Attribute", testType("A"));
+    }
+
+    @Test
+    public void getObjectType_whenIndex_shouldReturnIndex() {
+        Assertions.assertEquals("Index", testType("i0"));
+    }
+
+    @Test
+    public void getObjectType_whenView_shouldReturnView() {
+        Assertions.assertEquals("View", testType("v0"));
+    }
+
+    @Test
+    public void getObjectType_whenMaterializedView_shouldReturnMaterializedView() {
+        Assertions.assertEquals("Materialized View", testType("m0"));
+    }
+
+    @Test
+    public void getObjectType_whenCompositeType_shouldReturnCompositeType() {
+        Assertions.assertEquals("Composite Type", testType("c0"));
+    }
+
+    @Test
+    public void getObjectType_whenForeignTable_shouldReturnForeignTable() {
+        Assertions.assertEquals("Foreign Table", testType("f0"));
+    }
+
+    @Test
+    public void getObjectType_whenPrimaryKeyConstraint_shouldReturnPrimaryKey() {
+        Assertions.assertEquals("Primary Key", testType("Cp"));
+    }
+
+    @Test
+    public void getObjectType_whenForeignKeyConstraint_shouldReturnForeignKey() {
+        Assertions.assertEquals("Foreign Key", testType("Cf"));
+    }
+
+    @Test
+    public void getObjectType_whenUniqueConstraint_shouldReturnUniqueConstraint() {
+        Assertions.assertEquals("Unique Constraint", testType("Cu"));
+    }
+
+    @Test
+    public void getObjectType_whenCheckConstraint_shouldReturnCheckConstraint() {
+        Assertions.assertEquals("Check Constraint", testType("Cc"));
+    }
+
+    @Test
+    public void getObjectType_whenExclusionConstraint_shouldReturnExclusionConstraint() {
+        Assertions.assertEquals("Exclusion Constraint", testType("Cx"));
+    }
+
+    @Test
+    public void getObjectType_whenUnknownCode_shouldReturnCodeAsIs() {
+        Assertions.assertEquals("zz", testType("zz"));
+    }
+
+    @Test
+    public void getObjectType_whenCodeIsMissing_shouldReturnEmptyString() {
+        Assertions.assertEquals("", testType(""));
+    }
+
+    private static String testType(String objectType) {
+        PostgreDependency dependency = new PostgreDependency(null, 0, "a", "some_object", null, objectType, null, null);
+        return dependency.getObjectType();
+    }
+}

--- a/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependencyTest.java
+++ b/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDependencyTest.java
@@ -23,119 +23,124 @@ import org.junit.jupiter.api.Test;
 public class PostgreDependencyTest extends DBeaverUnitTest {
 
     @Test
-    public void getObjectType_whenTypeCodeIsKnown_shouldReturnReadableName() {
+    public void getObjectTypeWhenKnownCodeShouldReturnReadableName() {
         PostgreDependency dependency = new PostgreDependency(
             null, 0, "a", "some_object", null, "r0", null, null);
         Assertions.assertEquals("Table", dependency.getObjectType());
     }
 
     @Test
-    public void getObjectType_whenSequence_shouldReturnSequence() {
+    public void getObjectTypeWhenSequenceShouldReturnSequence() {
         Assertions.assertEquals("Sequence", testType("S0"));
     }
 
     @Test
-    public void getObjectType_whenToastTable_shouldReturnToastTable() {
+    public void getObjectTypeWhenToastTableShouldReturnToastTable() {
         Assertions.assertEquals("TOAST Table", testType("t0"));
     }
 
     @Test
-    public void getObjectType_whenDataType_shouldReturnType() {
+    public void getObjectTypeWhenDataTypeShouldReturnType() {
         Assertions.assertEquals("Type", testType("y"));
     }
 
     @Test
-    public void getObjectType_whenProcedure_shouldReturnProcedure() {
+    public void getObjectTypeWhenProcedureShouldReturnProcedure() {
         Assertions.assertEquals("Procedure", testType("p"));
     }
 
     @Test
-    public void getObjectType_whenPartitionedTable_shouldReturnPartitionedTable() {
+    public void getObjectTypeWhenPartitionedTableShouldReturnPartitionedTable() {
         Assertions.assertEquals("Partitioned Table", testType("p0"));
     }
 
     @Test
-    public void getObjectType_whenSchema_shouldReturnSchema() {
+    public void getObjectTypeWhenSchemaShouldReturnSchema() {
         Assertions.assertEquals("Schema", testType("n"));
     }
 
     @Test
-    public void getObjectType_whenLanguage_shouldReturnLanguage() {
+    public void getObjectTypeWhenLanguageShouldReturnLanguage() {
         Assertions.assertEquals("Language", testType("l"));
     }
 
     @Test
-    public void getObjectType_whenRule_shouldReturnRule() {
+    public void getObjectTypeWhenRuleShouldReturnRule() {
         Assertions.assertEquals("Rule", testType("R"));
     }
 
     @Test
-    public void getObjectType_whenTrigger_shouldReturnTrigger() {
+    public void getObjectTypeWhenTriggerShouldReturnTrigger() {
         Assertions.assertEquals("Trigger", testType("T"));
     }
 
     @Test
-    public void getObjectType_whenAttribute_shouldReturnAttribute() {
+    public void getObjectTypeWhenAttributeShouldReturnAttribute() {
         Assertions.assertEquals("Attribute", testType("A"));
     }
 
     @Test
-    public void getObjectType_whenIndex_shouldReturnIndex() {
+    public void getObjectTypeWhenIndexShouldReturnIndex() {
         Assertions.assertEquals("Index", testType("i0"));
     }
 
     @Test
-    public void getObjectType_whenView_shouldReturnView() {
+    public void getObjectTypeWhenViewShouldReturnView() {
         Assertions.assertEquals("View", testType("v0"));
     }
 
     @Test
-    public void getObjectType_whenMaterializedView_shouldReturnMaterializedView() {
+    public void getObjectTypeWhenMaterializedViewShouldReturnMaterializedView() {
         Assertions.assertEquals("Materialized View", testType("m0"));
     }
 
     @Test
-    public void getObjectType_whenCompositeType_shouldReturnCompositeType() {
+    public void getObjectTypeWhenCompositeTypeShouldReturnCompositeType() {
         Assertions.assertEquals("Composite Type", testType("c0"));
     }
 
     @Test
-    public void getObjectType_whenForeignTable_shouldReturnForeignTable() {
+    public void getObjectTypeWhenForeignTableShouldReturnForeignTable() {
         Assertions.assertEquals("Foreign Table", testType("f0"));
     }
 
     @Test
-    public void getObjectType_whenPrimaryKeyConstraint_shouldReturnPrimaryKey() {
+    public void getObjectTypeWhenPartitionedIndexShouldReturnPartitionedIndex() {
+        Assertions.assertEquals("Partitioned Index", testType("I0"));
+    }
+
+    @Test
+    public void getObjectTypeWhenPrimaryKeyConstraintShouldReturnPrimaryKey() {
         Assertions.assertEquals("Primary Key", testType("Cp"));
     }
 
     @Test
-    public void getObjectType_whenForeignKeyConstraint_shouldReturnForeignKey() {
+    public void getObjectTypeWhenForeignKeyConstraintShouldReturnForeignKey() {
         Assertions.assertEquals("Foreign Key", testType("Cf"));
     }
 
     @Test
-    public void getObjectType_whenUniqueConstraint_shouldReturnUniqueConstraint() {
+    public void getObjectTypeWhenUniqueConstraintShouldReturnUniqueConstraint() {
         Assertions.assertEquals("Unique Constraint", testType("Cu"));
     }
 
     @Test
-    public void getObjectType_whenCheckConstraint_shouldReturnCheckConstraint() {
+    public void getObjectTypeWhenCheckConstraintShouldReturnCheckConstraint() {
         Assertions.assertEquals("Check Constraint", testType("Cc"));
     }
 
     @Test
-    public void getObjectType_whenExclusionConstraint_shouldReturnExclusionConstraint() {
+    public void getObjectTypeWhenExclusionConstraintShouldReturnExclusionConstraint() {
         Assertions.assertEquals("Exclusion Constraint", testType("Cx"));
     }
 
     @Test
-    public void getObjectType_whenUnknownCode_shouldReturnCodeAsIs() {
+    public void getObjectTypeWhenUnknownCodeShouldReturnCodeAsIs() {
         Assertions.assertEquals("zz", testType("zz"));
     }
 
     @Test
-    public void getObjectType_whenCodeIsMissing_shouldReturnEmptyString() {
+    public void getObjectTypeWhenCodeIsMissingShouldReturnEmptyString() {
         Assertions.assertEquals("", testType(""));
     }
 


### PR DESCRIPTION
Closes dbeaver/dbeaver#7382

## Description

The **Dependencies** panel of the **Properties** tab of a PostgreSQL table lists
the objects that the table depends on. The **Type** column is meant to show what
kind of object each dependency is (view, table, trigger, rule, and so on), but
for many kinds it displayed the raw, cryptic PostgreSQL catalog type code
directly (e.g. `S0`, `t0`, `y`, `p`, `n`, `l`). This made it impossible to tell
what many of the dependencies actually are.

This happened in `PostgreDependency.getObjectType()`: the method only mapped a
small subset of PostgreSQL type codes to readable names and returned the
original cryptic string for everything else.

## Fix

`PostgreDependency.getObjectType()` now maps the complete set of PostgreSQL
object-type codes produced by the dependency query (`pg_depend` joined against
`pg_class`, `pg_proc`, `pg_trigger`, `pg_type`, `pg_namespace`, `pg_language`,
`pg_rewrite`, `pg_constraint` and `pg_attrdef`) to human-readable names:

- `pg_class.relkind` codes (`r`, `i`, `I`, `S`, `t`, `v`, `m`, `c`, `f`, `p`)
  to their corresponding object type (Table, Index, Sequence, TOAST Table,
  View, Materialized View, Composite Type, Foreign Table, Partitioned Table);
- non-`pg_class` codes: `T` -> Trigger, `y` -> Type, `n` -> Schema,
  `p` -> Procedure, `l` -> Language, `R` -> Rule, `A` -> Attribute;
- `C` + constraint type (`p`/`f`/`u`/`c`/`x`) to Primary Key, Foreign Key,
  Unique / Check / Exclusion Constraint.

The ambiguous `p` code is disambiguated by length: a single `p` denotes a
standalone procedure (`pg_proc`), whereas `p0` (relkind) denotes a partitioned
table.

An empty type code is handled gracefully instead of failing.

## Note on system dependencies

Some dependencies displayed in the panel are **normal PostgreSQL system
dependencies** — not user errors or incorrect data:

- **TOAST Table** (`pg_class.relkind = 't'`): every PostgreSQL table can have an
  associated TOAST table for out-of-line storage of large column values.
  See [Storage and SQL Syntax](https://www.postgresql.org/docs/current/storage-toast.html).
- **Type** (composite row type, `pg_class.relkind = 'c'`): PostgreSQL
  automatically creates a row type for each table, needed for column defaults,
  return types and `ROW()` expressions.
  See [Composite Types](https://www.postgresql.org/docs/current/rowtypes.html).

Both are created implicitly by `CREATE TABLE` and are tracked in `pg_depend`
as `DEPENDENCY_INTERNAL` (`deptype = 'i'`) or `DEPENDENCY_AUTO`
(`deptype = 'a'`).  See
[pg_depend](https://www.postgresql.org/docs/current/catalog-pg-depend.html)
and
[pg_class.relkind](https://www.postgresql.org/docs/current/catalog-pg-class.html)
for details.

## Tests

A new unit test class `PostgreDependencyTest` was added
(`test/org.jkiss.dbeaver.ext.postgresql.test`) covering the mapping of every
supported type code, including the previously cryptic `S0`, `t0` and `y`.
