### PR TITLE
dbeaver/dbeaver#42025 Only consume Escape key in SQL editor when suggestion hint is visible

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/src/org/jkiss/dbeaver/ui/editors/sql/SQLEditor.java
@@ -1257,7 +1257,7 @@ public class SQLEditor extends SQLEditorBase implements
             }
         });
         textWidget.addVerifyKeyListener(e -> {
-            if (e.keyCode == SWT.ESC) {
+            if (e.keyCode == SWT.ESC && suggestionTextPainter.hasContentToShow()) {
                 e.doit = false;
                 suggestionTextPainter.removeHint();
             }


### PR DESCRIPTION
Closes dbeaver/dbeaver#42025

### What
Since 25.2.0, the verify-key listener installed alongside SQLSuggestionTextPainter consumed every SWT.ESC keypress (doit = false), so Escape never reached the workbench keybinding dispatcher. User-defined Escape bindings (e.g. "End multi-selection") never fired in the SQL editor; Escape + modifiers were equally consumed. Key Assist showed no match.

### Fix
Consume Escape only when a suggestion hint is actually visible — suggestionTextPainter.hasContentToShow() — the same predicate the adjacent ArrowRight/Tab/Enter listener already uses. One-line change in SQLEditor.java.

### Testing
- Manual: bound "End multi-selection" to Escape (When = Editing Text) — the   binding now fires in the SQL editor; Escape still dismisses a visible  ghost-text suggestion; Escape dispatches normally when no hint is visible.
- Full product build passes (mvn package -f product/aggregate/pom.xml
-T1C -Pproduct-dbeaver-ce,product-dbeaver-eclipse-ce).

---
This PR was generated with AI (opencode). The change was verified and tested by a human contributor.