### PR TITLE
dbeaver/dbeaver#42027 Format nullable and parameterized ClickHouse JSON columns

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/plugin.xml
@@ -165,6 +165,9 @@
             <type name="TUPLE*"/>
             <type name="MAP*"/>
             <type name="JSON"/>
+            <type name="JSON(*"/>
+            <type name="NULLABLE(JSON)"/>
+            <type name="NULLABLE(JSON(*"/>
 
             <!-- https://clickhouse.com/docs/sql-reference/data-types/geo -->
             <type name="POINT"/>

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/plugin.xml
@@ -164,6 +164,10 @@
             <type name="IPV6"/>
             <type name="TUPLE*"/>
             <type name="MAP*"/>
+            <!--
+                Restrict matching to JSON, JSON(...), Nullable(JSON), and Nullable(JSON(...)).
+                Avoid matching alternative type names that may not be compatible with the current JSON formatter.
+            -->
             <type name="JSON"/>
             <type name="JSON(*"/>
             <type name="NULLABLE(JSON)"/>

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseConstants.java
@@ -35,6 +35,7 @@ public class ClickhouseConstants {
     public static final String DATA_TYPE_TUPLE = "Tuple";
     public static final String DATA_TYPE_MAP = "Map";
     public static final String DATA_TYPE_JSON = "JSON";
+    public static final String DATA_TYPE_NULLABLE_JSON = "Nullable(JSON)";
     public static final String CLICKHOUSE_SETTING_SESSION_ID = "clickhouse_setting_session_id";
     public static final String CLICKHOUSE_SETTING_SESSION_TIMEOUT = "clickhouse_setting_session_timeout";
     // Server setting that makes the driver serialize JSON columns as canonical JSON strings (so getString()

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseTypeParser.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/ClickhouseTypeParser.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,47 @@ public class ClickhouseTypeParser {
                 typeName.startsWith(ClickhouseConstants.DATA_TYPE_TUPLE) ||
                 typeName.startsWith(ClickhouseConstants.DATA_TYPE_ARRAY)
             );
+    }
+
+    /** Recognizes scalar JSON metadata, including type hints and an optional Nullable wrapper. */
+    public static boolean isJsonType(@NotNull String typeName) {
+        if (ClickhouseConstants.DATA_TYPE_JSON.equalsIgnoreCase(typeName)
+            || ClickhouseConstants.DATA_TYPE_NULLABLE_JSON.equalsIgnoreCase(typeName)
+        ) {
+            return true;
+        }
+
+        String nullablePrefix = "Nullable(";
+        boolean nullable = typeName.regionMatches(true, 0, nullablePrefix, 0, nullablePrefix.length());
+        int start = nullable ? nullablePrefix.length() : 0;
+        String jsonPrefix = ClickhouseConstants.DATA_TYPE_JSON + "(";
+        if (!typeName.regionMatches(true, start, jsonPrefix, 0, jsonPrefix.length())) {
+            return false;
+        }
+
+        // Type hints can contain nested types, quoted paths, enum labels and regular expressions.
+        int depth = 1;
+        char quote = 0;
+        for (int i = start + jsonPrefix.length(); i < typeName.length(); i++) {
+            char c = typeName.charAt(i);
+            if (quote != 0) {
+                if (c == '\\') {
+                    i++;
+                } else if (c == quote) {
+                    quote = 0;
+                }
+            } else if (c == '\'' || c == '"' || c == '`') {
+                quote = c;
+            } else if (c == '(') {
+                depth++;
+            } else if (c == ')' && --depth == 0) {
+                // JDBC v2 can omit the outer Nullable close in getColumnTypeName().
+                // Accept that metadata spelling without changing the original type name.
+                return i == typeName.length() - 1
+                    || (nullable && i == typeName.length() - 2 && typeName.charAt(i + 1) == ')');
+            }
+        }
+        return false;
     }
 
     @Nullable

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseDataSource.java
@@ -234,6 +234,9 @@ public class ClickhouseDataSource extends GenericDataSource {
     @Nullable
     @Override
     public DBSDataType getLocalDataType(@Nullable String typeName) {
+        if (typeName != null && ClickhouseTypeParser.isJsonType(typeName)) {
+            return super.getLocalDataType(ClickhouseConstants.DATA_TYPE_JSON);
+        }
         return super.getLocalDataType(ClickhouseTypeParser.getTypeNameWithoutModifiers(typeName));
     }
 
@@ -325,9 +328,9 @@ public class ClickhouseDataSource extends GenericDataSource {
             return DBPDataKind.ARRAY;
         } else if (typeName.startsWith(ClickhouseConstants.DATA_TYPE_TUPLE)) {
             return DBPDataKind.STRUCT;
-        } else if (typeName.equalsIgnoreCase(ClickhouseConstants.DATA_TYPE_JSON)) {
+        } else if (ClickhouseTypeParser.isJsonType(typeName)) {
             // Render JSON columns through the JSON content viewer/editor (see ClickhouseJSONValueHandler).
-            // Exact match only: parameterized JSON(...) and Nullable(JSON)/Array(JSON)/Map(_,JSON) stay UNKNOWN.
+            // Only scalar JSON variants; collection types retain their existing handling.
             return DBPDataKind.CONTENT;
         }
         return super.resolveDataKind(typeName, valueType);

--- a/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClickhouseValueHandlerProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.clickhouse/src/org/jkiss/dbeaver/ext/clickhouse/model/data/ClickhouseValueHandlerProvider.java
@@ -18,6 +18,7 @@ package org.jkiss.dbeaver.ext.clickhouse.model.data;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.ext.clickhouse.ClickhouseConstants;
+import org.jkiss.dbeaver.ext.clickhouse.ClickhouseTypeParser;
 import org.jkiss.dbeaver.model.DBPDataKind;
 import org.jkiss.dbeaver.model.DBPDataSource;
 import org.jkiss.dbeaver.model.data.DBDFormatSettings;
@@ -38,9 +39,9 @@ public class ClickhouseValueHandlerProvider implements DBDValueHandlerProvider {
     ) {
         String lowerTypeName = type.getTypeName().toLowerCase(Locale.ENGLISH);
         DBPDataKind dataKind = type.getDataKind();
-        if ("json".equals(lowerTypeName)) {
-            // Keyed on the type name (not data kind): result-set meta columns report JSON as UNKNOWN
-            // via the static type cache, while editable table columns resolve it to CONTENT.
+        if (ClickhouseTypeParser.isJsonType(type.getTypeName())) {
+            // Keyed on the type name so scalar JSON variants use the same handler,
+            // regardless of the data kind supplied by JDBC metadata.
             return ClickhouseJSONValueHandler.INSTANCE;
         } else if ("enum8".equals(lowerTypeName) || "enum16".equals(lowerTypeName)) {
             return ClickhouseEnumValueHandler.INSTANCE;

--- a/test/org.jkiss.dbeaver.ext.clickhouse.test/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseJSONRoutingTest.java
+++ b/test/org.jkiss.dbeaver.ext.clickhouse.test/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseJSONRoutingTest.java
@@ -25,7 +25,6 @@ import org.jkiss.dbeaver.ext.clickhouse.model.data.ClickhouseContentJSON;
 import org.jkiss.dbeaver.ext.clickhouse.model.data.ClickhouseJSONValueHandler;
 import org.jkiss.dbeaver.ext.clickhouse.model.data.ClickhouseStructValueHandler;
 import org.jkiss.dbeaver.ext.clickhouse.model.data.ClickhouseValueHandlerProvider;
-import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataType;
 import org.jkiss.dbeaver.model.DBPDataKind;
 import org.jkiss.dbeaver.model.DBPDataSource;
@@ -39,6 +38,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.impl.jdbc.exec.JDBCColumnMetaData;
+import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 import org.jkiss.dbeaver.model.struct.DBSTypedObject;
 import org.jkiss.dbeaver.registry.datatype.ValueHandlerDescriptor;
 import org.jkiss.dbeaver.utils.MimeTypes;
@@ -159,8 +159,20 @@ public class ClickhouseJSONRoutingTest extends DBeaverUnitTest {
 
     @NotNull
     private ClickhouseDataSource dataSourceWithTypeCache(boolean populated) throws Exception {
-        var dataSource = mock(ClickhouseDataSource.class, CALLS_REAL_METHODS);
-        var cache = new ClickhouseDataTypeCache(dataSource);
+        when(monitor.isForceCacheUsage()).thenReturn(true);
+        var dataSource = new ClickhouseDataSource(monitor, configureTestContainer("com_clickhouse"), new ClickhouseMetaModel()) {
+            @Override
+            protected void initializeRemoteInstance(@NotNull DBRProgressMonitor monitor) {
+                // Keep normal type-cache initialization without opening a database connection.
+            }
+
+            @NotNull
+            @Override
+            protected ClickhouseDataTypeCache getDataTypeCache() {
+                return (ClickhouseDataTypeCache) super.getDataTypeCache();
+            }
+        };
+        var cache = dataSource.getDataTypeCache();
         cache.setCache(populated ? List.of(
             new GenericDataType(dataSource, Types.CLOB, "JSON", null, false, false, 0, 0, 0),
             new GenericDataType(dataSource, Types.NULL, "Nullable", null, false, false, 0, 0, 0),
@@ -170,10 +182,6 @@ public class ClickhouseJSONRoutingTest extends DBeaverUnitTest {
             new GenericDataType(dataSource, Types.STRUCT, "Tuple", null, false, false, 0, 0, 0),
             new GenericDataType(dataSource, Types.NULL, "LowCardinality", null, false, false, 0, 0, 0)
         ) : List.of());
-        // Avoid opening a connection in the constructor while exercising the real cache lookup, not a stub.
-        var cacheField = GenericDataSource.class.getDeclaredField("dataTypeCache");
-        cacheField.setAccessible(true);
-        cacheField.set(dataSource, cache);
         return dataSource;
     }
 

--- a/test/org.jkiss.dbeaver.ext.clickhouse.test/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseJSONRoutingTest.java
+++ b/test/org.jkiss.dbeaver.ext.clickhouse.test/src/org/jkiss/dbeaver/ext/clickhouse/model/ClickhouseJSONRoutingTest.java
@@ -1,0 +1,293 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.clickhouse.model;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.Platform;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.ext.clickhouse.model.data.ClickhouseArrayValueHandler;
+import org.jkiss.dbeaver.ext.clickhouse.model.data.ClickhouseContentJSON;
+import org.jkiss.dbeaver.ext.clickhouse.model.data.ClickhouseJSONValueHandler;
+import org.jkiss.dbeaver.ext.clickhouse.model.data.ClickhouseStructValueHandler;
+import org.jkiss.dbeaver.ext.clickhouse.model.data.ClickhouseValueHandlerProvider;
+import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
+import org.jkiss.dbeaver.ext.generic.model.GenericDataType;
+import org.jkiss.dbeaver.model.DBPDataKind;
+import org.jkiss.dbeaver.model.DBPDataSource;
+import org.jkiss.dbeaver.model.data.DBDDisplayFormat;
+import org.jkiss.dbeaver.model.data.DBDFormatSettings;
+import org.jkiss.dbeaver.model.data.DBDValueHandler;
+import org.jkiss.dbeaver.model.exec.DBCException;
+import org.jkiss.dbeaver.model.exec.DBCExecutionContext;
+import org.jkiss.dbeaver.model.exec.DBCSession;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.impl.jdbc.exec.JDBCColumnMetaData;
+import org.jkiss.dbeaver.model.struct.DBSTypedObject;
+import org.jkiss.dbeaver.registry.datatype.ValueHandlerDescriptor;
+import org.jkiss.dbeaver.utils.MimeTypes;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/** Scalar JSON variants use the existing content viewer without changing collection or binding behavior. */
+public class ClickhouseJSONRoutingTest extends DBeaverUnitTest {
+    private final ClickhouseValueHandlerProvider provider = new ClickhouseValueHandlerProvider();
+
+    @NotNull
+    private static Stream<String> supportedJsonTypes() {
+        return Stream.of(
+            "JSON", "json", "JSON()", "JSON( )", "Nullable(JSON)", "nullable(json)", "Nullable(JSON())",
+            "JSON(a UInt64)", "json(a UInt64)", "JSON(max_dynamic_types=1, max_dynamic_paths=0)",
+            "JSON(a Array(Nullable(UInt64)))", "JSON(a Tuple(x UInt64, y String))", "JSON(a Map(String, UInt64))",
+            "JSON(a JSON)", "JSON(a Decimal(38, 9))", "JSON(SKIP a.b)", "JSON(SKIP REGEXP '^(foo|bar)$')",
+            "JSON(SKIP REGEXP '[)]')", "JSON(`a)b` UInt64)", "JSON(`a(b` UInt64)", "JSON(\"a)b\" UInt64)",
+            "JSON(`a``)b` UInt64)", "JSON(a Enum8('x(y)'=1, 'z'=2))", "JSON(a Enum8('x\\')y'=1))",
+            "Nullable(JSON(a UInt64))", "Nullable(JSON(a Array(Nullable(UInt64))))",
+            "Nullable(JSON(SKIP REGEXP '[)]'))", "Nullable(JSON(`a(b` UInt64))",
+            // JDBC v2 0.9.8/0.10.0 omit only the outer Nullable close in result-set metadata.
+            "Nullable(JSON()", "Nullable(JSON(a UInt64)", "Nullable(JSON(a Array(Nullable(UInt64)))",
+            "Nullable(JSON(SKIP REGEXP '[)]')", "Nullable(JSON(`a)b` UInt64)"
+        );
+    }
+
+    @NotNull
+    private DBSTypedObject type(@NotNull String name, @NotNull DBPDataKind kind) {
+        DBSTypedObject type = mock(DBSTypedObject.class);
+        when(type.getTypeName()).thenReturn(name);
+        when(type.getDataKind()).thenReturn(kind);
+        when(type.getTypeID()).thenReturn(Types.OTHER);
+        return type;
+    }
+
+    @Nullable
+    private DBDValueHandler handler(@NotNull String name, @NotNull DBPDataKind kind) {
+        return provider.getValueHandler(mock(DBPDataSource.class), mock(DBDFormatSettings.class), type(name, kind));
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedJsonTypes")
+    public void scalarJsonRoutingDoesNotDependOnMetadataKind(@NotNull String name) {
+        for (DBPDataKind kind : new DBPDataKind[] {DBPDataKind.UNKNOWN, DBPDataKind.CONTENT, DBPDataKind.STRING}) {
+            assertSame(ClickhouseJSONValueHandler.INSTANCE, handler(name, kind), kind.name());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedJsonTypes")
+    public void supportedJsonTypesUseContentKind(@NotNull String name) {
+        var dataSource = mock(ClickhouseDataSource.class, CALLS_REAL_METHODS);
+        doReturn(null).when(dataSource).getLocalDataType(anyString());
+        assertEquals(DBPDataKind.CONTENT, dataSource.resolveDataKind(name, Types.OTHER));
+        assertEquals(DBPDataKind.CONTENT, dataSource.resolveDataKind(name, Types.VARCHAR));
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedJsonTypes")
+    public void cachedJsonTypesUseContentKindInResultSets(@NotNull String name) throws Exception {
+        var dataSource = dataSourceWithTypeCache(true);
+        assertSame(dataSource.getLocalDataType("JSON"), dataSource.getLocalDataType(name));
+        for (int jdbcType : new int[] {Types.OTHER, Types.VARCHAR}) {
+            for (int nullable : new int[] {ResultSetMetaData.columnNoNulls, ResultSetMetaData.columnNullable}) {
+                var jdbcMetadata = mock(ResultSetMetaData.class);
+                when(jdbcMetadata.getColumnTypeName(1)).thenReturn(name);
+                when(jdbcMetadata.getColumnType(1)).thenReturn(jdbcType);
+                when(jdbcMetadata.isNullable(1)).thenReturn(nullable);
+                var column = new JDBCColumnMetaData(dataSource, jdbcMetadata, 0);
+                assertEquals(DBPDataKind.CONTENT, column.getDataKind());
+                assertEquals(Types.CLOB, column.getTypeID());
+                assertEquals(name, column.getTypeName());
+                assertEquals(nullable == ResultSetMetaData.columnNoNulls, column.isRequired());
+                assertSame(ClickhouseJSONValueHandler.INSTANCE,
+                    provider.getValueHandler(dataSource, mock(DBDFormatSettings.class), column));
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedJsonTypes")
+    public void emptyTypeCacheFallsBackToJsonContentKind(@NotNull String name) throws Exception {
+        var dataSource = dataSourceWithTypeCache(false);
+        var jdbcMetadata = mock(ResultSetMetaData.class);
+        when(jdbcMetadata.getColumnTypeName(1)).thenReturn(name);
+        when(jdbcMetadata.getColumnType(1)).thenReturn(Types.OTHER);
+        assertNull(dataSource.getLocalDataType(name));
+        assertEquals(DBPDataKind.CONTENT, new JDBCColumnMetaData(dataSource, jdbcMetadata, 0).getDataKind());
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "Nullable(String)|Nullable", "Nullable(Array(JSON))|Nullable", "Nullable(Nullable(JSON))|Nullable",
+        "Array(JSON)|Array", "Array(Nullable(JSON))|Array", "Map(String, JSON)|Map",
+        "Tuple(JSON, UInt64)|Tuple", "LowCardinality(JSON)|LowCardinality", "String|String"
+    }, delimiter = '|')
+    public void unrelatedTypesKeepExistingCacheLookup(@NotNull String name, @NotNull String cachedName) throws Exception {
+        var dataSource = dataSourceWithTypeCache(true);
+        assertSame(dataSource.getLocalDataType(cachedName), dataSource.getLocalDataType(name));
+        assertNotSame(ClickhouseJSONValueHandler.INSTANCE,
+            handler(name, dataSource.getLocalDataType(name).getDataKind()));
+    }
+
+    @NotNull
+    private ClickhouseDataSource dataSourceWithTypeCache(boolean populated) throws Exception {
+        var dataSource = mock(ClickhouseDataSource.class, CALLS_REAL_METHODS);
+        var cache = new ClickhouseDataTypeCache(dataSource);
+        cache.setCache(populated ? List.of(
+            new GenericDataType(dataSource, Types.CLOB, "JSON", null, false, false, 0, 0, 0),
+            new GenericDataType(dataSource, Types.NULL, "Nullable", null, false, false, 0, 0, 0),
+            new GenericDataType(dataSource, Types.VARCHAR, "String", null, false, false, 0, 0, 0),
+            new GenericDataType(dataSource, Types.ARRAY, "Array", null, false, false, 0, 0, 0),
+            new GenericDataType(dataSource, Types.ARRAY, "Map", null, false, false, 0, 0, 0),
+            new GenericDataType(dataSource, Types.STRUCT, "Tuple", null, false, false, 0, 0, 0),
+            new GenericDataType(dataSource, Types.NULL, "LowCardinality", null, false, false, 0, 0, 0)
+        ) : List.of());
+        // Avoid opening a connection in the constructor while exercising the real cache lookup, not a stub.
+        var cacheField = GenericDataSource.class.getDeclaredField("dataTypeCache");
+        cacheField.setAccessible(true);
+        cacheField.set(dataSource, cache);
+        return dataSource;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"String", "Nullable(String)", "Dynamic", "Object('json')", "JSONB", "JSONX",
+        "JSON)", "Nullable(JSON", "Nullable(JSON))", "Nullable(JSON)Extra", "LowCardinality(String)",
+        "Tuple(JSON)", "Map(String, JSON)", "Array(JSON)", "Array(Nullable(JSON))", "LowCardinality(JSON)",
+        "Nullable(Nullable(JSON))", "Nullable(Array(JSON))", "JSON(", "JSON(a UInt64", "JSON(a UInt64))",
+        "JSON(a UInt64)Extra", "JSON(a UInt64)Extra()", "Nullable(JSON(a UInt64", "Nullable(JSON(a UInt64)))",
+        "Nullable(JSON(a UInt64)Extra)", "Nullable(JSON(a UInt64))Extra", "Nullable(JSONX(a UInt64))",
+        "JSON(`a UInt64)", "JSON(SKIP REGEXP 'unfinished)", "JSON(\"a UInt64)", "JSON(a Array(UInt64)"})
+    public void unrelatedAndMalformedTypesAreNotJson(@NotNull String name) {
+        assertNotSame(ClickhouseJSONValueHandler.INSTANCE, handler(name, DBPDataKind.UNKNOWN));
+        assertNotSame(ClickhouseJSONValueHandler.INSTANCE, handler(name, DBPDataKind.CONTENT));
+        var dataSource = mock(ClickhouseDataSource.class, CALLS_REAL_METHODS);
+        doReturn(null).when(dataSource).getLocalDataType(anyString());
+        assertNotEquals(DBPDataKind.CONTENT, dataSource.resolveDataKind(name, Types.OTHER));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Array(JSON)", "Array(JSON(a UInt64))", "Array(Nullable(JSON))",
+        "Array(Array(JSON))", "Array(String)", "Array(UInt64)", "Map(String, JSON)", "Map(UInt64, String)"})
+    public void arraysAndMapsKeepCollectionHandler(@NotNull String name) {
+        assertSame(ClickhouseArrayValueHandler.INSTANCE, handler(name, DBPDataKind.ARRAY));
+        if (name.startsWith("Array(")) {
+            var dataSource = mock(ClickhouseDataSource.class, CALLS_REAL_METHODS);
+            assertEquals(DBPDataKind.ARRAY, dataSource.resolveDataKind(name, Types.OTHER));
+        }
+    }
+
+    @Test
+    public void tupleKeepsStructHandler() {
+        assertSame(ClickhouseStructValueHandler.INSTANCE, handler("Tuple(JSON, UInt64)", DBPDataKind.STRUCT));
+        var dataSource = mock(ClickhouseDataSource.class, CALLS_REAL_METHODS);
+        assertEquals(DBPDataKind.STRUCT, dataSource.resolveDataKind("Tuple(JSON, UInt64)", Types.OTHER));
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedJsonTypes")
+    public void fetchingUsesJdbcStringAndPreservesSqlNull(@NotNull String name) throws Exception {
+        DBCSession session = mock(DBCSession.class);
+        JDBCResultSet resultSet = mock(JDBCResultSet.class);
+        when(resultSet.getString(1)).thenReturn("{\"a\":1}", null);
+        var value = (ClickhouseContentJSON) ClickhouseJSONValueHandler.INSTANCE.fetchValueObject(
+            session, resultSet, type(name, DBPDataKind.CONTENT), 0);
+        assertEquals("{\"a\":1}", value.getDisplayString(DBDDisplayFormat.EDIT));
+        assertEquals(MimeTypes.TEXT_JSON, value.getContentType());
+        var nullValue = (ClickhouseContentJSON) ClickhouseJSONValueHandler.INSTANCE.fetchValueObject(
+            session, resultSet, type(name, DBPDataKind.CONTENT), 0);
+        assertTrue(nullValue.isNull());
+        verify(resultSet, times(2)).getString(1);
+        verify(resultSet, never()).getObject(anyInt());
+    }
+
+    @Test
+    public void fetchFailureIsNotTurnedIntoNullOrEmptyContent() throws Exception {
+        DBCSession session = mock(DBCSession.class);
+        when(session.getExecutionContext()).thenReturn(mock(DBCExecutionContext.class));
+        JDBCResultSet resultSet = mock(JDBCResultSet.class);
+        SQLException failure = new SQLException("Synthetic transport failure");
+        when(resultSet.getString(1)).thenThrow(failure);
+        var exception = assertThrows(DBCException.class, () -> ClickhouseJSONValueHandler.INSTANCE.fetchValueObject(
+            session, resultSet, type("Nullable(JSON(a UInt64))", DBPDataKind.CONTENT), 0));
+        assertSame(failure, exception.getCause());
+    }
+
+    @Test
+    public void copyingKeepsJsonMimeAndRawText() {
+        var value = new ClickhouseContentJSON(null, "{\"a\":1}");
+        var copy = value.cloneValue(monitor);
+        assertNotSame(value, copy);
+        assertEquals(MimeTypes.TEXT_JSON, copy.getContentType());
+        assertEquals(value.getRawValue(), copy.getRawValue());
+    }
+
+    @Test
+    public void handlerBindingKeepsSqlNullDistinctFromJsonNull() throws Exception {
+        JDBCPreparedStatement statement = mock(JDBCPreparedStatement.class);
+        JDBCSession session = mock(JDBCSession.class);
+        DBSTypedObject type = type("Nullable(JSON)", DBPDataKind.CONTENT);
+        ClickhouseJSONValueHandler.INSTANCE.bindValueObject(session, statement, type, 0, new ClickhouseContentJSON(null, null));
+        ClickhouseJSONValueHandler.INSTANCE.bindValueObject(session, statement, type, 1, new ClickhouseContentJSON(null, "null"));
+        verify(statement).setNull(1, Types.OTHER, "Nullable(JSON)");
+        verify(statement).setString(2, "null");
+    }
+
+    @Test
+    public void extensionRegistrationRemainsClickhouseSpecific() {
+        var config = providerConfiguration();
+        assertFalse(new ValueHandlerDescriptor(config).isGlobal());
+        assertEquals("clickhouse", config.getChildren("datasource")[0].getAttribute("id"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedJsonTypes")
+    public void extensionRegistrationAdmitsScalarJsonVariants(@NotNull String name) {
+        var descriptor = new ValueHandlerDescriptor(providerConfiguration());
+        assertTrue(descriptor.supportsType(type(name, DBPDataKind.UNKNOWN)));
+    }
+
+    @Test
+    public void extensionRegistrationDoesNotCaptureUnrelatedScalarTypes() {
+        var descriptor = new ValueHandlerDescriptor(providerConfiguration());
+        assertFalse(descriptor.supportsType(type("JSONB", DBPDataKind.UNKNOWN)));
+        assertFalse(descriptor.supportsType(type("JSONX", DBPDataKind.UNKNOWN)));
+        assertFalse(descriptor.supportsType(type("Nullable(JSON)Extra", DBPDataKind.UNKNOWN)));
+        assertFalse(descriptor.supportsType(type("Nullable(String)", DBPDataKind.STRING)));
+        assertFalse(descriptor.supportsType(type("String", DBPDataKind.STRING)));
+    }
+
+    @NotNull
+    private IConfigurationElement providerConfiguration() {
+        return Arrays.stream(Platform.getExtensionRegistry().getConfigurationElementsFor("org.jkiss.dbeaver.dataTypeProvider"))
+            .filter(element -> "ClickhouseValueHandlerProvider".equals(element.getAttribute("id")))
+            .findFirst().orElseThrow();
+    }
+}


### PR DESCRIPTION
Closes dbeaver/dbeaver#42027.

Follow-up to [#41315](https://github.com/dbeaver/dbeaver/issues/41315) and
[#41324](https://github.com/dbeaver/dbeaver/pull/41324), which introduced the JSON content viewer for bare `JSON` columns.

## What

Extend the existing JSON viewer routing to scalar JSON variants in both the table Data editor and SQL result grids:

- `Nullable(JSON)`
- `JSON(...)`, including `JSON()`
- `Nullable(JSON(...))`, including `Nullable(JSON())`

Existing bare `JSON` support is retained.

## Why

Nullable JSON values can already be returned as JSON text but still open in a plain-text panel without JSON formatting.
The local type lookup strips `Nullable(JSON)` to `Nullable`, whose cached data kind is `UNKNOWN`.
Since `JDBCColumnMetaData` accepts that cached kind, the `resolveDataKind` fallback is not reached.
Parameterized JSON names also need to be recognized by the value-handler registration and routing.

## How

- Use one `isJsonType` predicate for handler selection, data-kind resolution and local type lookup. It handles nested parentheses and quoted type parameters without changing the existing ANTLR grammar.
- Resolve recognized scalar JSON variants through the existing cached `JSON` entry (`CLOB` / `CONTENT`) before the usual name truncation. Keep `getTypeNameWithoutModifiers()` and the lookup path for other types unchanged.
- Extend the ClickHouse-specific type registration using the existing wildcard mechanism.
- Handle the observed JDBC metadata spelling that omits the outer closing parenthesis of parameterized `Nullable(JSON(...))`, without rewriting the original metadata name or nullability.

The existing JSON value handler, content class, serialization settings and binding implementation are unchanged. The predicate classifies type metadata; it is not a JSON document validator or a full ClickHouse type-grammar parser.

## Scope

This PR covers reading and JSON viewer/formatter selection. It reuses the existing editable content handler and does not disable editing.
INSERT support and fixes to pre-existing UPDATE/binding issues are outside this change; the validation below does not establish lossless write support for every JSON type hint.
Top-level Array, Map, Tuple, Dynamic and LowCardinality types are not added to scalar JSON routing.

## Tested

- Ran the unfiltered aggregate reactor with Java 21 (`mvn verify -f product/aggregate/pom.xml -Dtycho.localArtifacts=ignore`): BUILD SUCCESS, 1,212 reported cases, 1,208 passed, 4 skipped, 0 failures/errors across 21 test-module summaries (20 DBeaver test bundles plus `dbeaver-common` utils). This run used the default headless test configuration, without the CE/Eclipse product profiles; the separate native CE product builds are described below.
- Rechecked the unchanged patch against upstream `devel` commit `ae49ed3dcf90aa106d238ab1f4d5b7fb63443f98` (2026-09-06): CE product build succeeded and all 278 ClickHouse tests passed. On the same commit without the production patch, the added regression suite produced 155 assertion failures (0 errors); the original 25 tests passed. The upstream SHA was verified again after building.
- Manually compared clean `26.2.1.202609061336` and patched `26.2.1.202609061339` builds of this commit. The clean build reproduces the nullable/parameterized viewer issue in both SQL result grids and the table **Data** tab; the patched build selects the JSON viewer and shows formatted documents in both paths. Bare JSON and the `Array(JSON)` collection viewer retain their existing behavior. A fresh post-UI run again passed all 278 ClickHouse tests.
- **278 ClickHouse test cases passed** across all seven ClickHouse test classes, also confirmed in the unfiltered reactor run above.
- Coverage includes supported and malformed type names, quoted/nested parameters, extension registration, real populated/empty type-cache lookup through `JDBCColumnMetaData`, preservation of metadata names/nullability, SQL NULL, read failures and unchanged collection-handler selection. The new cache regression cases failed for 12 nullable variants before the lookup fix.
- Environment: ClickHouse `26.9.1.762`, JDBC `0.10.0` and Java 21 on macOS arm64. Successful document → SQL NULL → document transitions were observed in the patched table grid; table data was unchanged after both builds' UI checks (byte-for-byte JSONEachRow comparison).
- The contributor confirmed the final manual checks on 2026-09-07 in patched build `26.2.1.202609061339`: Auto Format off/on (switching rows after disabling it), clearing the preview on SQL NULL, and restoring the correct document when returning from NULL to the first/third `nullable_quoted` row. These are direct manual results, not an automated UI-test pass.

The server normalizes `JSON()` / `Nullable(JSON())` in table metadata; literal empty-parameter metadata names are covered separately by routing tests. Manual validation covers reading and formatting, not saving edits.

Implementation and tests were developed with AI assistance (Codex).
