### PR TITLE
dbeaver/dbeaver#34950 Move Refresh Materialized View to first-level menu

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/plugin.xml
@@ -257,14 +257,6 @@
                     singleton="false">
                 <task id="pgToolTriggerEnable"/>
             </tool>
-            <tool
-                    description="%tools.refesh.mview.description"
-                    id="org.jkiss.dbeaver.ext.postgresql.tools.maintenance.PostgreToolRefreshMView"
-                    group="org.jkiss.dbeaver.ext.postgresql.tools.maintenance"
-                    label="%tools.refesh.mview.name"
-                    singleton="false">
-                <task id="pgToolRefreshMView"/>
-            </tool>
 
             <toolGroup
                 id="org.jkiss.dbeaver.ext.postgresql.tools.config"
@@ -286,10 +278,37 @@
 
     <extension point="org.eclipse.ui.commands">
     	<command id="org.jkiss.dbeaver.ext.postgresql.ui.fdw" name="Foreign data wrappers configurator"/>
+        <command
+                id="org.jkiss.dbeaver.ext.postgresql.tools.refreshMView"
+                name="%tools.refesh.mview.name"
+                description="%tools.refesh.mview.description"/>
     </extension>
     
     <extension point="org.eclipse.ui.handlers">
         <handler commandId="org.jkiss.dbeaver.ext.postgresql.ui.fdw" class="org.jkiss.dbeaver.ext.postgresql.tools.fdw.PostgreFDWConfigToolCommandHandler"/>
+        <handler
+                commandId="org.jkiss.dbeaver.ext.postgresql.tools.refreshMView"
+                class="org.jkiss.dbeaver.ext.postgresql.tools.maintenance.PostgreToolRefreshMViewHandler">
+            <enabledWhen>
+                <with variable="selection">
+                    <count value="+"/>
+                    <iterate operator="and">
+                        <!-- Double check - adapt + instanceof to avoid forced plugin activation (E4.6+) -->
+                        <adapt type="org.jkiss.dbeaver.model.struct.DBSObject">
+                            <instanceof value="org.jkiss.dbeaver.ext.postgresql.model.PostgreMaterializedView"/>
+                        </adapt>
+                    </iterate>
+                </with>
+            </enabledWhen>
+        </handler>
+    </extension>
+
+    <extension point="org.eclipse.ui.menus">
+        <menuContribution allPopups="false" locationURI="popup:org.eclipse.ui.popup.any?after=navigator.filter">
+            <command commandId="org.jkiss.dbeaver.ext.postgresql.tools.refreshMView">
+                <visibleWhen checkEnabled="true"/>
+            </command>
+        </menuContribution>
     </extension>
     
     <extension point="org.jkiss.dbeaver.task.ui">

--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/maintenance/PostgreToolRefreshMViewHandler.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/maintenance/PostgreToolRefreshMViewHandler.java
@@ -1,0 +1,53 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.tools.maintenance;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.jkiss.dbeaver.ext.postgresql.tasks.PostgreSQLTasks;
+import org.jkiss.dbeaver.model.DBPDataSource;
+import org.jkiss.dbeaver.model.struct.DBSObject;
+import org.jkiss.dbeaver.tasks.ui.wizard.TaskConfigurationWizardDialog;
+import org.jkiss.dbeaver.ui.navigator.NavigatorUtils;
+
+import java.util.List;
+
+public class PostgreToolRefreshMViewHandler extends AbstractHandler {
+
+    @Override
+    public Object execute(ExecutionEvent event) {
+        List<DBSObject> selectedObjects = NavigatorUtils.getSelectedObjects(HandlerUtil.getCurrentSelection(event));
+        if (selectedObjects.isEmpty()) {
+            return null;
+        }
+        DBPDataSource dataSource = selectedObjects.get(0).getDataSource();
+        if (dataSource == null) {
+            return null;
+        }
+        IStructuredSelection selection = new StructuredSelection(selectedObjects.toArray());
+        TaskConfigurationWizardDialog.openNewToolTaskDialog(
+            HandlerUtil.getActiveWorkbenchWindow(event),
+            dataSource.getContainer().getProject(),
+            PostgreSQLTasks.TASK_MVIEW_REFRESH,
+            selection
+        );
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Closes dbeaver/dbeaver#34950

Moves PostgreSQL **Refresh Materialized View** from **Tools → Maintenance** to the first level of the Database Navigator context menu (after **Filter**), as discussed with the team in the issue.

### Motivation

The action already existed under Tools, but users often missed it and expected a top-level "refresh materialized view" entry (distinct from the ordinary navigator Refresh, which only reloads metadata).

### Changes

- Removed the Tools contribution `PostgreToolRefreshMView` from the Maintenance tool group in `org.jkiss.dbeaver.ext.postgresql.ui/plugin.xml`.
- Added Eclipse command `org.jkiss.dbeaver.ext.postgresql.tools.refreshMView` with an enabled-when condition for `PostgreMaterializedView` (adapt + instanceof pattern to avoid forced plugin activation).
- Added menu contribution `popup:org.eclipse.ui.popup.any?after=navigator.filter` so the action appears at the root context menu after Filter.
- New handler `PostgreToolRefreshMViewHandler` opens the existing task wizard via `TaskConfigurationWizardDialog.openNewToolTaskDialog(..., PostgreSQLTasks.TASK_MVIEW_REFRESH, ...)` — same execution path as before.
- Task definition `pgToolRefreshMView` / `PostgreToolMViewRefresh` unchanged.

### Notes

This intentionally does not change the dialog defaults (e.g. WITH DATA). Follow-up feedback in the issue about defaulting WITH DATA can be handled separately.

## Test plan

- [x] Code review: menu URI `after=navigator.filter` matches `navigator.filter` menu id in `org.jkiss.dbeaver.core`.
- [x] Code review: Tools contribution removed; task `pgToolRefreshMView` still registered; handler opens the same task id.
- [x] Code review: `enabledWhen` requires one-or-more selection of `PostgreMaterializedView` only (adapt + instanceof).
- [ ] Connect to PostgreSQL, create or select a materialized view in Database Navigator.
- [ ] Right-click the materialized view and verify **Refresh Materialized View** appears at the first menu level after **Filter** (not only under Tools).
- [ ] Run the action and confirm the existing refresh wizard/dialog still opens and executes `REFRESH MATERIALIZED VIEW` correctly (WITH DATA / WITH NO DATA options).
- [ ] Verify the action is **not** visible for ordinary tables/views.
- [ ] Confirm the action no longer appears under Tools → Maintenance (avoid duplicate entries).
- [ ] Multi-select multiple materialized views and verify the handler still opens the tool task dialog.

This PR was generated with AI (Cursor).