### PR TITLE
dbeaver/pro#10370 Deleted used Connection type remains applied

### DIFF
--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceSerializerModern.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/DataSourceSerializerModern.java
@@ -28,6 +28,7 @@ import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.*;
 import org.jkiss.dbeaver.model.access.DBAAuthProfile;
+import org.jkiss.dbeaver.model.app.DBPApplication;
 import org.jkiss.dbeaver.model.app.DBPDataSourceRegistry;
 import org.jkiss.dbeaver.model.auth.SMObjectType;
 import org.jkiss.dbeaver.model.connection.*;
@@ -88,6 +89,16 @@ public class DataSourceSerializerModern<T extends DataSourceDescriptor> implemen
 
     protected DataSourceSerializerModern(@NotNull DataSourceRegistry<T> registry) {
         this.registry = registry;
+    }
+
+    @NotNull
+    protected DBPApplication getApplication() {
+        return DBWorkbench.getPlatform().getApplication();
+    }
+
+    @NotNull
+    protected DBPDataSourceProviderRegistry getDataSourceProviderRegistry() {
+        return DBWorkbench.getPlatform().getDataSourceProviderRegistry();
     }
 
     @Override
@@ -437,43 +448,46 @@ public class DataSourceSerializerModern<T extends DataSourceDescriptor> implemen
                 }
             }
 
-            // Connection types
-            for (Map.Entry<String, Map<String, Object>> ctMap : JSONUtils.getNestedObjects(configurationMap, "connection-types")) {
-                String id = ctMap.getKey();
-                Map<String, Object> ctConfig = ctMap.getValue();
-                String name = JSONUtils.getObjectProperty(ctConfig, RegistryConstants.ATTR_NAME);
-                String description = JSONUtils.getObjectProperty(ctConfig, RegistryConstants.ATTR_DESCRIPTION);
-                String color = JSONUtils.getObjectProperty(ctConfig, RegistryConstants.ATTR_COLOR);
-                String alternativeColor = JSONUtils.getObjectProperty(ctConfig, RegistryConstants.ATTR_COLOR_DARK);
-                Boolean autoCommit = JSONUtils.getObjectProperty(ctConfig, "auto-commit");
-                Boolean confirmExecute = JSONUtils.getObjectProperty(ctConfig, "confirm-execute");
-                Boolean confirmDataChange = JSONUtils.getObjectProperty(ctConfig, "confirm-data-change");
-                Boolean smartCommit = JSONUtils.getObjectProperty(ctConfig, "smart-commit");
-                Boolean smartCommitRecover = JSONUtils.getObjectProperty(ctConfig, "smart-commit-recover");
-                Boolean autoCloseTransactions = JSONUtils.getObjectProperty(ctConfig, "auto-close-transactions");
-                Object closeTransactionsPeriod = JSONUtils.getObjectProperty(ctConfig, "close-transactions-period");
-                Boolean autoCloseConnections = JSONUtils.getObjectProperty(ctConfig, "auto-close-connections");
-                Object closeConnectionsPeriod = JSONUtils.getObjectProperty(ctConfig, "close-connections-period");
-                DBPConnectionType ct = DBWorkbench.getPlatform().getDataSourceProviderRegistry().getConnectionType(id, null);
-                if (ct == null) {
-                    ct = new DBPConnectionType(
-                        id,
-                        name,
-                        color,
-                        alternativeColor,
-                        description,
-                        CommonUtils.toBoolean(autoCommit),
-                        CommonUtils.toBoolean(confirmExecute),
-                        CommonUtils.toBoolean(confirmDataChange),
-                        CommonUtils.toBoolean(smartCommit),
-                        CommonUtils.toBoolean(smartCommitRecover),
-                        CommonUtils.toBoolean(autoCloseTransactions),
-                        CommonUtils.toInt(closeTransactionsPeriod),
-                        CommonUtils.toBoolean(autoCloseConnections),
-                        CommonUtils.toInt(closeConnectionsPeriod));
-                    DBWorkbench.getPlatform().getDataSourceProviderRegistry().addConnectionType(ct);
+            // Connection types are managed globally in multi-user environments.
+            if (!getApplication().isMultiuser() && !getApplication().isDistributed()) {
+                DBPDataSourceProviderRegistry providerRegistry = getDataSourceProviderRegistry();
+                for (Map.Entry<String, Map<String, Object>> ctMap : JSONUtils.getNestedObjects(configurationMap, "connection-types")) {
+                    String id = ctMap.getKey();
+                    Map<String, Object> ctConfig = ctMap.getValue();
+                    String name = JSONUtils.getObjectProperty(ctConfig, RegistryConstants.ATTR_NAME);
+                    String description = JSONUtils.getObjectProperty(ctConfig, RegistryConstants.ATTR_DESCRIPTION);
+                    String color = JSONUtils.getObjectProperty(ctConfig, RegistryConstants.ATTR_COLOR);
+                    String alternativeColor = JSONUtils.getObjectProperty(ctConfig, RegistryConstants.ATTR_COLOR_DARK);
+                    Boolean autoCommit = JSONUtils.getObjectProperty(ctConfig, "auto-commit");
+                    Boolean confirmExecute = JSONUtils.getObjectProperty(ctConfig, "confirm-execute");
+                    Boolean confirmDataChange = JSONUtils.getObjectProperty(ctConfig, "confirm-data-change");
+                    Boolean smartCommit = JSONUtils.getObjectProperty(ctConfig, "smart-commit");
+                    Boolean smartCommitRecover = JSONUtils.getObjectProperty(ctConfig, "smart-commit-recover");
+                    Boolean autoCloseTransactions = JSONUtils.getObjectProperty(ctConfig, "auto-close-transactions");
+                    Object closeTransactionsPeriod = JSONUtils.getObjectProperty(ctConfig, "close-transactions-period");
+                    Boolean autoCloseConnections = JSONUtils.getObjectProperty(ctConfig, "auto-close-connections");
+                    Object closeConnectionsPeriod = JSONUtils.getObjectProperty(ctConfig, "close-connections-period");
+                    DBPConnectionType ct = providerRegistry.getConnectionType(id, null);
+                    if (ct == null) {
+                        ct = new DBPConnectionType(
+                            id,
+                            name,
+                            color,
+                            alternativeColor,
+                            description,
+                            CommonUtils.toBoolean(autoCommit),
+                            CommonUtils.toBoolean(confirmExecute),
+                            CommonUtils.toBoolean(confirmDataChange),
+                            CommonUtils.toBoolean(smartCommit),
+                            CommonUtils.toBoolean(smartCommitRecover),
+                            CommonUtils.toBoolean(autoCloseTransactions),
+                            CommonUtils.toInt(closeTransactionsPeriod),
+                            CommonUtils.toBoolean(autoCloseConnections),
+                            CommonUtils.toInt(closeConnectionsPeriod));
+                        providerRegistry.addConnectionType(ct);
+                    }
+                    deserializeModifyPermissions(ctConfig, ct);
                 }
-                deserializeModifyPermissions(ctConfig, ct);
             }
 
             // Drivers

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/registry/DataSourceSerializerModernTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/registry/DataSourceSerializerModernTest.java
@@ -1,0 +1,138 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.registry;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.app.DBPApplication;
+import org.jkiss.dbeaver.model.app.DBPProject;
+import org.jkiss.dbeaver.model.connection.DBPConnectionType;
+import org.jkiss.dbeaver.model.connection.DBPDataSourceProviderRegistry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.nio.charset.StandardCharsets;
+
+public class DataSourceSerializerModernTest {
+    private static final String CONNECTION_TYPE_ID = "imported-type";
+    private static final String PROJECT_CONFIGURATION = """
+        {
+          "connection-types": {
+            "imported-type": {
+              "name": "Imported type",
+              "description": "Imported from project",
+              "color": "10,20,30",
+              "colorDark": "40,50,60",
+              "auto-commit": true,
+              "confirm-execute": true,
+              "confirm-data-change": true,
+              "smart-commit": true,
+              "smart-commit-recover": true,
+              "auto-close-transactions": true,
+              "close-transactions-period": 10,
+              "auto-close-connections": true,
+              "close-connections-period": 20
+            }
+          },
+          "connections": {}
+        }
+        """;
+
+    @Test
+    public void testStandaloneProjectImportsUnknownConnectionType() throws Exception {
+        DBPDataSourceProviderRegistry providerRegistry = parseProjectConfiguration(false, false);
+
+        ArgumentCaptor<DBPConnectionType> connectionTypeCaptor = ArgumentCaptor.forClass(DBPConnectionType.class);
+        Mockito.verify(providerRegistry).getConnectionType(CONNECTION_TYPE_ID, null);
+        Mockito.verify(providerRegistry).addConnectionType(connectionTypeCaptor.capture());
+
+        DBPConnectionType connectionType = connectionTypeCaptor.getValue();
+        Assertions.assertEquals(CONNECTION_TYPE_ID, connectionType.getId());
+        Assertions.assertEquals("Imported type", connectionType.getName());
+        Assertions.assertEquals("Imported from project", connectionType.getDescription());
+        Assertions.assertEquals("10,20,30", connectionType.getColorLight());
+        Assertions.assertEquals("40,50,60", connectionType.getColorDark());
+        Assertions.assertTrue(connectionType.isAutocommit());
+        Assertions.assertTrue(connectionType.isConfirmExecute());
+        Assertions.assertTrue(connectionType.isConfirmDataChange());
+        Assertions.assertTrue(connectionType.isSmartCommit());
+        Assertions.assertTrue(connectionType.isSmartCommitRecover());
+        Assertions.assertTrue(connectionType.isAutoCloseTransactions());
+        Assertions.assertEquals(10, connectionType.getCloseIdleTransactionPeriod());
+        Assertions.assertTrue(connectionType.isAutoCloseConnections());
+        Assertions.assertEquals(20, connectionType.getCloseIdleConnectionPeriod());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true, false", "false, true"})
+    public void testProjectConnectionTypesAreIgnoredOutsideStandaloneMode(boolean multiuser, boolean distributed)
+        throws Exception {
+        DBPDataSourceProviderRegistry providerRegistry = parseProjectConfiguration(multiuser, distributed);
+
+        Mockito.verify(providerRegistry, Mockito.never()).getConnectionType(CONNECTION_TYPE_ID, null);
+        Mockito.verify(providerRegistry, Mockito.never()).addConnectionType(Mockito.any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static DBPDataSourceProviderRegistry parseProjectConfiguration(boolean multiuser, boolean distributed)
+        throws Exception {
+        DBPDataSourceProviderRegistry providerRegistry = Mockito.mock(DBPDataSourceProviderRegistry.class);
+        DBPApplication application = Mockito.mock(DBPApplication.class);
+        Mockito.when(application.isMultiuser()).thenReturn(multiuser);
+        Mockito.when(application.isDistributed()).thenReturn(distributed);
+        DBPProject project = Mockito.mock(DBPProject.class);
+        DataSourceRegistry<DataSourceDescriptor> registry = Mockito.mock(DataSourceRegistry.class);
+        Mockito.when(registry.getProject()).thenReturn(project);
+        new TestSerializer(registry, application, providerRegistry).parseDataSources(
+            new DataSourceMemoryStorage(PROJECT_CONFIGURATION.getBytes(StandardCharsets.UTF_8)),
+            new DataSourceConfigurationManagerBuffer(),
+            new DataSourceParseResults(),
+            null
+        );
+        return providerRegistry;
+    }
+
+    private static final class TestSerializer extends DataSourceSerializerModern<DataSourceDescriptor> {
+        private final DBPApplication application;
+        private final DBPDataSourceProviderRegistry providerRegistry;
+
+        private TestSerializer(
+            DataSourceRegistry<DataSourceDescriptor> registry,
+            DBPApplication application,
+            DBPDataSourceProviderRegistry providerRegistry
+        ) {
+            super(registry);
+            this.application = application;
+            this.providerRegistry = providerRegistry;
+        }
+
+        @NotNull
+        @Override
+        protected DBPApplication getApplication() {
+            return application;
+        }
+
+        @NotNull
+        @Override
+        protected DBPDataSourceProviderRegistry getDataSourceProviderRegistry() {
+            return providerRegistry;
+        }
+    }
+}


### PR DESCRIPTION
Closes dbeaver/pro#10370

## Summary
- ignore project-scoped connection type snapshots in multiuser and distributed modes
- preserve standalone connection type import behavior
- add regression coverage for all three application modes

## Testing
- DataSourceSerializerModernTest (3 tests passed)