### PR TITLE
dbeaver/pro#10621 ResultSetViewer - bad performance on text column change

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/panel/valueviewer/ValueViewerPanel.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/controls/resultset/panel/valueviewer/ValueViewerPanel.java
@@ -50,6 +50,7 @@ import org.jkiss.dbeaver.ui.data.IValueController;
 import org.jkiss.dbeaver.ui.data.IValueEditor;
 import org.jkiss.dbeaver.ui.data.IValueManager;
 import org.jkiss.dbeaver.ui.data.editors.BaseValueEditor;
+import org.jkiss.dbeaver.ui.data.editors.ContentPanelEditor;
 import org.jkiss.dbeaver.ui.data.editors.ReferenceValueEditor;
 import org.jkiss.utils.CommonUtils;
 
@@ -70,6 +71,7 @@ public class ValueViewerPanel extends ResultSetPanelBase implements DBPAdaptable
     private ResultSetValueController previewController;
     private IValueEditor valueEditor;
     private ReferenceValueEditor referenceValueEditor;
+    private boolean dictionaryView;
 
     private volatile boolean valueSaving;
     private IValueManager valueManager;
@@ -223,28 +225,48 @@ public class ValueViewerPanel extends ResultSetPanelBase implements DBPAdaptable
             return;
         }
         if (forceRefresh) {
-            cleanupPanel();
             IResultSetController controller = presentation.getController();
 
-            referenceValueEditor = new ReferenceValueEditor(controller, previewController, valueEditor);
+            ReferenceValueEditor newReferenceValueEditor = new ReferenceValueEditor(controller, previewController, valueEditor);
             final boolean showDictionaryView = controller.getPreferenceStore().getInt(ModelPreferences.DICTIONARY_MAX_ROWS) > 0
-                && referenceValueEditor.isReferenceValue();
+                && newReferenceValueEditor.isReferenceValue();
             if (showDictionaryView) {
                 previewController.setEditType(IValueController.EditType.INLINE);
             } else {
                 previewController.setEditType(IValueController.EditType.PANEL);
             }
 
-            // Create a new one
-            valueManager = previewController.getValueManager();
+            IValueManager newValueManager = previewController.getValueManager();
+            IValueEditor newValueEditor;
             try {
-                valueEditor = valueManager.createEditor(previewController);
+                newValueEditor = newValueManager.createEditor(previewController);
             } catch (Throwable e) {
+                cleanupPanel();
+                valueManager = newValueManager;
+                referenceValueEditor = newReferenceValueEditor;
+                dictionaryView = showDictionaryView;
                 DBWorkbench.getPlatformUI()
                     .showError(ResultSetMessages.value_viewer_preview_error_title, ResultSetMessages.value_viewer_preview_error_message, e);
                 return;
             }
-            if (valueEditor != null) {
+            boolean reuseValueEditor = valueEditor != null && valueEditor.getControl() != null
+                && !valueEditor.getControl().isDisposed() && newValueEditor != null
+                && valueEditor.getClass() == newValueEditor.getClass()
+                && valueEditor instanceof ContentPanelEditor contentPanelEditor
+                && !dictionaryView && !showDictionaryView
+                && contentPanelEditor.canReuseControl();
+            if (reuseValueEditor) {
+                newValueEditor.dispose();
+                valueManager = newValueManager;
+                referenceValueEditor = newReferenceValueEditor;
+            } else {
+                cleanupPanel();
+                valueManager = newValueManager;
+                valueEditor = newValueEditor;
+                referenceValueEditor = newReferenceValueEditor;
+                dictionaryView = showDictionaryView;
+            }
+            if (valueEditor != null && !reuseValueEditor) {
                 try {
                     if (showDictionaryView) {
                         Label valueLabel = new Label(viewPlaceholder, SWT.NONE);
@@ -332,10 +354,17 @@ public class ValueViewerPanel extends ResultSetPanelBase implements DBPAdaptable
         }
     }
 
-    private void handleTraverseEvent(TraverseEvent e) {
+    private void handleTraverseEvent(@NotNull TraverseEvent e) {
         if (e.detail == SWT.TRAVERSE_TAB_NEXT) {
             e.doit = false;
-            UIUtils.asyncExec(() -> presentation.getControl().setFocus());
+            Control control = presentation.getControl();
+            if (control != null) {
+                UIUtils.asyncExec(() -> {
+                    if (!control.isDisposed()) {
+                        control.setFocus();
+                    }
+                });
+            }
         }
     }
 
@@ -360,6 +389,7 @@ public class ValueViewerPanel extends ResultSetPanelBase implements DBPAdaptable
         cleanupPanel();
         valueManager = null;
         valueEditor = null;
+        dictionaryView = false;
 
         presentation.getController().updateEditControls();
         viewPlaceholder.layout();
@@ -428,10 +458,6 @@ public class ValueViewerPanel extends ResultSetPanelBase implements DBPAdaptable
 
                 menuManager.add(
                     new Action(ResultSetMessages.value_viewer_auto_apply_action_text, Action.AS_CHECK_BOX) {
-                        {
-                            //setImageDescriptor(DBeaverIcons.getImageDescriptor(UIIcon.AUTO_SAVE));
-                        }
-
                         @Override
                         public boolean isChecked() {
                             return DBWorkbench.getPlatform().getPreferenceStore().getBoolean(

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/ContentPanelEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/editors/ContentPanelEditor.java
@@ -72,6 +72,7 @@ public class ContentPanelEditor extends BaseValueEditor<Control> implements IAda
 
     private static final Map<String, String> valueToManagerMap = new HashMap<>();
 
+    private final boolean readOnly;
     private Map<StreamValueManagerDescriptor, IStreamValueManager.MatchType> streamManagers;
     private volatile StreamValueManagerDescriptor curStreamManager;
     private IStreamValueEditor<Control> streamEditor;
@@ -81,6 +82,7 @@ public class ContentPanelEditor extends BaseValueEditor<Control> implements IAda
 
     public ContentPanelEditor(IValueController controller) {
         super(controller);
+        readOnly = controller.isReadOnly();
 
         // Load manager setting for current attribute
         if (controller.getExecutionContext() != null) {
@@ -90,6 +92,25 @@ public class ContentPanelEditor extends BaseValueEditor<Control> implements IAda
                 valueToManagerMap.put(makeValueId(true), managerId);
             }
         }
+    }
+
+    /**
+     * Checks whether the existing stream editor control is compatible with the controller's current value.
+     */
+    public boolean canReuseControl() {
+        if (readOnly != valueController.isReadOnly() || !isStringValue() || curStreamManager == null) {
+            return false;
+        }
+        StreamValueManagerDescriptor previousStreamManager = curStreamManager;
+        curStreamManager = null;
+        try {
+            loadStringStreamManagers();
+        } catch (DBException e) {
+            curStreamManager = previousStreamManager;
+            log.debug("Can't detect stream manager", e);
+            return false;
+        }
+        return curStreamManager == previousStreamManager;
     }
 
     @Override
@@ -573,7 +594,7 @@ public class ContentPanelEditor extends BaseValueEditor<Control> implements IAda
                 monitor.subTask("Prime LOB value");
                 UIUtils.syncExec(() -> {
                     try {
-                        if (streamEditor != null && !control.isDisposed()) {
+                        if (streamEditor != null && !control.isDisposed() && valueController.getValue() == content) {
                             streamEditor.primeEditorValue(monitor, control, content);
                         }
                     } catch (Exception e) {

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/AbstractTextPanelEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/AbstractTextPanelEditor.java
@@ -422,7 +422,7 @@ public abstract class AbstractTextPanelEditor<EDITOR extends BaseTextEditor>
         }
         try (final InputStream stream = contents.getContentStream()) {
             byte[] displayingContentBytes = stream.readNBytes(lengthInBytes);
-            final String content = new String(displayingContentBytes);
+            final String content = new String(displayingContentBytes, StandardCharsets.UTF_8);
             if (editor != null) {
                 resetEditorInput();
                 editorControl.setWordWrap(false);

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/AbstractTextPanelEditor.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/data/managers/AbstractTextPanelEditor.java
@@ -332,7 +332,6 @@ public abstract class AbstractTextPanelEditor<EDITOR extends BaseTextEditor>
 
             editorControl.setRedraw(false);
 
-            resetEditorInput();
             final DBPPreferenceStore store = valueController.getExecutionContext() != null
                 ? valueController.getExecutionContext().getDataSource().getContainer().getPreferenceStore()
                 : DBWorkbench.getPlatform().getPreferenceStore();
@@ -367,8 +366,26 @@ public abstract class AbstractTextPanelEditor<EDITOR extends BaseTextEditor>
         if (encoding == null) {
             encoding = StandardCharsets.UTF_8.name();
         }
-        final ContentEditorInput textInput = new ContentEditorInput(valueController, null, null, encoding, monitor);
+        final ContentEditorInput textInput;
         final TextViewer textViewer = editor.getTextViewer();
+        IEditorInput editorInput = editor.getEditorInput();
+        boolean inMemory = !(valueController.getValue() instanceof DBDContent);
+        if (editorInput instanceof ContentEditorInput contentEditorInput && contentEditorInput.isInMemory() == inMemory) {
+            try {
+                contentEditorInput.refreshContent(monitor, valueController, encoding);
+                editor.getDocumentProvider().resetDocument(contentEditorInput);
+            } catch (Exception e) {
+                resetEditorInput();
+                throw new DBException("Error refreshing text editor input", e);
+            }
+            if (textViewer != null && textViewer.getUndoManager() != null) {
+                textViewer.getUndoManager().reset();
+            }
+            textInput = contentEditorInput;
+        } else {
+            resetEditorInput();
+            textInput = new ContentEditorInput(valueController, null, null, encoding, monitor);
+        }
         if (textViewer != null) {
             long contentLength = textInput.getContentLength();
 
@@ -384,11 +401,15 @@ public abstract class AbstractTextPanelEditor<EDITOR extends BaseTextEditor>
                     }
                 }
                 editorControl.setWordWrap(false);
-                editor.setInput(textInput);
+                if (editor.getEditorInput() != textInput) {
+                    editor.setInput(textInput);
+                }
 
                 messageBar.hideMessage();
             } else {
-                editor.setInput(textInput);
+                if (editor.getEditorInput() != textInput) {
+                    editor.setInput(textInput);
+                }
             }
             applyEditorStyle();
         }
@@ -403,6 +424,7 @@ public abstract class AbstractTextPanelEditor<EDITOR extends BaseTextEditor>
             byte[] displayingContentBytes = stream.readNBytes(lengthInBytes);
             final String content = new String(displayingContentBytes);
             if (editor != null) {
+                resetEditorInput();
                 editorControl.setWordWrap(false);
                 editor.setInput(new StringEditorInput("Limited Content ", content, true, StandardCharsets.UTF_8.name()));
                 messageBar.showMessage(NLS.bind(ResultSetMessages.panel_editor_text_content_limitation_lbl, lengthInBytes / 1000));

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/content/ContentEditorInput.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/content/ContentEditorInput.java
@@ -123,7 +123,8 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
         this.prepareContent(monitor);
     }
 
-    public boolean isInMemory() {
+    public boolean isInMemory()
+    {
         return stringStorage != null;
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/content/ContentEditorInput.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/content/ContentEditorInput.java
@@ -64,8 +64,7 @@ import java.nio.file.Files;
 /**
  * ContentEditorInput
  */
-public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInput, DBPContextProvider, IEncodingSupport
-{
+public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInput, DBPContextProvider, IEncodingSupport {
     private static final Log log = Log.getLog(ContentEditorInput.class);
 
     private IValueController valueController;
@@ -81,23 +80,24 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
         @NotNull IValueController valueController,
         @Nullable IEditorPart[] editorParts,
         @Nullable IEditorPart defaultPart,
-        @NotNull DBRProgressMonitor monitor)
-        throws DBException
-    {
+        @NotNull DBRProgressMonitor monitor
+    )
+    throws DBException {
         this.valueController = valueController;
         this.editorParts = editorParts;
         this.defaultPart = defaultPart;
         this.fileCharset = getDefaultEncoding();
         this.prepareContent(monitor);
     }
+
     public ContentEditorInput(
         @NotNull IValueController valueController,
         @Nullable IEditorPart[] editorParts,
         @Nullable IEditorPart defaultPart,
         @Nullable String charset,
-        @NotNull DBRProgressMonitor monitor)
-        throws DBException
-    {
+        @NotNull DBRProgressMonitor monitor
+    )
+    throws DBException {
         this.valueController = valueController;
         this.editorParts = editorParts;
         this.defaultPart = defaultPart;
@@ -105,31 +105,26 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
         this.prepareContent(monitor);
     }
 
-    public IValueController getValueController()
-    {
+    public IValueController getValueController() {
         return valueController;
     }
 
-    public void refreshContent(DBRProgressMonitor monitor, IValueController valueController) throws DBException
-    {
+    public void refreshContent(DBRProgressMonitor monitor, IValueController valueController) throws DBException {
         this.valueController = valueController;
         this.prepareContent(monitor);
     }
 
-    public void refreshContent(DBRProgressMonitor monitor, IValueController valueController, @Nullable String charset) throws DBException
-    {
+    public void refreshContent(DBRProgressMonitor monitor, IValueController valueController, @Nullable String charset) throws DBException {
         this.valueController = valueController;
         this.fileCharset = CommonUtils.isEmpty(charset) ? getDefaultEncoding() : charset;
         this.prepareContent(monitor);
     }
 
-    public boolean isInMemory()
-    {
+    public boolean isInMemory() {
         return stringStorage != null;
     }
 
-    IEditorPart[] getEditors()
-    {
+    IEditorPart[] getEditors() {
         return editorParts;
     }
 
@@ -138,20 +133,17 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
     }
 
     @Override
-    public boolean exists()
-    {
+    public boolean exists() {
         return false;
     }
 
     @Override
-    public ImageDescriptor getImageDescriptor()
-    {
+    public ImageDescriptor getImageDescriptor() {
         return DBeaverIcons.getImageDescriptor(DBIcon.TYPE_LOB);
     }
 
     @Override
-    public String getName()
-    {
+    public String getName() {
         String inputName;
         if (valueController instanceof IAttributeController) {
             inputName = ((IAttributeController) valueController).getColumnId();
@@ -166,21 +158,18 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
 
     @Nullable
     @Override
-    public IPersistableElement getPersistable()
-    {
+    public IPersistableElement getPersistable() {
         return null;
     }
 
     @Override
-    public String getToolTipText()
-    {
+    public String getToolTipText() {
         return getName();
     }
 
     @Nullable
     @Override
-    public <T> T getAdapter(Class<T> adapter)
-    {
+    public <T> T getAdapter(Class<T> adapter) {
         if (adapter == IStorage.class) {
             if (stringStorage != null) {
                 return adapter.cast(stringStorage);
@@ -204,9 +193,8 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
             return 0;
         }
     }
-    private void prepareContent(DBRProgressMonitor monitor)
-        throws DBException
-    {
+
+    private void prepareContent(DBRProgressMonitor monitor) throws DBException {
         final Object[] value = new Object[1];
         UIUtils.syncExec(() -> value[0] = getValue());
         DBDContent content;
@@ -230,7 +218,7 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
                 release();
             }
             // User content's storage directly
-            contentFile = ((DBDContentStorageLocal)storage).getDataFile().toFile();
+            contentFile = ((DBDContentStorageLocal) storage).getDataFile().toFile();
             contentDetached = true;
         } else {
             // Copy content to local file
@@ -251,8 +239,7 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
 
                 // Write value to file
                 copyContentToFile(content, monitor);
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 // Delete temp file
                 if (contentFile != null && contentFile.exists()) {
                     if (!contentFile.delete()) {
@@ -269,15 +256,13 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
         }
     }
 
-    private void markReadOnly(boolean readOnly) throws DBException
-    {
+    private void markReadOnly(boolean readOnly) throws DBException {
         if (!contentFile.setWritable(!readOnly)) {
             throw new DBException("Can't set content read-only");
         }
     }
 
-    public void release()
-    {
+    public void release() {
         if (contentFile != null && !contentDetached) {
             if (!contentFile.delete()) {
                 log.warn("Can't delete temp file '" + contentFile.getAbsolutePath() + "'");
@@ -289,8 +274,7 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
 
     @Nullable
     @Override
-    public IPath getPath()
-    {
+    public IPath getPath() {
         return contentFile == null ?
             new Path("fake_path") : // To avoid NPE from the Eclipse
             new Path(contentFile.getAbsolutePath());
@@ -300,18 +284,19 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
         return valueController.isReadOnly();
     }
 
-    void saveToExternalFile(java.nio.file.Path file, IProgressMonitor monitor) throws CoreException {
+    void saveToExternalFile(@NotNull java.nio.file.Path file, @NotNull IProgressMonitor monitor) throws CoreException {
         try (InputStream is = openContents()) {
             ContentUtils.saveContentToFile(
                 is,
                 file,
-                RuntimeUtils.makeMonitor(monitor));
-        }
-        catch (Exception e) {
+                RuntimeUtils.makeMonitor(monitor)
+            );
+        } catch (Exception e) {
             throw new CoreException(GeneralUtils.makeExceptionStatus(e));
         }
     }
 
+    @NotNull
     private InputStream openContents() throws Exception {
         return stringStorage == null ? new FileInputStream(contentFile) : stringStorage.getContents();
     }
@@ -325,13 +310,13 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
             if (value instanceof DBDContent content) {
                 content.updateContents(
                     new DefaultProgressMonitor(monitor),
-                    new ExternalContentStorage(DBWorkbench.getPlatform(), extFile));
+                    new ExternalContentStorage(DBWorkbench.getPlatform(), extFile)
+                );
             } else {
                 updateStringValueFromFile(extFile);
             }
             refreshContentParts(extFile);
-        }
-        catch (Throwable e) {
+        } catch (Throwable e) {
             throw new CoreException(GeneralUtils.makeExceptionStatus(e));
         }
     }
@@ -356,9 +341,10 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
         }
     }
 
-    private void copyContentToFile(DBDContent contents, DBRProgressMonitor monitor)
-        throws DBException, IOException
-    {
+    private void copyContentToFile(
+        @NotNull DBDContent contents,
+        @NotNull DBRProgressMonitor monitor
+    ) throws DBException, IOException {
         DBDContentStorage storage = contents.getContents(monitor);
 
         markReadOnly(false);
@@ -380,9 +366,7 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
         markReadOnly(valueController.isReadOnly());
     }
 
-    public void updateContentFromFile(DBRProgressMonitor monitor, Object value)
-        throws DBException
-    {
+    public void updateContentFromFile(@NotNull DBRProgressMonitor monitor, Object value) throws DBException {
         if (valueController.isReadOnly()) {
             throw new DBCException("Can't update read-only value");
         }
@@ -438,7 +422,7 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
         return DBValueFormatting.getDefaultBinaryFileEncoding(valueController.getExecutionContext().getDataSource());
     }
 
-    public void setEncoding(String fileCharset) {
+    public void setEncoding(@NotNull String fileCharset) {
         this.fileCharset = fileCharset;
         for (IEditorPart part : editorParts) {
             try {

--- a/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/content/ContentEditorInput.java
+++ b/plugins/org.jkiss.dbeaver.ui.editors.data/src/org/jkiss/dbeaver/ui/editors/content/ContentEditorInput.java
@@ -116,6 +116,17 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
         this.prepareContent(monitor);
     }
 
+    public void refreshContent(DBRProgressMonitor monitor, IValueController valueController, @Nullable String charset) throws DBException
+    {
+        this.valueController = valueController;
+        this.fileCharset = CommonUtils.isEmpty(charset) ? getDefaultEncoding() : charset;
+        this.prepareContent(monitor);
+    }
+
+    public boolean isInMemory() {
+        return stringStorage != null;
+    }
+
     IEditorPart[] getEditors()
     {
         return editorParts;
@@ -210,9 +221,13 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
 
         if (contentDetached) {
             release();
+            contentFile = null;
             contentDetached = false;
         }
         if (storage instanceof DBDContentStorageLocal) {
+            if (contentFile != null && !contentDetached) {
+                release();
+            }
             // User content's storage directly
             contentFile = ((DBDContentStorageLocal)storage).getDataFile().toFile();
             contentDetached = true;
@@ -229,6 +244,8 @@ public class ContentEditorInput implements IPathEditorInput, IStatefulEditorInpu
                     }
 
                     contentFile = ContentUtils.createTempContentFile(monitor, DBWorkbench.getPlatform(), valueId).toFile();
+                } else if (!contentFile.canWrite()) {
+                    markReadOnly(false);
                 }
 
                 // Write value to file


### PR DESCRIPTION
Closes dbeaver/pro#10621

## Summary
- reuse compatible content panel editor controls when navigating text columns
- refresh existing Eclipse text editor inputs and documents instead of recreating editor state
- reset undo history and guard asynchronous LOB loading and backing-file lifecycle

## Verification
- `mvn clean package -T1C -DskipTests -Pproduct-dbeaver-ce`
- all 207 reactor modules built successfully

This PR was generated with AI (OpenAI GPT-5.6).