### PR TITLE
dbeaver/pro#10622 Prevent UI thread CPU spin in master password dialog

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIExecutionQueue.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIExecutionQueue.java
@@ -49,21 +49,28 @@ public class UIExecutionQueue {
     }
 
     public static void unblockQueue() {
+        boolean scheduleExecution;
         synchronized (execQueue) {
             if (runCount <= 0) {
                 throw new IllegalStateException("Queue is unblocked");
             }
             runCount--;
+            scheduleExecution = runCount == 0 && !execQueue.isEmpty();
+        }
+        if (scheduleExecution) {
+            UIUtils.asyncExec(UIExecutionQueue::executeInUI);
         }
     }
 
     private static void executeInUI() {
         synchronized (execQueue) {
             boolean workbenchStarted = DBWorkbench.getPlatform() instanceof DBPPlatformDesktop pd && pd.isWorkbenchStarted();
-            if (runCount > 0 || !workbenchStarted) {
-                // If workbench wasn't fully started or
-                // job is running or
-                // some Eclipse job is active in UI thread then retry later
+            if (runCount > 0) {
+                // The active job schedules the next one after it leaves any nested event loop and finishes.
+                return;
+            }
+            if (!workbenchStarted) {
+                // If workbench wasn't fully started then retry later
                 if (!DBWorkbench.getPlatform().isShuttingDown()) {
                     UIUtils.asyncExec(UIExecutionQueue::executeInUI);
                 }


### PR DESCRIPTION
Closes dbeaver/pro#10622

## Summary
- stop UI execution callbacks from immediately reposting while another queued task is active
- resume pending queue work when an external queue block is released
- prevent nested password and update dialog event loops from continuously consuming a CPU core

## Testing
- git diff --check
- targeted Tycho bundle build attempted; dependency resolution requires the full reactor (org.jkiss.dbeaver.model.rcp was unavailable)

This PR was generated with AI (OpenCode).