### PR TITLE
dbeaver/dbeaver#42041 Pass Snowflake warehouse as connection property

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
@@ -64,7 +64,20 @@ public class SnowflakeDataSource extends GenericDataSource {
         @NotNull String purpose,
         @NotNull DBPConnectionConfiguration connectionInfo
     ) {
+        return getInternalConnectionProperties(connectionInfo);
+    }
+
+    @NotNull
+    static Map<String, String> getInternalConnectionProperties(@NotNull DBPConnectionConfiguration connectionInfo) {
         Map<String, String> props = new HashMap<>();
+
+        String warehouse = connectionInfo.getServerName();
+        if (CommonUtils.isEmpty(warehouse)) {
+            warehouse = connectionInfo.getProviderProperty(SnowflakeConstants.PROP_WAREHOUSE);
+        }
+        if (!CommonUtils.isEmpty(warehouse)) {
+            props.put(SnowflakeConstants.PROP_WAREHOUSE, warehouse);
+        }
 
         // Backward compatibility - use legacy provider property
         // Newer versions use auth model

--- a/test/org.jkiss.dbeaver.ext.snowflake.test/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSourceTest.java
+++ b/test/org.jkiss.dbeaver.ext.snowflake.test/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSourceTest.java
@@ -1,0 +1,45 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.snowflake.model;
+
+import org.jkiss.dbeaver.ext.snowflake.SnowflakeConstants;
+import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SnowflakeDataSourceTest {
+    @Test
+    void internalConnectionPropertiesContainWarehouse() {
+        DBPConnectionConfiguration configuration = new DBPConnectionConfiguration();
+        configuration.setServerName("test_warehouse");
+
+        assertEquals(
+            "test_warehouse",
+            SnowflakeDataSource.getInternalConnectionProperties(configuration).get(SnowflakeConstants.PROP_WAREHOUSE));
+    }
+
+    @Test
+    void internalConnectionPropertiesContainLegacyWarehouse() {
+        DBPConnectionConfiguration configuration = new DBPConnectionConfiguration();
+        configuration.setProviderProperty(SnowflakeConstants.PROP_WAREHOUSE, "legacy_warehouse");
+
+        assertEquals(
+            "legacy_warehouse",
+            SnowflakeDataSource.getInternalConnectionProperties(configuration).get(SnowflakeConstants.PROP_WAREHOUSE));
+    }
+}


### PR DESCRIPTION
Closes dbeaver/dbeaver#42041

Pass the configured Snowflake warehouse through JDBC connection properties in addition to the generated URL. Preserve support for imported and legacy configurations that store the warehouse as a provider property.

Add regression coverage for both current and legacy warehouse storage.

Testing:
- `git diff --check` passed
- Aggregate Maven verification was attempted, but Tycho resolved JavaSE 17 for shared bundles requiring JavaSE 21 before reaching the Snowflake test module