### PR TITLE
dbeaver/dbeaver#9408 Fix table partition list not updated after Refresh in PostgreSQL

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -432,27 +432,35 @@ public abstract class PostgreTable extends PostgreTableReal
 
     @Nullable
     public List<PostgreTableInheritance> getSubInheritance(@NotNull DBRProgressMonitor monitor) throws DBException {
-        if (isPersisted() && subTables == null && hasSubClasses && getDataSource().getServerType().supportsInheritance()) {
+        if (isPersisted() && subTables == null && getDataSource().getServerType().supportsInheritance()) {
             List<PostgreTableInheritance> tables = new ArrayList<>();
             try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Load table inheritance info")) {
-                String sql = "SELECT i.*,c.relnamespace " +
+                String sql = "SELECT i.*,c.relnamespace,c.relname " +
                     "FROM pg_catalog.pg_inherits i,pg_catalog.pg_class c " +
                     "WHERE i.inhparent=? AND c.oid=i.inhrelid";
-//                if (getDataSource().isServerVersionAtLeast(10, 0)) {
-//                    sql += " AND c.relispartition=false";
-//                }
                 try (JDBCPreparedStatement dbStat = session.prepareStatement(sql)) {
                     dbStat.setLong(1, getObjectId());
                     try (JDBCResultSet dbResult = dbStat.executeQuery()) {
                         while (dbResult.next()) {
                             final long subSchemaId = JDBCUtils.safeGetLong(dbResult, "relnamespace"); //$NON-NLS-1$
                             final long subTableId = JDBCUtils.safeGetLong(dbResult, "inhrelid"); //$NON-NLS-1$
+                            final String subTableName = JDBCUtils.safeGetString(dbResult, "relname"); //$NON-NLS-1$
                             PostgreSchema schema = getDatabase().getSchema(monitor, subSchemaId);
                             if (schema == null) {
                                 log.warn("Can't find sub-table's schema '" + subSchemaId + "'");
                                 continue;
                             }
                             PostgreTableBase subTable = schema.getTable(monitor, subTableId);
+                            if (subTable == null && subTableName != null) {
+                                // The sub-table (e.g. a partition) can be created after the schema table cache was
+                                // loaded, so it may not be present there. Load such table separately and add it to the cache.
+                                schema.getTableCache().setFullCache(false);
+                                try {
+                                    subTable = schema.getTableCache().getObject(monitor, schema, subTableName);
+                                } finally {
+                                    schema.getTableCache().setFullCache(true);
+                                }
+                            }
                             if (subTable == null) {
                                 log.warn("Can't find sub-table '" + subTableId + "' in '" + schema.getName() + "'");
                                 continue;
@@ -470,6 +478,9 @@ public abstract class PostgreTable extends PostgreTableReal
                 }
             }
             DBUtils.orderObjects(tables);
+            if (!tables.isEmpty()) {
+                this.hasSubClasses = true;
+            }
             this.subTables = tables;
         }
         return subTables == null || subTables.isEmpty() ? null : subTables;

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreTable.java
@@ -438,6 +438,9 @@ public abstract class PostgreTable extends PostgreTableReal
                 String sql = "SELECT i.*,c.relnamespace,c.relname " +
                     "FROM pg_catalog.pg_inherits i,pg_catalog.pg_class c " +
                     "WHERE i.inhparent=? AND c.oid=i.inhrelid";
+//                if (getDataSource().isServerVersionAtLeast(10, 0)) {
+//                    sql += " AND c.relispartition=false";
+//                }
                 try (JDBCPreparedStatement dbStat = session.prepareStatement(sql)) {
                     dbStat.setLong(1, getObjectId());
                     try (JDBCResultSet dbResult = dbStat.executeQuery()) {


### PR DESCRIPTION
Closes dbeaver/dbeaver#9408

Fixes dbeaver/dbeaver#26854

### Problem

In PostgreSQL, when a partition is added to a partitioned table from outside of DBeaver (e.g. directly in the SQL editor with `CREATE TABLE ... PARTITION OF ...`), the partition list in the table properties/“Partitions” folder stays empty even after clicking **Refresh**.

Two independent causes were found:

1. **Stale `hasSubClasses` flag.** `PostgreTable.getSubInheritance` was guarded by the cached `hasSubClasses` field (fed from `pg_class.relhassubclass`). After an external `CREATE TABLE ... PARTITION OF ...` this cache flag remains `false`, so the `pg_catalog.pg_inherits` lookup was never executed and the list returned `null`.
2. **Sub-table missing from the schema table cache.** The `pg_inherits` query returns an OID of the newly created partition, but `PostgreSchema.getTable(monitor, oid)` iterates the fully cached schema table list, which does not contain the externally created table, so the sub-table resolved to `null` and was silently skipped with a warning.

The previous maintainer response to the first report (#9408) suggested this could not be fixed without refreshing the whole parent schema because partitions “are tables too”, but the fix below avoids any schema-wide refresh.

### Fix

In `PostgreTable.getSubInheritance` (plugins/org.jkiss.dbeaver.ext.postgresql):

- Query `pg_inherits` whenever `subTables == null`, without relying on the (possibly stale) `hasSubClasses` flag. This mirrors the already-existing behavior of `getSuperInheritance`, which queries `pg_catalog` unconditionally.
- Select `c.relname` together with the sub-table OID, and if the sub-table is not found in the schema table cache, load it by name on demand using the existing `JDBCCachedObjectCache.setFullCache(false)` + `getObject(monitor, schema, name)` retry pattern (the same pattern used in `SQLServerStructureAssistant`).
- Set `hasSubClasses = true` when actual sub-tables are found, keeping `fetchStatistics`/inheritance state consistent.

This makes the partition list appear immediately after a refresh of the table properties editor, of an already open table, or of the “Partitions” folder in the database navigator, without refreshing the parent schema.

### Performance notes

No performance regression for large schemas: `getSubInheritance` is only invoked when the partitions/inheritance section is actually displayed, the `pg_inherits` lookup is indexed by `inhparent`, and the OID-based cache lookup usually hits. The by-name load happens only for tables genuinely missing from the cache.

### Testing

- No new unit tests, as `getSubInheritance` requires JDBC/mock setup disproportionate to the change; existing PostgreSQL model tests pass.
