### PR TITLE
dbeaver/dbeaver#40575 Fix PostgreSQL backup selection

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.postgresql.PostgreMessages;
@@ -37,6 +38,7 @@ import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableBase;
 import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableContainer;
 import org.jkiss.dbeaver.ext.postgresql.tasks.PostgreDatabaseBackupInfo;
+import org.jkiss.dbeaver.ext.postgresql.tasks.PostgreDatabaseBackupSelection;
 import org.jkiss.dbeaver.model.DBIcon;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.impl.jdbc.struct.JDBCTable;
@@ -53,29 +55,29 @@ import org.jkiss.utils.CommonUtils;
 import java.util.*;
 
 
-class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<PostgreBackupWizard>
-{
+class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<PostgreBackupWizard> {
     private static final Log log = Log.getLog(PostgreBackupWizardPageObjects.class);
 
     private Table schemasTable;
     private Table tablesTable;
-    private Map<PostgreSchema, Set<PostgreTableBase>> checkedObjects = new HashMap<>();
+    private Composite tableButtonsPanel;
+    private final PostgreDatabaseBackupSelection selection = new PostgreDatabaseBackupSelection();
+    private int tableLoadId;
+    private boolean settingsLoaded;
 
     private PostgreSchema curSchema;
     private PostgreDatabase dataBase;
     private Button exportViewsCheck;
     private Button fullSchemaBackupCheck;
 
-    PostgreBackupWizardPageObjects(PostgreBackupWizard wizard)
-    {
+    PostgreBackupWizardPageObjects(@NotNull PostgreBackupWizard wizard) {
         super(wizard, PostgreMessages.wizard_backup_page_object_title_schema_table);
         setTitle(PostgreMessages.wizard_backup_page_object_title);
         setDescription(PostgreMessages.wizard_backup_page_object_description);
     }
 
     @Override
-    public void createControl(Composite parent)
-    {
+    public void createControl(@NotNull Composite parent) {
         Composite composite = UIUtils.createPlaceholder(parent, 1);
 
         Composite objectsGroup = UIUtils.createTitledComposite(
@@ -101,23 +103,32 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
                 PostgreSchema catalog = (PostgreSchema) item.getData();
                 if (event.detail == SWT.CHECK) {
                     schemasTable.select(schemasTable.indexOf(item));
-                    checkedObjects.remove(catalog);
+                    selection.selectSchema(catalog, item.getChecked());
+                    updateState();
                 }
-                loadTables(catalog);
-                updateState();
+                if (catalog == curSchema && tablesTable.getItemCount() > 0) {
+                    updateTableChecks();
+                } else {
+                    loadTables(catalog);
+                }
             });
             GridData gd = new GridData(GridData.FILL_BOTH);
             gd.heightHint = 50;
             schemasTable.setLayoutData(gd);
 
             Composite buttonsPanel = UIUtils.createComposite(catPanel, 3);
-            
-                        
-            fullSchemaBackupCheck = UIUtils.createCheckbox(buttonsPanel, PostgreMessages.wizard_backup_page_object_checkbox_complete_backup, false);
+
+            fullSchemaBackupCheck = UIUtils.createCheckbox(
+                buttonsPanel, PostgreMessages.wizard_backup_page_object_checkbox_complete_backup, false);
             fullSchemaBackupCheck.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
-                    wizard.getSettings().setFullSchemaBackup(fullSchemaBackupCheck.getSelection());
-                    tablesTable.setVisible(!fullSchemaBackupCheck.getSelection());
-                }));
+                if (fullSchemaBackupCheck.getSelection()) {
+                    updateTableCheckedStatus(schemasTable, true);
+                    updateSchemaChecks();
+                }
+                setFullSchemaBackup(fullSchemaBackupCheck.getSelection());
+                updatePageCompletion();
+                getContainer().updateButtons();
+            }));
             fullSchemaBackupCheck.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL));
             buttonsPanel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
             createCheckButtons(buttonsPanel, schemasTable);
@@ -138,16 +149,17 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
                 }
             });
 
-            Composite buttonsPanel = UIUtils.createComposite(tablesPanel, 3);
-            buttonsPanel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-            exportViewsCheck = UIUtils.createCheckbox(buttonsPanel, PostgreMessages.wizard_backup_page_object_checkbox_show_view, false);
-            exportViewsCheck.setSelection(wizard.getSettings().isFullSchemaBackup());
+            tableButtonsPanel = UIUtils.createComposite(tablesPanel, 3);
+            tableButtonsPanel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+            exportViewsCheck = UIUtils.createCheckbox(
+                tableButtonsPanel, PostgreMessages.wizard_backup_page_object_checkbox_show_view, false);
+            exportViewsCheck.setSelection(wizard.getSettings().isShowViews());
             exportViewsCheck.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
-                    wizard.getSettings().setShowViews(exportViewsCheck.getSelection());
-                    loadTables(null);
-                }));
+                wizard.getSettings().setShowViews(exportViewsCheck.getSelection());
+                loadTables(null);
+            }));
             exportViewsCheck.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL));
-            createCheckButtons(buttonsPanel, tablesTable);
+            createCheckButtons(tableButtonsPanel, tablesTable);
         }
         {
             PostgreUIUtils.addCompatibilityInfoLabelForForks(composite, wizard, dataBase != null ? dataBase.getDataSource() : null);
@@ -159,9 +171,6 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
     @Override
     protected boolean determinePageCompletion() {
         boolean complete = false;
-        if (!checkedObjects.isEmpty()) {
-            complete = true;
-        }
         for (TableItem item : schemasTable.getItems()) {
             if (item.getChecked()) {
                 complete = true;
@@ -175,9 +184,12 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
     @Override
     public void activatePage() {
         super.activatePage();
+        boolean fullSchemaBackup = wizard.getSettings().isFullSchemaBackup();
         loadSettings();
-
-        updateState();
+        setFullSchemaBackup(selection.isCompleteBackup(getSchemas()) && (!settingsLoaded || fullSchemaBackup));
+        settingsLoaded = true;
+        updatePageCompletion();
+        getContainer().updateButtons();
     }
 
     @Override
@@ -186,13 +198,17 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
     }
 
     private void loadSettings() {
-        checkedObjects.clear();
+        selection.clear();
+        tableLoadId++;
+        curSchema = null;
         schemasTable.removeAll();
         tablesTable.removeAll();
+        UIUtils.enableWithChildren(tableButtonsPanel, false);
 
         dataBase = null;
         boolean hasViews = false;
         Set<PostgreSchema> activeSchemas = new LinkedHashSet<>();
+        Map<PostgreSchema, Set<PostgreTableBase>> checkedObjects = new HashMap<>();
         for (PostgreDatabaseBackupInfo info : wizard.getSettings().getExportObjects()) {
             dataBase = info.getDatabase();
 
@@ -217,8 +233,8 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
         }
         if (hasViews) {
             wizard.getSettings().setShowViews(true);
-            exportViewsCheck.setSelection(true);
         }
+        exportViewsCheck.setSelection(wizard.getSettings().isShowViews());
         if (dataBase != null) {
             setConnectionInfo(dataBase.getDataSource().getContainer(), dataBase.getName());
 
@@ -234,12 +250,22 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
                     item.setData(schema);
                     if (activeSchemas.contains(schema)) {
                         item.setChecked(true);
-                        schemasTable.select(schemasTable.indexOf(item));
+                        Set<PostgreTableBase> tables = checkedObjects.get(schema);
+                        if (tables == null) {
+                            selection.selectSchema(schema, true);
+                        } else {
+                            selection.selectTables(schema, tables, false);
+                        }
                         if (!tablesLoaded) {
+                            schemasTable.select(schemasTable.indexOf(item));
                             loadTables(schema);
                             tablesLoaded = true;
                         }
                     }
+                }
+                if (!tablesLoaded && schemasTable.getItemCount() > 0) {
+                    schemasTable.select(0);
+                    loadTables((PostgreSchema) schemasTable.getItem(0).getData());
                 }
             } catch (DBException e) {
                 log.error(e);
@@ -250,80 +276,91 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
     private void updateCheckedTables() {
         Set<PostgreTableBase> checkedTables = new HashSet<>();
         TableItem[] tableItems = tablesTable.getItems();
+        if (curSchema == null || tableItems.length == 0) {
+            return;
+        }
         for (TableItem item : tableItems) {
             if (item.getChecked()) {
                 checkedTables.add((PostgreTableBase) item.getData());
             }
         }
-        int selectionIndex = schemasTable.getSelectionIndex();
-        if (selectionIndex > -1) {
-            TableItem catalogItem = schemasTable.getItem(selectionIndex);
-            catalogItem.setChecked(!checkedTables.isEmpty());
-        }
-        if (checkedTables.isEmpty() || checkedTables.size() == tableItems.length) {
-            checkedObjects.remove(curSchema);
-        } else {
-            checkedObjects.put(curSchema, checkedTables);
+        selection.selectTables(curSchema, checkedTables, checkedTables.size() == tableItems.length);
+        updateSchemaChecks();
+    }
+
+    private void updateSchemaChecks() {
+        for (TableItem item : schemasTable.getItems()) {
+            item.setChecked(selection.isSchemaSelected((PostgreSchema) item.getData()));
         }
     }
 
-    private boolean isChecked(PostgreSchema catalog) {
-        for (TableItem item : schemasTable.getItems()) {
-            if (item.getData() == catalog) {
-                return item.getChecked();
+    private void updateTableChecks() {
+        if (curSchema != null) {
+            for (TableItem item : tablesTable.getItems()) {
+                item.setChecked(selection.isTableSelected(curSchema, (PostgreTableBase) item.getData()));
             }
         }
-        return false;
     }
 
-    private List<PostgreTableBase> loadTables(final PostgreSchema catalog) {
+    private void loadTables(@Nullable PostgreSchema catalog) {
         if (catalog != null) {
             curSchema = catalog;
         }
         if (curSchema == null) {
-            return null;
+            return;
         }
-        final boolean isCatalogChecked = isChecked(curSchema);
-        final Set<PostgreTableBase> checkedObjects = this.checkedObjects.get(curSchema);
+        final PostgreSchema schema = curSchema;
+        final int loadId = ++tableLoadId;
+        final boolean showViews = wizard.getSettings().isShowViews();
         final List<PostgreTableBase> objects = new ArrayList<>();
-        new AbstractJob("Load '" + curSchema.getName() + "' tables") {
+        tablesTable.removeAll();
+        UIUtils.enableWithChildren(tableButtonsPanel, false);
+        new AbstractJob("Load '" + schema.getName() + "' tables") {
             {
                 setUser(true);
             }
+
             @NotNull
             @Override
             protected IStatus run(@NotNull DBRProgressMonitor monitor) {
                 monitor.beginTask("Collect tables", 1);
                 try {
                     monitor.subTask("Collect tables to dump");
-                    for (JDBCTable table : curSchema.getTables(monitor)) {
+                    for (JDBCTable table : schema.getTables(monitor)) {
                         if (table instanceof PostgreTableBase) {
                             objects.add((PostgreTableBase) table);
                         }
                     }
-                    if (wizard.getSettings().isShowViews()) {
-                        objects.addAll(curSchema.getViews(monitor));
+                    if (showViews) {
+                        objects.addAll(schema.getViews(monitor));
                     }
                     objects.sort(DBUtils.nameComparator());
                     UIUtils.syncExec(() -> {
+                        if (tablesTable.isDisposed() || loadId != tableLoadId) {
+                            return;
+                        }
                         tablesTable.removeAll();
                         for (PostgreTableBase table : objects) {
                             TableItem item = new TableItem(tablesTable, SWT.NONE);
                             item.setImage(DBeaverIcons.getImage(table.isView() ? DBIcon.TREE_VIEW : DBIcon.TREE_TABLE));
                             item.setText(0, table.getName());
                             item.setData(table);
-                            item.setChecked(isCatalogChecked && (checkedObjects == null || checkedObjects.contains(table)));
+                            item.setChecked(selection.isTableSelected(schema, table));
                         }
                     });
                 } catch (DBException e) {
                     DBWorkbench.getPlatformUI().showError("Table list", "Can't read table list", e);
                 } finally {
                     monitor.done();
+                    UIUtils.syncExec(() -> {
+                        if (!tablesTable.isDisposed() && loadId == tableLoadId) {
+                            UIUtils.enableWithChildren(tableButtonsPanel, true);
+                        }
+                    });
                 }
                 return Status.OK_STATUS;
             }
         }.schedule();
-        return objects;
     }
 
     public void saveState() {
@@ -331,48 +368,26 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
 
         List<PostgreDatabaseBackupInfo> objects = wizard.getSettings().getExportObjects();
         objects.clear();
-        List<PostgreSchema> entireSchemas = new ArrayList<>();
-        for (TableItem item : schemasTable.getItems()) {
-            if (item.getChecked()) {
-                PostgreSchema schema = (PostgreSchema) item.getData();
-                Set<PostgreTableBase> checkedTables = checkedObjects.get(schema);
-                if (checkedTables == null) {
-                    // All tables checked, we can add this schema in the full dump
-                    entireSchemas.add(schema);
-                    continue;
-                }
-                // Only a few tables checked, we need to use separate file for this case, because -n and -t arguments can be used together
-                PostgreDatabaseBackupInfo info = new PostgreDatabaseBackupInfo(
-                    dataBase,
-                    Collections.singletonList(schema),
-                    new ArrayList<>(checkedTables));
-                objects.add(info);
-            }
-        }
-        if (!entireSchemas.isEmpty()) {
-            PostgreDatabaseBackupInfo info = new PostgreDatabaseBackupInfo(dataBase, entireSchemas, null);
-            objects.add(info);
+        if (dataBase != null) {
+            objects.addAll(selection.getExportObjects(dataBase, wizard.getSettings().isFullSchemaBackup()));
         }
     }
 
-    private boolean isAllSchemaSelected() {
-        for (TableItem item : schemasTable.getItems()) {
-            if (!item.getChecked()) {
-                return false;
-            }
-        }
-        return true;
+    @NotNull
+    private List<PostgreSchema> getSchemas() {
+        return Arrays.stream(schemasTable.getItems()).map(item -> (PostgreSchema) item.getData()).toList();
     }
-    
-    private void updatefullSchemaBackupState() {
-    	boolean allSchemasSelected =isAllSchemaSelected();
-        fullSchemaBackupCheck.setEnabled(allSchemasSelected);
-        wizard.getSettings().setFullSchemaBackup(allSchemasSelected);
+
+    private void setFullSchemaBackup(boolean completeBackup) {
+        fullSchemaBackupCheck.setEnabled(schemasTable.getItemCount() > 0);
+        fullSchemaBackupCheck.setSelection(completeBackup);
+        wizard.getSettings().setFullSchemaBackup(completeBackup);
     }
+
     @Override
-    protected void updateState()
-    {
-    	updatefullSchemaBackupState();
+    protected void updateState() {
+        // a full selection must include database-level objects such as extensions, not just -n for every schema
+        setFullSchemaBackup(selection.isCompleteBackup(getSchemas()));
         updatePageCompletion();
         getContainer().updateButtons();
     }
@@ -381,33 +396,15 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
     protected void updateTableCheckedStatus(@NotNull Table table, boolean check) {
         // Handle event from buttons "All" and "None"
         if (table == schemasTable) {
-            TableItem[] items = tablesTable.getItems();
-            if (items.length != 0) {
-                for (TableItem tableItem : items) {
-                    tableItem.setChecked(check);
-                }
-            } else {
-                // This is the case when the user selects a backup by pressing the database, and not the scheme. Then tablesTable is empty.
-                TableItem[] schemasItems = schemasTable.getItems();
-                if (schemasItems.length != 0) {
-                    for (TableItem schemaItem : schemasItems) {
-                        Object data = schemaItem.getData();
-                        if (data instanceof PostgreSchema) {
-                            PostgreSchema postgreSchema = (PostgreSchema) data;
-                            if (schemaItem.getChecked() && check && !checkedObjects.containsKey(postgreSchema)) {
-                                List<PostgreTableBase> tableBaseList = loadTables(postgreSchema);
-                                if (!CommonUtils.isEmpty(tableBaseList)) {
-                                    checkedObjects.put(postgreSchema, new HashSet<>(tableBaseList));
-                                }
-                            } else if (!schemaItem.getChecked() && !check) {
-                                checkedObjects.remove(postgreSchema);
-                            }
-                        }
-                    }
-                }
+            selection.selectSchemas(getSchemas(), check);
+            updateTableChecks();
+            if (curSchema == null && schemasTable.getItemCount() > 0) {
+                schemasTable.select(0);
+                loadTables((PostgreSchema) schemasTable.getItem(0).getData());
             }
+        } else {
+            updateCheckedTables();
         }
-        updateCheckedTables();
     }
 
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql.ui/src/org/jkiss/dbeaver/ext/postgresql/tools/PostgreBackupWizardPageObjects.java
@@ -63,7 +63,6 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
     private Composite tableButtonsPanel;
     private final PostgreDatabaseBackupSelection selection = new PostgreDatabaseBackupSelection();
     private int tableLoadId;
-    private boolean settingsLoaded;
 
     private PostgreSchema curSchema;
     private PostgreDatabase dataBase;
@@ -125,9 +124,7 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
                     updateTableCheckedStatus(schemasTable, true);
                     updateSchemaChecks();
                 }
-                setFullSchemaBackup(fullSchemaBackupCheck.getSelection());
-                updatePageCompletion();
-                getContainer().updateButtons();
+                updateState();
             }));
             fullSchemaBackupCheck.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL));
             buttonsPanel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
@@ -184,12 +181,8 @@ class PostgreBackupWizardPageObjects extends AbstractNativeToolWizardPage<Postgr
     @Override
     public void activatePage() {
         super.activatePage();
-        boolean fullSchemaBackup = wizard.getSettings().isFullSchemaBackup();
         loadSettings();
-        setFullSchemaBackup(selection.isCompleteBackup(getSchemas()) && (!settingsLoaded || fullSchemaBackup));
-        settingsLoaded = true;
-        updatePageCompletion();
-        getContainer().updateButtons();
+        updateState();
     }
 
     @Override

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreDatabaseBackupSelection.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreDatabaseBackupSelection.java
@@ -1,0 +1,106 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.tasks;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableBase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PostgreDatabaseBackupSelection {
+    // a null value selects the entire schema, independently of whether its tables have been loaded
+    private final Map<PostgreSchema, Set<PostgreTableBase>> selectedObjects = new LinkedHashMap<>();
+
+    public void clear() {
+        selectedObjects.clear();
+    }
+
+    public void selectSchema(@NotNull PostgreSchema schema, boolean selected) {
+        if (selected) {
+            selectedObjects.put(schema, null);
+        } else {
+            selectedObjects.remove(schema);
+        }
+    }
+
+    public void selectSchemas(@NotNull Collection<PostgreSchema> schemas, boolean selected) {
+        for (PostgreSchema schema : schemas) {
+            selectSchema(schema, selected);
+        }
+    }
+
+    public void selectTables(@NotNull PostgreSchema schema, @NotNull Collection<PostgreTableBase> tables, boolean allTablesSelected) {
+        if (tables.isEmpty()) {
+            selectSchema(schema, false);
+        } else if (allTablesSelected) {
+            selectSchema(schema, true);
+        } else {
+            selectedObjects.put(schema, new LinkedHashSet<>(tables));
+        }
+    }
+
+    public boolean isSchemaSelected(@NotNull PostgreSchema schema) {
+        return selectedObjects.containsKey(schema);
+    }
+
+    public boolean isTableSelected(@NotNull PostgreSchema schema, @NotNull PostgreTableBase table) {
+        Set<PostgreTableBase> tables = selectedObjects.get(schema);
+        return isSchemaSelected(schema) && (tables == null || tables.contains(table));
+    }
+
+    public boolean isCompleteBackup(@NotNull Collection<PostgreSchema> schemas) {
+        if (schemas.isEmpty() || selectedObjects.size() != schemas.size()) {
+            return false;
+        }
+        for (PostgreSchema schema : schemas) {
+            if (!isSchemaSelected(schema) || selectedObjects.get(schema) != null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @NotNull
+    public List<PostgreDatabaseBackupInfo> getExportObjects(@NotNull PostgreDatabase database, boolean completeBackup) {
+        List<PostgreDatabaseBackupInfo> objects = new ArrayList<>();
+        if (completeBackup && !selectedObjects.isEmpty()) {
+            objects.add(new PostgreDatabaseBackupInfo(database, new ArrayList<>(selectedObjects.keySet()), null));
+            return objects;
+        }
+        List<PostgreSchema> entireSchemas = new ArrayList<>();
+        for (Map.Entry<PostgreSchema, Set<PostgreTableBase>> entry : selectedObjects.entrySet()) {
+            if (entry.getValue() == null) {
+                entireSchemas.add(entry.getKey());
+            } else {
+                // pg_dump ignores -n when -t is present, so partial schemas need separate invocations
+                objects.add(new PostgreDatabaseBackupInfo(database, List.of(entry.getKey()), new ArrayList<>(entry.getValue())));
+            }
+        }
+        if (!entireSchemas.isEmpty()) {
+            objects.add(new PostgreDatabaseBackupInfo(database, entireSchemas, null));
+        }
+        return objects;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreDatabaseBackupSettings.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreDatabaseBackupSettings.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2025 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -307,6 +307,20 @@ public class PostgreDatabaseBackupSettings extends PostgreBackupRestoreSettings 
     @NotNull
     public String getOutputFile(@NotNull PostgreDatabaseBackupInfo info) {
         String outputFileName = resolveVars(info.getDatabase(), info.getSchemas(), info.getTables(), getOutputFilePattern());
+        if (exportObjects.size() > 1) {
+            // separate pg_dump invocations must not overwrite each other when the pattern only names the database
+            int objectIndex = exportObjects.indexOf(info);
+            if (objectIndex >= 0) {
+                String suffix = "-" + (objectIndex + 1);
+                int extensionIndex = outputFileName.lastIndexOf('.');
+                int separatorIndex = Math.max(outputFileName.lastIndexOf('/'), outputFileName.lastIndexOf('\\'));
+                if (extensionIndex > separatorIndex + 1) {
+                    outputFileName = outputFileName.substring(0, extensionIndex) + suffix + outputFileName.substring(extensionIndex);
+                } else {
+                    outputFileName += suffix;
+                }
+            }
+        }
         String outputFolder = getOutputFolder(info);
         return makeOutFilePath(outputFolder, outputFileName);
     }

--- a/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreDatabaseBackupSelectionTest.java
+++ b/test/org.jkiss.dbeaver.ext.postgresql.test/src/org/jkiss/dbeaver/ext/postgresql/tasks/PostgreDatabaseBackupSelectionTest.java
@@ -1,0 +1,248 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.postgresql.tasks;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDataSource;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDatabase;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreDialect;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreSchema;
+import org.jkiss.dbeaver.ext.postgresql.model.PostgreTableBase;
+import org.jkiss.dbeaver.model.DBPDataSourceContainer;
+import org.jkiss.dbeaver.model.DBPEvaluationContext;
+import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
+import org.jkiss.dbeaver.model.connection.DBPNativeClientLocation;
+import org.jkiss.dbeaver.utils.RuntimeUtils;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PostgreDatabaseBackupSelectionTest extends DBeaverUnitTest {
+    private final PostgreDatabase database = Mockito.mock(PostgreDatabase.class);
+    private final PostgreSchema publicSchema = Mockito.mock(PostgreSchema.class);
+    private final PostgreSchema otherSchema = Mockito.mock(PostgreSchema.class);
+    private final PostgreTableBase firstTable = Mockito.mock(PostgreTableBase.class);
+    private final PostgreTableBase secondTable = Mockito.mock(PostgreTableBase.class);
+    private final PostgreDatabaseBackupSelection selection = new PostgreDatabaseBackupSelection();
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void completeSchemaSelectionDoesNotRequireLoadingTables() throws IOException {
+        selection.selectSchema(publicSchema, true);
+
+        Assertions.assertTrue(selection.isCompleteBackup(List.of(publicSchema)));
+        Assertions.assertTrue(selection.isTableSelected(publicSchema, firstTable));
+        Assertions.assertTrue(selection.isTableSelected(publicSchema, secondTable));
+        List<PostgreDatabaseBackupInfo> objects = selection.getExportObjects(database, true);
+        Assertions.assertEquals(1, objects.size());
+        Assertions.assertEquals(List.of(publicSchema), objects.getFirst().getSchemas());
+        Assertions.assertNull(objects.getFirst().getTables());
+        Mockito.verifyNoInteractions(publicSchema, firstTable, secondTable);
+        List<String> command = getCommand(objects.getFirst(), true);
+        Assertions.assertFalse(command.contains("-n"));
+        Assertions.assertFalse(command.contains("-t"));
+    }
+
+    @Test
+    void deselectingTableDisablesCompleteBackupForSingleSchema() throws IOException {
+        selection.selectSchema(publicSchema, true);
+        selection.selectTables(publicSchema, List.of(firstTable), false);
+
+        Assertions.assertFalse(selection.isCompleteBackup(List.of(publicSchema)));
+        Assertions.assertTrue(selection.isSchemaSelected(publicSchema));
+        Assertions.assertFalse(selection.isTableSelected(publicSchema, secondTable));
+        List<PostgreDatabaseBackupInfo> objects = selection.getExportObjects(database, false);
+        Assertions.assertEquals(1, objects.size());
+        Assertions.assertEquals(List.of(firstTable), objects.getFirst().getTables());
+        Mockito.when(firstTable.getFullyQualifiedName(DBPEvaluationContext.DDL)).thenReturn("\"public\".\"first\"");
+        List<String> command = getCommand(objects.getFirst(), false);
+        Assertions.assertFalse(command.contains("-n"));
+        Assertions.assertEquals(
+            List.of("-t", PostgreNativeToolHandler.escapeCLIIdentifier("\"public\".\"first\"")),
+            command.subList(command.indexOf("-t"), command.size())
+        );
+    }
+
+    @Test
+    void partialSelectionInAnySchemaDisablesCompleteBackup() {
+        List<PostgreSchema> schemas = List.of(publicSchema, otherSchema);
+        selection.selectSchemas(schemas, true);
+        selection.selectTables(publicSchema, List.of(firstTable), false);
+
+        Assertions.assertFalse(selection.isCompleteBackup(schemas));
+        List<PostgreDatabaseBackupInfo> objects = selection.getExportObjects(database, false);
+        Assertions.assertEquals(2, objects.size());
+        Assertions.assertEquals(List.of(publicSchema), objects.get(0).getSchemas());
+        Assertions.assertEquals(List.of(firstTable), objects.get(0).getTables());
+        Assertions.assertEquals(List.of(otherSchema), objects.get(1).getSchemas());
+        Assertions.assertNull(objects.get(1).getTables());
+    }
+
+    @Test
+    void selectingAllSchemasClearsPartialSelectionsInEverySchema() {
+        List<PostgreSchema> schemas = List.of(publicSchema, otherSchema);
+        selection.selectTables(publicSchema, List.of(firstTable), false);
+        selection.selectTables(otherSchema, List.of(secondTable), false);
+        selection.selectSchemas(schemas, true);
+
+        Assertions.assertTrue(selection.isCompleteBackup(schemas));
+        List<PostgreDatabaseBackupInfo> objects = selection.getExportObjects(database, true);
+        Assertions.assertEquals(1, objects.size());
+        Assertions.assertEquals(schemas, objects.getFirst().getSchemas());
+        Assertions.assertNull(objects.getFirst().getTables());
+    }
+
+    @Test
+    void selectingNoSchemasClearsPreviouslySelectedTables() {
+        List<PostgreSchema> schemas = List.of(publicSchema, otherSchema);
+        selection.selectTables(publicSchema, List.of(firstTable), false);
+        selection.selectSchema(otherSchema, true);
+        selection.selectSchemas(schemas, false);
+
+        Assertions.assertFalse(selection.isCompleteBackup(schemas));
+        Assertions.assertFalse(selection.isTableSelected(publicSchema, firstTable));
+        Assertions.assertFalse(selection.isTableSelected(otherSchema, secondTable));
+        Assertions.assertTrue(selection.getExportObjects(database, false).isEmpty());
+    }
+
+    @Test
+    void selectingAllTablesRestoresCompleteBackup() {
+        selection.selectTables(publicSchema, List.of(firstTable), false);
+        selection.selectTables(publicSchema, List.of(firstTable, secondTable), true);
+
+        Assertions.assertTrue(selection.isCompleteBackup(List.of(publicSchema)));
+        Assertions.assertNull(selection.getExportObjects(database, true).getFirst().getTables());
+    }
+
+    @Test
+    void selectingNoTablesUnchecksTheirSchema() {
+        selection.selectSchema(publicSchema, true);
+        selection.selectTables(publicSchema, List.of(), false);
+
+        Assertions.assertFalse(selection.isSchemaSelected(publicSchema));
+        Assertions.assertFalse(selection.isCompleteBackup(List.of(publicSchema)));
+        Assertions.assertTrue(selection.getExportObjects(database, false).isEmpty());
+    }
+
+    @Test
+    void excludingSchemaKeepsSchemaFilter() throws IOException {
+        List<PostgreSchema> schemas = List.of(publicSchema, otherSchema);
+        selection.selectSchemas(schemas, true);
+        selection.selectSchema(otherSchema, false);
+
+        Assertions.assertFalse(selection.isCompleteBackup(schemas));
+        List<PostgreDatabaseBackupInfo> objects = selection.getExportObjects(database, false);
+        Assertions.assertEquals(1, objects.size());
+        Assertions.assertEquals(List.of(publicSchema), objects.getFirst().getSchemas());
+        Assertions.assertNull(objects.getFirst().getTables());
+        PostgreDataSource dataSource = Mockito.mock(PostgreDataSource.class);
+        Mockito.when(dataSource.getSQLDialect()).thenReturn(new PostgreDialect());
+        Mockito.when(publicSchema.getDataSource()).thenReturn(dataSource);
+        Mockito.when(publicSchema.getName()).thenReturn("public");
+        List<String> command = getCommand(objects.getFirst(), false);
+        Assertions.assertTrue(command.contains("-n"));
+        Assertions.assertFalse(command.contains("-t"));
+    }
+
+    @Test
+    void emptySelectionIsNotCompleteBackup() {
+        Assertions.assertFalse(selection.isCompleteBackup(List.of()));
+        Assertions.assertTrue(selection.getExportObjects(database, true).isEmpty());
+    }
+
+    @Test
+    void partialSchemaDumpsHaveDistinctFileNames() {
+        selection.selectTables(publicSchema, List.of(firstTable), false);
+        selection.selectSchema(otherSchema, true);
+        PostgreDatabaseBackupSettings settings = new PostgreDatabaseBackupSettings();
+        settings.setExportObjects(selection.getExportObjects(database, false));
+        settings.setOutputFolderPattern(temporaryDirectory.toString());
+        settings.setOutputFilePattern("dump.sql");
+
+        Assertions.assertEquals(
+            temporaryDirectory.resolve("dump-1.sql"),
+            Path.of(settings.getOutputFile(settings.getExportObjects().get(0)))
+        );
+        Assertions.assertEquals(
+            temporaryDirectory.resolve("dump-2.sql"),
+            Path.of(settings.getOutputFile(settings.getExportObjects().get(1)))
+        );
+    }
+
+    @Test
+    void partialSchemaDumpsHaveDistinctDirectoryNames() {
+        selection.selectTables(publicSchema, List.of(firstTable), false);
+        selection.selectSchema(otherSchema, true);
+        PostgreDatabaseBackupSettings settings = new PostgreDatabaseBackupSettings();
+        settings.setExportObjects(selection.getExportObjects(database, false));
+        settings.setFormat(PostgreBackupRestoreSettings.ExportFormat.DIRECTORY);
+        settings.setOutputFolderPattern(temporaryDirectory.toString());
+        settings.setOutputFilePattern("dump");
+
+        Assertions.assertEquals(
+            temporaryDirectory.resolve("dump-1"),
+            Path.of(settings.getOutputFile(settings.getExportObjects().get(0)))
+        );
+        Assertions.assertEquals(
+            temporaryDirectory.resolve("dump-2"),
+            Path.of(settings.getOutputFile(settings.getExportObjects().get(1)))
+        );
+    }
+
+    @Test
+    void completeBackupKeepsConfiguredFileName() {
+        selection.selectSchemas(List.of(publicSchema, otherSchema), true);
+        PostgreDatabaseBackupSettings settings = new PostgreDatabaseBackupSettings();
+        settings.setExportObjects(selection.getExportObjects(database, true));
+        settings.setOutputFolderPattern(temporaryDirectory.toString());
+        settings.setOutputFilePattern("dump.sql");
+
+        Assertions.assertEquals(
+            temporaryDirectory.resolve("dump.sql"),
+            Path.of(settings.getOutputFile(settings.getExportObjects().getFirst()))
+        );
+    }
+
+    @NotNull
+    private List<String> getCommand(@NotNull PostgreDatabaseBackupInfo info, boolean completeBackup) throws IOException {
+        Files.createFile(temporaryDirectory.resolve(RuntimeUtils.getNativeBinaryName("pg_dump")));
+        DBPNativeClientLocation clientHome = Mockito.mock(DBPNativeClientLocation.class);
+        Mockito.when(clientHome.getPath()).thenReturn(temporaryDirectory.toFile());
+        DBPDataSourceContainer container = Mockito.mock(DBPDataSourceContainer.class);
+        Mockito.when(container.getActualConnectionConfiguration()).thenReturn(new DBPConnectionConfiguration());
+        PostgreDatabaseBackupSettings settings = Mockito.mock(PostgreDatabaseBackupSettings.class);
+        Mockito.when(settings.getClientHome()).thenReturn(clientHome);
+        Mockito.when(settings.getDataSourceContainer()).thenReturn(container);
+        Mockito.when(settings.getFormat()).thenReturn(PostgreBackupRestoreSettings.ExportFormat.CUSTOM);
+        Mockito.when(settings.getOutputFile(info)).thenReturn(temporaryDirectory.resolve("dump.backup").toString());
+        Mockito.when(settings.getExportObjects()).thenReturn(List.of(info));
+        Mockito.when(settings.isFullSchemaBackup()).thenReturn(completeBackup);
+        List<String> command = new ArrayList<>();
+        new PostgreDatabaseBackupHandler().fillProcessParameters(settings, info, command);
+        return command;
+    }
+}


### PR DESCRIPTION
Closes dbeaver/dbeaver#40575

## Summary

- Honor partial table selection even when every schema is checked. Selecting all schemas entirely enables **Complete backup**, while excluding a table or schema switches to a filtered dump. Keep the table list editable in complete-backup mode and synchronize the checkbox with the effective setting.
- Extract schema/table selection state from SWT so **All/None** resets partial selections in every schema independently of table loading.
- Capture the schema for asynchronous loading, ignore obsolete results, and render the current selection when loading finishes. Load the first schema's tables on opening the wizard and avoid reloading an already displayed nonempty schema on every click.
- Give separate dump invocations numbered output filenames/directories to prevent them from overwriting each other.
- Add 12 regression tests for selection transitions, generated command-line filters, and output filenames.

## Previous regression: #41683

The restore log in #41683 contains `CREATE TABLE` statements that fail because `public.geometry` is missing. A dump restricted with `-n public` omits extensions by default, even if `public` is the only user schema. Such a dump is not equivalent to a complete database backup.

This implementation treats a complete object selection as a full database backup, without `-n`/`-t`, preserving extensions such as PostGIS. Partial selections still use schema/table filters; their dependencies may need to exist in the target database.

Related: #41550, #41694, #42008.

## Verification

- Java 21 / Maven Tycho: PostgreSQL model and UI bundles built successfully; **12 tests passed**, none skipped.
- Checkstyle passed for the new selection model, its tests, and the modified wizard page. `git diff --check` passed.
- PostgreSQL **17.5** with PostGIS **3.5.2** in local Docker, using native client **17.10**: **8 CLI checks passed**:
  - Negative control reproduced the missing-geometry failure with `-n public`, despite the affected tables being present in the archive.
  - Complete backup/restore in Custom, Tar, Directory, and Plain formats preserved PostGIS, geometry values, data, a view, GiST indexes, and a foreign key.
  - A single-table dump restored only the selected table.
  - A mixed table/schema selection restored from two distinct archives and excluded unselected schemas.
  - A complete multi-schema dump preserved all application tables and an empty schema.

Focused test command:

```sh
mvn verify -f product/aggregate/pom.xml \
  -pl :org.jkiss.dbeaver.model,:org.jkiss.dbeaver.model.sql,:org.jkiss.dbeaver.model.jdbc,:org.jkiss.dbeaver.ext.postgresql,:org.jkiss.dbeaver.ext.postgresql.ui,:org.jkiss.dbeaver.ext.postgresql.test \
  -am -Dtest=PostgreDatabaseBackupSelectionTest \
  -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false
```

## UI verification steps

1. In a database with one user schema and several tables, open **Tools → Backup**. Use the tables section's **None**, then select one table. **Complete backup** must be off and the command must contain only the corresponding `-t` filter.
2. Select all schemas entirely. **Complete backup** must turn on, the table list must remain editable, and the command must have no `-n`/`-t` filters. For the #41683 case, include PostGIS geometry columns and restore into a clean database created from `template0`.
3. Make partial selections in different schemas, then use the schemas section's **All** and **None**. Verify that no old partial selections remain.
4. Switch schemas while tables are loading. The visible table list and its checkboxes must belong to the currently selected schema. Repeated clicks on an already displayed nonempty schema should not clear/reload its list.
5. Verify selection and the complete-backup checkbox after **Next → Back**. For mixed table/schema exports, verify distinct output files and restore each archive into the intended target.

When restoring into an existing test database under a different name, leave **Create database** off: `pg_restore --create` uses the database name from the archive rather than the target supplied through `--dbname`.

AI-assisted implementation and testing with OpenCode.
