### PR TITLE
dbeaver/cloudbeaver#4643 Handle OpenAI stream completion marker

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAiAPIStreamConsumer.java
+++ b/plugins/org.jkiss.dbeaver.model.ai/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAiAPIStreamConsumer.java
@@ -40,6 +40,7 @@ public class OpenAiAPIStreamConsumer implements Consumer<String> {
     public static final String DATA_EVENT = "data: ";
     public static final String EVENT_TYPE_RESPONSE_COMPLETED = "response.completed";
     public static final String EVENT_TYPE_ITEM_DONE = "response.output_item.done";
+    private static final String DONE_EVENT = "[DONE]";
     private static final String EVENT_EVENT = "event: ";
     private static final String EVENT_TYPE_ARGUMENTS_DELTA = "response.function_call_arguments.delta";
     private final AIEngineResponseConsumer listener;
@@ -56,6 +57,9 @@ public class OpenAiAPIStreamConsumer implements Consumer<String> {
         }
         if (event.startsWith(DATA_EVENT)) {
             String data = event.substring(DATA_EVENT.length()).trim();
+            if (DONE_EVENT.equals(data)) {
+                return;
+            }
             try {
                 OAIResponsesChunk chunk = GSON.fromJson(data, OAIResponsesChunk.class);
                 if (chunk.error != null) {

--- a/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAiAPIStreamConsumerTest.java
+++ b/test/org.jkiss.dbeaver.model.ai.test/src/org/jkiss/dbeaver/model/ai/engine/openai/OpenAiAPIStreamConsumerTest.java
@@ -1,0 +1,91 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.ai.engine.openai;
+
+import com.google.gson.JsonSyntaxException;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.model.ai.engine.AIEngineResponseChunk;
+import org.jkiss.dbeaver.model.ai.engine.AIEngineResponseConsumer;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+
+public class OpenAiAPIStreamConsumerTest extends DBeaverUnitTest {
+    private final AIEngineResponseConsumer listener = Mockito.mock(AIEngineResponseConsumer.class);
+    private final OpenAiAPIStreamConsumer consumer = new OpenAiAPIStreamConsumer(listener);
+
+    @Test
+    public void ignoresDoneMarker() {
+        consumer.accept("data: [DONE]");
+        consumer.accept("data:   [DONE]  ");
+
+        Mockito.verifyNoInteractions(listener);
+    }
+
+    @Test
+    public void preservesTextBeforeDoneMarker() {
+        consumer.accept("data: {\"type\":\"response.output_text.delta\",\"delta\":\"There are 25 tables.\"}");
+        consumer.accept("data: [DONE]");
+
+        ArgumentCaptor<AIEngineResponseChunk> chunk = ArgumentCaptor.forClass(AIEngineResponseChunk.class);
+        Mockito.verify(listener).nextChunk(chunk.capture());
+        Assertions.assertEquals(List.of("There are 25 tables."), chunk.getValue().getChoices());
+        Mockito.verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    public void preservesFunctionCallBeforeDoneMarker() {
+        consumer.accept("""
+            data: {"type":"response.output_item.done","item":{"type":"function_call",\
+            "name":"db_listTableNames","call_id":"call_1","arguments":"{\\"schemaNames\\":\\"dbo\\"}"}}
+            """);
+        consumer.accept("data: [DONE]");
+
+        ArgumentCaptor<AIEngineResponseChunk> chunk = ArgumentCaptor.forClass(AIEngineResponseChunk.class);
+        Mockito.verify(listener).nextChunk(chunk.capture());
+        var functionCall = chunk.getValue().getFunctionCall();
+        Assertions.assertNotNull(functionCall);
+        Assertions.assertEquals("db_listTableNames", functionCall.getFunctionName());
+        Assertions.assertEquals(Map.of("schemaNames", "dbo"), functionCall.getArguments());
+        Assertions.assertEquals(Map.of("call_id", "call_1"), functionCall.getMessageMetadata());
+        Mockito.verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    public void reportsUnexpectedJsonArray() {
+        consumer.accept("data: []");
+
+        Mockito.verify(listener).error(Mockito.isA(JsonSyntaxException.class));
+        Mockito.verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    public void reportsApiError() {
+        consumer.accept("data: {\"error\":{\"code\":\"invalid_request\",\"message\":\"Invalid model\"}}");
+
+        ArgumentCaptor<Throwable> error = ArgumentCaptor.forClass(Throwable.class);
+        Mockito.verify(listener).error(error.capture());
+        Assertions.assertInstanceOf(DBException.class, error.getValue());
+        Assertions.assertEquals("invalid_request: Invalid model", error.getValue().getMessage());
+        Mockito.verifyNoMoreInteractions(listener);
+    }
+}


### PR DESCRIPTION
Closes dbeaver/cloudbeaver#4643

## Summary
Handle the `data: [DONE]` stream terminator before JSON deserialization in `OpenAiAPIStreamConsumer`. Previously, Gson tried to deserialize `[DONE]` as an `OAIResponsesChunk`, reporting `Expected BEGIN_OBJECT but was BEGIN_ARRAY` after otherwise successful text responses and tool calls through LiteLLM.

## API compatibility
`data: [DONE]` is part of the documented OpenAI Chat Completions streaming API. The [API reference](https://platform.openai.com/docs/api-reference/chat/create) explicitly states for `stream_options.include_usage`:

> If set, an additional chunk will be streamed before the `data: [DONE]` message.

The [Responses API streaming guide](https://developers.openai.com/api/docs/guides/streaming-responses) describes successful completion using the typed `response.completed` event. LiteLLM also appends `[DONE]` to its Responses streams via its [shared streaming generator in v1.100.0](https://github.com/BerriAI/litellm/blob/v1.100.0/litellm/proxy/proxy_server.py#L8761-L8764). This change accepts that additional protocol marker without treating it as JSON or emitting duplicate completion callbacks.

## Testing
Added five regression tests covering the terminator (including surrounding whitespace), preceding text and tool-call payloads, unexpected JSON arrays, and API errors. Before the fix, the three terminator-related tests failed; after the fix, all five passed in Maven/Tycho.

```sh
mvn verify -f product/aggregate/pom.xml -pl :org.jkiss.dbeaver.model.ai,:org.jkiss.dbeaver.model.ai.test -am -Dtest=OpenAiAPIStreamConsumerTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false
```

`git diff --check` passed.

AI assistance: implementation and regression tests were generated with OpenCode (OpenAI).