### PR TITLE
Hotfix release versioning

### DIFF
--- a/plugins/org.jkiss.dbeaver.model.cli/src/org/jkiss/dbeaver/model/cli/ApplicationCommandLine.java
+++ b/plugins/org.jkiss.dbeaver.model.cli/src/org/jkiss/dbeaver/model/cli/ApplicationCommandLine.java
@@ -158,7 +158,7 @@ public abstract class ApplicationCommandLine<T extends ApplicationInstanceContro
             }
 
             if (parseResult.isVersionHelpRequested()) {
-                String version = GeneralUtils.getLongProductTitle();
+                String version = GeneralUtils.getProductTitle();
                 return new CLIProcessResult(CLIProcessResult.PostAction.SHUTDOWN, version);
             }
 

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/utils/GeneralUtils.java
@@ -64,6 +64,12 @@ import java.util.regex.Pattern;
 public class GeneralUtils {
     private static final Log log = Log.getLog(GeneralUtils.class);
 
+    private static final String PRODUCT_MARKER_FILE = ".eclipseproduct";
+    private static final String PRODUCT_ID_PROPERTY = "id";
+    private static final String PRODUCT_VERSION_PROPERTY = "version";
+    private static final String[] PRODUCT_ID_PREFIXES = {"org.jkiss.dbeaver.", "com.dbeaver.", "org.dbvr."};
+    private static final Pattern PUBLIC_VERSION_PATTERN = Pattern.compile("\\d+(?:\\.\\d+){2,3}");
+
     public static final Pattern URI_SCHEMA_PATTERN = Pattern.compile("([a-zA-Z0-9-_]+:).+");
 
     public static final String UTF8_ENCODING = StandardCharsets.UTF_8.name();
@@ -337,8 +343,51 @@ public class GeneralUtils {
 
     @NotNull
     public static String getPlainVersion() {
+        return ProductVersionHolder.PLAIN_VERSION;
+    }
+
+    @NotNull
+    static String readProductVersion(@NotNull Path productMarker, @NotNull String fallback) {
+        try (InputStream input = Files.newInputStream(productMarker)) {
+            Properties properties = new Properties();
+            properties.load(input);
+            String productId = properties.getProperty(PRODUCT_ID_PROPERTY);
+            String version = properties.getProperty(PRODUCT_VERSION_PROPERTY);
+            if (isDBeaverProduct(productId) && version != null && PUBLIC_VERSION_PATTERN.matcher(version.trim()).matches()) {
+                return version.trim();
+            }
+        } catch (IOException | IllegalArgumentException e) {
+            // The marker is only available in installed products.
+        }
+        return fallback;
+    }
+
+    private static String loadProductVersion() {
         Version version = getProductVersion();
-        return version.getMajor() + "." + version.getMinor() + "." + version.getMicro();
+        String fallback = version.getMajor() + "." + version.getMinor() + "." + version.getMicro();
+        try {
+            Path installPath = RuntimeUtils.getLocalPathFromURL(Platform.getInstallLocation().getURL());
+            return readProductVersion(installPath.resolve(PRODUCT_MARKER_FILE), fallback);
+        } catch (Exception e) {
+            return fallback;
+        }
+    }
+
+    private static boolean isDBeaverProduct(@Nullable String productId) {
+        if (productId == null) {
+            return false;
+        }
+        String id = productId.trim();
+        for (String prefix : PRODUCT_ID_PREFIXES) {
+            if (id.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static class ProductVersionHolder {
+        private static final String PLAIN_VERSION = loadProductVersion();
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/updater/VersionDescriptor.java
+++ b/plugins/org.jkiss.dbeaver.registry/src/org/jkiss/dbeaver/registry/updater/VersionDescriptor.java
@@ -70,6 +70,10 @@ public class VersionDescriptor {
         return programVersion.getMajor() + "." + programVersion.getMinor() + "." + programVersion.getMicro();
     }
 
+    public String getReleaseVersion() {
+        return programVersion.toString();
+    }
+
     public String getUpdateTime() {
         return updateTime;
     }

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/about/AboutBoxDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/about/AboutBoxDialog.java
@@ -203,7 +203,7 @@ public class AboutBoxDialog extends InformationDialog
         Text versionLabel = new Text(group, SWT.NONE);
         versionLabel.setEditable(false);
         versionLabel.setBackground(background);
-        versionLabel.setText(CoreMessages.dialog_about_label_version + GeneralUtils.getProductVersion());
+        versionLabel.setText(CoreMessages.dialog_about_label_version + GeneralUtils.getPlainVersion());
         gd = new GridData(GridData.FILL_HORIZONTAL);
         gd.horizontalAlignment = GridData.CENTER;
         versionLabel.setLayoutData(gd);

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/DBeaverVersionChecker.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/DBeaverVersionChecker.java
@@ -33,6 +33,7 @@ import org.jkiss.dbeaver.ui.app.standalone.DBeaverApplication;
 import org.jkiss.dbeaver.ui.app.standalone.internal.CoreApplicationActivator;
 import org.jkiss.dbeaver.ui.services.UIServiceApplicationVersionUpdater;
 import org.jkiss.dbeaver.utils.GeneralUtils;
+import org.jkiss.dbeaver.utils.VersionUtils;
 import org.jkiss.utils.CommonUtils;
 import org.osgi.framework.Version;
 
@@ -134,7 +135,8 @@ public class DBeaverVersionChecker extends AbstractJob {
             return Status.CANCEL_STATUS;
         }
 
-        if (showAlways || (!isSuppressed(newVersion) && (SKIP_VERSION_CHECK || newVersion.getProgramVersion().compareTo(currentVersion) > 0))) {
+        if (showAlways || (!isSuppressed(newVersion) && (SKIP_VERSION_CHECK ||
+            VersionUtils.compareVersions(newVersion.getReleaseVersion(), currentVersion.toString()) > 0))) {
             UIServiceApplicationVersionUpdater updater = DBWorkbench.findService(UIServiceApplicationVersionUpdater.class);
             if (updater != null) {
                 UIUtils.asyncExec(updater::handleVersionUpdate);
@@ -155,11 +157,11 @@ public class DBeaverVersionChecker extends AbstractJob {
 
     private static boolean isSuppressed(@NotNull VersionDescriptor version) {
         CoreApplicationActivator activator = CoreApplicationActivator.getDefault();
-        return activator != null && activator.getPreferenceStore().getBoolean("suppressUpdateCheck." + version.getPlainVersion());
+        return activator != null && activator.getPreferenceStore().getBoolean("suppressUpdateCheck." + version.getReleaseVersion());
     }
 
     @NotNull
     private static Version getProductVersion() {
-        return OVERRIDE_PRODUCT_VERSION == null ? GeneralUtils.getProductVersion() : OVERRIDE_PRODUCT_VERSION;
+        return OVERRIDE_PRODUCT_VERSION == null ? Version.parseVersion(GeneralUtils.getPlainVersion()) : OVERRIDE_PRODUCT_VERSION;
     }
 }

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
@@ -45,6 +45,7 @@ import org.jkiss.dbeaver.ui.app.standalone.DBeaverApplication;
 import org.jkiss.dbeaver.ui.app.standalone.internal.CoreApplicationActivator;
 import org.jkiss.dbeaver.utils.GeneralUtils;
 import org.jkiss.dbeaver.utils.RuntimeUtils;
+import org.jkiss.dbeaver.utils.VersionUtils;
 import org.jkiss.utils.CommonUtils;
 import org.osgi.framework.Version;
 
@@ -99,7 +100,7 @@ public class VersionUpdateDialog extends Dialog {
     }
 
     private boolean isNewVersionAvailable() {
-        return newVersion.getProgramVersion().compareTo(currentVersion) > 0;
+        return VersionUtils.compareVersions(newVersion.getReleaseVersion(), currentVersion.toString()) > 0;
     }
 
     @Override
@@ -133,7 +134,7 @@ public class VersionUpdateDialog extends Dialog {
 
         UIUtils.createControlLabel(propGroup, CoreMessages.dialog_version_update_new_version);
         new Label(propGroup, SWT.NONE)
-            .setText(newVersion.getProgramVersion().toString() + "    (" + newVersion.getUpdateTime() + ")"); //$NON-NLS-2$ //$NON-NLS-3$
+            .setText(newVersion.getReleaseVersion() + "    (" + newVersion.getUpdateTime() + ")"); //$NON-NLS-2$ //$NON-NLS-3$
 
         if (isNewVersionAvailable()) {
             final Label notesLabel = UIUtils.createControlLabel(propGroup, CoreMessages.dialog_version_update_notes);
@@ -158,7 +159,7 @@ public class VersionUpdateDialog extends Dialog {
             hintLabel.setText(NLS.bind(
                 CoreMessages.dialog_version_update_press_more_info,
                 CoreMessages.dialog_version_update_button_more_info,
-                newVersion.getPlainVersion()));
+                newVersion.getReleaseVersion()));
             gd = new GridData(GridData.FILL_HORIZONTAL);
             gd.horizontalSpan = 2;
             hintLabel.setLayoutData(gd);
@@ -206,7 +207,7 @@ public class VersionUpdateDialog extends Dialog {
     protected void createButtonsForButtonBar(Composite parent) {
         if (showConfig && isNewVersionAvailable()) {
             ((GridLayout) parent.getLayout()).numColumns++;
-            dontShowAgainCheck = UIUtils.createCheckbox(parent, NLS.bind(CoreMessages.dialog_version_update_ignore_version, newVersion.getPlainVersion()), false);
+            dontShowAgainCheck = UIUtils.createCheckbox(parent, NLS.bind(CoreMessages.dialog_version_update_ignore_version, newVersion.getReleaseVersion()), false);
         }
 
         if (isNewVersionAvailable()) {
@@ -241,7 +242,7 @@ public class VersionUpdateDialog extends Dialog {
     protected void buttonPressed(int buttonId)
     {
         if (dontShowAgainCheck != null && dontShowAgainCheck.getSelection()) {
-            CoreApplicationActivator.getDefault().getPreferenceStore().setValue("suppressUpdateCheck." + newVersion.getPlainVersion(), true);
+            CoreApplicationActivator.getDefault().getPreferenceStore().setValue("suppressUpdateCheck." + newVersion.getReleaseVersion(), true);
         }
         if (buttonId == INFO_ID) {
             ShellUtils.launchProgram(newVersion.getBaseURL());

--- a/product/snap-build/snap/snapcraft.yaml
+++ b/product/snap-build/snap/snapcraft.yaml
@@ -49,12 +49,15 @@ parts:
     override-build: |
       set -e
       snapcraftctl build
-      VERSION=$(echo $SNAPCRAFT_PART_INSTALL/usr/share/dbeaver-ce/plugins/org.jkiss.dbeaver.core_*.jar)
-      VERSION="${VERSION##*_}"
-      VERSION="${VERSION%.*}"
+      if [ -s "$SNAPCRAFT_PROJECT_DIR/release-version" ]; then
+        VERSION=$(cat "$SNAPCRAFT_PROJECT_DIR/release-version")
+      else
+        VERSION=$(echo "$SNAPCRAFT_PART_INSTALL"/usr/share/dbeaver-ce/plugins/org.jkiss.dbeaver.core_*.jar)
+        VERSION="${VERSION##*_}"
+        VERSION="${VERSION%.*}"
+      fi
       snapcraftctl set-version "$VERSION"
       LD_BIND_NOW=1
     override-prime: |
       snapcraftctl prime
       rm -vf usr/lib/jvm/java-*/lib/security/blacklisted.certs
-

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/utils/ProductVersionTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/utils/ProductVersionTest.java
@@ -1,0 +1,87 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.utils;
+
+import org.jkiss.dbeaver.registry.updater.VersionDescriptor;
+import org.jkiss.dbeaver.runtime.DBWorkbench;
+import org.jkiss.junit.DBeaverUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ProductVersionTest extends DBeaverUnitTest {
+
+    @Test
+    public void comparePublicVersions() {
+        assertTrue(VersionUtils.compareVersions("26.0.0", "26.0.0.1") < 0);
+        assertTrue(VersionUtils.compareVersions("26.0.0.1", "26.0.0.2") < 0);
+        assertTrue(VersionUtils.compareVersions("26.0.1", "26.0.0.9") > 0);
+    }
+
+    @Test
+    public void readPublicVersionFromProductMarker(@TempDir Path tempDir) throws IOException {
+        Path marker = tempDir.resolve(".eclipseproduct");
+        for (String productId : new String[] {"org.jkiss.dbeaver.product", "com.dbeaver.enterprise", "org.dbvr.product"}) {
+            Files.writeString(marker, "id=" + productId + "\nversion=26.0.0.1\n");
+            assertEquals("26.0.0.1", readProductVersion(marker, "26.0.0"));
+        }
+    }
+
+    @Test
+    public void fallBackForInvalidProductMarker(@TempDir Path tempDir) throws IOException {
+        Path marker = tempDir.resolve(".eclipseproduct");
+        Files.writeString(marker, "id=org.jkiss.dbeaver.product\nversion=${dbeaver-version}\n");
+
+        assertEquals("26.0.0", readProductVersion(marker, "26.0.0"));
+        assertEquals("26.0.0", readProductVersion(tempDir.resolve("missing"), "26.0.0"));
+    }
+
+    @Test
+    public void rejectHostEclipseProductMarker(@TempDir Path tempDir) throws IOException {
+        Path marker = tempDir.resolve(".eclipseproduct");
+        Files.writeString(marker, "id=org.eclipse.platform.ide\nversion=26.0.0.1\n");
+
+        assertEquals("26.0.0", readProductVersion(marker, "26.0.0"));
+    }
+
+    @Test
+    public void preservePlainVersionAndExposeReleaseVersion(@TempDir Path tempDir) throws IOException {
+        Path versionFile = tempDir.resolve("version.xml");
+        Files.writeString(versionFile, "<version><number>26.0.0.1</number><date>09.09.2026</date></version>");
+
+        VersionDescriptor descriptor = new VersionDescriptor(DBWorkbench.getPlatform(), versionFile.toUri().toString());
+        assertEquals("26.0.0", descriptor.getPlainVersion());
+        assertEquals("26.0.0.1", descriptor.getReleaseVersion());
+    }
+
+    private static String readProductVersion(Path marker, String fallback) {
+        try {
+            var method = GeneralUtils.class.getDeclaredMethod("readProductVersion", Path.class, String.class);
+            method.setAccessible(true);
+            return (String) method.invoke(null, marker, fallback);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new AssertionError(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose the four-part installed product version from `.eclipseproduct`
- compare full public versions in update checks and display them in desktop/CLI surfaces
- keep OSGi bundle-version APIs unchanged
- pass the four-part release version to Snap builds

## Testing
- full Maven reactor `verify` (202 modules)
- `ProductVersionTest` (5 tests)
