### PR TITLE
dbeaver/pro#9427 Refresh database navigator on project add

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/database/DatabaseNavigatorView.java
+++ b/plugins/org.jkiss.dbeaver.ui.navigator/src/org/jkiss/dbeaver/ui/navigator/database/DatabaseNavigatorView.java
@@ -106,19 +106,26 @@ public class DatabaseNavigatorView extends NavigatorViewBase implements DBPProje
     }
 
     @Override
-    public void handleActiveProjectChange(@NotNull DBPProject oldValue, @NotNull DBPProject newValue) {
-        UIExecutionQueue.queueExec(() -> {
-            DBNNode rootNode;
-            try {
-                rootNode = getRootNode();
-            } catch (Exception e) {
-                log.error(e);
-                rootNode = new DBNEmptyNode();
-            }
-            getNavigatorTree().setInput(rootNode);
-            getSite().getSelectionProvider().setSelection(new StructuredSelection());
-        });
-
+    public void handleProjectAdd(@NotNull DBPProject project) {
+        if (project.equals(DBPPlatformDesktop.getInstance().getWorkspace().getActiveProject())) {
+            UIExecutionQueue.queueExec(this::updateNavigatorRoot);
+        }
     }
 
+    @Override
+    public void handleActiveProjectChange(@NotNull DBPProject oldValue, @NotNull DBPProject newValue) {
+        UIExecutionQueue.queueExec(this::updateNavigatorRoot);
+    }
+
+    private void updateNavigatorRoot() {
+        DBNNode rootNode;
+        try {
+            rootNode = getRootNode();
+        } catch (Exception e) {
+            log.error(e);
+            rootNode = new DBNEmptyNode();
+        }
+        getNavigatorTree().setInput(rootNode);
+        getSite().getSelectionProvider().setSelection(new StructuredSelection());
+    }
 }


### PR DESCRIPTION
Closes dbeaver/pro#9427

## Summary
- refresh the Connections view when its already-active project is registered
- reuse the same navigator root update path for project additions and active-project changes
- keep empty Eclipse workspaces unchanged and avoid creating a default project

## Testing
- `mvn verify -f product/aggregate/pom.xml -T1C -Pproduct-dbeaver-ce,product-dbeaver-eclipse-ce`

This PR was generated with AI assistance.