### PR TITLE
dbeaver/dbeaver#42041 Activate configured Snowflake warehouse

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.snowflake.ui/src/org/jkiss/dbeaver/ext/snowflake/ui/SnowflakeConnectionPage.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake.ui/src/org/jkiss/dbeaver/ext/snowflake/ui/SnowflakeConnectionPage.java
@@ -33,6 +33,7 @@ import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.snowflake.SnowflakeConstants;
+import org.jkiss.dbeaver.ext.snowflake.SnowflakeUtils;
 import org.jkiss.dbeaver.ext.snowflake.model.auth.SnowflakeAuthModelSnowflake;
 import org.jkiss.dbeaver.ext.snowflake.ui.internal.SnowflakeMessages;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
@@ -198,11 +199,7 @@ public class SnowflakeConnectionPage extends ConnectionPageWithAuth implements I
             dbText.setText(databaseName);
         }
         if (warehouseText != null) {
-            String warehouse = connectionInfo.getServerName();
-            if (CommonUtils.isEmpty(warehouse)) {
-                warehouse = connectionInfo.getProviderProperty(SnowflakeConstants.PROP_WAREHOUSE);
-            }
-            warehouseText.setText(CommonUtils.notEmpty(warehouse));
+            warehouseText.setText(CommonUtils.notEmpty(SnowflakeUtils.getWarehouse(connectionInfo)));
         }
         if (schemaText != null) {
             String schema = connectionInfo.getProviderProperty(SnowflakeConstants.PROP_SCHEMA);

--- a/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/SnowflakeDataSourceProvider.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/SnowflakeDataSourceProvider.java
@@ -54,10 +54,7 @@ public class SnowflakeDataSourceProvider extends GenericDataSourceProvider<Snowf
         }
         url.append("/?");
 
-        String warehouse = connectionInfo.getServerName();
-        if (CommonUtils.isEmpty(warehouse)) {
-            warehouse = connectionInfo.getProviderProperty(SnowflakeConstants.PROP_WAREHOUSE);
-        }
+        String warehouse = SnowflakeUtils.getWarehouse(connectionInfo);
         String schemaName = connectionInfo.getProviderProperty(SnowflakeConstants.PROP_SCHEMA);
         if (CommonUtils.isEmpty(schemaName)) {
             schemaName = connectionInfo.getProviderProperty(SnowflakeConstants.PROP_SCHEMA2);

--- a/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/SnowflakeUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/SnowflakeUtils.java
@@ -1,0 +1,36 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ext.snowflake;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
+import org.jkiss.utils.CommonUtils;
+
+public final class SnowflakeUtils {
+    private SnowflakeUtils() {
+    }
+
+    @Nullable
+    public static String getWarehouse(@NotNull DBPConnectionConfiguration connectionInfo) {
+        String warehouse = connectionInfo.getServerName();
+        if (CommonUtils.isEmpty(warehouse)) {
+            warehouse = connectionInfo.getProviderProperty(SnowflakeConstants.PROP_WAREHOUSE);
+        }
+        return warehouse;
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
@@ -23,6 +23,7 @@ import org.jkiss.dbeaver.ext.generic.model.GenericCatalog;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.GenericSchema;
 import org.jkiss.dbeaver.ext.snowflake.SnowflakeConstants;
+import org.jkiss.dbeaver.ext.snowflake.SnowflakeUtils;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
 import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
@@ -71,10 +72,7 @@ public class SnowflakeDataSource extends GenericDataSource {
     static Map<String, String> getInternalConnectionProperties(@NotNull DBPConnectionConfiguration connectionInfo) {
         Map<String, String> props = new HashMap<>();
 
-        String warehouse = connectionInfo.getServerName();
-        if (CommonUtils.isEmpty(warehouse)) {
-            warehouse = connectionInfo.getProviderProperty(SnowflakeConstants.PROP_WAREHOUSE);
-        }
+        String warehouse = SnowflakeUtils.getWarehouse(connectionInfo);
         if (!CommonUtils.isEmpty(warehouse)) {
             props.put(SnowflakeConstants.PROP_WAREHOUSE, warehouse);
         }
@@ -116,9 +114,16 @@ public class SnowflakeDataSource extends GenericDataSource {
     }
 
     @Override
-    protected void initializeContextState(@NotNull DBRProgressMonitor monitor, @NotNull JDBCExecutionContext context,
-                                          @Nullable JDBCExecutionContext initFrom) throws DBException {
+    protected void initializeContextState(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull JDBCExecutionContext context,
+        @Nullable JDBCExecutionContext initFrom
+    ) throws DBException {
         SnowflakeExecutionContext executionContext = (SnowflakeExecutionContext) context;
+        String warehouse = SnowflakeUtils.getWarehouse(container.getConnectionConfiguration());
+        if (!CommonUtils.isEmpty(warehouse)) {
+            executionContext.setActiveWarehouse(monitor, warehouse);
+        }
         if (initFrom == null) {
             executionContext.refreshDefaults(monitor, true);
             return;

--- a/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeDataSource.java
@@ -120,7 +120,7 @@ public class SnowflakeDataSource extends GenericDataSource {
         @Nullable JDBCExecutionContext initFrom
     ) throws DBException {
         SnowflakeExecutionContext executionContext = (SnowflakeExecutionContext) context;
-        String warehouse = SnowflakeUtils.getWarehouse(container.getConnectionConfiguration());
+        String warehouse = SnowflakeUtils.getWarehouse(container.getActualConnectionConfiguration());
         if (!CommonUtils.isEmpty(warehouse)) {
             executionContext.setActiveWarehouse(monitor, warehouse);
         }

--- a/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
+++ b/plugins/org.jkiss.dbeaver.ext.snowflake/src/org/jkiss/dbeaver/ext/snowflake/model/SnowflakeExecutionContext.java
@@ -30,6 +30,7 @@ import org.jkiss.dbeaver.model.connection.DBPConnectionConfiguration;
 import org.jkiss.dbeaver.model.exec.DBCCachedContextDefaults;
 import org.jkiss.dbeaver.model.exec.DBCException;
 import org.jkiss.dbeaver.model.exec.DBCExecutionPurpose;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCStatement;
@@ -205,6 +206,18 @@ class SnowflakeExecutionContext extends GenericExecutionContext {
         }
 
         return isRefreshed;
+    }
+
+    void setActiveWarehouse(@NotNull DBRProgressMonitor monitor, @NotNull String warehouseName) throws DBCException {
+        try (JDBCSession session = openSession(monitor, DBCExecutionPurpose.UTIL, "Set active warehouse")) {
+            try (JDBCPreparedStatement dbStat = session.prepareStatement("USE WAREHOUSE IDENTIFIER(?)")) {
+                dbStat.setString(1, warehouseName);
+                dbStat.executeUpdate();
+            }
+        } catch (SQLException e) {
+            log.error("Unable to set active warehouse due to unexpected SQLException. warehouseName=" + warehouseName);
+            throw new DBCException(e, this);
+        }
     }
 
     private void setActiveDatabase(DBRProgressMonitor monitor, @NotNull String databaseName) throws DBCException {


### PR DESCRIPTION
Closes dbeaver/dbeaver#42041

Explicitly activate the configured warehouse for every Snowflake execution context. This handles external-browser SSO sessions where the JDBC driver receives the warehouse parameter but Snowflake leaves the session without an active warehouse.

Centralize current and legacy warehouse configuration lookup in `SnowflakeUtils.getWarehouse(...)` and reuse it for URL generation, JDBC properties, context initialization, and the connection UI.

Testing:
- Snowflake model bundle: `mvn package -DskipTests`
- Snowflake UI bundle: `mvn package -DskipTests`
- `git diff --check`
- Standalone Snowflake test verification was attempted but Tycho did not expose JUnit Jupiter to the test bundle compiler outside the aggregate build.

This PR was generated with AI assistance (OpenCode).