### PR TITLE
dbeaver/pro#10648 Fix launcher unit tests on Windows

### DIFF
--- a/test/org.jkiss.dbeaver.launcher.test/src/org/jkiss/dbeaver/launcher/LauncherUtilsTest.java
+++ b/test/org.jkiss.dbeaver.launcher.test/src/org/jkiss/dbeaver/launcher/LauncherUtilsTest.java
@@ -62,7 +62,10 @@ public class LauncherUtilsTest {
         URL legacy = new URL("file://" + UNC_SERVER + "/private/joe/AppData2022");
         File decoded = LauncherUtils.toFile(legacy);
         String path = decoded.getPath();
-        assertEquals(UNC_SERVER + "/private/joe/AppData2022", path.substring(path.indexOf(UNC_SERVER)));
+        assertEquals(
+            UNC_SERVER + File.separator + "private" + File.separator + "joe" + File.separator + "AppData2022",
+            path.substring(path.indexOf(UNC_SERVER))
+        );
     }
 
     @Test


### PR DESCRIPTION
Closes dbeaver/pro#10648

Use the platform-specific file separator when asserting the reconstructed legacy UNC path.

Tests: LauncherUtilsTest on Windows (7 tests, 0 failures).

This PR was generated with AI (OpenCode).