### PR TITLE
dbeaver/pro#10649 Fix AI chat background blinking

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/chat/controls/WebCSSInitializer.java
+++ b/plugins/org.jkiss.dbeaver.ui.ai/src/org/jkiss/dbeaver/ui/ai/chat/controls/WebCSSInitializer.java
@@ -104,10 +104,11 @@ public class WebCSSInitializer {
         Files.createDirectories(path.getParent());
         if (resource.equals(WEB_CSS_PATH)) {
             String cssContent = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-            cssContent = updateCss(cssContent);
+            cssContent = updateThemeValues(cssContent);
             Files.writeString(path, cssContent);
         } else if (resource.equals(WEB_HTML_PATH)) {
             String htmlContent = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            htmlContent = updateThemeValues(htmlContent);
             htmlContent = htmlContent.replace(EXTRA_HEAD_PLACEHOLDER, getExtraHeadContent());
             Files.writeString(path, htmlContent);
         } else {
@@ -121,12 +122,12 @@ public class WebCSSInitializer {
     }
 
     @NotNull
-    private String updateCss(@NotNull String cssContent) {
+    private String updateThemeValues(@NotNull String content) {
         Map<String, String> values = fillValues();
         for (var entry : values.entrySet()) {
-            cssContent = cssContent.replace(entry.getKey(), entry.getValue());
+            content = content.replace(entry.getKey(), entry.getValue());
         }
-        return cssContent;
+        return content;
     }
 
     @NotNull

--- a/plugins/org.jkiss.dbeaver.ui.ai/web/index.html
+++ b/plugins/org.jkiss.dbeaver.ui.ai/web/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
+    <meta name="color-scheme" content="{{COLOR_SCHEME}}"/>
     <!-- https://github.com/dbeaver/pro/issues/9933
     The chat makes no network requests; forbid them so injected script (XSS) on this file:// origin can't read local files or reach the IPC server. -->
     <meta http-equiv="Content-Security-Policy" content="connect-src 'none'; frame-src 'none'; object-src 'none'"/>


### PR DESCRIPTION
Closes dbeaver/pro#10649

Declares the active DBeaver color scheme in the chat HTML before external styles load, preventing the WebView's initial white paint in dark theme. The same generated theme value is now applied to both HTML and CSS.

Testing:
- `git diff --check`
- Targeted Maven build attempted; dependency resolution stopped before compilation because `org.jkiss.dbeaver.model.jdbc` was unavailable in the partial reactor.