### PR TITLE
dbeaver/pro#10665 Hide CREATE generator for dynamic metadata sources

### DIFF
--- a/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.editors.sql/plugin.xml
@@ -1623,7 +1623,9 @@
 
     <extension point="org.jkiss.dbeaver.sqlGenerator">
         <generator id="ddlByResultSet" class="org.jkiss.dbeaver.ui.editors.sql.generator.SQLGeneratorDDLFromResultSet" label="CREATE" description="%generator.org.jkiss.dbeaver.ui.editors.sql.ddlByResultSet.description" order="6">
-            <objectType name="org.jkiss.dbeaver.ui.controls.resultset.IResultSetController"/>
+            <!-- Hidden for dynamic-metadata (schemaless) sources: same condition the generator checks at run time -->
+            <objectType name="org.jkiss.dbeaver.ui.controls.resultset.IResultSetController"
+                        if="!object.getDataContainer().getDataSource().getInfo().isDynamicMetadata()"/>
         </generator>
     </extension>
 


### PR DESCRIPTION
Closes dbeaver/pro#10665

## Summary
- hide the result-set CREATE SQL generator for dynamic-metadata sources
- keep the generator available for regular data sources without affecting the Database Navigator

## Testing
- validated `plugin.xml` with the JDK XML parser
- ran `git diff --check`

This PR was generated with AI (OpenCode).