### PR TITLE
dbeaver/pro#10647 Redesign version update notifications and dialog

### DIFF
--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/runtime/DefaultProgressMonitor.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/runtime/DefaultProgressMonitor.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2025 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/runtime/DefaultProgressMonitor.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/runtime/DefaultProgressMonitor.java
@@ -78,13 +78,16 @@ public class DefaultProgressMonitor implements DBRProgressMonitor {
 
         // Restore previous state
         if (!states.isEmpty()) {
-            ProgressState lastState = states.removeLast();
-            nestedMonitor.beginTask(lastState.taskName, lastState.totalWork);
-            if (lastState.subTask != null) {
-                nestedMonitor.subTask(lastState.subTask);
-            }
-            if (lastState.progress > 0) {
-                nestedMonitor.worked(lastState.progress);
+            states.removeLast();
+            if (!states.isEmpty()) {
+                ProgressState previousState = states.getLast();
+                nestedMonitor.beginTask(previousState.taskName, previousState.totalWork);
+                if (previousState.subTask != null) {
+                    nestedMonitor.subTask(previousState.subTask);
+                }
+                if (previousState.progress > 0) {
+                    nestedMonitor.worked(previousState.progress);
+                }
             }
         } else {
             log.trace(new DBCException("Progress ended without start"));

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/runtime/WebUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/runtime/WebUtils.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.runtime;
 
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.osgi.util.NLS;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
@@ -48,6 +49,7 @@ import java.util.Map;
 public class WebUtils {
     private static final Log log = Log.getLog(WebUtils.class);
     private static final int MAX_RETRY_COUNT = 10;
+    private static final int DOWNLOAD_PROGRESS_MAX = 1000;
 
     @NotNull
     public static URLConnection openConnection(String urlString, String referrer) throws IOException {
@@ -204,11 +206,15 @@ public class WebUtils {
         final NumberFormat numberFormat = new ByteNumberFormat(ByteNumberFormat.BinaryPrefix.ISO);
 
         // The value of getContentLength() may be -1 and this should not be handled, see IProgressMonitor#UNKNOWN
-        monitor.beginTask(taskName + " - " + externalURL, contentLength);
+        monitor.beginTask(
+            taskName + " - " + externalURL,
+            contentLength >= 0 ? DOWNLOAD_PROGRESS_MAX : IProgressMonitor.UNKNOWN
+        );
         try (final InputStream inputStream = connection.getInputStream()) {
             final long startTime = System.currentTimeMillis();
             long updateTime = 0;
             long totalRead = 0;
+            int reportedProgress = 0;
 
             while (true) {
                 if (monitor.isCanceled()) {
@@ -236,8 +242,15 @@ public class WebUtils {
                     return totalRead;
                 }
                 outputStream.write(buffer, 0, count);
-                monitor.worked(count);
                 totalRead += count;
+                if (contentLength > 0) {
+                    int progress = (int) Math.min(
+                        DOWNLOAD_PROGRESS_MAX,
+                        totalRead * DOWNLOAD_PROGRESS_MAX / contentLength
+                    );
+                    monitor.worked(progress - reportedProgress);
+                    reportedProgress = progress;
+                }
             }
         } finally {
             monitor.done();

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/runtime/WebUtils.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/runtime/WebUtils.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2025 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class WebUtils {
     private static final int DOWNLOAD_PROGRESS_MAX = 1000;
 
     @NotNull
-    public static URLConnection openConnection(String urlString, String referrer) throws IOException {
+    public static URLConnection openConnection(@NotNull String urlString, @Nullable String referrer) throws IOException {
         return openConnection(urlString, null, referrer);
     }
 

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/OSGI-INF/l10n/bundle.properties
@@ -46,6 +46,9 @@ command.org.jkiss.dbeaver.ui.try.pro.name                            = Try DBeav
 command.org.jkiss.dbeaver.ui.try.pro.description                     = Go to DBeaver PRO web-site download page
 command.org.jkiss.dbeaver.ext.ui.tipoftheday.showPopup.name = Show "Tip of the day"
 command.org.jkiss.dbeaver.ext.ui.tipoftheday.showPopup.description = Show popup dialog with "Tip of the day"
+command.org.jkiss.dbeaver.ui.versionUpdate.name = Update
+command.org.jkiss.dbeaver.ui.versionUpdate.description = Download and install the new version
+command.org.jkiss.dbeaver.ui.versionUpdate.releaseNotes.name = Release notes
 
 
 trimmedwindow.label.dbeaver = DBeaver

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/OSGI-INF/l10n/bundle.properties
@@ -49,6 +49,7 @@ command.org.jkiss.dbeaver.ext.ui.tipoftheday.showPopup.description = Show popup 
 command.org.jkiss.dbeaver.ui.versionUpdate.name = Update
 command.org.jkiss.dbeaver.ui.versionUpdate.description = Download and install the new version
 command.org.jkiss.dbeaver.ui.versionUpdate.releaseNotes.name = Release notes
+toolbar.versionUpdate.label = Version update
 
 
 trimmedwindow.label.dbeaver = DBeaver

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/plugin.xml
@@ -361,7 +361,7 @@
         <menuContribution allPopups="false" locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
         </menuContribution>
         <menuContribution allPopups="false" locationURI="toolbar:org.eclipse.ui.trim.command2">
-            <toolbar label="Version update" id="dbeaver-version-update">
+            <toolbar label="%toolbar.versionUpdate.label" id="dbeaver-version-update">
                 <command
                         commandId="org.jkiss.dbeaver.ui.versionUpdate"
                         icon="platform:/plugin/org.jkiss.dbeaver.ui/icons/misc/download.svg"

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/plugin.xml
@@ -101,6 +101,13 @@
                 name="Minimize Window"
                 description="Minimize the current window"
                 categoryId="org.eclipse.ui.category.window"/>
+        <command
+                id="org.jkiss.dbeaver.ui.versionUpdate"
+                name="%command.org.jkiss.dbeaver.ui.versionUpdate.name"
+                description="%command.org.jkiss.dbeaver.ui.versionUpdate.description"/>
+        <command
+                id="org.jkiss.dbeaver.ui.versionUpdate.releaseNotes"
+                name="%command.org.jkiss.dbeaver.ui.versionUpdate.releaseNotes.name"/>
     </extension>
 
     <extension point="org.eclipse.ui.commandImages">
@@ -203,6 +210,8 @@
         <handler commandId="org.jkiss.dbeaver.ext.ui.tipoftheday.showPopup" class="org.jkiss.dbeaver.ui.app.standalone.tipoftheday.ShowTipOfTheDayHandler"/>
         <handler commandId="org.jkiss.dbeaver.core.try.pro" class="org.jkiss.dbeaver.ui.app.standalone.actions.TryPROHandler"/>
         <handler commandId="org.jkiss.dbeaver.ui.window.minimize" class="org.jkiss.dbeaver.ui.app.standalone.actions.MinimizeWindowHandler"/>
+        <handler commandId="org.jkiss.dbeaver.ui.versionUpdate" class="org.jkiss.dbeaver.ui.app.standalone.update.VersionUpdateHandler"/>
+        <handler commandId="org.jkiss.dbeaver.ui.versionUpdate.releaseNotes" class="org.jkiss.dbeaver.ui.app.standalone.update.VersionUpdateHandler"/>
     </extension>
 
     <extension point="org.eclipse.ui.menus">
@@ -350,6 +359,25 @@
         <!-- Main toolbar -->
 
         <menuContribution allPopups="false" locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
+        </menuContribution>
+        <menuContribution allPopups="false" locationURI="toolbar:org.eclipse.ui.trim.command2">
+            <toolbar label="Version update" id="dbeaver-version-update">
+                <command
+                        commandId="org.jkiss.dbeaver.ui.versionUpdate"
+                        icon="platform:/plugin/org.jkiss.dbeaver.ui/icons/misc/download.svg"
+                        id="org.jkiss.dbeaver.ui.versionUpdate.menu"
+                        mode="FORCE_TEXT"
+                        style="pulldown">
+                    <visibleWhen>
+                        <test
+                                forcePluginActivation="true"
+                                property="org.jkiss.dbeaver.ui.versionUpdate.available"/>
+                    </visibleWhen>
+                </command>
+            </toolbar>
+        </menuContribution>
+        <menuContribution allPopups="false" locationURI="menu:org.jkiss.dbeaver.ui.versionUpdate.menu">
+            <command commandId="org.jkiss.dbeaver.ui.versionUpdate.releaseNotes"/>
         </menuContribution>
     </extension>
 
@@ -546,6 +574,12 @@
                 id="org.jkiss.dbeaver.ui.app.standalone.actions.MenuConfigurationPropertyTester"
                 namespace="org.jkiss.dbeaver.ui.app.standalone.menu.configuration"
                 properties="isCommunity"
+                type="java.lang.Object"/>
+        <propertyTester
+                class="org.jkiss.dbeaver.ui.app.standalone.update.VersionUpdatePropertyTester"
+                id="org.jkiss.dbeaver.ui.app.standalone.update.VersionUpdatePropertyTester"
+                namespace="org.jkiss.dbeaver.ui.versionUpdate"
+                properties="available"
                 type="java.lang.Object"/>
     </extension>
 

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/DBeaverVersionChecker.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/DBeaverVersionChecker.java
@@ -37,6 +37,7 @@ import org.jkiss.utils.CommonUtils;
 import org.osgi.framework.Version;
 
 import java.io.IOException;
+
 /**
  * Version checker job
  */

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/DBeaverVersionChecker.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/DBeaverVersionChecker.java
@@ -37,20 +37,17 @@ import org.jkiss.utils.CommonUtils;
 import org.osgi.framework.Version;
 
 import java.io.IOException;
-import java.util.Calendar;
-
 /**
  * Version checker job
  */
 public class DBeaverVersionChecker extends AbstractJob {
 
     private static final Log log = Log.getLog(DBeaverVersionChecker.class);
-
     private static final boolean SKIP_VERSION_CHECK;
     private static final Version OVERRIDE_PRODUCT_VERSION;
 
     static {
-        String versionProperty = CommonUtils.toString(System.getProperty("dbeaver.debug.override-product-version"));
+        String versionProperty = System.getProperty("dbeaver.debug.override-product-version");
         Version version = null;
 
         if (CommonUtils.isNotEmpty(versionProperty)) {
@@ -86,30 +83,11 @@ public class DBeaverVersionChecker extends AbstractJob {
         if (!showUpdateDialog) {
             // Check for auto-update settings
             showUpdateDialog = DBWorkbench.getPlatform().getPreferenceStore().getBoolean(DBeaverPreferences.UI_AUTO_UPDATE_CHECK);
-            if (showUpdateDialog) {
-
-                long lastVersionCheckTime = DBWorkbench.getPlatform().getPreferenceStore().getLong(DBeaverPreferences.UI_UPDATE_CHECK_TIME);
-                if (lastVersionCheckTime > 0) {
-                    // Do not check more often than daily
-                    Calendar cal = Calendar.getInstance();
-                    cal.setTimeInMillis(lastVersionCheckTime);
-                    int checkMonth = cal.get(Calendar.MONTH);
-                    int checkDay = cal.get(Calendar.DAY_OF_MONTH);
-                    cal.setTimeInMillis(System.currentTimeMillis());
-                    int curMonth = cal.get(Calendar.MONTH);
-                    int curDay = cal.get(Calendar.DAY_OF_MONTH);
-                    if (curMonth == checkMonth && curDay == checkDay) {
-                        // Already checked today
-                        return Status.OK_STATUS;
-                    }
-                }
-            }
         }
         if (!showAlways && !showUpdateDialog) {
             return Status.OK_STATUS;
         }
 
-        DBWorkbench.getPlatform().getPreferenceStore().setValue(DBeaverPreferences.UI_UPDATE_CHECK_TIME, System.currentTimeMillis());
         IProduct product = Platform.getProduct();
         if (product == null) {
             // No product!
@@ -134,10 +112,15 @@ public class DBeaverVersionChecker extends AbstractJob {
             return Status.CANCEL_STATUS;
         }
 
-        if (showAlways || (!isSuppressed(newVersion) && (SKIP_VERSION_CHECK || newVersion.getProgramVersion().compareTo(currentVersion) > 0))) {
-            UIServiceApplicationVersionUpdater updater = DBWorkbench.findService(UIServiceApplicationVersionUpdater.class);
+        boolean newVersionAvailable = newVersion.getProgramVersion().compareTo(currentVersion) > 0;
+        boolean suppressed = isSuppressed(newVersion);
+        UIServiceApplicationVersionUpdater updater = DBWorkbench.findService(UIServiceApplicationVersionUpdater.class);
+        boolean showToolbarNotification = updater == null && newVersionAvailable && (showAlways || !suppressed);
+        if (showAlways || (!suppressed && (SKIP_VERSION_CHECK || newVersionAvailable))) {
             if (updater != null) {
                 UIUtils.asyncExec(updater::handleVersionUpdate);
+            } else if (showToolbarNotification) {
+                UIUtils.asyncExec(() -> VersionUpdateHandler.showNotification(currentVersion, newVersion));
             } else {
                 showUpdaterDialog(currentVersion, newVersion);
             }
@@ -153,7 +136,7 @@ public class DBeaverVersionChecker extends AbstractJob {
         });
     }
 
-    private static boolean isSuppressed(@NotNull VersionDescriptor version) {
+    static boolean isSuppressed(@NotNull VersionDescriptor version) {
         CoreApplicationActivator activator = CoreApplicationActivator.getDefault();
         return activator != null && activator.getPreferenceStore().getBoolean("suppressUpdateCheck." + version.getPlainVersion());
     }

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
@@ -19,6 +19,8 @@ package org.jkiss.dbeaver.ui.app.standalone.update;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.osgi.util.NLS;
@@ -52,6 +54,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.function.Consumer;
 
 public class VersionUpdateDialog extends Dialog {
 
@@ -246,14 +249,7 @@ public class VersionUpdateDialog extends Dialog {
         if (buttonId == INFO_ID) {
             ShellUtils.launchProgram(newVersion.getBaseURL());
         } else if (buttonId == UPGRADE_ID) {
-            var app = (DBeaverApplication) DBWorkbench.getPlatform().getApplication();
-            var installer = getPlatformInstaller();
-            var downloadUrl = app.getLatestVersionDownloadUrl(newVersion);
-            if (installer != null && downloadUrl != null) {
-                scheduleDownloadAndInstall(installer, downloadUrl);
-            } else {
-                ShellUtils.launchProgram(getDownloadPageURL(newVersion));
-            }
+            performUpdate(newVersion);
         } else if (buttonId == CHECK_EA_ID) {
             if (!CommonUtils.isEmpty(earlyAccessURL)) {
                 ShellUtils.launchProgram(earlyAccessURL);
@@ -270,7 +266,28 @@ public class VersionUpdateDialog extends Dialog {
         close();
     }
 
-    private void scheduleDownloadAndInstall(@NotNull PlatformInstaller installer, @NotNull URI downloadUrl) {
+    public static void performUpdate(@NotNull VersionDescriptor version) {
+        performUpdate(version, null);
+    }
+
+    static boolean performUpdate(@NotNull VersionDescriptor version, @Nullable Consumer<IStatus> completion) {
+        var app = (DBeaverApplication) DBWorkbench.getPlatform().getApplication();
+        var installer = getPlatformInstaller();
+        var downloadUrl = app.getLatestVersionDownloadUrl(version);
+        if (installer != null && downloadUrl != null) {
+            scheduleDownloadAndInstall(installer, downloadUrl, completion);
+            return true;
+        } else {
+            ShellUtils.launchProgram(getDownloadPageURL(version));
+            return false;
+        }
+    }
+
+    private static void scheduleDownloadAndInstall(
+        @NotNull PlatformInstaller installer,
+        @NotNull URI downloadUrl,
+        @Nullable Consumer<IStatus> completion
+    ) {
         final AbstractJob job = new AbstractJob("Downloading installation file") {
             @NotNull
             @Override
@@ -281,16 +298,23 @@ public class VersionUpdateDialog extends Dialog {
                 try {
                     var url = downloadUrl.toString();
                     var filename = url.substring(url.lastIndexOf('/') + 1);
-                    folder = Files.createTempDirectory(filename);
-                    file = Files.createFile(folder.resolve(filename));
+                    folder = DBWorkbench.getPlatform().getTempFolder(monitor, "updates");
+                    file = folder.resolve(filename);
 
                     log.debug("Downloading installation file to " + file);
-                    WebUtils.downloadRemoteFile(monitor, "Obtaining installer", url, file, null);
+                    try {
+                        WebUtils.downloadRemoteFile(monitor, "Obtaining installer", url, file, null);
+                    } catch (InterruptedException e) {
+                        log.debug("Canceled by user", e);
+                        try {
+                            Files.deleteIfExists(file);
+                        } catch (IOException deleteError) {
+                            log.warn("Could not delete partially downloaded installation file '" + file + "'", deleteError);
+                        }
+                        return Status.CANCEL_STATUS;
+                    }
                 } catch (IOException e) {
                     return GeneralUtils.makeErrorStatus(CoreMessages.dialog_version_update_downloader_error_cannot_download, e);
-                } catch (InterruptedException e) {
-                    log.debug("Canceled by user", e);
-                    return Status.OK_STATUS;
                 }
 
                 if (UIUtils.confirmAction(
@@ -337,11 +361,19 @@ public class VersionUpdateDialog extends Dialog {
             }
         };
         job.setUser(true);
+        if (completion != null) {
+            job.addJobChangeListener(new JobChangeAdapter() {
+                @Override
+                public void done(IJobChangeEvent event) {
+                    completion.accept(job.isCanceled() ? Status.CANCEL_STATUS : event.getResult());
+                }
+            });
+        }
         job.schedule();
     }
 
     @Nullable
-    private PlatformInstaller getPlatformInstaller() {
+    private static PlatformInstaller getPlatformInstaller() {
         return switch (Platform.getOS()) {
             case Platform.OS_WIN32 -> new WindowsInstaller();
             case Platform.OS_MACOSX -> new MacintoshInstaller();
@@ -350,7 +382,7 @@ public class VersionUpdateDialog extends Dialog {
     }
 
     @NotNull
-    private String getDownloadPageURL(@NotNull VersionDescriptor version) {
+    private static String getDownloadPageURL(@NotNull VersionDescriptor version) {
         String os;
         if (RuntimeUtils.isWindows()) {
             os = OS_WINDOWS;

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateDialog.java
@@ -65,6 +65,7 @@ public class VersionUpdateDialog extends Dialog {
     private static final String OS_LINUX = "linux";
     private static final String DISTRIBUTION_DEB = "deb";
     private static final String DISTRIBUTION_RPM = "rpm";
+    private static final String UPDATES_FOLDER = "dbeaver-updates";
 
     private static final int INFO_ID = 1000;
     private static final int UPGRADE_ID = 1001;
@@ -298,7 +299,12 @@ public class VersionUpdateDialog extends Dialog {
                 try {
                     var url = downloadUrl.toString();
                     var filename = url.substring(url.lastIndexOf('/') + 1);
-                    folder = DBWorkbench.getPlatform().getTempFolder(monitor, "updates");
+                    Path globalTempFolder = DBWorkbench.getPlatform().getTempFolder(monitor, UPDATES_FOLDER).getParent();
+                    if (globalTempFolder == null) {
+                        throw new IOException("Could not resolve the parent directory of the DBeaver temporary folder");
+                    }
+                    folder = globalTempFolder.resolveSibling(UPDATES_FOLDER);
+                    Files.createDirectories(folder);
                     file = folder.resolve(filename);
 
                     log.debug("Downloading installation file to " + file);
@@ -364,7 +370,7 @@ public class VersionUpdateDialog extends Dialog {
         if (completion != null) {
             job.addJobChangeListener(new JobChangeAdapter() {
                 @Override
-                public void done(IJobChangeEvent event) {
+                public void done(@NotNull IJobChangeEvent event) {
                     completion.accept(job.isCanceled() ? Status.CANCEL_STATUS : event.getResult());
                 }
             });

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateHandler.java
@@ -1,0 +1,124 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.app.standalone.update;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.ui.commands.IElementUpdater;
+import org.eclipse.ui.menus.UIElement;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.registry.updater.VersionDescriptor;
+import org.jkiss.dbeaver.ui.ActionUtils;
+import org.jkiss.dbeaver.ui.DBeaverIcons;
+import org.jkiss.dbeaver.ui.UIIcon;
+import org.jkiss.dbeaver.ui.UIUtils;
+import org.jkiss.dbeaver.ui.app.standalone.DBeaverApplication;
+import org.osgi.framework.Version;
+
+import java.util.Map;
+
+public class VersionUpdateHandler extends AbstractHandler implements IElementUpdater {
+    private static final int ANIMATION_DELAY = 100;
+
+    public static final String COMMAND_UPDATE = "org.jkiss.dbeaver.ui.versionUpdate";
+    public static final String COMMAND_RELEASE_NOTES = "org.jkiss.dbeaver.ui.versionUpdate.releaseNotes";
+    public static final String PROPERTY_AVAILABLE = "org.jkiss.dbeaver.ui.versionUpdate.available";
+
+    private static Version currentVersion;
+    private static VersionDescriptor newVersion;
+    private static boolean updateStarted;
+    private static boolean downloading;
+    private static int animationFrame;
+
+    static void showNotification(@NotNull Version current, @NotNull VersionDescriptor available) {
+        currentVersion = current;
+        newVersion = available;
+        ActionUtils.evaluatePropertyState(PROPERTY_AVAILABLE);
+        ActionUtils.fireCommandRefresh(COMMAND_UPDATE);
+    }
+
+    static boolean isUpdateAvailable() {
+        return newVersion != null;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return !updateStarted && super.isEnabled();
+    }
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        VersionDescriptor available = newVersion;
+        if (available == null) {
+            return null;
+        }
+        if (COMMAND_RELEASE_NOTES.equals(event.getCommand().getId())) {
+            DBeaverApplication.getInstance().notifyVersionUpgrade(currentVersion, available, true);
+            if (DBeaverVersionChecker.isSuppressed(available)) {
+                newVersion = null;
+                currentVersion = null;
+                ActionUtils.evaluatePropertyState(PROPERTY_AVAILABLE);
+            }
+        } else if (!updateStarted) {
+            updateStarted = true;
+            downloading = true;
+            setBaseEnabled(false);
+            refreshUpdateButton();
+            animateDownload();
+            if (!VersionUpdateDialog.performUpdate(available, this::downloadFinished)) {
+                downloading = false;
+                updateStarted = false;
+                setBaseEnabled(true);
+                refreshUpdateButton();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void updateElement(UIElement element, Map parameters) {
+        var icon = downloading ? UIIcon.LOADING.get(animationFrame % UIIcon.LOADING.size()) : UIIcon.DOWNLOAD;
+        element.setIcon(DBeaverIcons.getImageDescriptor(icon));
+    }
+
+    private void downloadFinished(@NotNull IStatus status) {
+        UIUtils.asyncExec(() -> {
+            downloading = false;
+            if (!status.isOK()) {
+                updateStarted = false;
+                setBaseEnabled(true);
+            }
+            refreshUpdateButton();
+        });
+    }
+
+    private static void animateDownload() {
+        UIUtils.timerExec(ANIMATION_DELAY, () -> {
+            if (downloading) {
+                animationFrame++;
+                refreshUpdateButton();
+                animateDownload();
+            }
+        });
+    }
+
+    private static void refreshUpdateButton() {
+        ActionUtils.fireCommandRefresh(COMMAND_UPDATE);
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateHandler.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdateHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.ui.commands.IElementUpdater;
 import org.eclipse.ui.menus.UIElement;
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.registry.updater.VersionDescriptor;
 import org.jkiss.dbeaver.ui.ActionUtils;
 import org.jkiss.dbeaver.ui.DBeaverIcons;
@@ -63,7 +64,8 @@ public class VersionUpdateHandler extends AbstractHandler implements IElementUpd
     }
 
     @Override
-    public Object execute(ExecutionEvent event) throws ExecutionException {
+    @Nullable
+    public Object execute(@NotNull ExecutionEvent event) throws ExecutionException {
         VersionDescriptor available = newVersion;
         if (available == null) {
             return null;
@@ -92,7 +94,7 @@ public class VersionUpdateHandler extends AbstractHandler implements IElementUpd
     }
 
     @Override
-    public void updateElement(UIElement element, Map parameters) {
+    public void updateElement(@NotNull UIElement element, @NotNull Map parameters) {
         var icon = downloading ? UIIcon.LOADING.get(animationFrame % UIIcon.LOADING.size()) : UIIcon.DOWNLOAD;
         element.setIcon(DBeaverIcons.getImageDescriptor(icon));
     }

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdatePropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdatePropertyTester.java
@@ -17,10 +17,17 @@
 package org.jkiss.dbeaver.ui.app.standalone.update;
 
 import org.eclipse.core.expressions.PropertyTester;
+import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 
 public class VersionUpdatePropertyTester extends PropertyTester {
     @Override
-    public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+    public boolean test(
+        @Nullable Object receiver,
+        @NotNull String property,
+        @NotNull Object[] args,
+        @Nullable Object expectedValue
+    ) {
         return VersionUpdateHandler.isUpdateAvailable();
     }
 }

--- a/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdatePropertyTester.java
+++ b/plugins/org.jkiss.dbeaver.ui.app.standalone/src/org/jkiss/dbeaver/ui/app/standalone/update/VersionUpdatePropertyTester.java
@@ -1,0 +1,26 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.ui.app.standalone.update;
+
+import org.eclipse.core.expressions.PropertyTester;
+
+public class VersionUpdatePropertyTester extends PropertyTester {
+    @Override
+    public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+        return VersionUpdateHandler.isUpdateAvailable();
+    }
+}

--- a/plugins/org.jkiss.dbeaver.ui/icons/misc/download.svg
+++ b/plugins/org.jkiss.dbeaver.ui/icons/misc/download.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.5 2H7.5V9.17L4.33 6H3L8 11L13 6H11.67L8.5 9.17V2Z" fill="#3387C5"/>
+<path d="M3 13V12H13V13H3Z" fill="#3387C5"/>
+</svg>

--- a/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIIcon.java
+++ b/plugins/org.jkiss.dbeaver.ui/src/org/jkiss/dbeaver/ui/UIIcon.java
@@ -91,6 +91,7 @@ public class UIIcon {
     public static final DBIcon ARROW_TOP = new DBIcon("arrow_top", "misc/arrow_top.svg"); //$NON-NLS-1$ //$NON-NLS-2$
     public static final DBIcon ARROW_UP = new DBIcon("arrow_up", "misc/arrow_up.svg"); //$NON-NLS-1$ //$NON-NLS-2$
     public static final DBIcon ARROW_DOWN = new DBIcon("arrow_down", "misc/arrow_down.svg"); //$NON-NLS-1$ //$NON-NLS-2$
+    public static final DBIcon DOWNLOAD = new DBIcon("download", "misc/download.svg"); //$NON-NLS-1$ //$NON-NLS-2$
     public static final DBIcon ARROW_BOTTOM = new DBIcon("arrow_bottom", "misc/arrow_bottom.svg"); //$NON-NLS-1$ //$NON-NLS-2$
     public static final DBIcon ARROW_LEFT = new DBIcon("arrow_left", "misc/arrow_left.svg"); //$NON-NLS-1$ //$NON-NLS-2$
     public static final DBIcon ARROW_LEFT_ALL = new DBIcon("arrow_left_all", "misc/arrow_left_all.svg"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/runtime/DefaultProgressMonitorTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/runtime/DefaultProgressMonitorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class DefaultProgressMonitorTest {
     @Test
     public void doneDoesNotRestartCompletedTask() {

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/runtime/DefaultProgressMonitorTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/model/runtime/DefaultProgressMonitorTest.java
@@ -1,0 +1,62 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.dbeaver.model.runtime;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class DefaultProgressMonitorTest {
+    @Test
+    public void doneDoesNotRestartCompletedTask() {
+        IProgressMonitor nested = Mockito.mock(IProgressMonitor.class);
+        DefaultProgressMonitor monitor = new DefaultProgressMonitor(nested);
+
+        monitor.beginTask("Download", 100);
+        monitor.worked(100);
+        monitor.done();
+
+        InOrder calls = Mockito.inOrder(nested);
+        calls.verify(nested).beginTask("Download", 100);
+        calls.verify(nested).worked(100);
+        calls.verify(nested).done();
+        calls.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void doneRestoresParentTask() {
+        IProgressMonitor nested = Mockito.mock(IProgressMonitor.class);
+        DefaultProgressMonitor monitor = new DefaultProgressMonitor(nested);
+
+        monitor.beginTask("Parent", 10);
+        monitor.worked(2);
+        monitor.beginTask("Child", 5);
+        monitor.worked(5);
+        monitor.done();
+
+        InOrder calls = Mockito.inOrder(nested);
+        calls.verify(nested).beginTask("Parent", 10);
+        calls.verify(nested).worked(2);
+        calls.verify(nested).beginTask("Child", 5);
+        calls.verify(nested).worked(5);
+        calls.verify(nested).done();
+        calls.verify(nested).beginTask("Parent", 10);
+        calls.verify(nested).worked(2);
+        calls.verifyNoMoreInteractions();
+    }
+}


### PR DESCRIPTION
Closes dbeaver/pro#10647

## Summary
- replace the version update popup with a conditional toolbar pull-down action
- download and install updates from the toolbar while showing progress and handling cancellation
- keep distro files in DBeaver's managed temp folder and remove partial downloads
- fix nested progress restoration and large-download progress reporting

## Testing
- `mvn -f plugins/pom.xml -pl '!org.jkiss.dbeaver.model.datadam,!org.jkiss.dbeaver.ui.datadam' package -DskipTests`
- `git diff --check origin/devel...HEAD`