### PR TITLE
dbeaver/pro#10443 Fix trimming missing CSV values

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/importer/DataImporterCSV.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/stream/importer/DataImporterCSV.java
@@ -263,7 +263,9 @@ public class DataImporterCSV extends StreamImporterAbstract {
                                 }
                                 if (trimWhitespaces) {
                                     for (int i = 0; i < line.length; i++) {
-                                        line[i] = line[i].trim();
+                                        if (line[i] != null) {
+                                            line[i] = line[i].trim();
+                                        }
                                     }
                                 }
                                 if (emptyStringNull) {

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/tools/transfer/CSVImporterTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/tools/transfer/CSVImporterTest.java
@@ -18,9 +18,13 @@ package org.jkiss.dbeaver.tools.transfer;
 
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.DBPDataKind;
+import org.jkiss.dbeaver.model.exec.DBCResultSet;
+import org.jkiss.dbeaver.model.runtime.VoidProgressMonitor;
+import org.jkiss.dbeaver.tools.transfer.IDataTransferConsumer;
 import org.jkiss.dbeaver.tools.transfer.stream.IStreamDataImporterSite;
 import org.jkiss.dbeaver.tools.transfer.stream.StreamDataImporterColumnInfo;
 import org.jkiss.dbeaver.tools.transfer.stream.StreamEntityMapping;
+import org.jkiss.dbeaver.tools.transfer.stream.StreamProducerSettings;
 import org.jkiss.dbeaver.tools.transfer.stream.importer.DataImporterCSV;
 import org.jkiss.junit.DBeaverUnitTest;
 import org.junit.jupiter.api.Assertions;
@@ -32,6 +36,7 @@ import org.mockito.Mockito;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +45,7 @@ public class CSVImporterTest  extends DBeaverUnitTest {
 
     private static final Path DUMMY_FILE = Path.of("dummy");
     private final DataImporterCSV importer = new DataImporterCSV();
+    private final StreamProducerSettings settings = new StreamProducerSettings();
     private StreamEntityMapping mapping;
     private final Map<String, Object> properties = new HashMap<>();
 
@@ -50,6 +56,8 @@ public class CSVImporterTest  extends DBeaverUnitTest {
     public void init() throws DBException {
         mapping = new StreamEntityMapping(DUMMY_FILE);
         importer.init(site);
+        Mockito.when(site.getSettings()).thenReturn(settings);
+        Mockito.when(site.getSourceObject()).thenReturn(mapping);
         Mockito.when(site.getProcessorProperties()).thenReturn(properties);
     }
 
@@ -117,6 +125,30 @@ public class CSVImporterTest  extends DBeaverUnitTest {
         Assertions.assertEquals(2, columnsInfo.size());
         Assertions.assertEquals(DBPDataKind.STRING, columnsInfo.get(0).getDataKind());
         Assertions.assertEquals(DBPDataKind.STRING, columnsInfo.get(1).getDataKind());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void trimWhitespacesInRowWithMissingTrailingColumn() throws DBException, IOException {
+        String data = "ID,TEXT_VALUE\n14\n";
+        properties.put("trimWhitespaces", true);
+        mapping.getStreamColumns().addAll(readColumnsInfo(data, true));
+
+        List<Object[]> rows = new ArrayList<>();
+        IDataTransferConsumer<?, ?> consumer = Mockito.mock(IDataTransferConsumer.class);
+        Mockito.doAnswer(invocation -> {
+            DBCResultSet resultSet = invocation.getArgument(1);
+            rows.add(new Object[] {resultSet.getAttributeValue(0), resultSet.getAttributeValue(1)});
+            return null;
+        }).when(consumer).fetchRow(Mockito.any(), Mockito.any());
+
+        try (ByteArrayInputStream input = new ByteArrayInputStream(data.getBytes())) {
+            importer.runImport(new VoidProgressMonitor(), mapping.getDataSource(), input, consumer);
+        }
+
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals("14", rows.getFirst()[0]);
+        Assertions.assertNull(rows.getFirst()[1]);
     }
 
     private List<StreamDataImporterColumnInfo> readColumnsInfo(String data, boolean isHeaderPresent) throws DBException, IOException {

--- a/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/tools/transfer/CSVImporterTest.java
+++ b/test/org.jkiss.dbeaver.test.platform/src/org/jkiss/dbeaver/tools/transfer/CSVImporterTest.java
@@ -16,6 +16,7 @@
  */
 package org.jkiss.dbeaver.tools.transfer;
 
+import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.model.DBPDataKind;
 import org.jkiss.dbeaver.model.exec.DBCResultSet;
@@ -151,7 +152,11 @@ public class CSVImporterTest  extends DBeaverUnitTest {
         Assertions.assertNull(rows.getFirst()[1]);
     }
 
-    private List<StreamDataImporterColumnInfo> readColumnsInfo(String data, boolean isHeaderPresent) throws DBException, IOException {
+    @NotNull
+    private List<StreamDataImporterColumnInfo> readColumnsInfo(
+        @NotNull String data,
+        boolean isHeaderPresent
+    ) throws DBException, IOException {
         properties.put("header", isHeaderPresent ? DataImporterCSV.HeaderPosition.top : DataImporterCSV.HeaderPosition.none);
         try (ByteArrayInputStream is = new ByteArrayInputStream(data.getBytes())) {
             return importer.readColumnsInfo(mapping, is);


### PR DESCRIPTION
Closes dbeaver/pro#10443

## Summary

- Preserve null values added when a CSV row has fewer columns than its mapping while trimming whitespaces.
- Add a regression test that imports a short row with `trimWhitespaces=true` and verifies the missing trailing value remains null.

## Testing

`mvn verify -f product/aggregate/pom.xml -T1C -Pproduct-dbeaver-ce,product-dbeaver-eclipse-ce -Dtest=CSVImporterTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false`

Result: `BUILD SUCCESS`; `CSVImporterTest` passed all 8 tests.

This PR was generated with AI assistance.