### PR TITLE
dbeaver/dbeaver#11061 Fix PostgreSQL PUBLIC meta-role missing from Permissions tabs

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreConstants.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreConstants.java
@@ -41,6 +41,12 @@ public class PostgreConstants {
     public static final String DEFAULT_DATA_TYPE = "varchar";
     public static final String DEFAULT_USER = "postgres";
     public static final String USER_VARIABLE = "$user";
+    /**
+     * Name of the PUBLIC pseudo-role which exists in every database since cluster initialization.
+     * PUBLIC is not stored in pg_authid/pg_roles. It is manifested by 0 (zero) value in ACL objects
+     * and 'PUBLIC' string in information_schema views.
+     */
+    public static final String PUBLIC_ROLE_NAME = "public";
 
     public static final String PROP_CHOSEN_ROLE = DBConstants.INTERNAL_PROP_PREFIX + "chosen-role@";
     public static final String PROP_SHOW_NON_DEFAULT_DB = DBConstants.INTERNAL_PROP_PREFIX + "show-non-default-db@";

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreUtils.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/PostgreUtils.java
@@ -742,7 +742,9 @@ public class PostgreUtils {
     ) throws DBException {
         if (!(acl instanceof java.sql.Array)) {
             if (acl == null) {
-                // Special case. Means ALL permissions are granted to table owner
+                // Special case. NULL ACL means the object has default privileges:
+                // all privileges are granted to the object owner plus the default PUBLIC
+                // privileges for the specific object type (e.g. EXECUTE for procedures).
                 PostgreRole objectOwner = owner.getOwner(monitor);
                 PostgreRoleReference granteeReference = objectOwner == null ? null : objectOwner.getRoleReference();
 
@@ -757,8 +759,28 @@ public class PostgreUtils {
                                 PostgrePrivilegeType.ALL,
                                 false,
                                 false));
-                PostgreObjectPrivilege permission = new PostgreObjectPrivilege(owner, granteeReference, privileges);
-                return Collections.singletonList(permission);
+                List<PostgrePrivilege> permissions = new ArrayList<>();
+                permissions.add(new PostgreObjectPrivilege(owner, granteeReference, privileges));
+                if (owner instanceof PostgreProcedure) {
+                    // Procedures and functions are granted EXECUTE to PUBLIC by default (#11061)
+                    PostgreRoleReference publicReference = new PostgreRoleReference(
+                        owner.getDatabase(),
+                        PostgreConstants.PUBLIC_ROLE_NAME,
+                        null
+                    );
+                    privileges = new ArrayList<>();
+                    privileges.add(new PostgrePrivilegeGrant(
+                            granteeReference,
+                            publicReference,
+                            owner.getDatabase().getName(),
+                            owner.getSchema().getName(),
+                            owner.getName(),
+                            PostgrePrivilegeType.EXECUTE,
+                            false,
+                            false));
+                    permissions.add(new PostgreObjectPrivilege(owner, publicReference, privileges));
+                }
+                return permissions;
             }
             return Collections.emptyList();
         }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreCommandGrantPrivilege.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/edit/PostgreCommandGrantPrivilege.java
@@ -18,6 +18,7 @@ package org.jkiss.dbeaver.ext.postgresql.edit;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
+import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.PostgreUtils;
 import org.jkiss.dbeaver.ext.postgresql.model.*;
 import org.jkiss.dbeaver.model.DBPEvaluationContext;
@@ -85,7 +86,7 @@ public class PostgreCommandGrantPrivilege extends DBECommandAbstract<PostgrePriv
         String objectName = "", roleName;
         String roleType = null;
         if (object instanceof PostgreRole role) {
-            roleName = DBUtils.getQuotedIdentifier(object);
+            roleName = getGranteeName(object, role.getName());
             if (privilegeOwner instanceof PostgreProcedure) {
                 objectName = ((PostgreProcedure) privilegeOwner).getFullQualifiedSignature();
             } else if (privilege instanceof PostgreRolePrivilege) {
@@ -95,7 +96,7 @@ public class PostgreCommandGrantPrivilege extends DBECommandAbstract<PostgrePriv
         } else {
             PostgreObjectPrivilege permission = (PostgreObjectPrivilege) this.privilege;
             if (permission.getGrantee() != null) {
-                roleName = DBUtils.getQuotedIdentifier(object.getDataSource(), permission.getGrantee().getRoleName());
+                roleName = getGranteeName(object, permission.getGrantee().getRoleName());
                 roleType = permission.getGrantee().getRoleType();
             } else {
                 roleName = "";
@@ -220,5 +221,19 @@ public class PostgreCommandGrantPrivilege extends DBECommandAbstract<PostgrePriv
     @NotNull
     private String makeUniqueName(@NotNull String name) {
         return name + "#" + privilege.hashCode() + "#" + privilegeOwner.hashCode();
+    }
+
+    /**
+     * Returns the grantee name for the generated DDL.
+     * The PUBLIC pseudo-role is a PostgreSQL keyword and must never be quoted:
+     * {@code GRANT SELECT ON TABLE mytab TO "PUBLIC"} is invalid,
+     * the only correct form is {@code GRANT SELECT ON TABLE mytab TO PUBLIC}.
+     */
+    @NotNull
+    private static String getGranteeName(@NotNull PostgrePrivilegeOwner object, @Nullable String roleName) {
+        if (PostgreConstants.PUBLIC_ROLE_NAME.equalsIgnoreCase(roleName)) {
+            return PostgreConstants.PUBLIC_ROLE_NAME.toUpperCase();
+        }
+        return DBUtils.getQuotedIdentifier(object.getDataSource(), roleName);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDatabase.java
@@ -395,7 +395,13 @@ public class PostgreDatabase extends JDBCRemoteInstance
             return null;
         }
         checkInstanceConnection(monitor);
-        return roleCache.getObject(monitor, this, reference.getRoleName());
+        PostgreRole role = roleCache.getObject(monitor, this, reference.getRoleName());
+        if (role == null && PostgreConstants.PUBLIC_ROLE_NAME.equalsIgnoreCase(reference.getRoleName())) {
+            // information_schema reports the PUBLIC pseudo-role as 'PUBLIC' while ACL parsing
+            // produces lowercase 'public'. Resolve both variants to the same role.
+            role = roleCache.getObject(monitor, this, PostgreConstants.PUBLIC_ROLE_NAME);
+        }
+        return role;
     }
 
     @Property(editable = false, updatable = false, order = 5/*, listProvider = CharsetListProvider.class*/)
@@ -1086,6 +1092,21 @@ public class PostgreDatabase extends JDBCRemoteInstance
         protected PostgreRole fetchObject(@NotNull JDBCSession session, @NotNull PostgreDatabase owner, @NotNull JDBCResultSet dbResult)
             throws SQLException, DBException {
             return new PostgreRole(owner, dbResult);
+        }
+
+        @Override
+        protected void addCustomObjects(
+            @NotNull DBRProgressMonitor monitor,
+            @NotNull PostgreDatabase owner,
+            @NotNull List<PostgreRole> objectList
+        ) {
+            // Add the PUBLIC pseudo-role. It is not stored in pg_roles but exists in every
+            // database since cluster initialization and is represented by zero ACL grantee id.
+            // Without it PUBLIC grants are invisible in the permissions editors.
+            // See https://github.com/dbeaver/dbeaver/issues/11061
+            PostgreRole publicRole = new PostgreRole(owner, PostgreConstants.PUBLIC_ROLE_NAME, null, false);
+            publicRole.setPersisted(true);
+            objectList.add(publicRole);
         }
 
         @Override

--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreRole.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreRole.java
@@ -20,6 +20,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ext.postgresql.PostgreConstants;
 import org.jkiss.dbeaver.ext.postgresql.PostgreUtils;
 import org.jkiss.dbeaver.model.*;
 import org.jkiss.dbeaver.model.access.DBARole;
@@ -180,6 +181,16 @@ public class PostgreRole implements
 
     public boolean isUser() {
         return canLogin;
+    }
+
+    /**
+     * Returns true if this is the special PUBLIC pseudo-role.
+     * PUBLIC is not stored in pg_roles but exists since cluster initialization and grants
+     * privileges to any connected user. In SQL statements and information_schema views it is
+     * represented by the 'PUBLIC' keyword (cannot be quoted) and by zero grantee id in ACLs.
+     */
+    public boolean isPublicRole() {
+        return PostgreConstants.PUBLIC_ROLE_NAME.equalsIgnoreCase(getName());
     }
 
     @Override
@@ -395,6 +406,12 @@ public class PostgreRole implements
     @NotNull
     @Override
     public String getObjectDefinitionText(@NotNull DBRProgressMonitor monitor, @NotNull Map<String, Object> options) throws DBException {
+        if (isPublicRole()) {
+            // PUBLIC is a special PostgreSQL meta-role. It always exists since cluster initialization
+            // and cannot be created, altered or dropped via SQL.
+            return "-- " + getName() + " is the special PUBLIC meta-role. It grants privileges to any connected user.\n"
+                + "-- It always exists in every database and cannot be created or dropped.";
+        }
         final String lineBreak = System.lineSeparator();
         PostgreDataSource dataSource = getDataSource();
         final PostgreServerExtension extension = dataSource.getServerType();
@@ -487,6 +504,9 @@ public class PostgreRole implements
     public List<PostgrePrivilege> getPrivileges(@NotNull DBRProgressMonitor monitor, boolean includeNestedObjects) throws DBCException {
         List<PostgrePrivilege> permissions = new ArrayList<>();
         try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Read role privileges")) {
+            // The PUBLIC pseudo-role is reported by information_schema views and pg_get_userbyid()
+            // as the uppercase 'PUBLIC' keyword, while other roles are stored in lowercase.
+            String granteeName = isPublicRole() ? PostgreConstants.PUBLIC_ROLE_NAME.toUpperCase() : getName();
             String tablePrivilegeSql = """
                 SELECT * FROM information_schema.table_privileges
                 WHERE table_catalog=? AND grantee=?""";
@@ -514,7 +534,7 @@ public class PostgreRole implements
             }
             try (JDBCPreparedStatement dbStat = session.prepareStatement(tablePrivilegeSql)) {
                 dbStat.setString(1, getDatabase().getName());
-                dbStat.setString(2, getName());
+                dbStat.setString(2, granteeName);
                 if (supportsMaintainPrivilege) {
                     dbStat.setLong(3, getObjectId());
                 }
@@ -525,7 +545,7 @@ public class PostgreRole implements
             try (JDBCPreparedStatement dbStat = session.prepareStatement(
                     "SELECT * FROM information_schema.routine_privileges WHERE specific_catalog=? AND grantee=?")) {
                 dbStat.setString(1, getDatabase().getName());
-                dbStat.setString(2, getName());
+                dbStat.setString(2, granteeName);
                 permissions.addAll(getRolePermissions(monitor, this, PostgrePrivilegeGrant.Kind.FUNCTION, dbStat));
             } catch (Throwable e) {
                 log.error("Error reading routine privileges", e);
@@ -533,6 +553,13 @@ public class PostgreRole implements
             // Select acl for all schemas, sequences and materialized views
             boolean supportsDistinct = getDataSource().getServerType().supportsDistinctForStatementsWithAcl(); // Greenplum do not support DISTINCT keyword with the acl data type in the query
             boolean supportsOnlySchemasPermissions = !getDataSource().isServerVersionAtLeast(9,0); // So we can't use aclexplode in old PG versions. Let's read only schemas permissions then
+            // PUBLIC pseudo-role is represented in ACLs by zero grantee oid.
+            // pg_get_userbyid(0) does not return 'PUBLIC' in modern PostgreSQL versions,
+            // so it must be filtered by the zero oid directly.
+            boolean publicRole = isPublicRole();
+            String otherObjectsGranteeFilter = publicRole
+                ? "(tr.granteeI = 0 OR pg_get_userbyid(tr.granteeI) = 'PUBLIC')"
+                : "pg_get_userbyid(tr.granteeI) = ?";
             String otherObjectsSQL;
             if (supportsOnlySchemasPermissions) {
                 otherObjectsSQL = "SELECT n.oid, n.nspacl FROM pg_catalog.pg_namespace n WHERE n.nspacl IS NOT NULL";
@@ -563,12 +590,14 @@ public class PostgreRole implements
                     "WHERE\n" +
                     "\tn.nspacl IS NOT NULL \n" +
                     "\t) AS tr\n" +
-                    "WHERE pg_get_userbyid(tr.granteeI)= ?" +
+                    "WHERE " + otherObjectsGranteeFilter +
                     " AND tr.relkind IN('S', 'm', 'C')";
             }
             try (JDBCPreparedStatement dbStat = session.prepareStatement(otherObjectsSQL)) {
                 if (!supportsOnlySchemasPermissions) {
-                    dbStat.setString(1, getName());
+                    if (!publicRole) {
+                        dbStat.setString(1, granteeName);
+                    }
                 }
                 try (JDBCResultSet dbResult = dbStat.executeQuery()) {
                     while (dbResult.nextRow()) {
@@ -632,14 +661,19 @@ public class PostgreRole implements
                 }
             }
             if (getDataSource().getServerType().supportsDefaultPrivileges()) {
+                String defaultPrivilegeGranteeFilter = publicRole
+                    ? "g.grantee = 0"
+                    : "pg_get_userbyid(g.grantee) = ?";
                 try (JDBCPreparedStatement dbStat = session.prepareStatement(
                     """
                         SELECT DISTINCT g.* FROM (
                         SELECT *,
                         (aclexplode(defaclacl)).grantee as grantee
                         FROM pg_default_acl a WHERE a.defaclnamespace <> 0) as g
-                        where pg_get_userbyid(g.grantee) = ?""")) {
-                    dbStat.setString(1, getName());
+                        where """ + " " + defaultPrivilegeGranteeFilter)) {
+                    if (!publicRole) {
+                        dbStat.setString(1, granteeName);
+                    }
                     try (JDBCResultSet dbResult = dbStat.executeQuery()) {
                         while (dbResult.nextRow()) {
                             long schemaId = JDBCUtils.safeGetLong(dbResult, "defaclnamespace");


### PR DESCRIPTION
Closes dbeaver/dbeaver#11061

### Problem

The PostgreSQL PUBLIC pseudo-role does not appear in the Permissions tab for any database object (functions, schemas, tables, etc.), despite being a critical part of PostgreSQL's access control model. Every database connection includes PUBLIC implicitly, and PostgreSQL assigns default privileges to PUBLIC (e.g. `EXECUTE` on all functions, `USAGE` on the `public` schema). The inability to see or manage these grants through DBeaver's UI is a security concern.

PUBLIC does not exist in `pg_roles` or `pg_authid` — it is a virtual role with OID 0, represented as the string `'PUBLIC'` in `information_schema` tables and as the integer 0 in ACL objects.

### Solution

Synthesize the PUBLIC pseudo-role in the PostgreSQL role cache so it participates in the Permissions tab like any other role.

**Changes across 5 files:**

1. **`PostgreConstants.java`** — Add `PUBLIC_ROLE_NAME = "public"` constant.

2. **`PostgreDatabase.java`** — Override `addCustomObjects()` in `RoleCache` to inject a synthetic `PostgreRole` for PUBLIC (oid=0, canLogin=false, persisted=true). Add case-insensitive fallback in `getRoleByReference()` so that both `"public"` and `"PUBLIC"` resolve to the same cached role.

3. **`PostgreRole.java`** — Add `isPublicRole()` helper. In `getPrivileges()`, use uppercase `'PUBLIC'` as the grantee filter in `information_schema` queries (matching PostgreSQL's casing). Guard `getObjectDefinitionText()` to return a descriptive comment instead of invalid `CREATE ROLE "public"` DDL. Fix `otherObjectsSQL` to resolve the PUBLIC pseudo-role by OID 0 instead of `pg_get_userbyid()` (which returns `'unknown (OID=0)'` instead of `'PUBLIC'` on modern PostgreSQL). Fix default privileges query: add missing space in SQL text block concatenation (`where` + filter) that caused a syntax error at runtime (`wherepg_get_userbyid`).

4. **`PostgreCommandGrantPrivilege.java`** — Add `getGranteeName()` static helper that emits the unquoted keyword `PUBLIC` instead of the quoted identifier `"PUBLIC"` (which PostgreSQL rejects). Used in both the `PostgreRole` and `PostgreObjectPrivilege` code paths for DDL generation.

5. **`PostgreUtils.java`** — Fix NULL ACL handling. When an object's ACL is NULL (i.e. it has never been explicitly granted), PostgreSQL applies its default access privileges. For procedures/functions the default grants `EXECUTE` to PUBLIC, but DBeaver only synthesized the owner grant. Now the PUBLIC `EXECUTE` grant is also synthesized, so default function permissions match what `information_schema.routine_privileges` reports.

### Technical notes

- PUBLIC is a SQL keyword — `GRANT ... TO "PUBLIC"` is invalid; it must be `GRANT ... TO PUBLIC`. The fix ensures DDL generation never quotes it.
- `information_schema` reports PUBLIC in uppercase (`'PUBLIC'`), while `DBUtils.getQuotedIdentifier` produces lowercase `"public"` for cache lookup. The case-insensitive fallback in `getRoleByReference()` bridges this gap.
- The `addCustomObjects` callback in `JDBCObjectCache` runs after the database fetch from `pg_roles`, so the synthetic role is added regardless of query results.
- A NULL ACL (no explicit GRANT/REVOKE ever issued) means "default privileges" in PostgreSQL. `acldefault()` grants PUBLIC `EXECUTE` on functions/procedures and `USAGE` on types/languages by default, and this must be reflected when DBeaver loads privileges from likely-NULL ACL columns.

### Testing

Key checks:
- PUBLIC row visible in Permissions tab for functions, schemas, tables
- Granting/revoking privileges to/from PUBLIC via UI succeeds
- DDL for PUBLIC shows a comment, not invalid `CREATE ROLE`
- Generated `GRANT ... TO PUBLIC` uses unquoted keyword
