### PR TITLE
dbeaver/dbeaver#41437 Fix Doris CSV import

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.doris/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.doris/plugin.xml
@@ -11,6 +11,9 @@
                 label="Apache Doris"
                 icon="icons/doris_icon.svg">
 
+            <treeInjection path="generic/catalog/schema/table"
+                changeFolderType="org.jkiss.dbeaver.ext.doris.model.DorisTable"/>
+
             <drivers managable="true">
                 <driver
                         id="doris"

--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
@@ -17,11 +17,17 @@
 package org.jkiss.dbeaver.ext.doris.edit;
 
 import org.jkiss.code.NotNull;
-import org.jkiss.dbeaver.ext.doris.model.DorisTable;
+import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.generic.edit.GenericTableManager;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
+import org.jkiss.dbeaver.model.DBUtils;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
+import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 
+import java.sql.SQLException;
 import java.util.Map;
 
 /**
@@ -29,8 +35,10 @@ import java.util.Map;
  */
 public class DorisTableManager extends GenericTableManager {
 
+    private static final Log log = Log.getLog(DorisTableManager.class);
+
     private static final String DEFAULT_DISTRIBUTION = "DISTRIBUTED BY RANDOM BUCKETS 1"; //$NON-NLS-1$
-    private static final String DEFAULT_PROPERTIES = "PROPERTIES (\"replication_num\" = \"1\")"; //$NON-NLS-1$
+    private static final String SINGLE_BACKEND_PROPERTIES = "PROPERTIES (\"replication_num\" = \"1\")"; //$NON-NLS-1$
 
     @Override
     protected void appendTableModifiers(
@@ -41,10 +49,27 @@ public class DorisTableManager extends GenericTableManager {
         boolean alter,
         @NotNull Map<String, Object> options
     ) {
-        if (table instanceof DorisTable) {
-            String delimiter = getDelimiter(options);
-            ddl.append(delimiter).append(DEFAULT_DISTRIBUTION);
-            ddl.append(delimiter).append(DEFAULT_PROPERTIES);
+        String delimiter = getDelimiter(options);
+        ddl.append(delimiter).append(DEFAULT_DISTRIBUTION);
+        if (hasSingleBackend(monitor, table)) {
+            ddl.append(delimiter).append(SINGLE_BACKEND_PROPERTIES);
+        }
+    }
+
+    private static boolean hasSingleBackend(@NotNull DBRProgressMonitor monitor, @NotNull GenericTableBase table) {
+        try (JDBCSession session = DBUtils.openMetaSession(monitor, table, "Read Doris backends");
+             JDBCPreparedStatement statement = session.prepareStatement("SHOW BACKENDS"); //$NON-NLS-1$
+             JDBCResultSet resultSet = statement.executeQuery()) {
+            int backendCount = 0;
+            while (resultSet.next()) {
+                if (++backendCount > 1) {
+                    return false;
+                }
+            }
+            return backendCount == 1;
+        } catch (DBException | SQLException e) {
+            log.debug("Unable to determine Doris backend count", e); //$NON-NLS-1$
+            return false;
         }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
@@ -17,6 +17,7 @@
 package org.jkiss.dbeaver.ext.doris.edit;
 
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.generic.edit.GenericTableManager;
@@ -38,8 +39,9 @@ public class DorisTableManager extends GenericTableManager {
 
     private static final Log log = Log.getLog(DorisTableManager.class);
 
+    private static final int DEFAULT_REPLICA_COUNT = 3;
     private static final String DEFAULT_DISTRIBUTION = "DISTRIBUTED BY RANDOM BUCKETS 1"; //$NON-NLS-1$
-    private static final String SINGLE_BACKEND_PROPERTIES = "PROPERTIES (\"replication_num\" = \"1\")"; //$NON-NLS-1$
+    private static final String REPLICATION_PROPERTIES = "PROPERTIES (\"replication_num\" = \"%d\")"; //$NON-NLS-1$
 
     @Override
     protected void appendTableModifiers(
@@ -52,12 +54,14 @@ public class DorisTableManager extends GenericTableManager {
     ) {
         String delimiter = getDelimiter(options);
         ddl.append(delimiter).append(DEFAULT_DISTRIBUTION);
-        if (useSingleReplica(monitor, table)) {
-            ddl.append(delimiter).append(SINGLE_BACKEND_PROPERTIES);
+        Integer replicaCount = getReplicaCount(monitor, table);
+        if (replicaCount != null) {
+            ddl.append(delimiter).append(REPLICATION_PROPERTIES.formatted(replicaCount));
         }
     }
 
-    private static boolean useSingleReplica(
+    @Nullable
+    private static Integer getReplicaCount(
         @NotNull DBRProgressMonitor monitor,
         @NotNull GenericTableBase table
     ) {
@@ -68,18 +72,21 @@ public class DorisTableManager extends GenericTableManager {
             int availableBackendCount = 0;
             while (resultSet.next()) {
                 if (!JDBCUtils.safeGetBoolean(resultSet, "Alive") || //$NON-NLS-1$
-                    JDBCUtils.safeGetBoolean(resultSet, "SystemDecommissioned")
-                ) { //$NON-NLS-1$
+                    JDBCUtils.safeGetBoolean(resultSet, "SystemDecommissioned") //$NON-NLS-1$
+                ) {
                     continue;
                 }
-                if (++availableBackendCount > 1) {
-                    return false;
-                }
+                availableBackendCount++;
             }
-            return availableBackendCount == 1;
+            if (availableBackendCount == 0) {
+                return null;
+            }
+            if (availableBackendCount < DEFAULT_REPLICA_COUNT) {
+                return availableBackendCount;
+            }
         } catch (DBException | SQLException e) {
             log.debug("Unable to determine Doris backend count", e); //$NON-NLS-1$
-            return false;
         }
+        return null;
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
@@ -18,26 +18,17 @@ package org.jkiss.dbeaver.ext.doris.edit;
 
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
-import org.jkiss.dbeaver.DBException;
-import org.jkiss.dbeaver.Log;
+import org.jkiss.dbeaver.ext.doris.model.DorisDataSource;
 import org.jkiss.dbeaver.ext.generic.edit.GenericTableManager;
 import org.jkiss.dbeaver.ext.generic.model.GenericTableBase;
-import org.jkiss.dbeaver.model.DBUtils;
-import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
-import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
-import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
-import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
 
-import java.sql.SQLException;
 import java.util.Map;
 
 /**
  * Doris table manager.
  */
 public class DorisTableManager extends GenericTableManager {
-
-    private static final Log log = Log.getLog(DorisTableManager.class);
 
     // Doris uses three replicas when CREATE TABLE omits replication properties.
     private static final int DEFAULT_REPLICA_COUNT = 3;
@@ -66,27 +57,9 @@ public class DorisTableManager extends GenericTableManager {
         @NotNull DBRProgressMonitor monitor,
         @NotNull GenericTableBase table
     ) {
-        try (JDBCSession session = DBUtils.openMetaSession(monitor, table, "Read Doris backends");
-             JDBCPreparedStatement statement = session.prepareStatement("SHOW BACKENDS"); //$NON-NLS-1$
-             JDBCResultSet resultSet = statement.executeQuery()
-        ) {
-            int availableBackendCount = 0;
-            while (resultSet.next()) {
-                if (!JDBCUtils.safeGetBoolean(resultSet, "Alive") || //$NON-NLS-1$
-                    JDBCUtils.safeGetBoolean(resultSet, "SystemDecommissioned") //$NON-NLS-1$
-                ) {
-                    continue;
-                }
-                availableBackendCount++;
-            }
-            if (availableBackendCount == 0) {
-                return null;
-            }
-            if (availableBackendCount < DEFAULT_REPLICA_COUNT) {
-                return availableBackendCount;
-            }
-        } catch (DBException | SQLException e) {
-            log.debug("Unable to determine Doris backend count", e); //$NON-NLS-1$
+        int availableBackendCount = ((DorisDataSource) table.getDataSource()).getAvailableBackendCount(monitor);
+        if (availableBackendCount > 0 && availableBackendCount < DEFAULT_REPLICA_COUNT) {
+            return availableBackendCount;
         }
         return null;
     }

--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
@@ -26,6 +26,7 @@ import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.utils.CommonUtils;
 
 import java.sql.SQLException;
 import java.util.Map;
@@ -51,12 +52,16 @@ public class DorisTableManager extends GenericTableManager {
     ) {
         String delimiter = getDelimiter(options);
         ddl.append(delimiter).append(DEFAULT_DISTRIBUTION);
-        if (hasSingleBackend(monitor, table)) {
+        if (useSingleReplica(monitor, table, options)) {
             ddl.append(delimiter).append(SINGLE_BACKEND_PROPERTIES);
         }
     }
 
-    private static boolean hasSingleBackend(@NotNull DBRProgressMonitor monitor, @NotNull GenericTableBase table) {
+    private static boolean useSingleReplica(
+        @NotNull DBRProgressMonitor monitor,
+        @NotNull GenericTableBase table,
+        @NotNull Map<String, Object> options
+    ) {
         try (JDBCSession session = DBUtils.openMetaSession(monitor, table, "Read Doris backends");
              JDBCPreparedStatement statement = session.prepareStatement("SHOW BACKENDS"); //$NON-NLS-1$
              JDBCResultSet resultSet = statement.executeQuery()) {
@@ -69,7 +74,8 @@ public class DorisTableManager extends GenericTableManager {
             return backendCount == 1;
         } catch (DBException | SQLException e) {
             log.debug("Unable to determine Doris backend count", e); //$NON-NLS-1$
-            return false;
+            // SHOW BACKENDS requires cluster-level privileges, which users may not have
+            return CommonUtils.getOption(options, OPTION_SKIP_CONFIGURATION);
         }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
@@ -25,8 +25,8 @@ import org.jkiss.dbeaver.model.DBUtils;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCPreparedStatement;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCResultSet;
 import org.jkiss.dbeaver.model.exec.jdbc.JDBCSession;
+import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
-import org.jkiss.utils.CommonUtils;
 
 import java.sql.SQLException;
 import java.util.Map;
@@ -52,30 +52,34 @@ public class DorisTableManager extends GenericTableManager {
     ) {
         String delimiter = getDelimiter(options);
         ddl.append(delimiter).append(DEFAULT_DISTRIBUTION);
-        if (useSingleReplica(monitor, table, options)) {
+        if (useSingleReplica(monitor, table)) {
             ddl.append(delimiter).append(SINGLE_BACKEND_PROPERTIES);
         }
     }
 
     private static boolean useSingleReplica(
         @NotNull DBRProgressMonitor monitor,
-        @NotNull GenericTableBase table,
-        @NotNull Map<String, Object> options
+        @NotNull GenericTableBase table
     ) {
         try (JDBCSession session = DBUtils.openMetaSession(monitor, table, "Read Doris backends");
              JDBCPreparedStatement statement = session.prepareStatement("SHOW BACKENDS"); //$NON-NLS-1$
-             JDBCResultSet resultSet = statement.executeQuery()) {
-            int backendCount = 0;
+             JDBCResultSet resultSet = statement.executeQuery()
+        ) {
+            int availableBackendCount = 0;
             while (resultSet.next()) {
-                if (++backendCount > 1) {
+                if (!JDBCUtils.safeGetBoolean(resultSet, "Alive") || //$NON-NLS-1$
+                    JDBCUtils.safeGetBoolean(resultSet, "SystemDecommissioned")
+                ) { //$NON-NLS-1$
+                    continue;
+                }
+                if (++availableBackendCount > 1) {
                     return false;
                 }
             }
-            return backendCount == 1;
+            return availableBackendCount == 1;
         } catch (DBException | SQLException e) {
             log.debug("Unable to determine Doris backend count", e); //$NON-NLS-1$
-            // SHOW BACKENDS requires cluster-level privileges, which users may not have
-            return CommonUtils.getOption(options, OPTION_SKIP_CONFIGURATION);
+            return false;
         }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
@@ -30,6 +30,7 @@ import java.util.Map;
 public class DorisTableManager extends GenericTableManager {
 
     private static final String DEFAULT_DISTRIBUTION = "DISTRIBUTED BY RANDOM BUCKETS 1"; //$NON-NLS-1$
+    private static final String DEFAULT_PROPERTIES = "PROPERTIES (\"replication_num\" = \"1\")"; //$NON-NLS-1$
 
     @Override
     protected void appendTableModifiers(
@@ -41,7 +42,9 @@ public class DorisTableManager extends GenericTableManager {
         @NotNull Map<String, Object> options
     ) {
         if (table instanceof DorisTable) {
-            ddl.append(getDelimiter(options)).append(DEFAULT_DISTRIBUTION);
+            String delimiter = getDelimiter(options);
+            ddl.append(delimiter).append(DEFAULT_DISTRIBUTION);
+            ddl.append(delimiter).append(DEFAULT_PROPERTIES);
         }
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/edit/DorisTableManager.java
@@ -39,6 +39,7 @@ public class DorisTableManager extends GenericTableManager {
 
     private static final Log log = Log.getLog(DorisTableManager.class);
 
+    // Doris uses three replicas when CREATE TABLE omits replication properties.
     private static final int DEFAULT_REPLICA_COUNT = 3;
     private static final String DEFAULT_DISTRIBUTION = "DISTRIBUTED BY RANDOM BUCKETS 1"; //$NON-NLS-1$
     private static final String REPLICATION_PROPERTIES = "PROPERTIES (\"replication_num\" = \"%d\")"; //$NON-NLS-1$

--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/model/DorisDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/model/DorisDataSource.java
@@ -19,6 +19,7 @@ package org.jkiss.dbeaver.ext.doris.model;
 import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.dbeaver.DBException;
+import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.ext.generic.model.GenericDataSource;
 import org.jkiss.dbeaver.ext.generic.model.meta.GenericMetaObject;
 import org.jkiss.dbeaver.model.DBPDataSourceContainer;
@@ -31,6 +32,7 @@ import org.jkiss.dbeaver.model.impl.jdbc.JDBCExecutionContext;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCRemoteInstance;
 import org.jkiss.dbeaver.model.impl.jdbc.JDBCUtils;
 import org.jkiss.dbeaver.model.runtime.DBRProgressMonitor;
+import org.jkiss.dbeaver.model.struct.DBSObject;
 import org.jkiss.dbeaver.model.struct.DBSObjectFilter;
 
 import java.sql.SQLException;
@@ -44,6 +46,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class DorisDataSource extends GenericDataSource {
 
+    private static final Log log = Log.getLog(DorisDataSource.class);
+
     public static final String DEFAULT_CATALOG_NAME = "internal"; //$NON-NLS-1$
     private static final String COL_CATALOG_NAME = "CatalogName"; //$NON-NLS-1$
     private static final String COL_TYPE = "Type"; //$NON-NLS-1$
@@ -53,6 +57,7 @@ public class DorisDataSource extends GenericDataSource {
      * catalog name -> [type, comment]
      */
     private final Map<String, CatalogMetadata> catalogMetadataCache = new ConcurrentHashMap<>();
+    private Integer availableBackendCount;
 
     public record CatalogMetadata(@Nullable String type, @Nullable String comment) {
     }
@@ -131,6 +136,33 @@ public class DorisDataSource extends GenericDataSource {
         return catalogMetadataCache.get(catalogName);
     }
 
+    public synchronized int getAvailableBackendCount(@NotNull DBRProgressMonitor monitor) {
+        if (availableBackendCount == null) {
+            availableBackendCount = readAvailableBackendCount(monitor);
+        }
+        return availableBackendCount;
+    }
+
+    private int readAvailableBackendCount(@NotNull DBRProgressMonitor monitor) {
+        try (JDBCSession session = DBUtils.openMetaSession(monitor, this, "Read Doris backends");
+             JDBCPreparedStatement statement = session.prepareStatement("SHOW BACKENDS"); //$NON-NLS-1$
+             JDBCResultSet resultSet = statement.executeQuery()
+        ) {
+            int backendCount = 0;
+            while (resultSet.next()) {
+                if (JDBCUtils.safeGetBoolean(resultSet, "Alive") && //$NON-NLS-1$
+                    !JDBCUtils.safeGetBoolean(resultSet, "SystemDecommissioned") //$NON-NLS-1$
+                ) {
+                    backendCount++;
+                }
+            }
+            return backendCount;
+        } catch (DBException | SQLException e) {
+            log.debug("Unable to determine Doris backend count", e); //$NON-NLS-1$
+            return 0;
+        }
+    }
+
     @Nullable
     public DorisCatalog getCatalog(@NotNull String name) {
         return (DorisCatalog) super.getCatalog(name);
@@ -144,5 +176,11 @@ public class DorisDataSource extends GenericDataSource {
     @Override
     public boolean isOmitSchema() {
         return false;
+    }
+
+    @Override
+    public synchronized DBSObject refreshObject(@NotNull DBRProgressMonitor monitor) throws DBException {
+        availableBackendCount = null;
+        return super.refreshObject(monitor);
     }
 }

--- a/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/model/DorisMetaModel.java
+++ b/plugins/org.jkiss.dbeaver.ext.doris/src/org/jkiss/dbeaver/ext/doris/model/DorisMetaModel.java
@@ -195,10 +195,6 @@ public class DorisMetaModel extends GenericMetaModel {
         @NotNull GenericStructContainer owner,
         @Nullable GenericTableBase forTable
     ) throws SQLException {
-        if (forTable == null) {
-            throw new SQLException("Cannot load columns without specifying a table"); //$NON-NLS-1$
-        }
-
         // Switch to the catalog context
         GenericCatalog catalog = owner.getCatalog();
         if (catalog != null) {
@@ -210,6 +206,7 @@ public class DorisMetaModel extends GenericMetaModel {
 
         // Use information_schema.columns to get ORDINAL_POSITION
         String sql = "SELECT " + //$NON-NLS-1$
+            "TABLE_NAME, " + //$NON-NLS-1$
             "COLUMN_NAME, " + //$NON-NLS-1$
             "DATA_TYPE, " + //$NON-NLS-1$
             "COLUMN_TYPE, " + //$NON-NLS-1$
@@ -219,12 +216,15 @@ public class DorisMetaModel extends GenericMetaModel {
             "COLUMN_COMMENT, " + //$NON-NLS-1$
             "ORDINAL_POSITION " + //$NON-NLS-1$
             "FROM information_schema.columns " + //$NON-NLS-1$
-            "WHERE table_schema = ? AND table_name = ? " + //$NON-NLS-1$
-            "ORDER BY ORDINAL_POSITION"; //$NON-NLS-1$
+            "WHERE table_schema = ?" + //$NON-NLS-1$
+            (forTable == null ? " " : " AND table_name = ? ") + //$NON-NLS-1$ //$NON-NLS-2$
+            "ORDER BY TABLE_NAME, ORDINAL_POSITION"; //$NON-NLS-1$
 
         JDBCPreparedStatement stmt = session.prepareStatement(sql);
         stmt.setString(1, schemaName);
-        stmt.setString(2, forTable.getName());
+        if (forTable != null) {
+            stmt.setString(2, forTable.getName());
+        }
         return stmt;
     }
 


### PR DESCRIPTION
Closes dbeaver/dbeaver#41437

## Summary
- generate Doris import tables with one replica so CSV imports work on single-backend installations
- support loading columns for all tables during the post-import schema refresh
- include the table name in column metadata so refreshed columns are assigned to the correct table

## Testing
- manually verified that the CSV import completes successfully

This PR was generated with AI (OpenCode).