### PR TITLE
dbeaver/pro#9786 Fix Firestore data transfer

### DIFF
--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferConsumer.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferConsumer.java
@@ -76,6 +76,7 @@ public class DatabaseTransferConsumer implements IDataTransferConsumer<DatabaseC
     private DBCExecutionContext targetContext;
     private DBCSession targetSession;
     private DBSDataManipulator.ExecuteBatch executeBatch;
+    private boolean useDirectTarget;
     private DBSDataBulkLoader.BulkLoadManager bulkLoadManager;
     private long rowsExported = 0;
     private boolean ignoreErrors = false;
@@ -706,13 +707,18 @@ public class DatabaseTransferConsumer implements IDataTransferConsumer<DatabaseC
         }
         if (session.getDataSource().getInfo().isDynamicMetadata()) {
             if (containerMapping.hasNewTargetObject()) {
-                DatabaseTransferUtils.createTargetDynamicTable(
+                DBSDataManipulator target = DatabaseTransferUtils.createTargetDynamicTable(
                     session.getProgressMonitor(),
                     session.getExecutionContext(),
                     schema,
                     containerMapping,
                     containerMapping.getTarget() != null
                 );
+                if (target != null) {
+                    DatabaseTransferUtils.setMappingTarget(containerMapping, target);
+                    useDirectTarget = true;
+                    return false;
+                }
             }
             return true;
         } else {
@@ -781,7 +787,9 @@ public class DatabaseTransferConsumer implements IDataTransferConsumer<DatabaseC
             try {
                 // Mappings can be outdated so is the target object.
                 // This may happen when several database consumers point to the same container node
-                DatabaseTransferUtils.refreshDatabaseMappings(monitor, settings, containerMapping, true);
+                if (!useDirectTarget) {
+                    DatabaseTransferUtils.refreshDatabaseMappings(monitor, settings, containerMapping, true);
+                }
             } catch (Exception e) {
                 log.error("Error refreshing database model", e);
             }

--- a/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferUtils.java
+++ b/plugins/org.jkiss.dbeaver.data.transfer/src/org/jkiss/dbeaver/tools/transfer/database/DatabaseTransferUtils.java
@@ -121,10 +121,7 @@ public class DatabaseTransferUtils {
                 } else if (!(newTarget instanceof DBSDataManipulator)) {
                     throw new DBCException("New table " + DBUtils.getObjectFullName(newTarget, DBPEvaluationContext.UI) + " doesn't support data manipulation");
                 }
-                containerMapping.setTarget((DBSDataManipulator) newTarget);
-                if (containerMapping.getMappingType() == DatabaseMappingType.create) {
-                    containerMapping.setMappingType(DatabaseMappingType.existing);
-                }
+                setMappingTarget(containerMapping, (DBSDataManipulator) newTarget);
             }
 
             if (updateMappingAttributes || force) {
@@ -137,6 +134,16 @@ public class DatabaseTransferUtils {
                     }
                 }
             }
+        }
+    }
+
+    static void setMappingTarget(
+        @NotNull DatabaseMappingContainer containerMapping,
+        @NotNull DBSDataManipulator target
+    ) {
+        containerMapping.setTarget(target);
+        if (containerMapping.getMappingType() == DatabaseMappingType.create) {
+            containerMapping.setMappingType(DatabaseMappingType.existing);
         }
     }
 
@@ -660,7 +667,8 @@ public class DatabaseTransferUtils {
         }
     }
 
-    static void createTargetDynamicTable(
+    @Nullable
+    static DBSDataManipulator createTargetDynamicTable(
         @NotNull DBRProgressMonitor monitor,
         @NotNull DBCExecutionContext executionContext,
         @NotNull DBSObjectContainer schema,
@@ -689,6 +697,13 @@ public class DatabaseTransferUtils {
             throw new DBException("Can not set name for target entity '" + targetEntity.getClass().getName() + "'");
         }
         commandContext.saveChanges(monitor, options);
+        if (targetEntity instanceof DBSDataManipulator dataManipulator) {
+            if (targetEntity instanceof DBSDocumentContainer && tableManager.getObjectsCache(targetEntity) == null) {
+                return dataManipulator;
+            }
+            return null;
+        }
+        throw new DBException("Target entity doesn't support data manipulation: '" + targetEntity.getClass().getName() + "'");
     }
 
     @NotNull
@@ -744,7 +759,7 @@ public class DatabaseTransferUtils {
         }
     }
 
-    public static class TargetCommandContext extends AbstractCommandContext {
+    public static class TargetCommandContext extends AbstractCommandContext implements DBETransientObjectContext {
         public TargetCommandContext(DBCExecutionContext executionContext) {
             super(executionContext, true);
         }

--- a/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/edit/DBETransientObjectContext.java
+++ b/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/edit/DBETransientObjectContext.java
@@ -1,0 +1,24 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jkiss.dbeaver.model.edit;
+
+/**
+ * Marks a command context that creates objects for direct use before they are available from database metadata.
+ */
+public interface DBETransientObjectContext extends DBECommandContext {
+}


### PR DESCRIPTION
Closes dbeaver/pro#9786

Adds a transient object command context for database objects that must be used before metadata materialization. Dynamic document targets can now be bound directly and skip premature metadata refreshes.

Also avoids forced finish-time remapping for direct targets while retaining the normal mapping transition behavior.

Counterpart: dbeaver/dbeaver-ee#4835

This PR was generated with AI (OpenCode).